### PR TITLE
Add setup_commit_msg_hook.sh

### DIFF
--- a/setup_commit_msg_hook.sh
+++ b/setup_commit_msg_hook.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cat >.git/hooks/commit-msg <<'EOF'
+#!/bin/sh
+
+grep "^License:" "$1" || {
+        echo >>"$1"
+        echo "License: MIT" >>"$1"
+        echo "Signed-off-by: $(git config user.name) <$(git config user.email)>" >>"$1"
+}
+EOF
+chmod +x .git/hooks/commit-msg
+


### PR DESCRIPTION
This script can be used by developers to add a commit-msg hook to their repo.
It comes from discussions in issue #207.

This commit-msg hook will automatically add the following 2 trailers at the end of each commit message:

```
License: MIT
Signed-off-by: User Name <user.email@example.com>
```

There are at least the following points to consider before merging this PR:

- The script setup_commit_msg_hook.sh should probably be moved inside a subdirectory instead of being at the root of the repo.
- There should be some documentation explaining why developers should sign their work and how the script can help.  
- Maybe it's better to add these trailers before the user fills up the commit message instead of after.
