### PR TITLE
Fix config option

### DIFF
--- a/Godeps/_workspace/src/github.com/jbenet/commander/commands.go
+++ b/Godeps/_workspace/src/github.com/jbenet/commander/commands.go
@@ -179,6 +179,20 @@ func (c *Command) Dispatch(args []string) error {
 	// Ensure command is initialized.
 	c.init()
 
+	// Parse options
+	if !c.CustomFlags {
+		var err = error(nil)
+		c.Flag.Usage = func() {
+			c.Usage()
+			err = fmt.Errorf("Failed to parse flags.")
+		}
+		c.Flag.Parse(args)
+		if err != nil {
+			return err
+		}
+		args = c.Flag.Args()
+	}
+
 	// First, try a sub-command
 	if len(args) > 0 {
 		for _, cmd := range c.Subcommands {
@@ -206,18 +220,6 @@ func (c *Command) Dispatch(args []string) error {
 
 	// then, try running this command
 	if c.Runnable() {
-		if !c.CustomFlags {
-			var err = error(nil)
-			c.Flag.Usage = func() {
-				c.Usage()
-				err = fmt.Errorf("Failed to parse flags.")
-			}
-			c.Flag.Parse(args)
-			if err != nil {
-				return err
-			}
-			args = c.Flag.Args()
-		}
 		return c.Run(c, args)
 	}
 

--- a/test/t0020-init.sh
+++ b/test/t0020-init.sh
@@ -25,5 +25,25 @@ test_expect_success "ipfs config succeeds" '
 	test_cmp expected actual
 '
 
+test_expect_success "ipfs -c='dir' init succeeds" '
+	rm -r "$IPFS_DIR" &&
+	unset IPFS_DIR &&
+	ipfs -c="$(pwd)/.go-ipfs" init
+'
+
+test_expect_success "ipfs config Datastore.Path works" '
+	echo "$(pwd)/.go-ipfs/datastore" >expected &&
+	ipfs config Datastore.Path >actual &&
+	test_cmp expected actual
+'
+
+test_expect_success "ipfs init fails when config exists" '
+	test_must_fail ipfs -c="$(pwd)/.go-ipfs" init
+'
+
+test_expect_success "ipfs init -f=true succeeds when config exists" '
+	ipfs -c="$(pwd)/.go-ipfs" init -f=true
+'
+
 test_done
 


### PR DESCRIPTION
The first patch in this PR makes "ipfs -c=dir/.go-ipfs init" work.
The second patch adds some tests to catch any regression. 