### PR TITLE
Add color for --help when output a tty

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -208,6 +208,10 @@
 			"Rev": "9955b0ab8708602d411341e55fffd7e0700f86bd"
 		},
 		{
+			"ImportPath": "github.com/mattn/go-isatty",
+			"Rev": "fdbe02a1b44e75977b2690062b83cf507d70c013"
+		},
+		{
 			"ImportPath": "github.com/maybebtc/logrus",
 			"Comment": "v0.6.0-5-gf92b795",
 			"Rev": "f92b7950b372b1db80bd3527e4d40e42555fe6c2"
@@ -215,6 +219,10 @@
 		{
 			"ImportPath": "github.com/maybebtc/pubsub",
 			"Rev": "39ce5f556423a4c7223b370fa17a3bbd75b2d197"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/colorstring",
+			"Rev": "15fc698eaae194ff160846daf77922a45b9290a7"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/go-homedir",

--- a/Godeps/_workspace/src/github.com/mattn/go-isatty/README.md
+++ b/Godeps/_workspace/src/github.com/mattn/go-isatty/README.md
@@ -1,0 +1,37 @@
+# go-isatty
+
+isatty for golang
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func main() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}
+```
+
+## Installation
+
+```
+$ go get github.com/mattn/go-isatty
+```
+
+# License
+
+MIT
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/Godeps/_workspace/src/github.com/mattn/go-isatty/doc.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,17 @@
+// +build darwin freebsd
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_linux.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,17 @@
+// +build linux
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_windows.go
+++ b/Godeps/_workspace/src/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/colorstring/.travis.yml
+++ b/Godeps/_workspace/src/github.com/mitchellh/colorstring/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+    - 1.0
+    - 1.1
+    - 1.2
+    - 1.3
+    - tip
+
+script:
+    - go test
+
+matrix:
+    allow_failures:
+        - go: tip

--- a/Godeps/_workspace/src/github.com/mitchellh/colorstring/LICENSE
+++ b/Godeps/_workspace/src/github.com/mitchellh/colorstring/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/mitchellh/colorstring/README.md
+++ b/Godeps/_workspace/src/github.com/mitchellh/colorstring/README.md
@@ -1,0 +1,30 @@
+# colorstring [![Build Status](https://travis-ci.org/mitchellh/colorstring.svg)](https://travis-ci.org/mitchellh/colorstring)
+
+colorstring is a [Go](http://www.golang.org) library for outputting colored
+strings to a console using a simple inline syntax in your string to specify
+the color to print as.
+
+For example, the string `[blue]hello [red]world` would output the text
+"hello world" in two colors. The API of colorstring allows for easily disabling
+colors, adding aliases, etc.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/colorstring
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/colorstring).
+
+Usage is easy enough:
+
+```go
+fmt.Println(colorstring.Color("[blue]Hello [red]World!"))
+```
+
+Additionally, the `Colorize` struct can be used to set options such as
+custom colors, color disabling, etc.

--- a/Godeps/_workspace/src/github.com/mitchellh/colorstring/colorstring.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/colorstring/colorstring.go
@@ -1,0 +1,161 @@
+// colorstring provides functions for colorizing strings for terminal
+// output.
+package colorstring
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+// Color colorizes your strings using the default settings.
+//
+// Strings given to Color should use the syntax `[color]` to specify the
+// color for text following. For example: `[blue]Hello` will return "Hello"
+// in blue. See DefaultColors for all the supported colors and attributes.
+//
+// If an unrecognized color is given, it is ignored and assumed to be part
+// of the string. For example: `[hi]world` will result in "[hi]world".
+//
+// A color reset is appended to the end of every string. This will reset
+// the color of following strings when you output this text to the same
+// terminal session.
+//
+// If you want to customize any of this behavior, use the Colorize struct.
+func Color(v string) string {
+	return def.Color(v)
+}
+
+// Colorize colorizes your strings, giving you the ability to customize
+// some of the colorization process.
+//
+// The options in Colorize can be set to customize colorization. If you're
+// only interested in the defaults, just use the top Color function directly,
+// which creates a default Colorize.
+type Colorize struct {
+	// Colors maps a color string to the code for that color. The code
+	// is a string so that you can use more complex colors to set foreground,
+	// background, attributes, etc. For example, "boldblue" might be
+	// "1;34"
+	Colors map[string]string
+
+	// If true, color attributes will be ignored. This is useful if you're
+	// outputting to a location that doesn't support colors and you just
+	// want the strings returned.
+	Disable bool
+
+	// Reset, if true, will reset the color after each colorization by
+	// adding a reset code at the end.
+	Reset bool
+}
+
+// Color colorizes a string according to the settings setup in the struct.
+//
+// For more details on the syntax, see the top-level Color function.
+func (c *Colorize) Color(v string) string {
+	matches := parseRe.FindAllStringIndex(v, -1)
+	if len(matches) == 0 {
+		return v
+	}
+
+	result := new(bytes.Buffer)
+	colored := false
+	m := []int{0, 0}
+	for _, nm := range matches {
+		// Write the text in between this match and the last
+		result.WriteString(v[m[1]:nm[0]])
+		m = nm
+
+		var replace string
+		if code, ok := c.Colors[v[m[0]+1:m[1]-1]]; ok {
+			colored = true
+
+			if !c.Disable {
+				replace = fmt.Sprintf("\033[%sm", code)
+			}
+		} else {
+			replace = v[m[0]:m[1]]
+		}
+
+		result.WriteString(replace)
+	}
+	result.WriteString(v[m[1]:])
+
+	if colored && c.Reset && !c.Disable {
+		// Write the clear byte at the end
+		result.WriteString("\033[0m")
+	}
+
+	return result.String()
+}
+
+// DefaultColors are the default colors used when colorizing.
+//
+// If the color is surrounded in underscores, such as "_blue_", then that
+// color will be used for the background color.
+var DefaultColors map[string]string
+
+func init() {
+	DefaultColors = map[string]string{
+		// Default foreground/background colors
+		"default":   "39",
+		"_default_": "49",
+
+		// Foreground colors
+		"black":         "30",
+		"red":           "31",
+		"green":         "32",
+		"yellow":        "33",
+		"blue":          "34",
+		"magenta":       "35",
+		"cyan":          "36",
+		"light_gray":    "37",
+		"dark_gray":     "90",
+		"light_red":     "91",
+		"light_green":   "92",
+		"light_yellow":  "93",
+		"light_blue":    "94",
+		"light_magenta": "95",
+		"light_cyan":    "96",
+		"white":         "97",
+
+		// Background colors
+		"_black_":         "40",
+		"_red_":           "41",
+		"_green_":         "42",
+		"_yellow_":        "43",
+		"_blue_":          "44",
+		"_magenta_":       "45",
+		"_cyan_":          "46",
+		"_light_gray_":    "47",
+		"_dark_gray_":     "100",
+		"_light_red_":     "101",
+		"_light_green_":   "102",
+		"_light_yellow_":  "103",
+		"_light_blue_":    "104",
+		"_light_magenta_": "105",
+		"_light_cyan_":    "106",
+		"_white_":         "107",
+
+		// Attributes
+		"bold":       "1",
+		"dim":        "2",
+		"underline":  "4",
+		"blink_slow": "5",
+		"blink_fast": "6",
+		"invert":     "7",
+		"hidden":     "8",
+
+		// Reset to reset everything to their defaults
+		"reset":      "0",
+		"reset_bold": "21",
+	}
+
+	def = Colorize{
+		Colors: DefaultColors,
+		Reset:  true,
+	}
+}
+
+var def Colorize
+var parseRe = regexp.MustCompile(`(?i)\[[a-z0-9_-]+\]`)

--- a/Godeps/_workspace/src/github.com/mitchellh/colorstring/colorstring_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/colorstring/colorstring_test.go
@@ -1,0 +1,104 @@
+package colorstring
+
+import (
+	"testing"
+)
+
+func TestColor(t *testing.T) {
+	cases := []struct {
+		Input, Output string
+	}{
+		{
+			Input:  "foo",
+			Output: "foo",
+		},
+
+		{
+			Input:  "[blue]foo",
+			Output: "\033[34mfoo\033[0m",
+		},
+
+		{
+			Input:  "foo[blue]foo",
+			Output: "foo\033[34mfoo\033[0m",
+		},
+
+		{
+			Input:  "foo[what]foo",
+			Output: "foo[what]foo",
+		},
+		{
+			Input:  "foo[_blue_]foo",
+			Output: "foo\033[44mfoo\033[0m",
+		},
+		{
+			Input:  "foo[bold]foo",
+			Output: "foo\033[1mfoo\033[0m",
+		},
+		{
+			Input:  "[blue]foo[bold]bar",
+			Output: "\033[34mfoo\033[1mbar\033[0m",
+		},
+		{
+			Input:  "[underline]foo[reset]bar",
+			Output: "\033[4mfoo\033[0mbar\033[0m",
+		},
+	}
+
+	for _, tc := range cases {
+		actual := Color(tc.Input)
+		if actual != tc.Output {
+			t.Errorf(
+				"Input: %#v\n\nOutput: %#v\n\nExpected: %#v",
+				tc.Input,
+				actual,
+				tc.Output)
+		}
+	}
+}
+
+func TestColorizeColor_disable(t *testing.T) {
+	c := def
+	c.Disable = true
+
+	cases := []struct {
+		Input, Output string
+	}{
+		{
+			"[blue]foo",
+			"foo",
+		},
+
+		{
+			"[foo]bar",
+			"[foo]bar",
+		},
+	}
+
+	for _, tc := range cases {
+		actual := c.Color(tc.Input)
+		if actual != tc.Output {
+			t.Errorf(
+				"Input: %#v\n\nOutput: %#v\n\nExpected: %#v",
+				tc.Input,
+				actual,
+				tc.Output)
+		}
+	}
+}
+
+func TestColorizeColor_noReset(t *testing.T) {
+	c := def
+	c.Reset = false
+
+	input := "[blue]foo"
+	output := "\033[34mfoo"
+	actual := c.Color(input)
+	if actual != output {
+		t.Errorf(
+			"Input: %#v\n\nOutput: %#v\n\nExpected: %#v",
+			input,
+			actual,
+			output)
+	}
+}

--- a/cmd/ipfs/invocation.go
+++ b/cmd/ipfs/invocation.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	cmds "github.com/jbenet/go-ipfs/commands"
+	cmdsCli "github.com/jbenet/go-ipfs/commands/cli"
+	core "github.com/jbenet/go-ipfs/core"
+	fsrepo "github.com/jbenet/go-ipfs/repo/fsrepo"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+type cmdInvocation struct {
+	path []string
+	cmd  *cmds.Command
+	req  cmds.Request
+	node *core.IpfsNode
+}
+
+func (i *cmdInvocation) Run(ctx context.Context) (output io.Reader, err error) {
+	// setup our global interrupt handler.
+	i.setupInterruptHandler()
+
+	// check if user wants to debug. option OR env var.
+	debug, _, err := i.req.Option("debug").Bool()
+	if err != nil {
+		return nil, err
+	}
+	if debug || u.GetenvBool("DEBUG") || os.Getenv("IPFS_LOGGING") == "debug" {
+		u.Debug = true
+		u.SetDebugLogging()
+	}
+
+	res, err := callCommand(ctx, i.req, Root, i.cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := res.Error(); err != nil {
+		return nil, err
+	}
+
+	return res.Reader()
+}
+
+func (i *cmdInvocation) constructNodeFunc(ctx context.Context) func() (*core.IpfsNode, error) {
+	return func() (*core.IpfsNode, error) {
+		if i.req == nil {
+			return nil, errors.New("constructing node without a request")
+		}
+
+		cmdctx := i.req.Context()
+		if cmdctx == nil {
+			return nil, errors.New("constructing node without a request context")
+		}
+
+		r := fsrepo.At(i.req.Context().ConfigRoot)
+		if err := r.Open(); err != nil { // repo is owned by the node
+			return nil, err
+		}
+
+		// ok everything is good. set it on the invocation (for ownership)
+		// and return it.
+		n, err := core.NewIPFSNode(ctx, core.Standard(r, cmdctx.Online))
+		if err != nil {
+			return nil, err
+		}
+		i.node = n
+		return i.node, nil
+	}
+}
+
+func (i *cmdInvocation) close() {
+	// let's not forget teardown. If a node was initialized, we must close it.
+	// Note that this means the underlying req.Context().Node variable is exposed.
+	// this is gross, and should be changed when we extract out the exec Context.
+	if i.node != nil {
+		log.Info("Shutting down node...")
+		i.node.Close()
+	}
+}
+
+func (i *cmdInvocation) Parse(ctx context.Context, args []string) error {
+	var err error
+
+	i.req, i.cmd, i.path, err = cmdsCli.Parse(args, os.Stdin, Root)
+	if err != nil {
+		return err
+	}
+	i.req.Context().Context = ctx
+
+	repoPath, err := getRepoPath(i.req)
+	if err != nil {
+		return err
+	}
+	log.Debugf("config path is %s", repoPath)
+
+	// this sets up the function that will initialize the config lazily.
+	cmdctx := i.req.Context()
+	cmdctx.ConfigRoot = repoPath
+	cmdctx.LoadConfig = loadConfig
+	// this sets up the function that will initialize the node
+	// this is so that we can construct the node lazily.
+	cmdctx.ConstructNode = i.constructNodeFunc(ctx)
+
+	// if no encoding was specified by user, default to plaintext encoding
+	// (if command doesn't support plaintext, use JSON instead)
+	if !i.req.Option("encoding").Found() {
+		if i.req.Command().Marshalers != nil && i.req.Command().Marshalers[cmds.Text] != nil {
+			i.req.SetOption("encoding", cmds.Text)
+		} else {
+			i.req.SetOption("encoding", cmds.JSON)
+		}
+	}
+
+	return nil
+}
+
+func (i *cmdInvocation) requestedHelp() (short bool, long bool, err error) {
+	longHelp, _, err := i.req.Option("help").Bool()
+	if err != nil {
+		return false, false, err
+	}
+	shortHelp, _, err := i.req.Option("h").Bool()
+	if err != nil {
+		return false, false, err
+	}
+	return longHelp, shortHelp, nil
+}

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -66,6 +66,9 @@ func main() {
 	}
 	defer stopFunc() // to be executed as late as possible
 
+	// parse the commandline into a command invocation
+	parseErr := invoc.Parse(ctx, os.Args[1:])
+
 	// this is a local helper to print out help text.
 	// there's some considerations that this makes easier.
 	printHelp := func(long bool, w io.Writer) {
@@ -74,7 +77,7 @@ func main() {
 			helpFunc = cmdsCli.LongHelp
 		}
 
-		helpFunc("ipfs", Root, invoc.path, w)
+		helpFunc("ipfs", Root, invoc.req, invoc.path, w)
 	}
 
 	// this is a message to tell the user how to get the help text
@@ -82,9 +85,6 @@ func main() {
 		cmdPath := strings.Join(invoc.path, " ")
 		fmt.Fprintf(w, "Use 'ipfs %s --help' for information about this command\n", cmdPath)
 	}
-
-	// parse the commandline into a command invocation
-	parseErr := invoc.Parse(ctx, os.Args[1:])
 
 	// BEFORE handling the parse error, if we have enough information
 	// AND the user requested help, print it out and exit

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -20,11 +20,9 @@ import (
 	cmds "github.com/jbenet/go-ipfs/commands"
 	cmdsCli "github.com/jbenet/go-ipfs/commands/cli"
 	cmdsHttp "github.com/jbenet/go-ipfs/commands/http"
-	core "github.com/jbenet/go-ipfs/core"
 	config "github.com/jbenet/go-ipfs/repo/config"
 	fsrepo "github.com/jbenet/go-ipfs/repo/fsrepo"
 	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
-	u "github.com/jbenet/go-ipfs/util"
 	"github.com/jbenet/go-ipfs/util/debugerror"
 )
 
@@ -40,13 +38,6 @@ const (
 	heapProfile        = "ipfs.memprof"
 	errorFormat        = "ERROR: %v\n\n"
 )
-
-type cmdInvocation struct {
-	path []string
-	cmd  *cmds.Command
-	req  cmds.Request
-	node *core.IpfsNode
-}
 
 // main roadmap:
 // - parse the commandline to get a cmdInvocation
@@ -111,7 +102,7 @@ func main() {
 
 	// here we handle the cases where
 	// - commands with no Run func are invoked directly.
-	// - the main command is invoked.
+	// - the main command is invoked (that is, only `ipfs` without any arguments is called)
 	if invoc.cmd == nil || invoc.cmd.Run == nil {
 		printHelp(false, os.Stdout)
 		os.Exit(0)
@@ -145,117 +136,6 @@ func main() {
 
 	// everything went better than expected :)
 	io.Copy(os.Stdout, output)
-}
-
-func (i *cmdInvocation) Run(ctx context.Context) (output io.Reader, err error) {
-	// setup our global interrupt handler.
-	i.setupInterruptHandler()
-
-	// check if user wants to debug. option OR env var.
-	debug, _, err := i.req.Option("debug").Bool()
-	if err != nil {
-		return nil, err
-	}
-	if debug || u.GetenvBool("DEBUG") || os.Getenv("IPFS_LOGGING") == "debug" {
-		u.Debug = true
-		u.SetDebugLogging()
-	}
-
-	res, err := callCommand(ctx, i.req, Root, i.cmd)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := res.Error(); err != nil {
-		return nil, err
-	}
-
-	return res.Reader()
-}
-
-func (i *cmdInvocation) constructNodeFunc(ctx context.Context) func() (*core.IpfsNode, error) {
-	return func() (*core.IpfsNode, error) {
-		if i.req == nil {
-			return nil, errors.New("constructing node without a request")
-		}
-
-		cmdctx := i.req.Context()
-		if cmdctx == nil {
-			return nil, errors.New("constructing node without a request context")
-		}
-
-		r := fsrepo.At(i.req.Context().ConfigRoot)
-		if err := r.Open(); err != nil { // repo is owned by the node
-			return nil, err
-		}
-
-		// ok everything is good. set it on the invocation (for ownership)
-		// and return it.
-		n, err := core.NewIPFSNode(ctx, core.Standard(r, cmdctx.Online))
-		if err != nil {
-			return nil, err
-		}
-		i.node = n
-		return i.node, nil
-	}
-}
-
-func (i *cmdInvocation) close() {
-	// let's not forget teardown. If a node was initialized, we must close it.
-	// Note that this means the underlying req.Context().Node variable is exposed.
-	// this is gross, and should be changed when we extract out the exec Context.
-	if i.node != nil {
-		log.Info("Shutting down node...")
-		i.node.Close()
-	}
-}
-
-func (i *cmdInvocation) Parse(ctx context.Context, args []string) error {
-	var err error
-
-	i.req, i.cmd, i.path, err = cmdsCli.Parse(args, os.Stdin, Root)
-	if err != nil {
-		return err
-	}
-	i.req.Context().Context = ctx
-
-	repoPath, err := getRepoPath(i.req)
-	if err != nil {
-		return err
-	}
-	log.Debugf("config path is %s", repoPath)
-
-	// this sets up the function that will initialize the config lazily.
-	cmdctx := i.req.Context()
-	cmdctx.ConfigRoot = repoPath
-	cmdctx.LoadConfig = loadConfig
-	// this sets up the function that will initialize the node
-	// this is so that we can construct the node lazily.
-	cmdctx.ConstructNode = i.constructNodeFunc(ctx)
-
-	// if no encoding was specified by user, default to plaintext encoding
-	// (if command doesn't support plaintext, use JSON instead)
-	if !i.req.Option("encoding").Found() {
-		if i.req.Command().Marshalers != nil && i.req.Command().Marshalers[cmds.Text] != nil {
-			i.req.SetOption("encoding", cmds.Text)
-		} else {
-			i.req.SetOption("encoding", cmds.JSON)
-		}
-	}
-
-	return nil
-}
-
-func (i *cmdInvocation) requestedHelp() (short bool, long bool, err error) {
-	longHelp, _, err := i.req.Option("help").Bool()
-	if err != nil {
-		return false, false, err
-	}
-	shortHelp, _, err := i.req.Option("h").Bool()
-	if err != nil {
-		return false, false, err
-	}
-	return longHelp, shortHelp, nil
 }
 
 func callPreCommandHooks(ctx context.Context, details cmdDetails, req cmds.Request, root *cmds.Command) error {

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -85,7 +85,7 @@ const longHelpFormat = `
 
 {{.Subcommands}}
 
-{{.Indent}}Use [yellow]'{{.Path}} <subcmd> --help'[white] for more information about each command.
+{{.Indent}}Use [USAGE]{{.Path}} <subcmd> --help[DEFAULT] for more information about each command.
 
 {{end}}[DESCRIPTION]{{if .Description}}[HEADER]DESCRIPTION[DEFAULT]:
 

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"text/template"
 
-	cmds "github.com/jbenet/go-ipfs/commands"
 	isatty "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/mattn/go-isatty"
 	c "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/colorstring"
+	cmds "github.com/jbenet/go-ipfs/commands"
 )
 
 const (
@@ -124,7 +124,7 @@ func init() {
 			"USAGE":        c.DefaultColors["light_yellow"],
 			"ARGUSAGE":     c.DefaultColors["light_cyan"],
 			"ARGUSAGETEXT": c.DefaultColors["light_red"],
-			"DESCRIPTION":  c.DefaultColors["white"],
+			"DESCRIPTION":  c.DefaultColors["default"],
 			"requiredArg":  c.DefaultColors["light_red"],
 			"optionalArg":  c.DefaultColors["light_green"],
 			"variadicArg":  c.DefaultColors["light_green"],

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -105,16 +105,22 @@ const shortHelpFormat = `USAGE:
 {{end}}
 `
 
-var usageTemplate *template.Template
-var longHelpTemplate *template.Template
-var shortHelpTemplate *template.Template
+var (
+	usageTemplate     *template.Template
+	longHelpTemplate  *template.Template
+	shortHelpTemplate *template.Template
+)
+
 var colorScheme c.Colorize
-var requiredArg string
-var subcommandPrefix string
-var optionalArg string
-var variadicArg string
-var optionFlag string
-var optionType string
+
+var (
+	requiredArg      = "[requiredArg]<%v>[DEFAULT]"
+	optionalArg      = "[optionalArg]<%v>[DEFAULT]"
+	variadicArg      = "[variadicArg]%v[DEFAULT]..."
+	optionFlag       = "[optionFlag]-%v[DEFAULT]"
+	optionType       = "[optionType]%v[DEFAULT]"
+	subcommandPrefix = "[USAGE]%v[DEFAULT]"
+)
 
 func init() {
 	colorScheme = c.Colorize{
@@ -135,12 +141,12 @@ func init() {
 		Disable: !isatty.IsTerminal(os.Stdout.Fd()),
 	}
 
-	requiredArg = colorScheme.Color("[requiredArg]<%v>[DEFAULT]")
-	optionalArg = colorScheme.Color("[optionalArg]<%v>[DEFAULT]")
-	variadicArg = colorScheme.Color("[variadicArg]%v[DEFAULT]...")
-	optionFlag = colorScheme.Color("[optionFlag]-%v[DEFAULT]")
-	optionType = colorScheme.Color("[optionType]%v[DEFAULT]")
-	subcommandPrefix = colorScheme.Color("[USAGE]%v[DEFAULT]")
+	requiredArg = colorScheme.Color(requiredArg)
+	optionalArg = colorScheme.Color(optionalArg)
+	variadicArg = colorScheme.Color(variadicArg)
+	optionFlag = colorScheme.Color(optionFlag)
+	optionType = colorScheme.Color(optionType)
+	subcommandPrefix = colorScheme.Color(subcommandPrefix)
 
 	usageTemplate = template.Must(template.New("usage").Parse(colorScheme.Color(usageFormat)))
 	longHelpTemplate = template.Must(usageTemplate.New("longHelp").Parse(colorScheme.Color(longHelpFormat)))

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -9,8 +9,8 @@ import (
 	"text/template"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
-	isatty "github.com/mattn/go-isatty"
-	c "github.com/mitchellh/colorstring"
+	isatty "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/mattn/go-isatty"
+	c "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/colorstring"
 )
 
 const (

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -110,6 +110,7 @@ var longHelpTemplate *template.Template
 var shortHelpTemplate *template.Template
 var colorScheme c.Colorize
 var requiredArg string
+var subcommandPrefix string
 var optionalArg string
 var variadicArg string
 var optionFlag string
@@ -139,6 +140,7 @@ func init() {
 	variadicArg = colorScheme.Color("[variadicArg]%v[DEFAULT]...")
 	optionFlag = colorScheme.Color("[optionFlag]-%v[DEFAULT]")
 	optionType = colorScheme.Color("[optionType]%v[DEFAULT]")
+	subcommandPrefix = colorScheme.Color("[USAGE]%v[DEFAULT]")
 
 	usageTemplate = template.Must(template.New("usage").Parse(colorScheme.Color(usageFormat)))
 	longHelpTemplate = template.Must(usageTemplate.New("longHelp").Parse(colorScheme.Color(longHelpFormat)))
@@ -302,7 +304,7 @@ func optionText(cmd ...*cmds.Command) []string {
 }
 
 func subcommandText(cmd *cmds.Command, rootName string, path []string) []string {
-	prefix := fmt.Sprintf("%v %v", rootName, strings.Join(path, " "))
+	prefix := fmt.Sprintf(subcommandPrefix, rootName) + " " + fmt.Sprintf(subcommandPrefix, strings.Join(path, " "))
 	if len(path) > 0 {
 		prefix += " "
 	}
@@ -315,7 +317,7 @@ func subcommandText(cmd *cmds.Command, rootName string, path []string) []string 
 		if len(usage) > 0 {
 			usage = " " + usage
 		}
-		lines[i] = prefix + name + usage
+		lines[i] = prefix + fmt.Sprintf(subcommandPrefix, name) + usage
 		subcmds[i] = sub
 		i++
 	}

--- a/repo/config/config.go
+++ b/repo/config/config.go
@@ -16,15 +16,16 @@ var log = u.Logger("config")
 
 // Config is used to load IPFS config files.
 type Config struct {
-	Identity  Identity  // local node's peer identity
-	Datastore Datastore // local node's storage
-	Addresses Addresses // local node's addresses
-	Mounts    Mounts    // local node's mount points
-	Version   Version   // local node's version management
-	Bootstrap []string  // local nodes's bootstrap peer addresses
-	Tour      Tour      // local node's tour position
-	Gateway   Gateway   // local node's gateway server options
-	Log       Log
+	Identity    Identity    // local node's peer identity
+	Datastore   Datastore   // local node's storage
+	Addresses   Addresses   // local node's addresses
+	Mounts      Mounts      // local node's mount points
+	Version     Version     // local node's version management
+	Preferences Preferences // local node's appearance preferences for terminal/WebUI
+	Bootstrap   []string    // local nodes's bootstrap peer addresses
+	Tour        Tour        // local node's tour position
+	Gateway     Gateway     // local node's gateway server options
+	Log         Log
 }
 
 const (

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -54,7 +54,8 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 
 		// tracking ipfs version used to generate the init folder and adding
 		// update checker default setting.
-		Version: VersionDefaultValue(),
+		Version:     VersionDefaultValue(),
+		Preferences: PreferencesDefaultValue(),
 
 		Gateway: Gateway{
 			RootRedirect: "",

--- a/repo/config/preferences.go
+++ b/repo/config/preferences.go
@@ -1,0 +1,15 @@
+package config
+
+// Preferences stores local appearance and formatting settings
+// for terminal and webUI output
+type Preferences struct {
+	// TerminalColors flag is for terminal text coloring
+	// with escape characters
+	TerminalColors bool
+}
+
+func PreferencesDefaultValue() Preferences {
+	return Preferences{
+		TerminalColors: false,
+	}
+}


### PR DESCRIPTION
IPFS's `--help` output now gets Chrismas lights when the output is on the terminal! 

See [#340](https://github.com/jbenet/go-ipfs/issues/340) 

Color rendering is only when stdoutput is on the terminal.

This uses 
* `github.com/mattn/go-isatty` for checking if the output is on a terminal
* `https://github.com/mitchellh/colorstring` for color coding strings

I was not able to add these packages to Godep. It probably should be `make vendor` or `godep save -r ./...` but these don't do the trick. What is up with that?


Here is what it looks like for the standard Ubuntu color scheme:
![ipfs-colors](https://cloud.githubusercontent.com/assets/816895/5157208/84115404-72c8-11e4-92e5-8fd949d0633e.png)
