### PR TITLE
daemon: add options to set the API and GW addresses

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -56,7 +56,7 @@ var initCmd = &cmds.Command{
 		rpipe, wpipe := io.Pipe()
 		go func() {
 			defer wpipe.Close()
-			if err := doInit(wpipe, req.Context().ConfigRoot, force, nBitsForKeypair); err != nil {
+			if err := doInit(wpipe, req.Context().ConfigRoot, force, nBitsForKeypair, config.Addresses{}); err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
@@ -70,8 +70,8 @@ Reinitializing would overwrite your keys.
 (use -f to force overwrite)
 `)
 
-func initWithDefaults(out io.Writer, repoRoot string) error {
-	err := doInit(out, repoRoot, false, nBitsForKeypairDefault)
+func initWithDefaults(out io.Writer, repoRoot string, addresses config.Addresses) error {
+	err := doInit(out, repoRoot, false, nBitsForKeypairDefault, addresses)
 	return debugerror.Wrap(err)
 }
 
@@ -80,7 +80,7 @@ func writef(out io.Writer, format string, ifs ...interface{}) error {
 	return err
 }
 
-func doInit(out io.Writer, repoRoot string, force bool, nBitsForKeypair int) error {
+func doInit(out io.Writer, repoRoot string, force bool, nBitsForKeypair int, addresses config.Addresses) error {
 	if err := writef(out, "initializing ipfs node at %s\n", repoRoot); err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func doInit(out io.Writer, repoRoot string, force bool, nBitsForKeypair int) err
 	if fsrepo.IsInitialized(repoRoot) && !force {
 		return errRepoExists
 	}
-	conf, err := config.Init(out, nBitsForKeypair)
+	conf, err := config.Init(out, nBitsForKeypair, addresses)
 	if err != nil {
 		return err
 	}

--- a/cmd/ipfs_bootstrapd/main.go
+++ b/cmd/ipfs_bootstrapd/main.go
@@ -48,7 +48,7 @@ func run() error {
 	}
 
 	if !fsrepo.IsInitialized(repoPath) {
-		conf, err := config.Init(os.Stdout, *nBitsForKeypair)
+		conf, err := config.Init(os.Stdout, *nBitsForKeypair, config.Addresses{})
 		if err != nil {
 			return err
 		}

--- a/cmd/ipfs_routingd/main.go
+++ b/cmd/ipfs_routingd/main.go
@@ -49,7 +49,7 @@ func run() error {
 	}
 
 	if !fsrepo.IsInitialized(repoPath) {
-		conf, err := config.Init(os.Stdout, *nBitsForKeypair)
+		conf, err := config.Init(os.Stdout, *nBitsForKeypair, config.Addresses{})
 		if err != nil {
 			return err
 		}

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -10,7 +10,7 @@ import (
 	errors "github.com/jbenet/go-ipfs/util/debugerror"
 )
 
-func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
+func Init(out io.Writer, nBitsForKeypair int, addresses Addresses) (*Config, error) {
 	ds, err := datastoreConfig()
 	if err != nil {
 		return nil, err
@@ -31,18 +31,24 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		return nil, err
 	}
 
+	if addresses.Swarm == nil {
+		addresses.Swarm = []string{
+			"/ip4/0.0.0.0/tcp/4001",
+			// "/ip4/0.0.0.0/udp/4002/utp", // disabled for now.
+		}
+	}
+	if addresses.API == "" {
+		addresses.API = "/ip4/127.0.0.1/tcp/5001"
+	}
+	if addresses.Gateway == "" {
+		addresses.Gateway = "/ip4/127.0.0.1/tcp/8080"
+	}
+
 	conf := &Config{
 
 		// setup the node's default addresses.
 		// Note: two swarm listen addrs, one tcp, one utp.
-		Addresses: Addresses{
-			Swarm: []string{
-				"/ip4/0.0.0.0/tcp/4001",
-				// "/ip4/0.0.0.0/udp/4002/utp", // disabled for now.
-			},
-			API:     "/ip4/127.0.0.1/tcp/5001",
-			Gateway: "/ip4/127.0.0.1/tcp/8080",
-		},
+		Addresses: addresses,
 
 		Bootstrap: BootstrapPeerStrings(bootstrapPeers),
 		SupernodeRouting:       *snr,

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -125,7 +125,7 @@ func run() error {
 
 func ensureRepoInitialized(path string) error {
 	if !fsrepo.IsInitialized(path) {
-		conf, err := config.Init(ioutil.Discard, *nBitsForKeypair)
+		conf, err := config.Init(ioutil.Discard, *nBitsForKeypair, config.Addresses{})
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func runFileAddingWorker(n *core.IpfsNode) error {
 }
 
 func runFileCattingWorker(ctx context.Context, n *core.IpfsNode) error {
-	conf, err := config.Init(ioutil.Discard, *nBitsForKeypair)
+	conf, err := config.Init(ioutil.Discard, *nBitsForKeypair, config.Addresses{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The ipfs daemon command lets you initialize the configuration with
default parameters, but in certain situations (like starting ipfs daemon
in a docker container), it would be convenient to be able to set the
API and gateway addresses to something more meaningful.

This patch introduces two new options for the ipfs daemon command:
-address-api and -address-gateway. When used together with -init, they
set the respective addresses in the generated configuration file:

  $ ipfs daemon -init -address-api=/ip4/0.0.0.0/tcp/5001 \
  -address-gateway=/ip4/0.0.0.0/tcp/8080

When used without -init, they simply override value for that run of the
daemon, without overwriting it in the configuration file:

  $ ipfs daemon -address-api=/ip4/0.0.0.0/tcp/5001 \
  -address-gateway=/ip4/0.0.0.0/tcp/8080