### PR TITLE
t0030: replace some expect_failure with expect_success

### DIFF
--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -18,13 +18,13 @@ fi
 test_init_ipfs
 test_launch_ipfs_daemon
 
-# run this mount failure before mounting properly.
+#  test mount failure before mounting properly.
 
-test_expect_failure "'ipfs mount' fails when no mount dir (issue #341)" '
+test_expect_success "'ipfs mount' fails when no mount dir" '
 	test_must_fail ipfs mount -f=not_ipfs -n=not_ipns >actual
 '
 
-test_expect_failure "'ipfs mount' looks good when it fails (issue #341)" '
+test_expect_success "'ipfs mount' output looks good when it fails" '
 	! grep "IPFS mounted at: $(pwd)/ipfs" actual >/dev/null &&
 	! grep "IPNS mounted at: $(pwd)/ipns" actual >/dev/null ||
 	test_fsh cat actual


### PR DESCRIPTION
It looks like some tests that were expected failures
are now always succeeding, so let's mark them as such.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>