### PR TITLE
config: change default config dir name to .ipfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 *.test
 *.orig
 *~
-.go-ipfs
 
 /test/bin
+.ipfs

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Basic proof of 'ipfs working' locally:
 ### Troubleshooting
 If you have previously installed ipfs before and you are running into
 problems getting a newer version to work, try deleting (or backing up somewhere
-else) your ipfs config directory (~/.go-ipfs by default) and rerunning `ipfs init`.
+else) your ipfs config directory (~/.ipfs by default) and rerunning `ipfs init`.
 This will reinitialize the config file to its defaults and clear out the local
 datastore of any bad entries.
 

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -49,7 +49,7 @@ Get the value of the 'datastore.path' key:
 
 Set the value of the 'datastore.path' key:
 
-  ipfs config datastore.path ~/.go-ipfs/datastore
+  ipfs config datastore.path ~/.ipfs/datastore
 `,
 	},
 

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -1,6 +1,6 @@
 # FUSE
 
-As a golang project, `go-ipfs` is easily downloaded and installed with `go get github.com/ipfs/go-ipfs`. All data is stored in a leveldb data store in `~/.go-ipfs/datastore`. If, however, you would like to mount the datastore (`ipfs mount /ipfs`) and use it as you would a normal filesystem, you will need to install fuse.
+As a golang project, `go-ipfs` is easily downloaded and installed with `go get github.com/ipfs/go-ipfs`. All data is stored in a leveldb data store in `~/.ipfs/datastore`. If, however, you would like to mount the datastore (`ipfs mount /ipfs`) and use it as you would a normal filesystem, you will need to install fuse.
 
 As a precursor, you will have to create the `/ipfs` and `/ipns` directories explicitly. Note that modifying root requires sudo permissions.
 

--- a/jenkins/network-test.sh
+++ b/jenkins/network-test.sh
@@ -8,6 +8,6 @@ make clean
 make test
 make save_logs
 
-docker cp dockertest_server_1:/root/.go-ipfs/logs/events.log    $(PWD)/build/server-events.log
-docker cp dockertest_bootstrap_1:/root/.go-ipfs/logs/events.log $(PWD)/build/bootstrap-events.log
-docker cp dockertest_client_1:/root/.go-ipfs/logs/events.log    $(PWD)/build/client-events.log
+docker cp dockertest_server_1:/root/.ipfs/logs/events.log    $(PWD)/build/server-events.log
+docker cp dockertest_bootstrap_1:/root/.ipfs/logs/events.log $(PWD)/build/bootstrap-events.log
+docker cp dockertest_client_1:/root/.ipfs/logs/events.log    $(PWD)/build/client-events.log

--- a/repo/config/config.go
+++ b/repo/config/config.go
@@ -29,8 +29,10 @@ type Config struct {
 }
 
 const (
+	// DefaultPathName is the default config dir name
+	DefaultPathName = ".ipfs"
 	// DefaultPathRoot is the path to the default config dir location.
-	DefaultPathRoot = "~/.go-ipfs"
+	DefaultPathRoot = "~/" + DefaultPathName
 	// DefaultConfigFile is the filename of the configuration file
 	DefaultConfigFile = "config"
 	// EnvDir is the environment variable used to change the path root.

--- a/repo/fsrepo/doc.go
+++ b/repo/fsrepo/doc.go
@@ -2,7 +2,7 @@
 //
 // TODO explain the package roadmap...
 //
-//   .go-ipfs/
+//   .ipfs/
 //   ├── client/
 //   |   ├── client.lock          <------ protects client/ + signals its own pid
 //   │   ├── ipfs-client.cpuprof

--- a/test/3nodetest/bootstrap/Dockerfile
+++ b/test/3nodetest/bootstrap/Dockerfile
@@ -2,7 +2,7 @@ FROM zaqwsx_ipfs-test-img
 
 RUN ipfs init -b=1024
 ADD . /tmp/id
-RUN mv -f /tmp/id/config /root/.go-ipfs/config
+RUN mv -f /tmp/id/config /root/.ipfs/config
 RUN ipfs id
 
 ENV IPFS_PROF true

--- a/test/3nodetest/bootstrap/config
+++ b/test/3nodetest/bootstrap/config
@@ -5,7 +5,7 @@
   },
   "Datastore": {
     "Type": "leveldb",
-    "Path": "/root/.go-ipfs/datastore"
+    "Path": "/root/.ipfs/datastore"
   },
   "Addresses": {
     "Swarm": [
@@ -30,7 +30,7 @@
     "Last": ""
   },
   "Logs": {
-    "Filename": "/root/.go-ipfs/logs/events.log",
+    "Filename": "/root/.ipfs/logs/events.log",
     "MaxSizeMB": 0,
     "MaxBackups": 0,
     "MaxAgeDays": 0

--- a/test/3nodetest/client/Dockerfile
+++ b/test/3nodetest/client/Dockerfile
@@ -2,7 +2,7 @@ FROM zaqwsx_ipfs-test-img
 
 RUN ipfs init -b=1024
 ADD . /tmp/id
-RUN mv -f /tmp/id/config /root/.go-ipfs/config
+RUN mv -f /tmp/id/config /root/.ipfs/config
 RUN ipfs id
 
 EXPOSE 4031 4032/udp

--- a/test/3nodetest/client/config
+++ b/test/3nodetest/client/config
@@ -8,7 +8,7 @@
     "Bootstrap": [
     ],
     "Datastore": {
-        "Path": "/root/.go-ipfs/datastore",
+        "Path": "/root/.ipfs/datastore",
         "Type": "leveldb"
     },
     "Identity": {
@@ -16,7 +16,7 @@
         "PrivKey": "CAAS4AQwggJcAgEAAoGBANlJUjOCbPXgYUfo1Pr6nlIjJDPNwN81ACamhaoEZ9VRHXI3fPe7RVAaaXrWLHb892mRqFi1ScE2lcMTLc7WGfyc7dwPqBOZqkVvT0KpCx3Mg246+WvnG8I3HCbWyjSP9tJflOBQxVq6qT2yZSXjNTtDdO4skd4PsPqBco53guYTAgMBAAECgYEAtIcYhrdMNBSSfp5RpZxnwbJ0t52xK0HruDEOSK2UX0Ufg+/aIjEza1QmYupi0xFltg5QojMs7hyd3Q+oNXro5tKsYVeiqrLsUh9jMjaQofzSlV9Oc+bhkkl48YWvF6Y8qx88UYAX+oJqB627H4S1gxLdNEJhPjEAD6n/jql3zUECQQDmHP75wJ7nC4TlxT1SHim5syMAqWNs/SOHnvX8yLrFV9FrMRzsD5qMlIEGBrAjaESzEck6XpbqkyxB8KKGo7OjAkEA8brtEh/AMoQ/yoSWdYT2MRbJxCAn+KG2c6Hi9AMMmJ+K779HxywpUIDYIa22hzLKYumYIuRa1X++1glOAFGq0QJAPQgXwFoMSy9M8jwcBXmmi3AtqnFCw5doIwJQL9l1X/3ot0txZlLFJOAGUHjZoqp2/h+LhYWs9U5PgLW4BYnJjQJAPydY/J0y93+5ss1FCdr8/wI3IHhOORT2t+sZgiqxxcYY5F4TAKQ2/wNKdDIQN+47FfB1gNgsKw8+6mhv6oFroQJACBF2yssNVXiXa2Na/a9tKYutGvxbm3lXzOvmpkW3FukbsObKYS344J1vdg0nzM6EWQCaiBweSA5TQ27iNW6BzQ=="
     },
     "Logs": {
-        "Filename": "/root/.go-ipfs/logs/events.log",
+        "Filename": "/root/.ipfs/logs/events.log",
         "MaxAgeDays": 0,
         "MaxBackups": 0,
         "MaxSizeMB": 0

--- a/test/3nodetest/server/Dockerfile
+++ b/test/3nodetest/server/Dockerfile
@@ -2,7 +2,7 @@ FROM zaqwsx_ipfs-test-img
 
 RUN ipfs init -b=1024
 ADD . /tmp/test
-RUN mv -f /tmp/test/config /root/.go-ipfs/config
+RUN mv -f /tmp/test/config /root/.ipfs/config
 RUN ipfs id
 RUN chmod +x /tmp/test/run.sh
 

--- a/test/3nodetest/server/config
+++ b/test/3nodetest/server/config
@@ -8,7 +8,7 @@
     "Bootstrap": [
     ],
     "Datastore": {
-        "Path": "/root/.go-ipfs/datastore",
+        "Path": "/root/.ipfs/datastore",
         "Type": "leveldb"
     },
     "Identity": {
@@ -16,7 +16,7 @@
         "PrivKey": "CAAS4AQwggJcAgEAAoGBANW3mJMmDSJbdRyykO0Ze5t6WL6jeTtpOhklxePBIkJL/Uil78Va/tODx6Mvv3GMCkbGvzWslTZXpaHa9vBmjE3MVZSmd5fLRybKT0zZ3juABKcx+WIVNw8JlkpEORihJdwb+5tRUC5pUcMzxqHSmGX+d6e9KZqLnv7piNKg2+r7AgMBAAECgYAqc6+w+wv82SHoM2gqULeG6MScCajZLkvGFwS5+vEtLh7/wUZhc3PO3AxZ0/A5Q9H+wRfWN5PkGYDjJ7WJhzUzGfTbrQ821JV6B3IUR4UHo2IgJkZO4EUB5L9KBUqvYxDJigtGBopgQh0EeDSS+9X8vaGmit5l4zcAfi+UGYPgMQJBAOCJQU8N2HW5SawBo2QX0bnCAAnu5Ilk2QaqwDZbDQaM5JWFcpRpGnjBhsZihHwVWvKCbnq83JhAGRQvKAEepMUCQQDzqjvIyM+Au42nP7SFDHoMjEnHW8Nimvz8zPbyrSUEHe4l9/yS4+BeRPxpwI5xgzp8g1wEYfNeXt08buYwCsy/AkBXWg5mSuSjJ+pZWGnQTtPwiGCrfJy8NteXmGYev11Z5wYmhTwGML1zrRZZp4oTG9u97LA+X6sSMB2RlKbjiKBhAkEAgl/hoSshK+YugwCpHE9ytmgRyeOlhYscNj+NGofeOHezRwmLUSUwlgAfdo4bKU1n69t1TrsCNspXYdCMxcPhjQJAMNxkJ8t2tFMpucCQfWJ09wvFKZSHX1/iD9GKWL0Qk2FcMCg3NXiqei5NL3NYqCWpdC/IfjsAEGCJrTFwp/OoUw=="
     },
     "Logs": {
-        "Filename": "/root/.go-ipfs/logs/events.log",
+        "Filename": "/root/.ipfs/logs/events.log",
         "MaxAgeDays": 0,
         "MaxBackups": 0,
         "MaxSizeMB": 0

--- a/test/bench/bench_cli_ipfs_add/main.go
+++ b/test/bench/bench_cli_ipfs_add/main.go
@@ -53,7 +53,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 			defer os.RemoveAll(tmpDir)
 
 			env := append(
-				[]string{fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, ".go-ipfs"))}, // first in order to override
+				[]string{fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, config.DefaultPathName))}, // first in order to override
 				os.Environ()...,
 			)
 			setupCmd := func(cmd *exec.Cmd) {

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -43,7 +43,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 			}
 			defer os.RemoveAll(tmpDir)
 
-			env := append(os.Environ(), fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, ".go-ipfs")))
+			env := append(os.Environ(), fmt.Sprintf("%s=%s", config.EnvDir, path.Join(tmpDir, config.DefaultPathName)))
 			setupCmd := func(cmd *exec.Cmd) {
 				cmd.Env = env
 			}

--- a/test/jenkins/network-test.sh
+++ b/test/jenkins/network-test.sh
@@ -8,6 +8,6 @@ make clean
 make test
 make save_logs
 
-docker cp 3nodetest_server_1:/root/.go-ipfs/logs/events.log    $(PWD)/build/server-events.log
-docker cp 3nodetest_bootstrap_1:/root/.go-ipfs/logs/events.log $(PWD)/build/bootstrap-events.log
-docker cp 3nodetest_client_1:/root/.go-ipfs/logs/events.log    $(PWD)/build/client-events.log
+docker cp 3nodetest_server_1:/root/.ipfs/logs/events.log    $(PWD)/build/server-events.log
+docker cp 3nodetest_bootstrap_1:/root/.ipfs/logs/events.log $(PWD)/build/bootstrap-events.log
+docker cp 3nodetest_client_1:/root/.ipfs/logs/events.log    $(PWD)/build/client-events.log

--- a/test/sharness/README.md
+++ b/test/sharness/README.md
@@ -68,11 +68,11 @@ This means cating certain files, or running diagnostic commands.
 For example:
 
 ```
-test_expect_success ".go-ipfs/ has been created" '
-  test -d ".go-ipfs" &&
-  test -f ".go-ipfs/config" &&
-  test -d ".go-ipfs/datastore" ||
-  test_fsh ls -al .go-ipfs
+test_expect_success ".ipfs/ has been created" '
+  test -d ".ipfs" &&
+  test -f ".ipfs/config" &&
+  test -d ".ipfs/datastore" ||
+  test_fsh ls -al .ipfs
 '
 ```
 

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -148,7 +148,7 @@ test_init_ipfs() {
 	# todo: in the future, use env?
 
 	test_expect_success "ipfs init succeeds" '
-		export IPFS_PATH="$(pwd)/.go-ipfs" &&
+		export IPFS_PATH="$(pwd)/.ipfs" &&
 		ipfs init -b=1024 > /dev/null
 	'
 

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -9,16 +9,16 @@ test_description="Test init command"
 . lib/test-lib.sh
 
 test_expect_success "ipfs init succeeds" '
-	export IPFS_PATH="$(pwd)/.go-ipfs" &&
+	export IPFS_PATH="$(pwd)/.ipfs" &&
 	BITS="2048" &&
 	ipfs init --bits="$BITS" >actual_init
 '
 
-test_expect_success ".go-ipfs/ has been created" '
-	test -d ".go-ipfs" &&
-	test -f ".go-ipfs/config" &&
-	test -d ".go-ipfs/datastore" ||
-	test_fsh ls -al .go-ipfs
+test_expect_success ".ipfs/ has been created" '
+	test -d ".ipfs" &&
+	test -f ".ipfs/config" &&
+	test -d ".ipfs/datastore" ||
+	test_fsh ls -al .ipfs
 '
 
 test_expect_success "ipfs config succeeds" '

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -10,7 +10,7 @@ test_description="Test daemon command"
 
 # this needs to be in a different test than "ipfs daemon --init" below
 test_expect_success "setup IPFS_PATH" '
-  IPFS_PATH="$(pwd)/.go-ipfs"
+  IPFS_PATH="$(pwd)/.ipfs"
 '
 
 # NOTE: this should remove bootstrap peers (needs a flag)
@@ -54,11 +54,11 @@ test_expect_failure "ipfs daemon output looks good" '
   test_cmp_repeat_10_sec expected actual_daemon
 '
 
-test_expect_success ".go-ipfs/ has been created" '
-  test -d ".go-ipfs" &&
-  test -f ".go-ipfs/config" &&
-  test -d ".go-ipfs/datastore" ||
-  test_fsh ls .go-ipfs
+test_expect_success ".ipfs/ has been created" '
+  test -d ".ipfs" &&
+  test -f ".ipfs/config" &&
+  test -d ".ipfs/datastore" ||
+  test_fsh ls .ipfs
 '
 
 # begin same as in t0010

--- a/test/supernode_client/.gitignore
+++ b/test/supernode_client/.gitignore
@@ -1,1 +1,1 @@
-.go-ipfs/
+.ipfs/

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -63,7 +63,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	repoPath := gopath.Join(cwd, ".go-ipfs")
+	repoPath := gopath.Join(cwd, config.DefaultPathName)
 	if err := ensureRepoInitialized(repoPath); err != nil {
 	}
 	repo, err := fsrepo.Open(repoPath)


### PR DESCRIPTION
This changes .go-ipfs to .ipfs everywhere.
And by the way this defines a DefaultPathName const
for this name.

This should fix issue #970 (move to using ~/.ipfs).
fixes #970 

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>