### PR TITLE
cache public keys and use better method for fetching

### DIFF
--- a/routing/dht/records.go
+++ b/routing/dht/records.go
@@ -18,7 +18,7 @@ func KeyForPublicKey(id peer.ID) u.Key {
 	return u.Key("/pk/" + string(id))
 }
 
-func (dht *IpfsDHT) getPublicKeyOnline(ctx context.Context, p peer.ID) (ci.PubKey, error) {
+func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	log.Debugf("getPublicKey for: %s", p)
 
 	// check locally.
@@ -42,7 +42,6 @@ func (dht *IpfsDHT) getPublicKeyOnline(ctx context.Context, p peer.ID) (ci.PubKe
 	log.Debugf("pk for %s not in peerstore, and peer failed. trying dht.", p)
 	pkkey := KeyForPublicKey(p)
 
-	// ok, now try the dht. Anyone who has previously fetched the key should have it
 	val, err := dht.GetValue(ctxT, pkkey)
 	if err != nil {
 		log.Warning("Failed to find requested public key.")
@@ -132,7 +131,7 @@ func (dht *IpfsDHT) verifyRecordOnline(ctx context.Context, r *pb.Record) error 
 	if len(r.Signature) > 0 {
 		// get the public key, search for it if necessary.
 		p := peer.ID(r.GetAuthor())
-		pk, err := dht.getPublicKeyOnline(ctx, p)
+		pk, err := dht.GetPublicKey(ctx, p)
 		if err != nil {
 			return err
 		}

--- a/routing/dht/records.go
+++ b/routing/dht/records.go
@@ -6,17 +6,11 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	routing "github.com/ipfs/go-ipfs/routing"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	record "github.com/ipfs/go-ipfs/routing/record"
-	u "github.com/ipfs/go-ipfs/util"
 	ctxutil "github.com/ipfs/go-ipfs/util/ctx"
 )
-
-// KeyForPublicKey returns the key used to retrieve public keys
-// from the dht.
-func KeyForPublicKey(id peer.ID) u.Key {
-	return u.Key("/pk/" + string(id))
-}
 
 func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, error) {
 	log.Debugf("getPublicKey for: %s", p)
@@ -40,7 +34,7 @@ func (dht *IpfsDHT) GetPublicKey(ctx context.Context, p peer.ID) (ci.PubKey, err
 
 	// last ditch effort: let's try the dht.
 	log.Debugf("pk for %s not in peerstore, and peer failed. trying dht.", p)
-	pkkey := KeyForPublicKey(p)
+	pkkey := routing.KeyForPublicKey(p)
 
 	val, err := dht.GetValue(ctxT, pkkey)
 	if err != nil {
@@ -65,7 +59,7 @@ func (dht *IpfsDHT) getPublicKeyFromNode(ctx context.Context, p peer.ID) (ci.Pub
 		return pk, nil
 	}
 
-	pkkey := KeyForPublicKey(p)
+	pkkey := routing.KeyForPublicKey(p)
 	pmes, err := dht.getValueSingle(ctx, p, pkkey)
 	if err != nil {
 		return nil, err

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -51,3 +51,25 @@ type IpfsRouting interface {
 type PubKeyFetcher interface {
 	GetPublicKey(context.Context, peer.ID) (ci.PubKey, error)
 }
+
+// KeyForPublicKey returns the key used to retrieve public keys
+// from the dht.
+func KeyForPublicKey(id peer.ID) u.Key {
+	return u.Key("/pk/" + string(id))
+}
+
+func GetPublicKey(r IpfsRouting, ctx context.Context, pkhash []byte) (ci.PubKey, error) {
+	if dht, ok := r.(PubKeyFetcher); ok {
+		// If we have a DHT as our routing system, use optimized fetcher
+		return dht.GetPublicKey(ctx, peer.ID(pkhash))
+	} else {
+		key := u.Key("/pk/" + string(pkhash))
+		pkval, err := r.GetValue(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+
+		// get PublicKey from node.Data
+		return ci.UnmarshalPublicKey(pkval)
+	}
+}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -45,4 +46,8 @@ type IpfsRouting interface {
 	Bootstrap(context.Context) error
 
 	// TODO expose io.Closer or plain-old Close error
+}
+
+type PubKeyFetcher interface {
+	GetPublicKey(context.Context, peer.ID) (ci.PubKey, error)
 }


### PR DESCRIPTION
created a new interface for optimized public key fetching that the DHT implements, otherwise fall back to a standard routing search.