### PR TITLE
Fuse allow options

### DIFF
--- a/fuse/ipns/mount_unix.go
+++ b/fuse/ipns/mount_unix.go
@@ -10,10 +10,13 @@ import (
 
 // Mount mounts ipns at a given location, and returns a mount.Mount instance.
 func Mount(ipfs *core.IpfsNode, ipnsmp, ipfsmp string) (mount.Mount, error) {
+	cfg := ipfs.Repo.Config()
+	allow_other := cfg.Mounts.FuseAllowOther
+
 	fsys, err := NewFileSystem(ipfs, ipfs.PrivateKey, ipfsmp)
 	if err != nil {
 		return nil, err
 	}
 
-	return mount.NewMount(ipfs, fsys, ipnsmp)
+	return mount.NewMount(ipfs, fsys, ipnsmp, allow_other)
 }

--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -23,8 +23,16 @@ type mount struct {
 
 // Mount mounts a fuse fs.FS at a given location, and returns a Mount instance.
 // parent is a ContextGroup to bind the mount's ContextGroup to.
-func NewMount(p ctxgroup.ContextGroup, fsys fs.FS, mountpoint string) (Mount, error) {
-	conn, err := fuse.Mount(mountpoint)
+func NewMount(p ctxgroup.ContextGroup, fsys fs.FS, mountpoint string, allow_other bool) (Mount, error) {
+	var conn *fuse.Conn
+	var err error
+
+	if allow_other {
+		conn, err = fuse.Mount(mountpoint, fuse.AllowOther())
+	} else {
+		conn, err = fuse.Mount(mountpoint)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/fuse/readonly/mount_unix.go
+++ b/fuse/readonly/mount_unix.go
@@ -10,6 +10,8 @@ import (
 
 // Mount mounts ipfs at a given location, and returns a mount.Mount instance.
 func Mount(ipfs *core.IpfsNode, mountpoint string) (mount.Mount, error) {
+	cfg := ipfs.Repo.Config()
+	allow_other := cfg.Mounts.FuseAllowOther
 	fsys := NewFileSystem(ipfs)
-	return mount.NewMount(ipfs, fsys, mountpoint)
+	return mount.NewMount(ipfs, fsys, mountpoint, allow_other)
 }

--- a/repo/config/mounts.go
+++ b/repo/config/mounts.go
@@ -2,6 +2,7 @@ package config
 
 // Mounts stores the (string) mount points
 type Mounts struct {
-	IPFS string
-	IPNS string
+	IPFS           string
+	IPNS           string
+	FuseAllowOther bool
 }


### PR DESCRIPTION
Fixes #991
Fixes #968 

```
    ipfs config Mounts.FuseAllowOther --bool true
    ipfs daemon --mount
```

## Discussion

Currently, `allow_root` does not work for some reason. However, `allow_other` does. Took out the `allow_root` option.
