### PR TITLE
Run tests with race flag using checkflags script

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,1 @@
-bin/ipfs
-bin/random
+IPFS-BUILD-OPTIONS

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,6 +45,11 @@ test_cheap:
 	cd sharness && make
 	cd 3nodetest && make
 
+test_race:
+	cd sharness && make GOFLAGS=-race TEST_EXPENSIVE=1
+	cd 3nodetest && make GOFLAGS=-race
+	cd dependencies && make GOFLAGS=-race
+
 IPFS-BUILD-OPTIONS: FORCE
 	@bin/checkflags '$@' '$(GOFLAGS)' '*** new Go flags ***'
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,6 +6,9 @@ RANDOM_SRC = ../Godeps/_workspace/src/github.com/jbenet/go-random
 MULTIHASH_SRC = ../Godeps/_workspace/src/github.com/jbenet/go-multihash
 POLLENDPOINT_SRC= ../thirdparty/pollEndpoint
 
+# User might want to override those on the command line
+GOFLAGS =
+
 all: deps
 
 deps: bins
@@ -15,17 +18,21 @@ clean:
 
 bins: $(BINS)
 
-bin/random: $(RANDOM_SRC)/**/*.go
-	go build -o bin/random $(RANDOM_SRC)/random
+bin/random: $(RANDOM_SRC)/**/*.go IPFS-BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/random $(RANDOM_SRC)/random
 
-bin/multihash: $(MULTIHASH_SRC)/**/*.go
-	go build -o bin/multihash $(MULTIHASH_SRC)/multihash
+bin/multihash: $(MULTIHASH_SRC)/**/*.go IPFS-BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/multihash $(MULTIHASH_SRC)/multihash
 
-bin/ipfs: $(IPFS_ROOT)/**/*.go
-	go build -o bin/ipfs $(IPFS_CMD)
+bin/ipfs: $(IPFS_ROOT)/**/*.go IPFS-BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/ipfs $(IPFS_CMD)
 
-bin/pollEndpoint: $(POLLENDPOINT_SRC)/*.go
-	go build -o bin/pollEndpoint $(POLLENDPOINT_SRC)
+bin/pollEndpoint: $(POLLENDPOINT_SRC)/*.go IPFS-BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/pollEndpoint $(POLLENDPOINT_SRC)
 
 test: test_expensive
 
@@ -38,4 +45,7 @@ test_cheap:
 	cd sharness && make
 	cd 3nodetest && make
 
-.PHONY: all clean
+IPFS-BUILD-OPTIONS: FORCE
+	@bin/checkflags '$@' '$(GOFLAGS)' '*** new Go flags ***'
+
+.PHONY: all clean FORCE

--- a/test/bin/checkflags
+++ b/test/bin/checkflags
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Author: Christian Couder <chriscool@tuxfamily.org>
+# MIT LICENSED
+
+if test "$#" -lt 3
+then
+    echo >&2 "usage $0 FILE VALUES MSG..."
+    exit 1
+fi
+
+FLAG_FILE="$1"
+FLAG_VALS="$2"
+shift
+shift
+FLAG_MSGS="$@"
+
+# Use x in front of tested values as flags could be
+# interpreted by "test" to be for itself.
+if test x"$FLAG_VALS" != x"$(cat "$FLAG_FILE" 2>/dev/null)"
+then
+    echo "$FLAG_MSGS"
+    echo "$FLAG_VALS" >"$FLAG_FILE"
+fi

--- a/test/sharness/Makefile
+++ b/test/sharness/Makefile
@@ -11,6 +11,9 @@ BINS = bin/random bin/multihash bin/ipfs bin/pollEndpoint
 SHARNESS = lib/sharness/sharness.sh
 IPFS_ROOT = ../..
 
+# User might want to override those on the command line
+GOFLAGS =
+
 all: clean deps $(T) aggregate
 
 clean:
@@ -32,11 +35,13 @@ $(SHARNESS):
 	@echo "*** installing $@ ***"
 	lib/install-sharness.sh
 
-bin/%: $(IPFS_ROOT)/**/*.go
-	@echo "*** installing $@ ***"
-	cd .. && make $@
+bin/%: FORCE
+	cd .. && make GOFLAGS=$(GOFLAGS) $@
 
-.PHONY: all clean $(T) aggregate
+race:
+	make GOFLAGS=-race all
+
+.PHONY: all clean $(T) aggregate FORCE
 
 # will fail if curl is not installed.
 # TODO: get rid of this and install curl with git or ipfs.


### PR DESCRIPTION
This is an alternative implementation of PR #1013 (Run tests with race flag) using a "checkflags" script. 

As for PR #1013 the goal is to make it easier to find race conditions like issue #1012.