### PR TITLE
Harden shutdown logic

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -282,9 +282,6 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		corehttp.VersionOption(),
 	}
 
-	// our global interrupt handler can now try to stop the daemon
-	close(req.Context().InitDone)
-
 	if rootRedirect != nil {
 		opts = append(opts, rootRedirect)
 	}

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -226,7 +226,6 @@ func (i *cmdInvocation) Parse(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	i.req.Context().Context = ctx
 
 	repoPath, err := getRepoPath(i.req)
 	if err != nil {
@@ -278,6 +277,8 @@ func callPreCommandHooks(ctx context.Context, details cmdDetails, req cmds.Reque
 func callCommand(ctx context.Context, req cmds.Request, root *cmds.Command, cmd *cmds.Command) (cmds.Response, error) {
 	log.Info(config.EnvDir, " ", req.Context().ConfigRoot)
 	var res cmds.Response
+
+	req.Context().Context = ctx
 
 	details, err := commandDetails(req.Path(), root)
 	if err != nil {

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -132,14 +132,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// our global interrupt handler may try to stop the daemon
-	// before the daemon is ready to be stopped; this dirty
-	// workaround is for the daemon only; other commands are always
-	// ready to be stopped
-	if invoc.cmd != daemonCmd {
-		close(invoc.req.Context().InitDone)
-	}
-
 	// ok, finally, run the command invocation.
 	intrh, ctx := invoc.SetupInterruptHandler(ctx)
 	defer intrh.Close()
@@ -524,15 +516,6 @@ func (i *cmdInvocation) SetupInterruptHandler(ctx context.Context) (io.Closer, c
 		switch count {
 		case 1:
 			fmt.Println() // Prevent un-terminated ^C character in terminal
-
-			ctx := i.req.Context()
-
-			// if we're still initializing, cannot use `ctx.GetNode()`
-			select {
-			default: // initialization not done
-				os.Exit(-1)
-			case <-ctx.InitDone:
-			}
 
 			ih.wg.Add(1)
 			go func() {

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -495,24 +495,22 @@ func (i *cmdInvocation) setupInterruptHandler() {
 			case <-ctx.InitDone:
 			}
 
+			// TODO cancel the command context instead
+
+			n, err := ctx.GetNode()
+			if err != nil {
+				log.Error(err)
+				fmt.Println(shutdownMessage)
+				os.Exit(-1)
+			}
+
 			switch count {
 			case 0:
 				fmt.Println(shutdownMessage)
-				if ctx.Online {
-					go func() {
-						// TODO cancel the command context instead
-						n, err := ctx.GetNode()
-						if err != nil {
-							log.Error(err)
-							fmt.Println(shutdownMessage)
-							os.Exit(-1)
-						}
-						n.Close()
-						log.Info("Gracefully shut down.")
-					}()
-				} else {
-					os.Exit(0)
-				}
+				go func() {
+					n.Close()
+					log.Info("Gracefully shut down.")
+				}()
 
 			default:
 				fmt.Println("Received another interrupt before graceful shutdown, terminating...")

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -181,6 +181,8 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 			dec := json.NewDecoder(httpRes.Body)
 			outputType := reflect.TypeOf(req.Command().Type)
 
+			ctx := req.Context().Context
+
 			for {
 				var v interface{}
 				var err error
@@ -194,6 +196,14 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 					fmt.Println(err.Error())
 					return
 				}
+
+				select {
+				case <-ctx.Done():
+					close(outChan)
+					return
+				default:
+				}
+
 				if err == io.EOF {
 					close(outChan)
 					return

--- a/commands/request.go
+++ b/commands/request.go
@@ -30,7 +30,6 @@ type Context struct {
 
 	node          *core.IpfsNode
 	ConstructNode func() (*core.IpfsNode, error)
-	InitDone      chan bool
 }
 
 // GetConfig returns the config of the current Command exection
@@ -288,7 +287,7 @@ func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd 
 		optDefs = make(map[string]Option)
 	}
 
-	ctx := Context{Context: context.TODO(), InitDone: make(chan bool)}
+	ctx := Context{Context: context.TODO()}
 	values := make(map[string]interface{})
 	req := &request{path, opts, args, file, cmd, ctx, optDefs, values, os.Stdin}
 	err := req.ConvertOptions()

--- a/core/corehttp/corehttp.go
+++ b/core/corehttp/corehttp.go
@@ -79,6 +79,10 @@ func listenAndServe(node *core.IpfsNode, addr ma.Multiaddr, handler http.Handler
 	// if node being closed before server exits, close server
 	case <-node.Closing():
 		log.Infof("server at %s terminating...", addr)
+
+		// make sure keep-alive connections do not keep the server running
+		server.InnerServer.SetKeepAlivesEnabled(false)
+
 		server.Shutdown <- true
 
 	outer:

--- a/core/corehttp/corehttp.go
+++ b/core/corehttp/corehttp.go
@@ -64,6 +64,9 @@ func listenAndServe(node *core.IpfsNode, addr ma.Multiaddr, handler http.Handler
 	var serverError error
 	serverExited := make(chan struct{})
 
+	node.Children().Add(1)
+	defer node.Children().Done()
+
 	go func() {
 		serverError = server.ListenAndServe(host, handler)
 		close(serverExited)


### PR DESCRIPTION
Fixes in my quest to make the daemon shut down cleanly on Ctrl+C. Having the daemon stuck, especially without any logging/info to the user of why it's stuck, gives a bad impression to new users, as it's not evident that pressing Ctrl+C a second time will not interrupt an important task and corrupt something.

Spawned from ipfs/webui#28