### PR TITLE
log listeners dying as at least a warning

### DIFF
--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -105,7 +105,7 @@ func (s *Swarm) setupListener(maddr ma.Multiaddr) error {
 				if !more {
 					return
 				}
-				log.Debugf("swarm listener accept error: %s", err)
+				log.Warningf("swarm listener accept error: %s", err)
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
I have a sneaking suspicion that listeners might be randomly dying. No way to know other than logging them, and debug logs are impossible to grep through.