### PR TITLE
remove msgio double wrap

### DIFF
--- a/p2p/net/conn/conn_test.go
+++ b/p2p/net/conn/conn_test.go
@@ -8,17 +8,25 @@ import (
 	"testing"
 	"time"
 
+	msgio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-msgio"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	travis "github.com/ipfs/go-ipfs/util/testutil/ci/travis"
 )
 
+func msgioWrap(c Conn) msgio.ReadWriter {
+	return msgio.NewReadWriter(c)
+}
+
 func testOneSendRecv(t *testing.T, c1, c2 Conn) {
+	mc1 := msgioWrap(c1)
+	mc2 := msgioWrap(c2)
+
 	log.Debugf("testOneSendRecv from %s to %s", c1.LocalPeer(), c2.LocalPeer())
 	m1 := []byte("hello")
-	if err := c1.WriteMsg(m1); err != nil {
+	if err := mc1.WriteMsg(m1); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := c2.ReadMsg()
+	m2, err := mc2.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,11 +36,14 @@ func testOneSendRecv(t *testing.T, c1, c2 Conn) {
 }
 
 func testNotOneSendRecv(t *testing.T, c1, c2 Conn) {
+	mc1 := msgioWrap(c1)
+	mc2 := msgioWrap(c2)
+
 	m1 := []byte("hello")
-	if err := c1.WriteMsg(m1); err == nil {
+	if err := mc1.WriteMsg(m1); err == nil {
 		t.Fatal("write should have failed", err)
 	}
-	_, err := c2.ReadMsg()
+	_, err := mc2.ReadMsg()
 	if err == nil {
 		t.Fatal("read should have failed", err)
 	}
@@ -72,10 +83,13 @@ func TestCloseLeak(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		c1, c2, _, _ := setupSingleConn(t, ctx)
 
+		mc1 := msgioWrap(c1)
+		mc2 := msgioWrap(c2)
+
 		for i := 0; i < num; i++ {
 			b1 := []byte(fmt.Sprintf("beep%d", i))
-			c1.WriteMsg(b1)
-			b2, err := c2.ReadMsg()
+			mc1.WriteMsg(b1)
+			b2, err := mc2.ReadMsg()
 			if err != nil {
 				panic(err)
 			}
@@ -84,8 +98,8 @@ func TestCloseLeak(t *testing.T) {
 			}
 
 			b2 = []byte(fmt.Sprintf("boop%d", i))
-			c2.WriteMsg(b2)
-			b1, err = c1.ReadMsg()
+			mc2.WriteMsg(b2)
+			b1, err = mc1.ReadMsg()
 			if err != nil {
 				panic(err)
 			}

--- a/p2p/net/conn/dial_test.go
+++ b/p2p/net/conn/dial_test.go
@@ -130,10 +130,10 @@ func testDialer(t *testing.T, secure bool) {
 	}
 
 	// fmt.Println("sending")
-	c.WriteMsg([]byte("beep"))
-	c.WriteMsg([]byte("boop"))
-
-	out, err := c.ReadMsg()
+	mc := msgioWrap(c)
+	mc.WriteMsg([]byte("beep"))
+	mc.WriteMsg([]byte("boop"))
+	out, err := mc.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func testDialer(t *testing.T, secure bool) {
 		t.Error("unexpected conn output", data)
 	}
 
-	out, err = c.ReadMsg()
+	out, err = mc.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/net/conn/interface.go
+++ b/p2p/net/conn/interface.go
@@ -9,7 +9,6 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	u "github.com/ipfs/go-ipfs/util"
 
-	msgio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-msgio"
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
 )
@@ -45,8 +44,8 @@ type Conn interface {
 	SetReadDeadline(t time.Time) error
 	SetWriteDeadline(t time.Time) error
 
-	msgio.Reader
-	msgio.Writer
+	io.Reader
+	io.Writer
 }
 
 // Dialer is an object that can open connections. We could have a "convenience"

--- a/p2p/net/conn/secure_conn.go
+++ b/p2p/net/conn/secure_conn.go
@@ -130,20 +130,6 @@ func (c *secureConn) Write(buf []byte) (int, error) {
 	return c.secure.Write(buf)
 }
 
-func (c *secureConn) NextMsgLen() (int, error) {
-	return c.secure.NextMsgLen()
-}
-
-// ReadMsg reads data, net.Conn style
-func (c *secureConn) ReadMsg() ([]byte, error) {
-	return c.secure.ReadMsg()
-}
-
-// WriteMsg writes data, net.Conn style
-func (c *secureConn) WriteMsg(buf []byte) error {
-	return c.secure.WriteMsg(buf)
-}
-
 // ReleaseMsg releases a buffer
 func (c *secureConn) ReleaseMsg(m []byte) {
 	c.secure.ReleaseMsg(m)

--- a/p2p/net/conn/secure_conn_test.go
+++ b/p2p/net/conn/secure_conn_test.go
@@ -136,13 +136,16 @@ func TestSecureCloseLeak(t *testing.T) {
 	}
 
 	runPair := func(c1, c2 Conn, num int) {
+		mc1 := msgioWrap(c1)
+		mc2 := msgioWrap(c2)
+
 		log.Debugf("runPair %d", num)
 
 		for i := 0; i < num; i++ {
 			log.Debugf("runPair iteration %d", i)
 			b1 := []byte("beep")
-			c1.WriteMsg(b1)
-			b2, err := c2.ReadMsg()
+			mc1.WriteMsg(b1)
+			b2, err := mc2.ReadMsg()
 			if err != nil {
 				panic(err)
 			}
@@ -151,8 +154,8 @@ func TestSecureCloseLeak(t *testing.T) {
 			}
 
 			b2 = []byte("beep")
-			c2.WriteMsg(b2)
-			b1, err = c1.ReadMsg()
+			mc2.WriteMsg(b2)
+			b1, err = mc1.ReadMsg()
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
There was doublewrapping with an unneeded msgio. given that we
use a stream muxer now, msgio is only needed by secureConn -- to
signal the boundaries of an encrypted / mac-ed ciphertext.

Side note: i think including the varint length in the clear is
actually a bad idea that can be exploited by an attacker. it should
be encrypted, too. (TODO)

WARNING: THIS PR BREAKS THE PROTOCOL. DO NOT MERGE UNTIL NEXT
PROTOCOL VERSION BUMP.