### PR TITLE
Fix hub.docker.com URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Basic proof of 'ipfs working' locally:
 
 ### Docker usage
 
-An ipfs docker image is hosted at [hub.docker.com/u/ipfs/go-ipfs](hub.docker.com/u/ipfs/go-ipfs).
+An ipfs docker image is hosted at [hub.docker.com/u/jbenet/go-ipfs](hub.docker.com/u/jbenet/go-ipfs).
 To make files visible inside the container you need to mount a host directory 
 with the `-v` option to docker. Choose a directory that you want to use to
 import/export files from ipfs. You should also choose a directory to store 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,17 @@ Start a container running ipfs and expose ports 4001, 5001 and 8080:
 
     docker run -d --name ipfs_host -v $ipfs_staging:/export -v $ipfs_data:/root/.go-ipfs -p 8080:8080 -p 4001:4001 -p 5001:5001 jbenet/go-ipfs:latest
     
+Watch the ipfs log:
+
+    docker logs -f ipfs_host
+    
 Wait for ipfs to start. ipfs is running when you see: 
 
     Gateway (readonly) server 
-    listening on /ip4/0.0.0.0/tcp/8080" in the container logs (`docker logs -f ipfs_host`)
-
+    listening on /ip4/0.0.0.0/tcp/8080
+    
+(you can now stop watching the log)
+   
 Run ipfs commands:
 
     docker exec ipfs_host ipfs <args...>


### PR DESCRIPTION
I had changed the url to reference /u/ipfs in a commit that is now skipped but it should really be /u/jbenet

Now the docker hub url is hub.docker.com/u/jbenet/go-ipfs