### PR TITLE
move log messages out of warning level

### DIFF
--- a/routing/dht/dht_net.go
+++ b/routing/dht/dht_net.go
@@ -54,7 +54,7 @@ func (dht *IpfsDHT) handleNewMessage(s inet.Stream) {
 
 	// if nil response, return it before serializing
 	if rpmes == nil {
-		log.Warning("Got back nil response from request.")
+		log.Debug("Got back nil response from request.")
 		return
 	}
 

--- a/routing/dht/handlers.go
+++ b/routing/dht/handlers.go
@@ -140,7 +140,7 @@ func (dht *IpfsDHT) handleFindPeer(ctx context.Context, p peer.ID, pmes *pb.Mess
 	}
 
 	if closest == nil {
-		log.Warningf("%s handleFindPeer %s: could not find anything.", dht.self, p)
+		log.Infof("%s handleFindPeer %s: could not find anything.", dht.self, p)
 		return resp, nil
 	}
 


### PR DESCRIPTION
I've been using loglevel warning for my development/bad-things-potentially-happening-on-gateways logging recently, I'd like to clean it up a bit.