### PR TITLE
Revert "fix ugly error message when killing commands"

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -496,24 +496,22 @@ func (i *cmdInvocation) setupInterruptHandler() {
 			case <-ctx.InitDone:
 			}
 
+			// TODO cancel the command context instead
+
+			n, err := ctx.GetNode()
+			if err != nil {
+				log.Error(err)
+				fmt.Println(shutdownMessage)
+				os.Exit(-1)
+			}
+
 			switch count {
 			case 0:
 				fmt.Println(shutdownMessage)
-				if ctx.Online {
-					go func() {
-						// TODO cancel the command context instead
-						n, err := ctx.GetNode()
-						if err != nil {
-							log.Error(err)
-							fmt.Println(shutdownMessage)
-							os.Exit(-1)
-						}
-						n.Close()
-						log.Info("Gracefully shut down.")
-					}()
-				} else {
-					os.Exit(0)
-				}
+				go func() {
+					n.Close()
+					log.Info("Gracefully shut down.")
+				}()
 
 			default:
 				fmt.Println("Received another interrupt before graceful shutdown, terminating...")


### PR DESCRIPTION
This reverts commit f74e71f96545b14f5293c9851ce624aecddb68aa.

The 'Online' flag of the command context does not seem to be set in
any code paths, at least not when running commands such as 'ipfs daemon'
or 'ipfs ping'. The result after f74e71f9 is that we never shutdown
cleanly, as we'll always os.Exit(0) from the interrupt handler.

The os.Exit(0) itself is also dubious, as conceptually the interrupt
handler should ask whatever is stalling to stop stalling, so that
main() can return like normal. Exiting with -1 in error cases where
the interrupt handler is unable to stop the stall is fine, but the
normal case of interrupting cleanly should exit through main().