### PR TITLE
increase window size for yamux streams

### DIFF
--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -16,13 +16,20 @@ import (
 	ctxgroup "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	ps "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+	pst "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
 	psy "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/yamux"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 var log = eventlog.Logger("swarm2")
 
-var PSTransport = psy.DefaultTransport
+var PSTransport pst.Transport
+
+func init() {
+	tpt := *psy.DefaultTransport
+	tpt.MaxStreamWindowSize = 512 * 1024
+	PSTransport = &tpt
+}
 
 // Swarm is a connection muxer, allowing connections to other peers to
 // be opened and closed, while still using the same Chan for all


### PR DESCRIPTION
improving overall transfer speed.

Since our blocksize is 256k, a window size of 256k incurs an extra RTT to send a single block. Bumping the window size to 512k goes a long way to improve the performance of bitswap transfers