### PR TITLE
WIP: ipfs pipe command

### DIFF
--- a/commands/argument.go
+++ b/commands/argument.go
@@ -5,6 +5,7 @@ type ArgumentType int
 const (
 	ArgString ArgumentType = iota
 	ArgFile
+	ArgStream
 )
 
 type Argument struct {
@@ -31,6 +32,16 @@ func FileArg(name string, required, variadic bool, description string) Argument 
 	return Argument{
 		Name:        name,
 		Type:        ArgFile,
+		Required:    required,
+		Variadic:    variadic,
+		Description: description,
+	}
+}
+
+func StreamArg(name string, required, variadic bool, description string) Argument {
+	return Argument{
+		Name:        name,
+		Type:        ArgStream,
 		Required:    required,
 		Variadic:    variadic,
 		Description: description,

--- a/commands/argument.go
+++ b/commands/argument.go
@@ -18,6 +18,7 @@ type Argument struct {
 	Description   string
 }
 
+// Regular string arugment passed to the command
 func StringArg(name string, required, variadic bool, description string) Argument {
 	return Argument{
 		Name:        name,
@@ -28,6 +29,8 @@ func StringArg(name string, required, variadic bool, description string) Argumen
 	}
 }
 
+// Opens the argument name as a file, supports EnableStdin and EnableRecursive
+// EnableStdin will use stdin as the file source only if it's not from the terminal
 func FileArg(name string, required, variadic bool, description string) Argument {
 	return Argument{
 		Name:        name,
@@ -38,6 +41,9 @@ func FileArg(name string, required, variadic bool, description string) Argument 
 	}
 }
 
+// Used for piping to a command, differs from FileArg with the SupportsStdin set to true
+// by making sure we always capture stdin.
+// FileArg will only use stdin if the input is not from the keyboard (terminal).
 func StreamArg(name string, required, variadic bool, description string) Argument {
 	return Argument{
 		Name:        name,
@@ -45,13 +51,13 @@ func StreamArg(name string, required, variadic bool, description string) Argumen
 		Required:    required,
 		Variadic:    variadic,
 		Description: description,
+		SupportsStdin: true,       // Always
 	}
 }
 
 // TODO: modifiers might need a different API?
 //       e.g. passing enum values into arg constructors variadically
 //       (`FileArg("file", ArgRequired, ArgStdin, ArgRecursive)`)
-
 func (a Argument) EnableStdin() Argument {
 	a.SupportsStdin = true
 	return a

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -198,7 +198,8 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 		}
 
 		var err error
-		if argDef.Type == cmds.ArgString {
+		switch argDef.Type {
+		case cmds.ArgString:
 			if stdin == nil {
 				// add string values
 				stringArgs, inputs = appendString(stringArgs, inputs)
@@ -211,7 +212,7 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 				}
 			}
 
-		} else if argDef.Type == cmds.ArgFile {
+		case cmds.ArgFile:
 			if stdin == nil {
 				// treat stringArg values as file paths
 				fileArgs, inputs, err = appendFile(fileArgs, inputs, argDef, recursive)
@@ -223,10 +224,11 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 				// if we have a stdin, create a file from it
 				fileArgs, stdin = appendStdinAsFile(fileArgs, stdin)
 			}
-		} else if argDef.Type == cmds.ArgStream {
+		case cmds.ArgStream:
 			if argDef.SupportsStdin {
 				// if we have a stdin, create a file from it
 				fileArgs, stdin = appendStdinAsFile(fileArgs, stdin)
+				stdin = nil
 			}
 		}
 
@@ -237,6 +239,7 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 	if len(argDefs) > argDefIndex {
 		for _, argDef := range argDefs[argDefIndex:] {
 			if argDef.Required {
+				panic(3)
 				return nil, nil, fmt.Errorf("Argument '%s' is required", argDef.Name)
 			}
 		}

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -160,8 +160,11 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 	if stdin != nil {
 		if term, err := isTerminal(stdin); err != nil {
 			return nil, nil, err
-		} else if term && hasStream == false {
-			stdin = nil // set to nil so we ignore it
+		} else if term {
+			if hasStream == false {
+				stdin = nil // set to nil so we ignore it
+			}
+			// TURN BUFFERING OFF
 		}
 	}
 

--- a/commands/command.go
+++ b/commands/command.go
@@ -206,7 +206,7 @@ func (c *Command) CheckArguments(req Request) error {
 	valueIndex := 0 // the index of the current value (in `args`)
 	for _, argDef := range c.Arguments {
 		// skip optional argument definitions if there aren't sufficient remaining values
-		if len(args)-valueIndex <= numRequired && !argDef.Required || argDef.Type == ArgFile {
+		if len(args)-valueIndex <= numRequired && !argDef.Required || argDef.Type == ArgFile || argDef.Type == ArgStream {
 			continue
 		}
 

--- a/core/commands/pipe.go
+++ b/core/commands/pipe.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"time"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	corenet "github.com/ipfs/go-ipfs/core/corenet"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	u "github.com/ipfs/go-ipfs/util"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+var PipeCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline:          "",
+		Synopsis:         ``,
+		ShortDescription: ``,
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("peer ID", true, true, "ID of peer to talk to"),
+	},
+	Options: []cmds.Option{
+		cmds.IntOption("count", "n", "number of ping messages to send"),
+		cmds.BoolOption("listen", "l", "listen for other peer to dial us"),
+	},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			out, ok := res.Output().(io.Reader)
+			if !ok {
+				fmt.Println(reflect.TypeOf(res.Output()))
+				return nil, u.ErrCast()
+			}
+
+			return out, nil
+		},
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		ctx := req.Context().Context
+		n, err := req.Context().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		pid, err := peer.IDB58Decode(req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		nctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+		pinfo, err := n.Routing.FindPeer(nctx, pid)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		n.Peerstore.AddAddrs(pinfo.ID, pinfo.Addrs, time.Minute)
+
+		listen, _, err := req.Option("listen").Bool()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		var rwc io.ReadWriteCloser
+		if listen {
+			list, err := corenet.Listen(n, protocolForPeer(pid))
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			for {
+				s, err := list.Accept()
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				if s.Conn().RemotePeer() != pid {
+					log.Warning("Got connection from incorrect peer")
+					continue
+				}
+
+				log.Error("Got connection!")
+
+				s.Write([]byte("HELLO!"))
+				rwc = s
+			}
+		} else {
+			s, err := corenet.Dial(n, pid, protocolForPeer(n.Identity))
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+			log.Error("Got connection!")
+			rwc = s
+		}
+
+		go io.Copy(os.Stdout, req.Stdin())
+
+		res.SetOutput(rwc)
+	},
+	Type: PingResult{},
+}
+
+func protocolForPeer(pid peer.ID) string {
+	return "/ipfs/pipe/" + string(pid)
+}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -93,6 +93,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"object":    ObjectCmd,
 	"pin":       PinCmd,
 	"ping":      PingCmd,
+	"pipe":      PipeCmd,
 	"refs":      RefsCmd,
 	"repo":      RepoCmd,
 	"stats":     StatsCmd,


### PR DESCRIPTION
A WIP on a pipe command ive wanted for a while, will allow you to pipe through ipfs to a given peer via the command line, only needing their peer ID.

Currently blocked on not knowing how Stdin works in the commands lib, @mappum I will buy you hella coffee if you can help me on this one.

once this is working you will be able to:
```
ipfs pipe -l QmPeerIDB
```

And then:

```
echo "hello" | ipfs pipe QmpeerIDA
```

