### PR TITLE
remove debugerrors

### DIFF
--- a/assets/contact.go
+++ b/assets/contact.go
@@ -1,4 +1,5 @@
 package assets
+
 var Init_doc_contact = `Come hang out in our IRC chat room if you have any questions.
 
 Contact the ipfs dev team:

--- a/assets/help.go
+++ b/assets/help.go
@@ -1,4 +1,5 @@
 package assets
+
 var Init_doc_help = `Some helpful resources for finding your way around ipfs:
 
 - quick-start: a quick show of various ipfs features.

--- a/assets/quick-start.go
+++ b/assets/quick-start.go
@@ -1,4 +1,5 @@
 package assets
+
 var Init_doc_quick_start = `# 0.1 - Quick Start
 
 This is a set of short examples with minmal explanation. It is meant as

--- a/assets/readme.go
+++ b/assets/readme.go
@@ -1,4 +1,5 @@
 package assets
+
 var Init_doc_readme = `Hello and Welcome to IPFS!
 
 ██╗██████╗ ███████╗███████╗

--- a/assets/security-notes.go
+++ b/assets/security-notes.go
@@ -1,4 +1,5 @@
 package assets
+
 var Init_doc_security_notes = `                    IPFS Alpha Security Notes
 
 We try hard to ensure our system is safe and robust, but all software

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -14,7 +14,6 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	util "github.com/ipfs/go-ipfs/util"
-	"github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 const (
@@ -56,7 +55,7 @@ in the network, use 0.0.0.0 as the ip address:
 
    ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 
-Be careful if you expose the API. It is a security risk, as anyone could use control 
+Be careful if you expose the API. It is a security risk, as anyone could use control
 your node remotely. If you need to control the node remotely, make sure to protect
 the port as you would other services or database (firewall, authenticated proxy, etc).`,
 	},
@@ -98,7 +97,7 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		if !util.FileExists(req.Context().ConfigRoot) {
 			err := initWithDefaults(os.Stdout, req.Context().ConfigRoot)
 			if err != nil {
-				res.SetError(debugerror.Wrap(err), cmds.ErrNormal)
+				res.SetError(err, cmds.ErrNormal)
 				return
 			}
 		}
@@ -120,7 +119,7 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 	// sure we are permitted to access the resources (datastore, etc.)
 	repo, err := fsrepo.Open(req.Context().ConfigRoot)
 	if err != nil {
-		res.SetError(debugerror.Errorf("Couldn't obtain lock. Is another daemon already running?"), cmds.ErrNormal)
+		res.SetError(fmt.Errorf("Couldn't obtain lock. Is another daemon already running?"), cmds.ErrNormal)
 		return
 	}
 

--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -15,7 +16,6 @@ import (
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	u "github.com/ipfs/go-ipfs/util"
-	debugerror "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 const nBitsForKeypairDefault = 4096
@@ -65,14 +65,14 @@ var initCmd = &cmds.Command{
 	},
 }
 
-var errRepoExists = debugerror.New(`ipfs configuration file already exists!
+var errRepoExists = errors.New(`ipfs configuration file already exists!
 Reinitializing would overwrite your keys.
 (use -f to force overwrite)
 `)
 
 func initWithDefaults(out io.Writer, repoRoot string) error {
 	err := doInit(out, repoRoot, false, nBitsForKeypairDefault)
-	return debugerror.Wrap(err)
+	return err
 }
 
 func doInit(out io.Writer, repoRoot string, force bool, nBitsForKeypair int) error {

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -26,7 +26,6 @@ import (
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
-	"github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // log is the command logger
@@ -355,7 +354,7 @@ func commandDetails(path []string, root *cmds.Command) (*cmdDetails, error) {
 		var found bool
 		cmd, found = cmd.Subcommands[cmp]
 		if !found {
-			return nil, debugerror.Errorf("subcommand %s should be in root", cmp)
+			return nil, fmt.Errorf("subcommand %s should be in root", cmp)
 		}
 
 		if cmdDetails, found := cmdDetailsMap[cmd]; found {

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -18,7 +18,6 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	u "github.com/ipfs/go-ipfs/util"
-	"github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // Error indicating the max depth has been exceded.
@@ -106,19 +105,19 @@ remains to be implemented.
 
 				rootnd, err := addFile(n, file, outChan, progress, wrap)
 				if err != nil {
-					res.SetError(debugerror.Wrap(err), cmds.ErrNormal)
+					res.SetError(err, cmds.ErrNormal)
 					return
 				}
 
 				err = n.Pinning.Pin(context.Background(), rootnd, true)
 				if err != nil {
-					res.SetError(debugerror.Wrap(err), cmds.ErrNormal)
+					res.SetError(err, cmds.ErrNormal)
 					return
 				}
 
 				err = n.Pinning.Flush()
 				if err != nil {
-					res.SetError(debugerror.Wrap(err), cmds.ErrNormal)
+					res.SetError(err, cmds.ErrNormal)
 					return
 				}
 			}

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sort"
 
@@ -10,7 +11,6 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	u "github.com/ipfs/go-ipfs/util"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 type BootstrapOutput struct {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -2,13 +2,13 @@ package commands
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 	iaddr "github.com/ipfs/go-ipfs/util/ipfsaddr"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -3,6 +3,7 @@
 package bitswap
 
 import (
+	"errors"
 	"math"
 	"sync"
 	"time"
@@ -21,7 +22,6 @@ import (
 	"github.com/ipfs/go-ipfs/thirdparty/delay"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 	pset "github.com/ipfs/go-ipfs/util/peerset" // TODO move this to peerstore
 )
 
@@ -432,7 +432,7 @@ func (bs *Bitswap) ReceiveError(err error) {
 func (bs *Bitswap) send(ctx context.Context, p peer.ID, m bsmsg.BitSwapMessage) error {
 	defer log.EventBegin(ctx, "sendMessage", p, m).Done()
 	if err := bs.network.SendMessage(ctx, p, m); err != nil {
-		return errors.Wrap(err)
+		return err
 	}
 	return bs.engine.MessageSent(p, m)
 }

--- a/exchange/reprovide/reprovide.go
+++ b/exchange/reprovide/reprovide.go
@@ -1,6 +1,7 @@
 package reprovide
 
 import (
+	"fmt"
 	"time"
 
 	backoff "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/cenkalti/backoff"
@@ -8,7 +9,6 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks/blockstore"
 	routing "github.com/ipfs/go-ipfs/routing"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	debugerror "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 var log = eventlog.Logger("reprovider")
@@ -50,7 +50,7 @@ func (rp *Reprovider) ProvideEvery(ctx context.Context, tick time.Duration) {
 func (rp *Reprovider) Reprovide(ctx context.Context) error {
 	keychan, err := rp.bstore.AllKeysChan(ctx)
 	if err != nil {
-		return debugerror.Errorf("Failed to get key chan from blockstore: %s", err)
+		return fmt.Errorf("Failed to get key chan from blockstore: %s", err)
 	}
 	for k := range keychan {
 		op := func() error {

--- a/p2p/net/conn/dial.go
+++ b/p2p/net/conn/dial.go
@@ -15,7 +15,6 @@ import (
 
 	addrutil "github.com/ipfs/go-ipfs/p2p/net/swarm/addr"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	debugerror "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // String returns the string rep of d.
@@ -107,7 +106,7 @@ func (d *Dialer) rawConnDial(ctx context.Context, raddr ma.Multiaddr, remote pee
 
 	if strings.HasPrefix(raddr.String(), "/ip4/0.0.0.0") {
 		log.Event(ctx, "connDialZeroAddr", lgbl.Dial("conn", d.LocalPeer, remote, nil, raddr))
-		return nil, debugerror.Errorf("Attempted to connect to zero address: %s", raddr)
+		return nil, fmt.Errorf("Attempted to connect to zero address: %s", raddr)
 	}
 
 	// get local addr to use.

--- a/p2p/net/conn/secure_conn.go
+++ b/p2p/net/conn/secure_conn.go
@@ -1,6 +1,7 @@
 package conn
 
 import (
+	"errors"
 	"net"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	ic "github.com/ipfs/go-ipfs/p2p/crypto"
 	secio "github.com/ipfs/go-ipfs/p2p/crypto/secio"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // secureConn wraps another Conn object with an encrypted channel.

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	metrics "github.com/ipfs/go-ipfs/metrics"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
@@ -130,7 +130,7 @@ func SubtestSwarm(t *testing.T, SwarmNum int, MsgNum int) {
 				// first, one stream per peer (nice)
 				stream, err := s1.NewStreamWithPeer(p)
 				if err != nil {
-					errChan <- errors.Wrap(err)
+					errChan <- err
 					return
 				}
 
@@ -177,12 +177,12 @@ func SubtestSwarm(t *testing.T, SwarmNum int, MsgNum int) {
 
 					// read from the stream
 					if _, err := stream.Read(msg); err != nil {
-						errChan <- errors.Wrap(err)
+						errChan <- err
 						continue
 					}
 
 					if string(msg) != "pong" {
-						errChan <- errors.Errorf("unexpected message: %s", msg)
+						errChan <- fmt.Errorf("unexpected message: %s", msg)
 						continue
 					}
 
@@ -195,7 +195,7 @@ func SubtestSwarm(t *testing.T, SwarmNum int, MsgNum int) {
 			}
 
 			if count != countShouldBe {
-				errChan <- errors.Errorf("count mismatch: %d != %d", count, countShouldBe)
+				errChan <- fmt.Errorf("count mismatch: %d != %d", count, countShouldBe)
 			}
 		}()
 

--- a/repo/config/bootstrap_peers.go
+++ b/repo/config/bootstrap_peers.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
+	"errors"
+	"fmt"
 
 	iaddr "github.com/ipfs/go-ipfs/util/ipfsaddr"
 )
@@ -40,7 +41,7 @@ func (c *Config) BootstrapPeers() ([]BootstrapPeer, error) {
 func DefaultBootstrapPeers() ([]BootstrapPeer, error) {
 	ps, err := ParseBootstrapPeers(DefaultBootstrapAddresses)
 	if err != nil {
-		return nil, errors.Errorf(`failed to parse hardcoded bootstrap peers: %s
+		return nil, fmt.Errorf(`failed to parse hardcoded bootstrap peers: %s
 This is a problem with the ipfs codebase. Please report it to the dev team.`, err)
 	}
 	return ps, nil

--- a/repo/config/gateway.go
+++ b/repo/config/gateway.go
@@ -3,5 +3,5 @@ package config
 // Gateway contains options for the HTTP gateway server.
 type Gateway struct {
 	RootRedirect string
-	Writable bool
+	Writable     bool
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -2,12 +2,12 @@ package config
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
@@ -44,10 +44,10 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			Gateway: "/ip4/127.0.0.1/tcp/8080",
 		},
 
-		Bootstrap: BootstrapPeerStrings(bootstrapPeers),
-		SupernodeRouting:       *snr,
-		Datastore: *ds,
-		Identity:  identity,
+		Bootstrap:        BootstrapPeerStrings(bootstrapPeers),
+		SupernodeRouting: *snr,
+		Datastore:        *ds,
+		Identity:         identity,
 		Log: Log{
 			MaxSizeMB:  250,
 			MaxBackups: 1,

--- a/repo/config/log.go
+++ b/repo/config/log.go
@@ -1,6 +1,5 @@
 package config
 
-
 type Log struct {
 	MaxSizeMB  int
 	MaxBackups int

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -1,6 +1,8 @@
 package fsrepo
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -20,7 +22,6 @@ import (
 	u "github.com/ipfs/go-ipfs/util"
 	util "github.com/ipfs/go-ipfs/util"
 	ds2 "github.com/ipfs/go-ipfs/util/datastore2"
-	debugerror "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 const (
@@ -100,7 +101,7 @@ func open(repoPath string) (repo.Repo, error) {
 	}()
 
 	if !isInitializedUnsynced(r.path) {
-		return nil, debugerror.New("ipfs not initialized, please run 'ipfs init'")
+		return nil, errors.New("ipfs not initialized, please run 'ipfs init'")
 	}
 	// check repo path, then check all constituent parts.
 	// TODO acquire repo lock
@@ -191,7 +192,7 @@ func Init(repoPath string, conf *config.Config) error {
 	// During Init, we merely check that the directory is writeable.
 	p := path.Join(repoPath, defaultDataStoreDirectory)
 	if err := dir.Writable(p); err != nil {
-		return debugerror.Errorf("datastore: %s", err)
+		return fmt.Errorf("datastore: %s", err)
 	}
 
 	if err := dir.Writable(path.Join(repoPath, "logs")); err != nil {
@@ -240,7 +241,7 @@ func (r *FSRepo) openDatastore() error {
 		Compression: ldbopts.NoCompression,
 	})
 	if err != nil {
-		return debugerror.New("unable to open leveldb datastore")
+		return errors.New("unable to open leveldb datastore")
 	}
 	r.ds = ds
 	return nil
@@ -264,7 +265,7 @@ func (r *FSRepo) Close() error {
 	defer packageLock.Unlock()
 
 	if r.closed {
-		return debugerror.New("repo is closed")
+		return errors.New("repo is closed")
 	}
 
 	if err := r.ds.Close(); err != nil {
@@ -349,7 +350,7 @@ func (r *FSRepo) GetConfigKey(key string) (interface{}, error) {
 	defer packageLock.Unlock()
 
 	if r.closed {
-		return nil, debugerror.New("repo is closed")
+		return nil, errors.New("repo is closed")
 	}
 
 	filename, err := config.Filename(r.path)
@@ -369,7 +370,7 @@ func (r *FSRepo) SetConfigKey(key string, value interface{}) error {
 	defer packageLock.Unlock()
 
 	if r.closed {
-		return debugerror.New("repo is closed")
+		return errors.New("repo is closed")
 	}
 
 	filename, err := config.Filename(r.path)

--- a/repo/fsrepo/lock/lock.go
+++ b/repo/fsrepo/lock/lock.go
@@ -6,7 +6,6 @@ import (
 
 	lock "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/camlistore/lock"
 	"github.com/ipfs/go-ipfs/util"
-	"github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // LockFile is the filename of the daemon lock, relative to config dir
@@ -15,7 +14,7 @@ const LockFile = "daemon.lock"
 
 func Lock(confdir string) (io.Closer, error) {
 	c, err := lock.Lock(path.Join(confdir, LockFile))
-	return c, debugerror.Wrap(err)
+	return c, err
 }
 
 func Locked(confdir string) bool {

--- a/repo/fsrepo/serialize/serialize.go
+++ b/repo/fsrepo/serialize/serialize.go
@@ -2,6 +2,7 @@ package fsrepo
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/facebookgo/atomicfile"
 	"github.com/ipfs/go-ipfs/repo/config"
 	"github.com/ipfs/go-ipfs/util"
-	"github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 var log = util.Logger("fsrepo")
@@ -59,7 +59,7 @@ func encode(w io.Writer, value interface{}) error {
 func Load(filename string) (*config.Config, error) {
 	// if nothing is there, fail. User must run 'ipfs init'
 	if !util.FileExists(filename) {
-		return nil, debugerror.New("ipfs not initialized, please run 'ipfs init'")
+		return nil, errors.New("ipfs not initialized, please run 'ipfs init'")
 	}
 
 	var cfg config.Config

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -13,7 +13,6 @@ import (
 	kb "github.com/ipfs/go-ipfs/routing/kbucket"
 	record "github.com/ipfs/go-ipfs/routing/record"
 	u "github.com/ipfs/go-ipfs/util"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 	pset "github.com/ipfs/go-ipfs/util/peerset"
 )
 
@@ -95,7 +94,7 @@ func (dht *IpfsDHT) GetValue(ctx context.Context, key u.Key) ([]byte, error) {
 	log.Debugf("peers in rt: %s", len(rtp), rtp)
 	if len(rtp) == 0 {
 		log.Warning("No peers from routing table!")
-		return nil, errors.Wrap(kb.ErrLookupFailure)
+		return nil, kb.ErrLookupFailure
 	}
 
 	// setup the Query
@@ -278,7 +277,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (peer.PeerInfo, er
 
 	peers := dht.routingTable.NearestPeers(kb.ConvertPeerID(id), AlphaValue)
 	if len(peers) == 0 {
-		return peer.PeerInfo{}, errors.Wrap(kb.ErrLookupFailure)
+		return peer.PeerInfo{}, kb.ErrLookupFailure
 	}
 
 	// Sanity...
@@ -344,7 +343,7 @@ func (dht *IpfsDHT) FindPeersConnectedToPeer(ctx context.Context, id peer.ID) (<
 
 	peers := dht.routingTable.NearestPeers(kb.ConvertPeerID(id), AlphaValue)
 	if len(peers) == 0 {
-		return nil, errors.Wrap(kb.ErrLookupFailure)
+		return nil, kb.ErrLookupFailure
 	}
 
 	// setup the Query

--- a/routing/mock/dht.go
+++ b/routing/mock/dht.go
@@ -30,7 +30,6 @@ func (rs *mocknetserver) ClientWithDatastore(ctx context.Context, p testutil.Ide
 	host, err := rs.mn.AddPeer(p.PrivateKey(), p.Address())
 	if err != nil {
 		panic("FIXME")
-		// return nil, debugerror.Wrap(err)
 	}
 	return dht.NewDHT(ctx, host, sync.MutexWrap(ds))
 }

--- a/routing/supernode/proxy/loopback.go
+++ b/routing/supernode/proxy/loopback.go
@@ -6,7 +6,6 @@ import (
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	dhtpb "github.com/ipfs/go-ipfs/routing/dht/pb"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // RequestHandler handles routing requests locally
@@ -43,7 +42,7 @@ func (lb *Loopback) HandleStream(s inet.Stream) {
 	pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)
 	var incoming dhtpb.Message
 	if err := pbr.ReadMsg(&incoming); err != nil {
-		log.Debug(errors.Wrap(err))
+		log.Debug(err)
 		return
 	}
 	ctx := context.TODO()

--- a/routing/supernode/proxy/standard.go
+++ b/routing/supernode/proxy/standard.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"errors"
+
 	ggio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/io"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	host "github.com/ipfs/go-ipfs/p2p/host"
@@ -10,7 +12,6 @@ import (
 	kbucket "github.com/ipfs/go-ipfs/routing/kbucket"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	"github.com/ipfs/go-ipfs/util"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 const ProtocolSNR = "/ipfs/supernoderouting"
@@ -103,7 +104,7 @@ func (px *standard) sendMessage(ctx context.Context, m *dhtpb.Message, remote pe
 	defer s.Close()
 	pbw := ggio.NewDelimitedWriter(s)
 	if err := pbw.WriteMsg(m); err != nil {
-		return errors.Wrap(err)
+		return err
 	}
 	return nil
 }

--- a/routing/supernode/server.go
+++ b/routing/supernode/server.go
@@ -1,6 +1,7 @@
 package supernode
 
 import (
+	"errors"
 	"fmt"
 
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/code.google.com/p/goprotobuf/proto"
@@ -11,7 +12,6 @@ import (
 	record "github.com/ipfs/go-ipfs/routing/record"
 	proxy "github.com/ipfs/go-ipfs/routing/supernode/proxy"
 	util "github.com/ipfs/go-ipfs/util"
-	errors "github.com/ipfs/go-ipfs/util/debugerror"
 )
 
 // Server handles routing queries using a database backend
@@ -117,7 +117,7 @@ func getRoutingRecord(ds datastore.Datastore, k util.Key) (*dhtpb.Record, error)
 	dskey := k.DsKey()
 	val, err := ds.Get(dskey)
 	if err != nil {
-		return nil, errors.Wrap(err)
+		return nil, err
 	}
 	recordBytes, ok := val.([]byte)
 	if !ok {


### PR DESCRIPTION
We now consider debugerrors harmful: we've run into cases where
debugerror.Wrap() hid valuable error information (err == io.EOF?).
I've removed them from the main code, but left them in some tests.
Go errors are lacking, but unfortunately, this isn't the solution.

It is possible that debugerros.New or debugerrors.Errorf should
remain still (i.e. only remove debugerrors.Wrap) but we don't use
these errors often enough to keep.