### PR TITLE
core: bugfix: bootstrap random permutation

### DIFF
--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -225,8 +225,11 @@ func toPeerInfo(bp config.BootstrapPeer) peer.PeerInfo {
 func randomSubsetOfPeers(in []peer.PeerInfo, max int) []peer.PeerInfo {
 	n := math2.IntMin(max, len(in))
 	var out []peer.PeerInfo
-	for _, val := range rand.Perm(n) {
+	for _, val := range rand.Perm(len(in)) {
 		out = append(out, in[val])
+		if len(out) >= n {
+			break
+		}
 	}
 	return out
 }


### PR DESCRIPTION
the random permutaton for bootstrap peers was not working as
intended, returning the first four bootstrap peers always.
this commit fixes it to be a random subset.