### PR TITLE
Check to see if the daemon is currently running

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -35,6 +35,17 @@ var initCmd = &cmds.Command{
 		// name of the file?
 		// TODO cmds.StringOption("event-logs", "l", "Location for machine-readable event logs"),
 	},
+	PreRun: func(req cmds.Request) error {
+		daemonLocked := fsrepo.LockedByOtherProcess(req.Context().ConfigRoot)
+
+		log.Info("checking if daemon is running...")
+		if daemonLocked {
+			e := "ipfs daemon is running. please stop it to run this command"
+			return cmds.ClientError(e)
+		}
+
+		return nil
+	},
 	Run: func(req cmds.Request, res cmds.Response) {
 
 		force, _, err := req.Option("f").Bool() // if !found, it's okay force == false

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -44,4 +44,15 @@ test_expect_success "ipfs init output looks good" '
 	test_cmp expected actual_init
 '
 
+test_launch_ipfs_daemon
+
+test_expect_failure "ipfs init should not run while daemon is running" '
+	ipfs init 2> daemon_running_output
+	echo "Error: ipfs daemon is running. please stop it to run this command" > daemon_running_expected
+	echo "Use \'ipfs init --help\' for information about this command" >> daemon_running_expected
+	test_cmp daemon_running_expected daemon_running_output
+'
+
+test_kill_ipfs_daemon
+
 test_done

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -48,10 +48,10 @@ test_init_ipfs
 
 test_launch_ipfs_daemon
 
-test_expect_failure "ipfs init should not run while daemon is running" '
-	ipfs init 2> daemon_running_err &&
-	expect="Error: ipfs daemon is running. please stop it to run this command" &&
-	cat daemon_running_err | grep $expect
+test_expect_success "ipfs init should not run while daemon is running" '
+	test_must_fail ipfs init 2> daemon_running_err &&
+	EXPECT="Error: ipfs daemon is running. please stop it to run this command" &&
+	grep "$EXPECT" daemon_running_err
 '
 
 test_kill_ipfs_daemon

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -44,13 +44,14 @@ test_expect_success "ipfs init output looks good" '
 	test_cmp expected actual_init
 '
 
+test_init_ipfs
+
 test_launch_ipfs_daemon
 
 test_expect_failure "ipfs init should not run while daemon is running" '
-	ipfs init 2> daemon_running_output
-	echo "Error: ipfs daemon is running. please stop it to run this command" > daemon_running_expected
-	echo "Use \'ipfs init --help\' for information about this command" >> daemon_running_expected
-	test_cmp daemon_running_expected daemon_running_output
+	ipfs init 2> daemon_running_err &&
+	expect="Error: ipfs daemon is running. please stop it to run this command" &&
+	cat daemon_running_err | grep $expect
 '
 
 test_kill_ipfs_daemon


### PR DESCRIPTION
If the daemon is running we do not want to proceed with an
an initialization.

Return a client error telling the user to kill the daemon
before proceeding with the command.

Fixes #1102 