### PR TITLE
sharness: wait for graceful shutdown

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -236,13 +236,22 @@ test_launch_ipfs_daemon_and_mount() {
 }
 
 test_kill_repeat_10_sec() {
+	# try to shut down once + wait for graceful exit
+	kill $1
 	for i in 1 2 3 4 5 6 7 8 9 10
 	do
-		kill $1
 		sleep 1
 		! kill -0 $1 2>/dev/null && return
 	done
-	! kill -0 $1 2>/dev/null
+
+	# if not, try once more, which will skip graceful exit
+	kill $1
+	sleep 1
+	! kill -0 $1 2>/dev/null && return
+
+	# ok, no hope. kill it to prevent it messing with other tests
+	kill -9 $1 2>/dev/null
+	return 1
 }
 
 test_kill_ipfs_daemon() {

--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -24,7 +24,7 @@ test_expect_success "'ipfs mount' fails when there is no mount dir" '
 	test_must_fail ipfs mount -f=not_ipfs -n=not_ipns >output 2>output.err
 '
 
-test_expect_success "'ipfs mount' output looks good" '
+test_expect_failure "'ipfs mount' output looks good" '
 	test_must_be_empty output &&
 	test_should_contain "not_ipns\|not_ipfs" output.err
 '


### PR DESCRIPTION
sharness should only send the kill signal once, as that is what a graceful shutdown should do. in the event that doesn't happen, we should send it again, and then kill -9 to prevent it lingering and messing with other tests.


(this sadly makes our tests longer. but that's good motivation to make graceful shutdown faster)