### PR TITLE
init: lower default rsa key size to 2048 for now

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -18,7 +18,7 @@ import (
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-const nBitsForKeypairDefault = 4096
+const nBitsForKeypairDefault = 2048
 
 var initCmd = &cmds.Command{
 	Helptext: cmds.HelpText{


### PR DESCRIPTION
I think we should lower the default rsa key size to 2048 for now -- until we have a proper focus on securing everything. It's always a pain for new users to get hung on 4096 rsa key gen, when we have not even made sure we're using the keys perfectly correctly yet. (And 2048 is still considered secure)