### PR TITLE
sharness: encapsulate ipfs mount

### DIFF
--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -25,7 +25,7 @@ test_expect_success "'ipfs mount' fails when there is no mount dir" '
 	test_must_fail tmp_ipfs_mount
 '
 
-test_expect_failure "'ipfs mount' output looks good" '
+test_expect_success "'ipfs mount' output looks good" '
 	test_must_be_empty output &&
 	test_should_contain "not_ipns\|not_ipfs" output.err
 '

--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -21,7 +21,8 @@ test_launch_ipfs_daemon
 #  test mount failure before mounting properly.
 
 test_expect_success "'ipfs mount' fails when there is no mount dir" '
-	test_must_fail ipfs mount -f=not_ipfs -n=not_ipns >output 2>output.err
+	tmp_ipfs_mount() { ipfs mount -f=not_ipfs -n=not_ipns >output 2>output.err; } &&
+	test_must_fail tmp_ipfs_mount
 '
 
 test_expect_failure "'ipfs mount' output looks good" '


### PR DESCRIPTION
This should fix issue #1109 (sharness: t0030-mount test_must_fail fails on osx).