### PR TITLE
test-lib.sh: fix umount calls

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -214,8 +214,8 @@ test_mount_ipfs() {
 
 	# make sure stuff is unmounted first.
 	test_expect_success FUSE "'ipfs mount' succeeds" '
-		umount $(pwd)/ipfs || true &&
-		umount $(pwd)/ipns || true &&
+		umount "$(pwd)/ipfs" || true &&
+		umount "$(pwd)/ipns" || true &&
 		ipfs mount >actual
 	'
 


### PR DESCRIPTION
As test directories contain a space, we need to
properly quote paths, otherwise we get errors like:

```
umount: /home/christian/gocode/src/github.com/ipfs/go-ipfs/test/sharness/trash is not mounted (according to mtab)
umount: /home/christian/gocode/src/github.com/ipfs/go-ipfs/test/sharness/trash is not mounted (according to mtab)
```

instead of:

```
umount: /home/christian/gocode/src/github.com/ipfs/go-ipfs/test/sharness/trash directory.t0030-mount.sh/ipfs is not mounted (according to mtab)
umount: /home/christian/gocode/src/github.com/ipfs/go-ipfs/test/sharness/trash directory.t0030-mount.sh/ipns is not mounted (according to mtab)
```

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>