### PR TITLE
Instructions for installing command completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependencies as well.
   We strongly recommend you use the [latest version of OSX FUSE](http://osxfuse.github.io/).
   (See https://github.com/ipfs/go-ipfs/issues/177)
 * For more details on setting up FUSE (so that you can mount the filesystem), see the docs folder
-* Shell command completion is available by running `source misc/completion/ipfs-completion.bash`.
+* Shell command completion is available in `misc/completion/ipfs-completion.bash`. Read [docs/command-completion.md](docs/command-completion.md) to learn how to install it.
 
 
 ## Usage

--- a/docs/command-completion.md
+++ b/docs/command-completion.md
@@ -2,7 +2,7 @@ Command Completion
 ==================
 
 Shell command completion is provided by the script at 
-`/misc/completion/ipfs-completion.bash`.
+[/misc/completion/ipfs-completion.bash](../misc/completion/ipfs-completion.bash).
 
 
 Installation

--- a/docs/command-completion.md
+++ b/docs/command-completion.md
@@ -13,8 +13,12 @@ Linux
 -----
 ### Bash
 
-For bash, completion can be enabled in a couple of ways. One is to add the line
-`source $GOPATH/src/github.com/ipfs/go-ipfs/misc/completion/ipfs-completion.bash` 
+For bash, completion can be enabled in a couple of ways. One is to add
+```bash
+if [ -n "$GOPATH" ]; then
+  source $GOPATH/src/github.com/ipfs/go-ipfs/misc/completion/ipfs-completion.bash
+fi
+```
 into your `~/.bash_completion`. It will automatically be loaded the next time 
 bash is loaded.
 To enable ipfs command completion globally on your system you may also 

--- a/docs/command-completion.md
+++ b/docs/command-completion.md
@@ -4,15 +4,15 @@ Command Completion
 Shell command completion is provided by the script at 
 `/misc/completion/ipfs-completion.bash`.
 
+
+Installation
+------------
 The simplest way to see it working is to run 
 `source misc/completion/ipfs-completion.bash` straight from your shell. This
 is only temporary and to fully enable it, you'll have to follow one of the steps
 below.
 
-Linux
------
-### Bash
-
+### Bash on Linux
 For bash, completion can be enabled in a couple of ways. One is to add
 ```bash
 if [ -n "$GOPATH" ]; then
@@ -23,3 +23,8 @@ into your `~/.bash_completion`. It will automatically be loaded the next time
 bash is loaded.
 To enable ipfs command completion globally on your system you may also 
 copy the completion script to `/etc/bash_completion.d/`.
+
+
+Additional References
+---------------------
+* https://www.debian-administration.org/article/316/An_introduction_to_bash_completion_part_1

--- a/docs/command-completion.md
+++ b/docs/command-completion.md
@@ -13,14 +13,13 @@ is only temporary and to fully enable it, you'll have to follow one of the steps
 below.
 
 ### Bash on Linux
-For bash, completion can be enabled in a couple of ways. One is to add
+For bash, completion can be enabled in a couple of ways. One is to copy the 
+completion script to the directory `~/.ipfs/` and then in the file 
+`~/.bash_completion` add
 ```bash
-if [ -n "$GOPATH" ]; then
-  source $GOPATH/src/github.com/ipfs/go-ipfs/misc/completion/ipfs-completion.bash
-fi
+source ~/.ipfs/ipfs-completion.bash
 ```
-into your `~/.bash_completion`. It will automatically be loaded the next time 
-bash is loaded.
+It will automatically be loaded the next time bash is loaded.
 To enable ipfs command completion globally on your system you may also 
 copy the completion script to `/etc/bash_completion.d/`.
 

--- a/docs/command-completion.md
+++ b/docs/command-completion.md
@@ -1,0 +1,21 @@
+Command Completion
+==================
+
+Shell command completion is provided by the script at 
+`/misc/completion/ipfs-completion.bash`.
+
+The simplest way to see it working is to run 
+`source misc/completion/ipfs-completion.bash` straight from your shell. This
+is only temporary and to fully enable it, you'll have to follow one of the steps
+below.
+
+Linux
+-----
+### Bash
+
+For bash, completion can be enabled in a couple of ways. One is to add the line
+`source $GOPATH/src/github.com/ipfs/go-ipfs/misc/completion/ipfs-completion.bash` 
+into your `~/.bash_completion`. It will automatically be loaded the next time 
+bash is loaded.
+To enable ipfs command completion globally on your system you may also 
+copy the completion script to `/etc/bash_completion.d/`.


### PR DESCRIPTION
I have instructions for installing command completion in Linux bash. If anyone would like to add instructions for other shells and OSX. That would be great.