### PR TITLE
Add timeout to ipns resolution at startup

### DIFF
--- a/ipnsfs/system.go
+++ b/ipnsfs/system.go
@@ -159,8 +159,10 @@ func (fs *Filesystem) newKeyRoot(parent context.Context, k ci.PrivKey) (*KeyRoot
 		}
 	}
 
-	mnode, err := fs.dserv.Get(ctx, pointsTo)
+	tctx, _ := context.WithTimeout(parent, time.Second*5)
+	mnode, err := fs.dserv.Get(tctx, pointsTo)
 	if err != nil {
+		log.Errorf("Failed to retreive value '%s' for ipns entry: %s\n", pointsTo, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
If you have an invalid ipns entry, or simply one that points to a non-existant block, the daemon will fail to initialize completely. This adds a timeout to that process (but still errors out if the object is not found)