### PR TITLE
core/commands: pin ls: display types by default

### DIFF
--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -49,7 +49,7 @@ test_expect_success "file no longer pinned" '
 	echo "$HASH_WELCOME_DOCS" >expected2 &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>expected2 &&
 	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >> expected2 &&
-	ipfs pin ls --type=recursive >actual2 &&
+	ipfs pin ls --type=recursive --quiet >actual2 &&
 	test_sort_cmp expected2 actual2
 '
 
@@ -105,6 +105,7 @@ test_expect_success "adding multiblock random file succeeds" '
 test_expect_success "'ipfs pin ls --type=indirect' is correct" '
 	ipfs refs "$MBLOCKHASH" >refsout &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>refsout &&
+	sed -i="" "s/\(.*\)/\1 indirect/g" refsout &&
 	ipfs pin ls --type=indirect >indirectpins &&
 	test_sort_cmp refsout indirectpins
 '
@@ -122,7 +123,7 @@ test_expect_success "pin something directly" '
 '
 
 test_expect_success "'ipfs pin ls --type=direct' is correct" '
-	echo "$DIRECTPIN" >directpinexpected &&
+	echo "$DIRECTPIN direct" >directpinexpected &&
 	ipfs pin ls --type=direct >directpinout &&
 	test_sort_cmp directpinexpected directpinout
 '
@@ -132,17 +133,18 @@ test_expect_success "'ipfs pin ls --type=recursive' is correct" '
 	echo "$HASH_WELCOME_DOCS" >>rp_expected &&
 	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >>rp_expected &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>rp_expected &&
+	sed -i="" "s/\(.*\)/\1 recursive/g" rp_expected &&
 	ipfs pin ls --type=recursive >rp_actual &&
 	test_sort_cmp rp_expected rp_actual
 '
 
-test_expect_success "'ipfs pin ls --type=all' is correct" '
+test_expect_success "'ipfs pin ls --type=all --quiet' is correct" '
 	cat directpinout >allpins &&
 	cat rp_actual >>allpins &&
 	cat indirectpins >>allpins &&
-	cat allpins | sort | uniq >> allpins_uniq &&
-	ipfs pin ls --type=all >actual_allpins &&
-	test_sort_cmp allpins_uniq actual_allpins
+	cut -f1 -d " " allpins | sort | uniq >> allpins_uniq_hashes &&
+	ipfs pin ls --type=all --quiet >actual_allpins &&
+	test_sort_cmp allpins_uniq_hashes actual_allpins
 '
 
 test_kill_ipfs_daemon


### PR DESCRIPTION
Please bear with me as these are my first lines of Go code :smile:

This fixes issue https://github.com/ipfs/go-ipfs/issues/1134

I tried following the convention on other files (for example, I named the struct `RefKeyObject` following the pattern on [`LsObject`](https://github.com/ipfs/go-ipfs/blob/master/core/commands/ls.go#L26-L29)), but let me know if I got something wrong.

It follows the usage pattern @jbenet described in the issue:

```bash
vitor@clarisse:~/go/src/github.com/ipfs/go-ipfs$ cmd/ipfs/ipfs pin ls 
QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o direct

vitor@clarisse:~/go/src/github.com/ipfs/go-ipfs$ cmd/ipfs/ipfs pin ls --type=indirect --count                          
QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ indirect 1
QmUFtMrBHqdjTtbebsL6YGebvjShh3Jud1insUv12fEVdA indirect 1
QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 indirect 1
QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y indirect 1
QmeEqpsKrvdhuuuVsguHaVdJcPnnUHHZ5qEWjCHavYbNqU indirect 1
QmfE3nUohq2nEYwieF7YFnJF1VfiL4i3wDxkMq8aGUg8Mt indirect 1

vitor@clarisse:~/go/src/github.com/ipfs/go-ipfs$ cmd/ipfs/ipfs pin ls --type=all
QmY5heUM5qgRubMDD1og9fhCPA6QdkMp3QCwd4s7gJsyE7 recursive
Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj recursive
QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn recursive
QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o direct
QmeEqpsKrvdhuuuVsguHaVdJcPnnUHHZ5qEWjCHavYbNqU recursive
QmUFtMrBHqdjTtbebsL6YGebvjShh3Jud1insUv12fEVdA recursive
QmfE3nUohq2nEYwieF7YFnJF1VfiL4i3wDxkMq8aGUg8Mt recursive
QmTumTjvcYCAvRRwQ8sDRxh8ezmrcr88YFU7iYNroGGTBZ recursive
QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y recursive
```

I couldn't find a `--quiet` option on `pin ls`, though, so there might be something missing.

The `golint` complains about a few things in this file:
```bash
vitor@clarisse:~/go/src/github.com/ipfs/go-ipfs$ golint core/commands/pin.go 
core/commands/pin.go:13:5: exported var PinCmd should have comment or be unexported
core/commands/pin.go:25:6: exported type PinOutput should have comment or be unexported
core/commands/pin.go:260:6: exported type RefKeyObject should have comment or be unexported
core/commands/pin.go:265:6: exported type RefKeyList should have comment or be unexported
```

But as it's already complaining about other similar things, I'm assuming this is a known issue and you've chosen to ignore it.

If there's any problem with the code, please tell me and I'll be happy to fix it.

Congratulations on IPFS! It's an amazing project.