### PR TITLE
Improve command line parsing

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -93,6 +93,12 @@ func main() {
 		fmt.Fprintf(w, "Use 'ipfs %s --help' for information about this command\n", cmdPath)
 	}
 
+	// Handle `ipfs help'
+	if len(os.Args) == 2 && os.Args[1] == "help" {
+		printHelp(false, os.Stdout)
+		os.Exit(0)
+	}
+
 	// parse the commandline into a command invocation
 	parseErr := invoc.Parse(ctx, os.Args[1:])
 
@@ -110,13 +116,6 @@ func main() {
 		}
 	}
 
-	// here we handle the cases where
-	// - commands with no Run func are invoked directly.
-	// - the main command is invoked.
-	if invoc.cmd == nil || invoc.cmd.Run == nil {
-		printHelp(false, os.Stdout)
-		os.Exit(0)
-	}
 
 	// ok now handle parse error (which means cli input was wrong,
 	// e.g. incorrect number of args, or nonexistent subcommand)
@@ -130,6 +129,14 @@ func main() {
 			printMetaHelp(os.Stderr)
 		}
 		os.Exit(1)
+	}
+
+	// here we handle the cases where
+	// - commands with no Run func are invoked directly.
+	// - the main command is invoked.
+	if invoc.cmd == nil || invoc.cmd.Run == nil {
+		printHelp(false, os.Stdout)
+		os.Exit(0)
 	}
 
 	// ok, finally, run the command invocation.

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -14,7 +14,8 @@ const (
 	requiredArg = "<%v>"
 	optionalArg = "[<%v>]"
 	variadicArg = "%v..."
-	optionFlag  = "-%v"
+	shortFlag  = "-%v"
+	longFlag  = "--%v"
 	optionType  = "(%v)"
 
 	whitespace = "\r\n\t "
@@ -219,6 +220,14 @@ func argumentText(cmd *cmds.Command) []string {
 	return lines
 }
 
+func optionFlag(flag string) string {
+	if len(flag) == 1 {
+		return fmt.Sprintf(shortFlag, flag)
+	} else {
+		return fmt.Sprintf(longFlag, flag)
+	}
+}
+
 func optionText(cmd ...*cmds.Command) []string {
 	// get a slice of the options we want to list out
 	options := make([]cmds.Option, 0)
@@ -241,7 +250,7 @@ func optionText(cmd ...*cmds.Command) []string {
 
 			names := sortByLength(opt.Names())
 			if len(names) >= j+1 {
-				lines[i] += fmt.Sprintf(optionFlag, names[j])
+				lines[i] += optionFlag(names[j])
 			}
 			if len(names) > j+1 {
 				lines[i] += ", "

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -40,7 +40,7 @@ Please run the ipfs migration tool before continuing.
 ` + migrationInstructions
 
 var (
-	ErrNoRepo    = errors.New("no ipfs repo found. please run: ipfs init")
+	ErrNoRepo    = func (path string) error { return fmt.Errorf("no ipfs repo found in '%s'. please run: ipfs init ", path) }
 	ErrNoVersion = errors.New("no version file found, please run 0-to-1 migration tool.\n" + migrationInstructions)
 	ErrOldRepo   = errors.New("ipfs repo found in old '~/.go-ipfs' location, please run migration tool.\n" + migrationInstructions)
 )
@@ -172,7 +172,7 @@ func checkInitialized(path string) error {
 		if isInitializedUnsynced(alt) {
 			return ErrOldRepo
 		}
-		return ErrNoRepo
+		return ErrNoRepo(path)
 	}
 	return nil
 }

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -105,7 +105,7 @@ test_wait_open_tcp_port_10_sec() {
 # was setting really weird things and am not sure why.
 test_config_set() {
 
-	# grab flags (like -bool in "ipfs config -bool")
+	# grab flags (like --bool in "ipfs config --bool")
 	test_cfg_flags="" # unset in case.
 	test "$#" = 3 && { test_cfg_flags=$1; shift; }
 
@@ -184,7 +184,7 @@ test_config_ipfs_gateway_writable() {
 	test_config_ipfs_gateway_readonly $1
 
 	test_expect_success "prepare config -- gateway writable" '
-		test_config_set -bool Gateway.Writable true ||
+		test_config_set --bool Gateway.Writable true ||
 		test_fsh cat "\"$IPFS_PATH/config\""
 	'
 }

--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -7,7 +7,7 @@ test_description="Test config command"
 # we use a function so that we can run it both offline + online
 test_config_cmd_set() {
 
-  # flags (like -bool in "ipfs config -bool")
+  # flags (like --bool in "ipfs config --bool")
   cfg_flags="" # unset in case.
   test "$#" = 3 && { cfg_flags=$1; shift; }
 
@@ -41,8 +41,8 @@ test_config_cmd() {
   test_config_cmd_set "beep" "boop"
   test_config_cmd_set "beep1" "boop2"
   test_config_cmd_set "beep1" "boop2"
-  test_config_cmd_set "-bool" "beep2" "true"
-  test_config_cmd_set "-bool" "beep2" "false"
+  test_config_cmd_set "--bool" "beep2" "true"
+  test_config_cmd_set "--bool" "beep2" "false"
 
 }
 

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -17,7 +17,7 @@ test_expect_success "'ipfs add afile' succeeds" '
 '
 
 test_expect_success "added file was pinned" '
-	ipfs pin ls -type=recursive >actual &&
+	ipfs pin ls --type=recursive >actual &&
 	grep "$HASH" actual
 '
 
@@ -49,7 +49,7 @@ test_expect_success "file no longer pinned" '
 	echo "$HASH_WELCOME_DOCS" >expected2 &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>expected2 &&
 	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >> expected2 &&
-	ipfs pin ls -type=recursive >actual2 &&
+	ipfs pin ls --type=recursive >actual2 &&
 	test_sort_cmp expected2 actual2
 '
 
@@ -102,10 +102,10 @@ test_expect_success "adding multiblock random file succeeds" '
 	MBLOCKHASH=`ipfs add -q multiblock`
 '
 
-test_expect_success "'ipfs pin ls -type=indirect' is correct" '
+test_expect_success "'ipfs pin ls --type=indirect' is correct" '
 	ipfs refs "$MBLOCKHASH" >refsout &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>refsout &&
-	ipfs pin ls -type=indirect >indirectpins &&
+	ipfs pin ls --type=indirect >indirectpins &&
 	test_sort_cmp refsout indirectpins
 '
 
@@ -121,27 +121,27 @@ test_expect_success "pin something directly" '
 	test_cmp expected10 actual10
 '
 
-test_expect_success "'ipfs pin ls -type=direct' is correct" '
+test_expect_success "'ipfs pin ls --type=direct' is correct" '
 	echo "$DIRECTPIN" >directpinexpected &&
-	ipfs pin ls -type=direct >directpinout &&
+	ipfs pin ls --type=direct >directpinout &&
 	test_sort_cmp directpinexpected directpinout
 '
 
-test_expect_success "'ipfs pin ls -type=recursive' is correct" '
+test_expect_success "'ipfs pin ls --type=recursive' is correct" '
 	echo "$MBLOCKHASH" >rp_expected &&
 	echo "$HASH_WELCOME_DOCS" >>rp_expected &&
 	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >>rp_expected &&
 	ipfs refs -r "$HASH_WELCOME_DOCS" >>rp_expected &&
-	ipfs pin ls -type=recursive >rp_actual &&
+	ipfs pin ls --type=recursive >rp_actual &&
 	test_sort_cmp rp_expected rp_actual
 '
 
-test_expect_success "'ipfs pin ls -type=all' is correct" '
+test_expect_success "'ipfs pin ls --type=all' is correct" '
 	cat directpinout >allpins &&
 	cat rp_actual >>allpins &&
 	cat indirectpins >>allpins &&
 	cat allpins | sort | uniq >> allpins_uniq &&
-	ipfs pin ls -type=all >actual_allpins &&
+	ipfs pin ls --type=all >actual_allpins &&
 	test_sort_cmp allpins_uniq actual_allpins
 '
 

--- a/test/sharness/t0081-repo-pinning.sh
+++ b/test/sharness/t0081-repo-pinning.sh
@@ -143,7 +143,7 @@ test_expect_success "added dir was NOT pinned indirectly" '
 '
 
 test_expect_success "nothing is pinned directly" '
-	ipfs pin ls -type=direct >actual4 &&
+	ipfs pin ls --type=direct >actual4 &&
 	test_must_be_empty actual4
 '
 

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -13,7 +13,7 @@ test_init_ipfs
 # test publishing a hash
 
 test_expect_success "'ipfs name publish' succeeds" '
-	PEERID=`ipfs id -format="<id>"` &&
+	PEERID=`ipfs id --format="<id>"` &&
 	ipfs name publish "$HASH_WELCOME_DOCS" >publish_out
 '
 
@@ -34,7 +34,7 @@ test_expect_success "resolve output looks good" '
 # now test with a path
 
 test_expect_success "'ipfs name publish' succeeds" '
-	PEERID=`ipfs id -format="<id>"` &&
+	PEERID=`ipfs id --format="<id>"` &&
 	ipfs name publish "/ipfs/$HASH_WELCOME_DOCS/help" >publish_out
 '
 


### PR DESCRIPTION
Fixes #1078 

I used the syntax I would usually expect from a unix command. This is a breaking change, but some of this breakage could be avoided with more code.

- short flags no longer use `=`. `-a=1` is now `-a 1` or `-a1`
- sub-command specific flags cannot apear before the sub-command, such as `--bar foo` instead of `foo --bar`
- `ipfs help` no longer works, it was only a by-product of errors being ignored. `ipfs` or `ipfs -h` can be used instead.

Here are some trimmed examples:

```
$ ipfs pin ls --help
    -t, --type  string - The type of pinned keys to list. Can be "direct", "indirect", "recursive", or "all". Defaults to "direct"
    -n, --count bool   - Show refcount when listing indirect pins
$ ipfs pin ls -t
Error: Missing argument for option 't'
$ ipfs pin ls -t foo
Error: Invalid type 'foo', must be one of {direct, indirect, recursive, all}
$ ipfs pin ls -t direct
$ ipfs pin ls -tdirect
$ ipfs pin ls -t=direct
Error: Invalid type '=direct', must be one of {direct, indirect, recursive, all}
$ ipfs pin ls -n
$ ipfs pin ls -nt direct
$ ipfs pin ls -tn
Error: Invalid type 'n', must be one of {direct, indirect, recursive, all}
$ ipfs pin ls --count foo
Error: Expected 0 arguments, got 1: [foo]
$ ipfs pin ls --count=foo
Error: Option 'count' takes no arguments, but was passed 'foo'
$ ipfs pin ls --type
Error: Missing argument for option 'type'
$ ipfs pin ls --type=direct
$ ipfs pin ls --type direct
$ ipfs --count pin ls
Error: Unrecognized option 'count'
$ ipfs --local pin ls
```