### PR TITLE
core/commands/add: Command-line <path> argument are optional

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -49,7 +49,7 @@ remains to be implemented.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.FileArg("path", true, true, "The path to a file to be added to IPFS").EnableRecursive().EnableStdin(),
+		cmds.FileArg("path", false, true, "The path to a file to be added to IPFS.  If not set, reads the file content from standard input.").EnableRecursive().EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.OptionRecursivePath, // a builtin option that allows recursive paths (-r, --recursive)


### PR DESCRIPTION
Adding a file from stdin works now, so pass that information along to
the user.