### PR TITLE
add a benchmark for our hash function

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -53,3 +53,33 @@ func TestXOR(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkHash256K(b *testing.B) {
+	buf := make([]byte, 256*1024)
+	NewTimeSeededRand().Read(buf)
+	b.SetBytes(int64(256 * 1024))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Hash(buf)
+	}
+}
+
+func BenchmarkHash512K(b *testing.B) {
+	buf := make([]byte, 512*1024)
+	NewTimeSeededRand().Read(buf)
+	b.SetBytes(int64(512 * 1024))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Hash(buf)
+	}
+}
+
+func BenchmarkHash1M(b *testing.B) {
+	buf := make([]byte, 1024*1024)
+	NewTimeSeededRand().Read(buf)
+	b.SetBytes(int64(1024 * 1024))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Hash(buf)
+	}
+}


### PR DESCRIPTION
im on a perf kick, again. a common bit of code between all 'critical' paths is out hash function. This just makes sure its not bottlenecking us.