### PR TITLE
Fix/dial error hiding

### DIFF
--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/impl_unix.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/impl_unix.go
@@ -115,7 +115,9 @@ func dial(dialer net.Dialer, netw, addr string) (c net.Conn, err error) {
 	// here we just try again 3 times.
 	for i := 0; i < 3; i++ {
 		if !deadline.IsZero() && deadline.Before(time.Now()) {
-			err = errTimeout
+			if err == nil {
+				err = errTimeout
+			}
 			break
 		}
 
@@ -355,6 +357,6 @@ var errTimeout = &timeoutError{}
 
 type timeoutError struct{}
 
-func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Error() string   { return "i/o timeout (reuseport)" }
 func (e *timeoutError) Timeout() bool   { return true }
 func (e *timeoutError) Temporary() bool { return true }

--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/poll/error.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/poll/error.go
@@ -4,6 +4,6 @@ var errTimeout = &timeoutError{}
 
 type timeoutError struct{}
 
-func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Error() string   { return "i/o timeout (reuseport poll)" }
 func (e *timeoutError) Timeout() bool   { return true }
 func (e *timeoutError) Temporary() bool { return true }

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -417,7 +417,7 @@ func (s *Swarm) dialAddrs(ctx context.Context, d *conn.Dialer, p peer.ID, remote
 	for i := 0; i < len(remoteAddrs); i++ {
 		select {
 		case exitErr = <-errs: //
-			log.Warning("dial error: ", exitErr)
+			log.Debug("dial error: ", exitErr)
 		case connC := <-conns:
 			// take the first + return asap
 			close(foundConn)

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -237,7 +237,8 @@ func (s *Swarm) gatedDialAttempt(ctx context.Context, p peer.ID) (*Conn, error) 
 			log.Event(ctx, "swarmDialBackoffAdd", logdial)
 			s.backf.AddBackoff(p) // let others know to backoff
 
-			return nil, ErrDialFailed // ok, we failed. try again. (if loop is done, our error is output)
+			// ok, we failed. try again. (if loop is done, our error is output)
+			return nil, fmt.Errorf("dial attempt failed: %s", err)
 		}
 		log.Event(ctx, "swarmDialBackoffClear", logdial)
 		s.backf.Clear(p) // okay, no longer need to backoff
@@ -416,7 +417,7 @@ func (s *Swarm) dialAddrs(ctx context.Context, d *conn.Dialer, p peer.ID, remote
 	for i := 0; i < len(remoteAddrs); i++ {
 		select {
 		case exitErr = <-errs: //
-			log.Debug(exitErr)
+			log.Warning("dial error: ", exitErr)
 		case connC := <-conns:
 			// take the first + return asap
 			close(foundConn)


### PR DESCRIPTION
it is fairly difficult to figure out what is happening when a dial fails. This goes a little ways towards making our dialing errors clearer.