### PR TITLE
advertise multiple addresses over mdns

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -44,6 +44,9 @@ type mdnsService struct {
 
 func getDialableListenAddr(ph host.Host) (*net.TCPAddr, error) {
 	for _, addr := range ph.Addrs() {
+		if manet.IsIPLoopback(addr) {
+			continue
+		}
 		na, err := manet.ToNetAddr(addr)
 		if err != nil {
 			continue


### PR DESCRIPTION
nodes were failing to connect to eachother on my LAN because they advertised their loopback address instead of their lan local address. just skip loopback addresses because any node on the same machine can connect via any of the interface addresses just the same.