### PR TITLE
hotfix: dont use nodes context because it might not be set yet

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -292,7 +292,7 @@ func setupDiscoveryOption(d config.Discovery) DiscoveryOption {
 
 func (n *IpfsNode) HandlePeerFound(p peer.PeerInfo) {
 	log.Warning("trying peer info: ", p)
-	ctx, _ := context.WithTimeout(n.Context(), time.Second*10)
+	ctx, _ := context.WithTimeout(context.TODO(), time.Second*10)
 	err := n.PeerHost.Connect(ctx, p)
 	if err != nil {
 		log.Warning("Failed to connect to peer found by discovery: ", err)


### PR DESCRIPTION
The issue was that mdns discovery was returning peers before node initialization was completed. 

Node construction right now is kinda sketch, and needs a refactor. But in the meantime, this fixes #1171 and lets people continue using ipfs.