### PR TITLE
dont create a new ticker each loop

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -182,10 +182,11 @@ func (bs *Bitswap) rebroadcastWorker(parent context.Context) {
 	defer cancel()
 
 	broadcastSignal := time.After(rebroadcastDelay.Get())
+	tick := time.Tick(10 * time.Second)
 
 	for {
 		select {
-		case <-time.Tick(10 * time.Second):
+		case <-tick:
 			n := bs.wantlist.Len()
 			if n > 0 {
 				log.Debug(n, inflect.FromNumber("keys", n), "in bitswap wantlist")


### PR DESCRIPTION
Well, it seems that my perf kick is turning up more bugs than perf improvements... *sigh*

But this one is a pretty ugly and subtle one which i believe is the cause of #1036 

A ticker starts a timer that continuously sends on the given channel, every loop, a new one was being created.

I wrote the following program and let it run for a few minutes, watching the number of context switches start out around an idle 600/s, slowly rise to over 10k/s before i killed the program, and the number of context switches resumed to the normal 600/s.

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	a := make(chan int)
	for {
		select {
		case <-time.Tick(time.Second / 10):
			fmt.Println("LOOP")
		case <-a:
		}
	}
}
```

I searched the codebase for any other similar mistakes and found none. 