### PR TITLE
increase iptb test stability

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -256,7 +256,7 @@
 		},
 		{
 			"ImportPath": "github.com/whyrusleeping/iptb",
-			"Rev": "4fa36405d0baea7773676f83fba9695e9a560473"
+			"Rev": "3970c95a864f1a40037f796ff596607ce8ae43be"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/blowfish",

--- a/test/sharness/t0101-iptb-name.sh
+++ b/test/sharness/t0101-iptb-name.sh
@@ -11,7 +11,7 @@ test_description="Test ipfs repo operations"
 export IPTB_ROOT="`pwd`/.iptb"
 
 test_expect_success "set up an iptb cluster" '
-	iptb -n=4 init &&
+	iptb -n=4 -p=9000 init &&
 	iptb -wait start
 '
 

--- a/test/sharness/t0130-multinode.sh
+++ b/test/sharness/t0130-multinode.sh
@@ -11,7 +11,7 @@ test_description="Test multiple ipfs nodes"
 export IPTB_ROOT="`pwd`/.iptb"
 
 test_expect_success "set up a few nodes" '
-	iptb -n=3 init &&
+	iptb -n=3 -p=9200 init &&
 	iptb -wait start
 '
 


### PR DESCRIPTION
This moves each iptb test to its own port range and also ensures that daemons are fully bootstrapped if the `-wait` option is specified to prevent the 'no peers in routing table' errors we were seeing.