### PR TITLE
mild refactor of bitswap

### DIFF
--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -19,12 +19,6 @@ type BitSwapNetwork interface {
 		peer.ID,
 		bsmsg.BitSwapMessage) error
 
-	// SendRequest sends a BitSwap message to a peer and waits for a response.
-	SendRequest(
-		context.Context,
-		peer.ID,
-		bsmsg.BitSwapMessage) (incoming bsmsg.BitSwapMessage, err error)
-
 	// SetDelegate registers the Reciver to handle messages received from the
 	// network.
 	SetDelegate(Receiver)
@@ -35,8 +29,9 @@ type BitSwapNetwork interface {
 // Implement Receiver to receive messages from the BitSwapNetwork
 type Receiver interface {
 	ReceiveMessage(
-		ctx context.Context, sender peer.ID, incoming bsmsg.BitSwapMessage) (
-		destination peer.ID, outgoing bsmsg.BitSwapMessage)
+		ctx context.Context,
+		sender peer.ID,
+		incoming bsmsg.BitSwapMessage) error
 
 	ReceiveError(error)
 


### PR DESCRIPTION
This is a mild cleanup of bitswap to remove some unused code and return errors from a few more functions because i hate not returning errors when i am able to. Functionally, nothing is changed.

I also removed a test from `exchange/bitswap/testnet` that was testing unused code.