### PR TITLE
correct the blocksize calculation for link blocks

### DIFF
--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -18,7 +18,7 @@ var BlockSizeLimit = 1048576 // 1 MB
 // rough estimates on expected sizes
 var roughDataBlockSize = chunk.DefaultBlockSize
 var roughLinkBlockSize = 1 << 13 // 8KB
-var roughLinkSize = 258 + 8 + 5  // sha256 multihash + size + no name + protobuf framing
+var roughLinkSize = 34 + 8 + 5   // sha256 multihash + size + no name + protobuf framing
 
 // DefaultLinksPerBlock governs how the importer decides how many links there
 // will be per block. This calculation is based on expected distributions of:

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -138,7 +138,7 @@ test_expect_success EXPENSIVE "ipfs add bigfile succeeds" '
 '
 
 test_expect_success EXPENSIVE "ipfs add bigfile output looks good" '
-	HASH="QmSVxWkYfbJ3cowQUUgF4iF4CQd92vubxw7bs2aZAVRUD9" &&
+	HASH="QmU9SWAPPmNEKZB8umYMmjYvN7VyHqABNvdA6GUi4MMEz3" &&
 	echo "added $HASH mountdir/bigfile" >expected &&
 	test_cmp expected actual
 '


### PR DESCRIPTION
This has been wrong for a while, and ive known about it for a while, but i finally decided to fix it.