### PR TITLE
Rework mutable namespace resolution to handle recursion

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -56,7 +56,7 @@ The resolver will give:
 
 		recursive, _, _ := req.Option("recursive").Bool()
 		name := req.Arguments()[0]
-		var resolver namesys.DNSResolver
+		resolver := namesys.NewDNSResolver()
 
 		depth := 1
 		if recursive {

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"io"
+	"strings"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	namesys "github.com/ipfs/go-ipfs/namesys"
+	util "github.com/ipfs/go-ipfs/util"
+)
+
+var DNSCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "DNS link resolver",
+		ShortDescription: `
+Multihashes are hard to remember, but domain names are usually easy to
+remember.  To create memorable aliases for multihashes, DNS TXT
+records can point to other DNS links, IPFS objects, IPNS keys, etc.
+This command resolves those links to the referenced object.
+`,
+		LongDescription: `
+Multihashes are hard to remember, but domain names are usually easy to
+remember.  To create memorable aliases for multihashes, DNS TXT
+records can point to other DNS links, IPFS objects, IPNS keys, etc.
+This command resolves those links to the referenced object.
+
+For example, with this DNS TXT record:
+
+  ipfs.io. TXT "dnslink=/ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy ..."
+
+The resolver will give:
+
+  > ipfs dns ipfs.io
+  /ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy
+
+And with this DNS TXT record:
+
+  ipfs.ipfs.io. TXT "dnslink=/dns/ipfs.io ..."
+
+The resolver will give:
+
+  > ipfs dns ipfs.io
+  /dns/ipfs.io
+  > ipfs dns --recursive
+  /ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy
+`,
+	},
+
+	Arguments: []cmds.Argument{
+		cmds.StringArg("domain-name", true, false, "The domain-name name to resolve.").EnableStdin(),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("recursive", "r", "Resolve until the result is not a DNS link"),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+
+		recursive, _, _ := req.Option("recursive").Bool()
+		name := req.Arguments()[0]
+		var resolver namesys.DNSResolver
+
+		depth := 1
+		if recursive {
+			depth = namesys.DefaultDepthLimit
+		}
+		output, err := resolver.ResolveN(req.Context().Context, name, depth)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		res.SetOutput(&ResolvedPath{output})
+	},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			output, ok := res.Output().(*ResolvedPath)
+			if !ok {
+				return nil, util.ErrCast()
+			}
+			return strings.NewReader(output.Path.String()), nil
+		},
+	},
+	Type: ResolvedPath{},
+}

--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	namesys "github.com/ipfs/go-ipfs/namesys"
+	u "github.com/ipfs/go-ipfs/util"
+)
+
+var ipnsCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Gets the value currently published at an IPNS name",
+		ShortDescription: `
+IPNS is a PKI namespace, where names are the hashes of public keys, and
+the private key enables publishing new (signed) values. In resolve, the
+default value of <name> is your own identity public key.
+`,
+		LongDescription: `
+IPNS is a PKI namespace, where names are the hashes of public keys, and
+the private key enables publishing new (signed) values. In resolve, the
+default value of <name> is your own identity public key.
+
+
+Examples:
+
+Resolve the value of your identity:
+
+  > ipfs name resolve
+  QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+
+Resolve the value of another name:
+
+  > ipfs name resolve QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n
+  QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+
+`,
+	},
+
+	Arguments: []cmds.Argument{
+		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID.").EnableStdin(),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("recursive", "r", "Resolve until the result is not an IPNS name"),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+
+		n, err := req.Context().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		if !n.OnlineMode() {
+			err := n.SetupOfflineRouting()
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+		}
+
+		var name string
+
+		if len(req.Arguments()) == 0 {
+			if n.Identity == "" {
+				res.SetError(errors.New("Identity not loaded!"), cmds.ErrNormal)
+				return
+			}
+			name = n.Identity.Pretty()
+
+		} else {
+			name = req.Arguments()[0]
+		}
+
+		recursive, _, _ := req.Option("recursive").Bool()
+		depth := 1
+		if recursive {
+			depth = namesys.DefaultDepthLimit
+		}
+
+		resolver := namesys.NewRoutingResolver(n.Routing)
+		output, err := resolver.ResolveN(n.Context(), name, depth)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// TODO: better errors (in the case of not finding the name, we get "failed to find any peer in table")
+
+		res.SetOutput(&ResolvedPath{output})
+	},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			output, ok := res.Output().(*ResolvedPath)
+			if !ok {
+				return nil, u.ErrCast()
+			}
+			return strings.NewReader(output.Path.String()), nil
+		},
+	},
+	Type: ResolvedPath{},
+}

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -40,18 +40,18 @@ Publish a <ref> to another public key:
 Resolve the value of your identity:
 
   > ipfs name resolve
-  QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  /ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Resolve the value of another name:
 
   > ipfs name resolve QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n
-  QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  /ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 `,
 	},
 
 	Subcommands: map[string]*cmds.Command{
 		"publish": publishCmd,
-		"resolve": resolveCmd,
+		"resolve": ipnsCmd,
 	},
 }

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -27,15 +27,15 @@ and resolve, the default value of <name> is your own identity public key.
 
 Examples:
 
-Publish a <ref> to your identity name:
+Publish an <ipfs-path> to your identity name:
 
-  > ipfs name publish QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  published name QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n to QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  > ipfs name publish /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
-Publish a <ref> to another public key:
+Publish an <ipfs-path> to another public key:
 
-  > ipfs name publish QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  published name QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n to QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  > ipfs name publish /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n
+  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Resolve the value of your identity:
 

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -35,12 +35,13 @@ Examples:
 Publish an <ipfs-path> to your identity name:
 
   > ipfs name publish /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  published name QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n to QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Publish an <ipfs-path> to another public key (not implemented):
 
-  > ipfs name publish QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  published name QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n to QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  > ipfs name publish /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n
+  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+
 `,
 	},
 
@@ -102,7 +103,7 @@ Publish an <ipfs-path> to another public key (not implemented):
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*IpnsEntry)
-			s := fmt.Sprintf("Published name %s to %s\n", v.Name, v.Value)
+			s := fmt.Sprintf("Published to %s: %s\n", v.Name, v.Value)
 			return strings.NewReader(s), nil
 		},
 	},

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -46,6 +47,9 @@ Resolve te value of another name:
 	Arguments: []cmds.Argument{
 		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID.").EnableStdin(),
 	},
+	Options: []cmds.Option{
+		cmds.BoolOption("recursive", "r", "Resolve until the result is not an IPNS name"),
+	},
 	Run: func(req cmds.Request, res cmds.Response) {
 
 		n, err := req.Context().GetNode()
@@ -75,7 +79,13 @@ Resolve te value of another name:
 			name = req.Arguments()[0]
 		}
 
-		output, err := n.Namesys.Resolve(n.Context(), "/ipns/"+name)
+		recursive, _, _ := req.Option("recursive").Bool()
+		depth := 1
+		if recursive {
+			depth = namesys.DefaultDepthLimit
+		}
+
+		output, err := n.Namesys.ResolveN(n.Context(), "/ipns/"+name, depth)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -75,7 +75,7 @@ Resolve te value of another name:
 			name = req.Arguments()[0]
 		}
 
-		output, err := n.Namesys.Resolve(n.Context(), name)
+		output, err := n.Namesys.Resolve(n.Context(), "/ipns/"+name)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -40,6 +40,7 @@ ADVANCED COMMANDS
 
     daemon        Start a long-running daemon process
     mount         Mount an ipfs read-only mountpoint
+    resolve       Resolve any type of name
     name          Publish or resolve IPNS names
     dns           Resolve DNS links
     pin           Pin objects to local storage
@@ -97,6 +98,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"ping":      PingCmd,
 	"refs":      RefsCmd,
 	"repo":      RepoCmd,
+	"resolve":   ResolveCmd,
 	"stats":     StatsCmd,
 	"swarm":     SwarmCmd,
 	"update":    UpdateCmd,

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -41,6 +41,7 @@ ADVANCED COMMANDS
     daemon        Start a long-running daemon process
     mount         Mount an ipfs read-only mountpoint
     name          Publish or resolve IPNS names
+    dns           Resolve DNS links
     pin           Pin objects to local storage
     repo gc       Garbage collect unpinned objects
 
@@ -84,6 +85,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"config":    ConfigCmd,
 	"dht":       DhtCmd,
 	"diag":      DiagCmd,
+	"dns":       DNSCmd,
 	"get":       GetCmd,
 	"id":        IDCmd,
 	"log":       LogCmd,

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -22,16 +22,15 @@ import (
 type mockNamesys map[string]path.Path
 
 func (m mockNamesys) Resolve(ctx context.Context, name string) (value path.Path, err error) {
+	return m.ResolveN(ctx, name, namesys.DefaultDepthLimit)
+}
+
+func (m mockNamesys) ResolveN(ctx context.Context, name string, depth int) (value path.Path, err error) {
 	p, ok := m[name]
 	if !ok {
 		return "", namesys.ErrResolveFailed
 	}
 	return p, nil
-}
-
-func (m mockNamesys) CanResolve(name string) bool {
-	_, ok := m[name]
-	return ok
 }
 
 func (m mockNamesys) Publish(ctx context.Context, name ci.PrivKey, value path.Path) error {

--- a/core/corehttp/ipns_hostname.go
+++ b/core/corehttp/ipns_hostname.go
@@ -20,7 +20,7 @@ func IPNSHostnameOption() ServeOption {
 
 			host := strings.SplitN(r.Host, ":", 2)[0]
 			if p, err := n.Namesys.Resolve(ctx, host); err == nil {
-				r.URL.Path = "/ipfs/" + p.String() + r.URL.Path
+				r.URL.Path = p.String() + r.URL.Path
 			}
 			childMux.ServeHTTP(w, r)
 		})

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -462,7 +462,7 @@ func TestFastRepublish(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubkeyHash := u.Key(h).Pretty()
+	pubkeyPath := "/ipns/" + u.Key(h).String()
 
 	// set them back
 	defer func() {
@@ -482,9 +482,9 @@ func TestFastRepublish(t *testing.T) {
 	writeFileData(t, dataA, fname) // random
 	<-time.After(shortRepublishTimeout * 2)
 	log.Debug("resolving first hash")
-	resolvedHash, err := node.Namesys.Resolve(context.Background(), pubkeyHash)
+	resolvedHash, err := node.Namesys.Resolve(context.Background(), pubkeyPath)
 	if err != nil {
-		t.Fatal("resolve err:", pubkeyHash, err)
+		t.Fatal("resolve err:", pubkeyPath, err)
 	}
 
 	// constantly keep writing to the file
@@ -501,7 +501,7 @@ func TestFastRepublish(t *testing.T) {
 	}(shortRepublishTimeout)
 
 	hasPublished := func() bool {
-		res, err := node.Namesys.Resolve(context.Background(), pubkeyHash)
+		res, err := node.Namesys.Resolve(context.Background(), pubkeyPath)
 		if err != nil {
 			t.Fatalf("resolve err: %v", err)
 		}

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -150,9 +150,6 @@ func (s *Root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	if segments[0] == "ipfs" {
 		p := strings.Join(resolved.Segments()[1:], "/")
 		return &Link{s.IpfsRoot + "/" + p}, nil
-	} else if segments[0] == "ipns" {
-		p := strings.Join(resolved.Segments()[1:], "/")
-		return &Link{s.IpnsRoot + "/" + p}, nil
 	} else {
 		log.Error("Invalid path.Path: ", resolved)
 		return nil, errors.New("invalid path from ipns record")

--- a/ipnsfs/system.go
+++ b/ipnsfs/system.go
@@ -141,7 +141,7 @@ func (fs *Filesystem) newKeyRoot(parent context.Context, k ci.PrivKey) (*KeyRoot
 		return nil, err
 	}
 
-	name := u.Key(hash).Pretty()
+	name := "/ipns/" + u.Key(hash).String()
 
 	root := new(KeyRoot)
 	root.key = k

--- a/namesys/base.go
+++ b/namesys/base.go
@@ -1,0 +1,54 @@
+package namesys
+
+import (
+	"strings"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+
+	path "github.com/ipfs/go-ipfs/path"
+)
+
+type resolver interface {
+	// resolveOnce looks up a name once (without recursion).
+	resolveOnce(ctx context.Context, name string) (value path.Path, err error)
+}
+
+// resolve is a helper for implementing Resolver.ResolveN using resolveOnce.
+func resolve(ctx context.Context, r resolver, name string, depth int, prefixes ...string) (path.Path, error) {
+	for {
+		p, err := r.resolveOnce(ctx, name)
+		if err != nil {
+			log.Warningf("Could not resolve %s", name)
+			return "", err
+		}
+		log.Debugf("Resolved %s to %s", name, p.String())
+
+		if strings.HasPrefix(p.String(), "/ipfs/") {
+			// we've bottomed out with an IPFS path
+			return p, nil
+		}
+
+		if depth == 1 {
+			return p, ErrResolveRecursion
+		}
+
+		matched := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(p.String(), prefix) {
+				matched = true
+				if len(prefixes) == 1 {
+					name = strings.TrimPrefix(p.String(), prefix)
+				}
+				break
+			}
+		}
+
+		if !matched {
+			return p, nil
+		}
+
+		if depth > 1 {
+			depth--
+		}
+	}
+}

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -52,10 +52,10 @@ func parseEntry(txt string) (path.Path, error) {
 }
 
 func tryParseDnsLink(txt string) (path.Path, error) {
-	parts := strings.Split(txt, "=")
-	if len(parts) == 1 || parts[0] != "dnslink" {
-		return "", errors.New("not a valid dnslink entry")
+	parts := strings.SplitN(txt, "=", 2)
+	if len(parts) == 2 && parts[0] == "dnslink" {
+		return path.ParsePath(parts[1])
 	}
 
-	return path.ParsePath(parts[1])
+	return "", errors.New("not a valid dnslink entry")
 }

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -11,10 +11,24 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 )
 
+type LookupTXTFunc func(name string) (txt []string, err error)
+
 // DNSResolver implements a Resolver on DNS domains
 type DNSResolver struct {
+	lookupTXT LookupTXTFunc
 	// TODO: maybe some sort of caching?
 	// cache would need a timeout
+}
+
+// NewDNSResolver constructs a name resolver using DNS TXT records.
+func NewDNSResolver() Resolver {
+	return &DNSResolver{lookupTXT: net.LookupTXT}
+}
+
+// newDNSResolver constructs a name resolver using DNS TXT records,
+// returning a resolver instead of NewDNSResolver's Resolver.
+func newDNSResolver() resolver {
+	return &DNSResolver{lookupTXT: net.LookupTXT}
 }
 
 // Resolve implements Resolver.
@@ -36,7 +50,7 @@ func (r *DNSResolver) resolveOnce(ctx context.Context, name string) (path.Path, 
 	}
 
 	log.Infof("DNSResolver resolving %s", name)
-	txt, err := net.LookupTXT(name)
+	txt, err := r.lookupTXT(name)
 	if err != nil {
 		return "", err
 	}

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -1,8 +1,23 @@
 package namesys
 
 import (
+	"fmt"
 	"testing"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
+
+type mockDNS struct {
+	entries map[string][]string
+}
+
+func (m *mockDNS) lookupTXT(name string) (txt []string, err error) {
+	txt, ok := m.entries[name]
+	if !ok {
+		return nil, fmt.Errorf("No TXT entry for %s", name)
+	}
+	return txt, nil
+}
 
 func TestDnsEntryParsing(t *testing.T) {
 	goodEntries := []string{
@@ -39,4 +54,75 @@ func TestDnsEntryParsing(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func newMockDNS() *mockDNS {
+	return &mockDNS{
+		entries: map[string][]string{
+			"multihash.example.com": []string{
+				"dnslink=QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
+			},
+			"ipfs.example.com": []string{
+				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
+			},
+			"dns1.example.com": []string{
+				"dnslink=/ipns/ipfs.example.com",
+			},
+			"dns2.example.com": []string{
+				"dnslink=/ipns/dns1.example.com",
+			},
+			"multi.example.com": []string{
+				"some stuff",
+				"dnslink=/ipns/dns1.example.com",
+				"masked dnslink=/ipns/example.invalid",
+			},
+			"equals.example.com": []string{
+				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/=equals",
+			},
+			"loop1.example.com": []string{
+				"dnslink=/ipns/loop2.example.com",
+			},
+			"loop2.example.com": []string{
+				"dnslink=/ipns/loop1.example.com",
+			},
+			"bad.example.com": []string{
+				"dnslink=",
+			},
+		},
+	}
+}
+
+func testResolution(t *testing.T, resolver Resolver, name string, depth int, expected string, expError error) {
+	p, err := resolver.ResolveN(context.Background(), name, depth)
+	if err != expError {
+		t.Fatal(fmt.Errorf(
+			"Expected %s with a depth of %d to have a '%s' error, but got '%s'",
+			name, depth, expError, err))
+	}
+	if p.String() != expected {
+		t.Fatal(fmt.Errorf(
+			"%s with depth %d resolved to %s != %s",
+			name, depth, p.String(), expected))
+	}
+}
+
+func TestDNSResolution(t *testing.T) {
+	mock := newMockDNS()
+	r := &DNSResolver{lookupTXT: mock.lookupTXT}
+	testResolution(t, r, "multihash.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "ipfs.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "dns1.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "dns1.example.com", 1, "/ipns/ipfs.example.com", ErrResolveRecursion)
+	testResolution(t, r, "dns2.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "dns2.example.com", 1, "/ipns/dns1.example.com", ErrResolveRecursion)
+	testResolution(t, r, "dns2.example.com", 2, "/ipns/ipfs.example.com", ErrResolveRecursion)
+	testResolution(t, r, "multi.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
+	testResolution(t, r, "multi.example.com", 1, "/ipns/dns1.example.com", ErrResolveRecursion)
+	testResolution(t, r, "multi.example.com", 2, "/ipns/ipfs.example.com", ErrResolveRecursion)
+	testResolution(t, r, "equals.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/=equals", nil)
+	testResolution(t, r, "loop1.example.com", 1, "/ipns/loop2.example.com", ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", 2, "/ipns/loop1.example.com", ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", 3, "/ipns/loop2.example.com", ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", DefaultDepthLimit, "/ipns/loop1.example.com", ErrResolveRecursion)
+	testResolution(t, r, "bad.example.com", DefaultDepthLimit, "", ErrResolveFailed)
 }

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -3,8 +3,6 @@ package namesys
 import (
 	"fmt"
 	"testing"
-
-	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 type mockDNS struct {
@@ -89,20 +87,6 @@ func newMockDNS() *mockDNS {
 				"dnslink=",
 			},
 		},
-	}
-}
-
-func testResolution(t *testing.T, resolver Resolver, name string, depth int, expected string, expError error) {
-	p, err := resolver.ResolveN(context.Background(), name, depth)
-	if err != expError {
-		t.Fatal(fmt.Errorf(
-			"Expected %s with a depth of %d to have a '%s' error, but got '%s'",
-			name, depth, expError, err))
-	}
-	if p.String() != expected {
-		t.Fatal(fmt.Errorf(
-			"%s with depth %d resolved to %s != %s",
-			name, depth, p.String(), expected))
 	}
 }
 

--- a/namesys/interface.go
+++ b/namesys/interface.go
@@ -1,4 +1,32 @@
-// package namesys implements various functionality for the ipns naming system.
+/*
+Package namesys implements resolvers and publishers for the IPFS
+naming system (IPNS).
+
+The core of IPFS is an immutable, content-addressable Merkle graph.
+That works well for many use cases, but doesn't allow you to answer
+questions like "what is Alice's current homepage?".  The mutable name
+system allows Alice to publish information like:
+
+  The current homepage for alice.example.com is
+  /ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj
+
+or:
+
+  The current homepage for node
+  QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  is
+  /ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj
+
+The mutable name system also allows users to resolve those references
+to find the immutable IPFS object currently referenced by a given
+mutable name.
+
+For command-line bindings to this functionality, see:
+
+  ipfs name
+  ipfs dns
+  ipfs resolve
+*/
 package namesys
 
 import (

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -27,7 +27,7 @@ type mpns struct {
 func NewNameSystem(r routing.IpfsRouting) NameSystem {
 	return &mpns{
 		resolvers: map[string]resolver{
-			"dns":      new(DNSResolver),
+			"dns":      newDNSResolver(),
 			"proquint": new(ProquintResolver),
 			"dht":      newRoutingResolver(r),
 		},

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -1,59 +1,83 @@
 package namesys
 
 import (
+	"strings"
+
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	path "github.com/ipfs/go-ipfs/path"
 	routing "github.com/ipfs/go-ipfs/routing"
 )
 
-// ipnsNameSystem implements IPNS naming.
+// mpns (a multi-protocol NameSystem) implements generic IPFS naming.
 //
-// Uses three Resolvers:
+// Uses several Resolvers:
 // (a) ipfs routing naming: SFS-like PKI names.
 // (b) dns domains: resolves using links in DNS TXT records
 // (c) proquints: interprets string as the raw byte data.
 //
 // It can only publish to: (a) ipfs routing naming.
 //
-type ipns struct {
-	resolvers []Resolver
-	publisher Publisher
+type mpns struct {
+	resolvers  map[string]resolver
+	publishers map[string]Publisher
 }
 
 // NewNameSystem will construct the IPFS naming system based on Routing
 func NewNameSystem(r routing.IpfsRouting) NameSystem {
-	return &ipns{
-		resolvers: []Resolver{
-			new(DNSResolver),
-			new(ProquintResolver),
-			NewRoutingResolver(r),
+	return &mpns{
+		resolvers: map[string]resolver{
+			"dns":      new(DNSResolver),
+			"proquint": new(ProquintResolver),
+			"dht":      newRoutingResolver(r),
 		},
-		publisher: NewRoutingPublisher(r),
+		publishers: map[string]Publisher{
+			"/ipns/": NewRoutingPublisher(r),
+		},
 	}
 }
 
-// Resolve implements Resolver
-func (ns *ipns) Resolve(ctx context.Context, name string) (path.Path, error) {
-	for _, r := range ns.resolvers {
-		if r.CanResolve(name) {
-			return r.Resolve(ctx, name)
+// Resolve implements Resolver.
+func (ns *mpns) Resolve(ctx context.Context, name string) (path.Path, error) {
+	return ns.ResolveN(ctx, name, DefaultDepthLimit)
+}
+
+// ResolveN implements Resolver.
+func (ns *mpns) ResolveN(ctx context.Context, name string, depth int) (path.Path, error) {
+	if strings.HasPrefix(name, "/ipfs/") {
+		return path.ParsePath(name)
+	}
+
+	if !strings.HasPrefix(name, "/") {
+		return path.ParsePath("/ipfs/" + name)
+	}
+
+	return resolve(ctx, ns, name, depth, "/ipns/")
+}
+
+// resolveOnce implements resolver.
+func (ns *mpns) resolveOnce(ctx context.Context, name string) (path.Path, error) {
+	if !strings.HasPrefix(name, "/ipns/") {
+		name = "/ipns/" + name
+	}
+	segments := strings.SplitN(name, "/", 3)
+	if len(segments) < 3 || segments[0] != "" {
+		log.Warningf("Invalid name syntax for %s", name)
+		return "", ErrResolveFailed
+	}
+
+	for protocol, resolver := range ns.resolvers {
+		log.Debugf("Attempting to resolve %s with %s", name, protocol)
+		p, err := resolver.resolveOnce(ctx, segments[2])
+		if err == nil {
+			return p, err
 		}
 	}
+	log.Warningf("No resolver found for %s", name)
 	return "", ErrResolveFailed
 }
 
-// CanResolve implements Resolver
-func (ns *ipns) CanResolve(name string) bool {
-	for _, r := range ns.resolvers {
-		if r.CanResolve(name) {
-			return true
-		}
-	}
-	return false
-}
-
 // Publish implements Publisher
-func (ns *ipns) Publish(ctx context.Context, name ci.PrivKey, value path.Path) error {
-	return ns.publisher.Publish(ctx, name, value)
+func (ns *mpns) Publish(ctx context.Context, name ci.PrivKey, value path.Path) error {
+	return ns.publishers["/ipns/"].Publish(ctx, name, value)
 }

--- a/namesys/namesys_test.go
+++ b/namesys/namesys_test.go
@@ -1,0 +1,71 @@
+package namesys
+
+import (
+	"fmt"
+	"testing"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+
+	path "github.com/ipfs/go-ipfs/path"
+)
+
+type mockResolver struct {
+	entries map[string]string
+}
+
+func testResolution(t *testing.T, resolver Resolver, name string, depth int, expected string, expError error) {
+	p, err := resolver.ResolveN(context.Background(), name, depth)
+	if err != expError {
+		t.Fatal(fmt.Errorf(
+			"Expected %s with a depth of %d to have a '%s' error, but got '%s'",
+			name, depth, expError, err))
+	}
+	if p.String() != expected {
+		t.Fatal(fmt.Errorf(
+			"%s with depth %d resolved to %s != %s",
+			name, depth, p.String(), expected))
+	}
+}
+
+func (r *mockResolver) resolveOnce(ctx context.Context, name string) (path.Path, error) {
+	return path.ParsePath(r.entries[name])
+}
+
+func mockResolverOne() *mockResolver {
+	return &mockResolver{
+		entries: map[string]string{
+			"QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy": "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj",
+			"QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n": "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy",
+			"QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD": "/ipns/ipfs.io",
+		},
+	}
+}
+
+func mockResolverTwo() *mockResolver {
+	return &mockResolver{
+		entries: map[string]string{
+			"ipfs.io": "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n",
+		},
+	}
+}
+
+func TestNamesysResolution(t *testing.T) {
+	r := &mpns{
+		resolvers: map[string]resolver{
+			"one": mockResolverOne(),
+			"two": mockResolverTwo(),
+		},
+	}
+
+	testResolution(t, r, "Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
+	testResolution(t, r, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
+	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
+	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", 1, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
+	testResolution(t, r, "/ipns/ipfs.io", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
+	testResolution(t, r, "/ipns/ipfs.io", 1, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", ErrResolveRecursion)
+	testResolution(t, r, "/ipns/ipfs.io", 2, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 1, "/ipns/ipfs.io", ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 2, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 3, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
+}

--- a/namesys/proquint.go
+++ b/namesys/proquint.go
@@ -10,16 +10,20 @@ import (
 
 type ProquintResolver struct{}
 
-// CanResolve implements Resolver. Checks whether the name is a proquint string.
-func (r *ProquintResolver) CanResolve(name string) bool {
-	ok, err := proquint.IsProquint(name)
-	return err == nil && ok
+// Resolve implements Resolver.
+func (r *ProquintResolver) Resolve(ctx context.Context, name string) (path.Path, error) {
+	return r.ResolveN(ctx, name, DefaultDepthLimit)
 }
 
-// Resolve implements Resolver. Decodes the proquint string.
-func (r *ProquintResolver) Resolve(ctx context.Context, name string) (path.Path, error) {
-	ok := r.CanResolve(name)
-	if !ok {
+// ResolveN implements Resolver.
+func (r *ProquintResolver) ResolveN(ctx context.Context, name string, depth int) (path.Path, error) {
+	return resolve(ctx, r, name, depth, "/ipns/")
+}
+
+// resolveOnce implements resolver. Decodes the proquint string.
+func (r *ProquintResolver) resolveOnce(ctx context.Context, name string) (path.Path, error) {
+	ok, err := proquint.IsProquint(name)
+	if err != nil || !ok {
 		return "", errors.New("not a valid proquint string")
 	}
 	return path.FromString(string(proquint.Decode(name))), nil

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -42,7 +42,7 @@ func NewRoutingPublisher(route routing.IpfsRouting) Publisher {
 // Publish implements Publisher. Accepts a keypair and a value,
 // and publishes it out to the routing system
 func (p *ipnsPublisher) Publish(ctx context.Context, k ci.PrivKey, value path.Path) error {
-	log.Debugf("namesys: Publish %s", value)
+	log.Debugf("Publish %s", value)
 
 	data, err := createRoutingEntryData(k, value)
 	if err != nil {

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -30,15 +30,28 @@ func NewRoutingResolver(route routing.IpfsRouting) Resolver {
 	return &routingResolver{routing: route}
 }
 
-// CanResolve implements Resolver. Checks whether name is a b58 encoded string.
-func (r *routingResolver) CanResolve(name string) bool {
-	_, err := mh.FromB58String(name)
-	return err == nil
+// newRoutingResolver returns a resolver instead of a Resolver.
+func newRoutingResolver(route routing.IpfsRouting) resolver {
+	if route == nil {
+		panic("attempt to create resolver with nil routing system")
+	}
+
+	return &routingResolver{routing: route}
 }
 
-// Resolve implements Resolver. Uses the IPFS routing system to resolve SFS-like
-// names.
+// Resolve implements Resolver.
 func (r *routingResolver) Resolve(ctx context.Context, name string) (path.Path, error) {
+	return r.ResolveN(ctx, name, DefaultDepthLimit)
+}
+
+// ResolveN implements Resolver.
+func (r *routingResolver) ResolveN(ctx context.Context, name string, depth int) (path.Path, error) {
+	return resolve(ctx, r, name, depth, "/ipns/")
+}
+
+// resolveOnce implements resolver. Uses the IPFS routing system to
+// resolve SFS-like names.
+func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Path, error) {
 	log.Debugf("RoutingResolve: '%s'", name)
 	hash, err := mh.FromB58String(name)
 	if err != nil {

--- a/path/path.go
+++ b/path/path.go
@@ -44,12 +44,8 @@ func (p Path) String() string {
 	return string(p)
 }
 
-func FromSegments(seg ...string) (Path, error) {
-	var pref string
-	if seg[0] == "ipfs" || seg[0] == "ipns" {
-		pref = "/"
-	}
-	return ParsePath(pref + strings.Join(seg, "/"))
+func FromSegments(prefix string, seg ...string) (Path, error) {
+	return ParsePath(prefix + strings.Join(seg, "/"))
 }
 
 func ParsePath(txt string) (Path, error) {
@@ -68,13 +64,13 @@ func ParsePath(txt string) (Path, error) {
 		return "", ErrBadPath
 	}
 
-	if parts[1] != "ipfs" && parts[1] != "ipns" {
+	if parts[1] == "ipfs" {
+		_, err := ParseKeyToPath(parts[2])
+		if err != nil {
+			return "", err
+		}
+	} else if parts[1] != "ipns" {
 		return "", ErrBadPath
-	}
-
-	_, err := ParseKeyToPath(parts[2])
-	if err != nil {
-		return "", err
 	}
 
 	return Path(txt), nil

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -59,8 +59,8 @@ func TestRecurivePathResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	segments := []string{"", "ipfs", aKey.String(), "child", "grandchild"}
-	p, err := path.FromSegments(segments...)
+	segments := []string{aKey.String(), "child", "grandchild"}
+	p, err := path.FromSegments("/ipfs/", segments...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -14,11 +14,11 @@ test_init_ipfs
 
 test_expect_success "'ipfs name publish' succeeds" '
 	PEERID=`ipfs id --format="<id>"` &&
-	ipfs name publish "$HASH_WELCOME_DOCS" >publish_out
+	ipfs name publish "/ipfs/$HASH_WELCOME_DOCS" >publish_out
 '
 
 test_expect_success "publish output looks good" '
-	echo "Published name $PEERID to /ipfs/$HASH_WELCOME_DOCS" >expected1 &&
+	echo "Published to ${PEERID}: /ipfs/$HASH_WELCOME_DOCS" >expected1 &&
 	test_cmp publish_out expected1
 '
 
@@ -39,7 +39,7 @@ test_expect_success "'ipfs name publish' succeeds" '
 '
 
 test_expect_success "publish a path looks good" '
-	echo "Published name $PEERID to /ipfs/$HASH_WELCOME_DOCS/help" >expected3 &&
+	echo "Published to ${PEERID}: /ipfs/$HASH_WELCOME_DOCS/help" >expected3 &&
 	test_cmp publish_out expected3
 '
 


### PR DESCRIPTION
There are detailed notes in the individual commits, but the meat is in
the opening "namesys: Add recursive resolution".  This is a work in
progress towards the separation sketched out [here][1] and endorsed
[here][2].  For example, with this PR you can:

    $ ipfs dns ipfs.tremily.us
    /dnslink/tremily.us
    $ ipfs dns tremily.us
    /dnslink/tremily.us
    $ ipfs dns --recursive ipfs.tremily.us
    /ipns/QmbqDJaoZYoGNw4dz7FqFDCf6q9EcHoMBQtoGViVFw2qv7

However, I'm currently sticking on the multihash encoding.  The
/ipns/… and /ipfs/… multihashes are base-58, but there's also the
proquint encoding.  However, proquint isn't a *protocol*, you can have
proquint-encoded multihashes in the IPNS and IPFS protocol spaces.
How do we distinguish that?  The heavy approach is:

  /ipfs-proquint/…
  /ipns-proquint/…

in which case maybe we want to be using:

  /ipns-base-58/…
  /ipfs-base-58/…

where we currently use /ipns/… and /ipfs/….  Thoughts?  More clever
solutions?  Should the encoding-choice be part of a layer between
binary multihashes and the IP*S libraries?  For example, maybe encoded
multihashes should have a leading character or two representing their
encoding (hex “a:1220…”, base-58 “b:Qm…”, proquint
“c:bikad-fokor-zihoj-bajir”, …).

Also, do we want to use /dnslink/… (to match dnslink=…) or /dns/…
(because “link” is mostly wasted space once we're in the context of
resolvable names)?

[1]: https://github.com/ipfs/go-ipfs/issues/1082#issuecomment-99255884
[2]: https://github.com/ipfs/go-ipfs/issues/1082#issuecomment-99417421