### PR TITLE
path/resolver: Fix recursive path resolution

### DIFF
--- a/path/resolver.go
+++ b/path/resolver.go
@@ -122,7 +122,8 @@ func (s *Resolver) ResolveLinks(ctx context.Context, ndd *merkledag.Node, names 
 			// fetch object for link and assign to nd
 			ctx, cancel := context.WithTimeout(ctx, time.Minute)
 			defer cancel()
-			nd, err := s.DAG.Get(ctx, next)
+			var err error
+			nd, err = s.DAG.Get(ctx, next)
 			if err != nil {
 				return append(result, nd), err
 			}

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -1,0 +1,83 @@
+package path_test
+
+import (
+	"fmt"
+	"testing"
+
+	datastore "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	sync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+
+	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	blockservice "github.com/ipfs/go-ipfs/blockservice"
+	offline "github.com/ipfs/go-ipfs/exchange/offline"
+	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	path "github.com/ipfs/go-ipfs/path"
+	util "github.com/ipfs/go-ipfs/util"
+)
+
+func randNode() (*merkledag.Node, util.Key) {
+	node := new(merkledag.Node)
+	node.Data = make([]byte, 32)
+	util.NewTimeSeededRand().Read(node.Data)
+	k, _ := node.Key()
+	return node, k
+}
+
+func TestRecurivePathResolution(t *testing.T) {
+	ctx := context.Background()
+	dstore := sync.MutexWrap(datastore.NewMapDatastore())
+	bstore := blockstore.NewBlockstore(dstore)
+	bserv, err := blockservice.New(bstore, offline.Exchange(bstore))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dagService := merkledag.NewDAGService(bserv)
+
+	a, _ := randNode()
+	b, _ := randNode()
+	c, cKey := randNode()
+
+	err = b.AddNodeLink("grandchild", c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = a.AddNodeLink("child", b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dagService.AddRecursive(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aKey, err := a.Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	segments := []string{"", "ipfs", aKey.String(), "child", "grandchild"}
+	p, err := path.FromSegments(segments...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := &path.Resolver{DAG: dagService}
+	node, err := resolver.ResolvePath(ctx, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := node.Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.String() != cKey.String() {
+		t.Fatal(fmt.Errorf(
+			"recursive path resolution failed for %s: %s != %s",
+			p.String(), key.String(), cKey.String()))
+	}
+}


### PR DESCRIPTION
I'm not entirely clear on Go's scoping (there's some text I can't
quite parse [here][1]), but it seems like the := version (because this
is the first time we use 'err') was masking the function-level 'nd'
just for this if block.  That means that after we get out of the if
block and return to the start of the for-loop for the next pass,
nd.Links would still be pointing at the original object's links.

This commit drops the :=, which fixes the earlier:

    $ ipfs ls QmXX7YRpU7nNBKfw75VG7Y1c3GwpSAGHRev67XVPgZFv9R/static/css
    Error: no link named "css" under QmXX7YRpU7nNBKfw75VG7Y1c3GwpSAGHRev67XVPgZFv9R

so we get the intended:

    $ ipfs ls QmXX7YRpU7nNBKfw75VG7Y1c3GwpSAGHRev67XVPgZFv9R/static/css
    Qme4r3eA4h1revFBgCEv1HF1U7sLL4vvAyzRLWJhCFhwg2 7051 style.css

It also means we're probably missing (or are unreliably using) a
multi-level-path-resolving test.

[1]: https://golang.org/ref/spec#Declarations_and_scope