### PR TITLE
large refactor of bitswap, implement wantmanager to manage wantlist

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -288,7 +288,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			bs.dupBlocksRecvd++
 		}
 		bs.counterLk.Unlock()
-		log.Debugf("got block %s from %s (%d,%d)", block, p, bs.blocksRecvd, bs.dupBlocksRecvd)
+		log.Infof("got block %s from %s (%d,%d)", block, p, bs.blocksRecvd, bs.dupBlocksRecvd)
 
 		hasBlockCtx, cancel := context.WithTimeout(ctx, hasBlockTimeout)
 		if err := bs.HasBlock(hasBlockCtx, block); err != nil {

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -288,7 +288,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			bs.dupBlocksRecvd++
 		}
 		bs.counterLk.Unlock()
-		log.Debugf("got block %s from %s", block, p)
+		log.Debugf("got block %s from %s (%d,%d)", block, p, bs.blocksRecvd, bs.dupBlocksRecvd)
 
 		hasBlockCtx, cancel := context.WithTimeout(ctx, hasBlockTimeout)
 		if err := bs.HasBlock(hasBlockCtx, block); err != nil {

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -86,9 +86,9 @@ func New(parent context.Context, p peer.ID, network bsnet.BitSwapNetwork,
 		process:       px,
 		newBlocks:     make(chan *blocks.Block, HasBlockBufferSize),
 		provideKeys:   make(chan u.Key),
-		wm:            NewWantManager(network),
+		wm:            NewWantManager(ctx, network),
 	}
-	go bs.wm.Run(ctx)
+	go bs.wm.Run()
 	network.SetDelegate(bs)
 
 	// Start up bitswaps async worker routines

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -316,8 +316,6 @@ func (bs *Bitswap) sendWantlistToProviders(ctx context.Context, entries []wantli
 
 // TODO(brian): handle errors
 func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage) error {
-	//defer log.EventBegin(ctx, "receiveMessage", p, incoming).Done()
-
 	// This call records changes to wantlists, blocks received,
 	// and number of bytes transfered.
 	bs.engine.MessageReceived(p, incoming)

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -120,6 +120,18 @@ func TestLargeFile(t *testing.T) {
 	PerformDistributionTest(t, numInstances, numBlocks)
 }
 
+func TestLargeFileNoRebroadcast(t *testing.T) {
+	rbd := rebroadcastDelay.Get()
+	rebroadcastDelay.Set(time.Hour * 24 * 365 * 10) // ten years should be long enough
+	if testing.Short() {
+		t.SkipNow()
+	}
+	numInstances := 10
+	numBlocks := 100
+	PerformDistributionTest(t, numInstances, numBlocks)
+	rebroadcastDelay.Set(rbd)
+}
+
 func TestLargeFileTwoPeers(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -92,7 +92,7 @@ func TestLargeSwarm(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	numInstances := 500
+	numInstances := 100
 	numBlocks := 2
 	if detectrace.WithRace() {
 		// when running with the race detector, 500 instances launches
@@ -124,7 +124,6 @@ func TestLargeFileTwoPeers(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	numInstances := 2
 	numBlocks := 100
 	PerformDistributionTest(t, numInstances, numBlocks)
@@ -164,6 +163,7 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 			}
 			for _ = range outch {
 			}
+			log.Error("DONE")
 		}(inst)
 	}
 	wg.Wait()

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -163,7 +163,6 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 			}
 			for _ = range outch {
 			}
-			log.Error("DONE")
 		}(inst)
 	}
 	wg.Wait()

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -13,6 +13,7 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
 	tn "github.com/ipfs/go-ipfs/exchange/bitswap/testnet"
+	p2ptestutil "github.com/ipfs/go-ipfs/p2p/test/util"
 	mockrouting "github.com/ipfs/go-ipfs/routing/mock"
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
 	u "github.com/ipfs/go-ipfs/util"
@@ -33,6 +34,28 @@ func TestClose(t *testing.T) {
 
 	bitswap.Exchange.Close()
 	bitswap.Exchange.GetBlock(context.Background(), block.Key())
+}
+
+func TestProviderForKeyButNetworkCannotFind(t *testing.T) { // TODO revisit this
+
+	rs := mockrouting.NewServer()
+	net := tn.VirtualNetwork(rs, delay.Fixed(kNetworkDelay))
+	g := NewTestSessionGenerator(net)
+	defer g.Close()
+
+	block := blocks.NewBlock([]byte("block"))
+	pinfo := p2ptestutil.RandTestBogusIdentityOrFatal(t)
+	rs.Client(pinfo).Provide(context.Background(), block.Key()) // but not on network
+
+	solo := g.Next()
+	defer solo.Exchange.Close()
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Nanosecond)
+	_, err := solo.Exchange.GetBlock(ctx, block.Key())
+
+	if err != context.DeadlineExceeded {
+		t.Fatal("Expected DeadlineExceeded error")
+	}
 }
 
 func TestGetBlockFromPeerAfterPeerAnnounces(t *testing.T) {

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -120,6 +120,16 @@ func TestLargeFile(t *testing.T) {
 	PerformDistributionTest(t, numInstances, numBlocks)
 }
 
+func TestLargeFileTwoPeers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	numInstances := 2
+	numBlocks := 100
+	PerformDistributionTest(t, numInstances, numBlocks)
+}
+
 func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 	if testing.Short() {
 		t.SkipNow()
@@ -128,8 +138,6 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 	sg := NewTestSessionGenerator(net)
 	defer sg.Close()
 	bg := blocksutil.NewBlockGenerator()
-
-	t.Log("Test a few nodes trying to get one file with a lot of blocks")
 
 	instances := sg.Instances(numInstances)
 	blocks := bg.Blocks(numBlocks)
@@ -238,7 +246,7 @@ func TestBasicBitswap(t *testing.T) {
 	defer sg.Close()
 	bg := blocksutil.NewBlockGenerator()
 
-	t.Log("Test a few nodes trying to get one file with a lot of blocks")
+	t.Log("Test a one node trying to get one block from another")
 
 	instances := sg.Instances(2)
 	blocks := bg.Blocks(1)

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -210,11 +210,11 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 
 	for _, entry := range m.Wantlist() {
 		if entry.Cancel {
-			log.Errorf("cancel %s", entry.Key)
+			log.Debugf("cancel %s", entry.Key)
 			l.CancelWant(entry.Key)
 			e.peerRequestQueue.Remove(entry.Key, p)
 		} else {
-			log.Errorf("wants %s - %d", entry.Key, entry.Priority)
+			log.Debugf("wants %s - %d", entry.Key, entry.Priority)
 			l.Wants(entry.Key, entry.Priority)
 			if exists, err := e.bs.Has(entry.Key); err == nil && exists {
 				e.peerRequestQueue.Push(entry.Entry, p)

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	blocks "github.com/ipfs/go-ipfs/blocks"
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	wl "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
@@ -53,8 +54,9 @@ const (
 type Envelope struct {
 	// Peer is the intended recipient
 	Peer peer.ID
-	// Message is the payload
-	Message bsmsg.BitSwapMessage
+
+	// Block is the payload
+	Block *blocks.Block
 
 	// A callback to notify the decision queue that the task is complete
 	Sent func()
@@ -151,12 +153,10 @@ func (e *Engine) nextEnvelope(ctx context.Context) (*Envelope, error) {
 			continue
 		}
 
-		m := bsmsg.New() // TODO: maybe add keys from our wantlist?
-		m.AddBlock(block)
 		return &Envelope{
-			Peer:    nextTask.Target,
-			Message: m,
-			Sent:    nextTask.Done,
+			Peer:  nextTask.Target,
+			Block: block,
+			Sent:  nextTask.Done,
 		}, nil
 	}
 }
@@ -185,7 +185,7 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 	defer e.lock.Unlock()
 
 	if len(m.Wantlist()) == 0 && len(m.Blocks()) == 0 {
-		log.Debug("received empty message from", p)
+		log.Debugf("received empty message from %s", p)
 	}
 
 	newWorkExists := false
@@ -202,11 +202,11 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 
 	for _, entry := range m.Wantlist() {
 		if entry.Cancel {
-			log.Debug("cancel", entry.Key)
+			log.Debugf("cancel %s", entry.Key)
 			l.CancelWant(entry.Key)
 			e.peerRequestQueue.Remove(entry.Key, p)
 		} else {
-			log.Debug("wants", entry.Key, entry.Priority)
+			log.Debugf("wants %s", entry.Key, entry.Priority)
 			l.Wants(entry.Key, entry.Priority)
 			if exists, err := e.bs.Has(entry.Key); err == nil && exists {
 				e.peerRequestQueue.Push(entry.Entry, p)
@@ -216,7 +216,7 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 	}
 
 	for _, block := range m.Blocks() {
-		log.Debug("got block %s %d bytes", block.Key(), len(block.Data))
+		log.Debugf("got block %s %d bytes", block.Key(), len(block.Data))
 		l.ReceivedBytes(len(block.Data))
 		for _, l := range e.ledgerMap {
 			if entry, ok := l.WantListContains(block.Key()); ok {

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -206,7 +206,7 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 			l.CancelWant(entry.Key)
 			e.peerRequestQueue.Remove(entry.Key, p)
 		} else {
-			log.Debugf("wants %s", entry.Key, entry.Priority)
+			log.Debugf("wants %s - %d", entry.Key, entry.Priority)
 			l.Wants(entry.Key, entry.Priority)
 			if exists, err := e.bs.Has(entry.Key); err == nil && exists {
 				e.peerRequestQueue.Push(entry.Entry, p)

--- a/exchange/bitswap/decision/engine_test.go
+++ b/exchange/bitswap/decision/engine_test.go
@@ -185,7 +185,7 @@ func checkHandledInOrder(t *testing.T, e *Engine, keys []string) error {
 	for _, k := range keys {
 		next := <-e.Outbox()
 		envelope := <-next
-		received := envelope.Message.Blocks()[0]
+		received := envelope.Block
 		expected := blocks.NewBlock([]byte(k))
 		if received.Key() != expected.Key() {
 			return errors.New(fmt.Sprintln("received", string(received.Data), "expected", string(expected.Data)))

--- a/exchange/bitswap/decision/engine_test.go
+++ b/exchange/bitswap/decision/engine_test.go
@@ -41,7 +41,7 @@ func TestConsistentAccounting(t *testing.T) {
 	// Send messages from Ernie to Bert
 	for i := 0; i < 1000; i++ {
 
-		m := message.New()
+		m := message.New(false)
 		content := []string{"this", "is", "message", "i"}
 		m.AddBlock(blocks.NewBlock([]byte(strings.Join(content, " "))))
 
@@ -73,7 +73,7 @@ func TestPeerIsAddedToPeersWhenMessageReceivedOrSent(t *testing.T) {
 	sanfrancisco := newEngine(ctx, "sf")
 	seattle := newEngine(ctx, "sea")
 
-	m := message.New()
+	m := message.New(true)
 
 	sanfrancisco.Engine.MessageSent(seattle.Peer, m)
 	seattle.Engine.MessageReceived(sanfrancisco.Peer, m)
@@ -164,7 +164,7 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 }
 
 func partnerWants(e *Engine, keys []string, partner peer.ID) {
-	add := message.New()
+	add := message.New(false)
 	for i, letter := range keys {
 		block := blocks.NewBlock([]byte(letter))
 		add.AddEntry(block.Key(), math.MaxInt32-i)
@@ -173,7 +173,7 @@ func partnerWants(e *Engine, keys []string, partner peer.ID) {
 }
 
 func partnerCancels(e *Engine, keys []string, partner peer.ID) {
-	cancels := message.New()
+	cancels := message.New(false)
 	for _, k := range keys {
 		block := blocks.NewBlock([]byte(k))
 		cancels.Cancel(block.Key())

--- a/exchange/bitswap/decision/peer_request_queue.go
+++ b/exchange/bitswap/decision/peer_request_queue.go
@@ -69,8 +69,8 @@ func (tl *prq) Push(entry wantlist.Entry, to peer.ID) {
 		Target:  to,
 		created: time.Now(),
 		Done: func() {
-			partner.TaskDone(entry.Key)
 			tl.lock.Lock()
+			partner.TaskDone(entry.Key)
 			tl.pQueue.Update(partner.Index())
 			tl.lock.Unlock()
 		},

--- a/exchange/bitswap/decision/peer_request_queue.go
+++ b/exchange/bitswap/decision/peer_request_queue.go
@@ -156,7 +156,7 @@ func (t *peerRequestTask) SetIndex(i int) {
 
 // taskKey returns a key that uniquely identifies a task.
 func taskKey(p peer.ID, k u.Key) string {
-	return string(p.String() + k.String())
+	return string(p) + string(k)
 }
 
 // FIFO is a basic task comparator that returns tasks in the order created.

--- a/exchange/bitswap/message/message.go
+++ b/exchange/bitswap/message/message.go
@@ -162,7 +162,7 @@ func (m *impl) ToProto() *pb.Message {
 		pbm.Wantlist.Entries = append(pbm.Wantlist.Entries, &pb.Message_Wantlist_Entry{
 			Block:    proto.String(string(e.Key)),
 			Priority: proto.Int32(int32(e.Priority)),
-			Cancel:   &e.Cancel,
+			Cancel:   proto.Bool(e.Cancel),
 		})
 	}
 	for _, b := range m.Blocks() {

--- a/exchange/bitswap/message/message.go
+++ b/exchange/bitswap/message/message.go
@@ -29,6 +29,8 @@ type BitSwapMessage interface {
 
 	Cancel(key u.Key)
 
+	Empty() bool
+
 	// Sets whether or not the contained wantlist represents the entire wantlist
 	// true = full wantlist
 	// false = wantlist 'patch'
@@ -51,7 +53,7 @@ type Exportable interface {
 type impl struct {
 	full     bool
 	wantlist map[u.Key]Entry
-	blocks   map[u.Key]*blocks.Block // map to detect duplicates
+	blocks   map[u.Key]*blocks.Block
 }
 
 func New() BitSwapMessage {
@@ -92,6 +94,10 @@ func (m *impl) Full() bool {
 	return m.full
 }
 
+func (m *impl) Empty() bool {
+	return len(m.blocks) == 0 && len(m.wantlist) == 0
+}
+
 func (m *impl) Wantlist() []Entry {
 	var out []Entry
 	for _, e := range m.wantlist {
@@ -101,7 +107,7 @@ func (m *impl) Wantlist() []Entry {
 }
 
 func (m *impl) Blocks() []*blocks.Block {
-	bs := make([]*blocks.Block, 0)
+	bs := make([]*blocks.Block, 0, len(m.blocks))
 	for _, block := range m.blocks {
 		bs = append(bs, block)
 	}
@@ -109,6 +115,7 @@ func (m *impl) Blocks() []*blocks.Block {
 }
 
 func (m *impl) Cancel(k u.Key) {
+	delete(m.wantlist, k)
 	m.addEntry(k, 0, true)
 }
 

--- a/exchange/bitswap/message/message_test.go
+++ b/exchange/bitswap/message/message_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAppendWanted(t *testing.T) {
 	const str = "foo"
-	m := New()
+	m := New(true)
 	m.AddEntry(u.Key(str), 1)
 
 	if !wantlistContains(m.ToProto().GetWantlist(), str) {
@@ -44,7 +44,7 @@ func TestAppendBlock(t *testing.T) {
 	strs = append(strs, "Celeritas")
 	strs = append(strs, "Incendia")
 
-	m := New()
+	m := New(true)
 	for _, str := range strs {
 		block := blocks.NewBlock([]byte(str))
 		m.AddBlock(block)
@@ -61,7 +61,7 @@ func TestAppendBlock(t *testing.T) {
 
 func TestWantlist(t *testing.T) {
 	keystrs := []string{"foo", "bar", "baz", "bat"}
-	m := New()
+	m := New(true)
 	for _, s := range keystrs {
 		m.AddEntry(u.Key(s), 1)
 	}
@@ -84,7 +84,7 @@ func TestWantlist(t *testing.T) {
 
 func TestCopyProtoByValue(t *testing.T) {
 	const str = "foo"
-	m := New()
+	m := New(true)
 	protoBeforeAppend := m.ToProto()
 	m.AddEntry(u.Key(str), 1)
 	if wantlistContains(protoBeforeAppend.GetWantlist(), str) {
@@ -93,7 +93,7 @@ func TestCopyProtoByValue(t *testing.T) {
 }
 
 func TestToNetFromNetPreservesWantList(t *testing.T) {
-	original := New()
+	original := New(true)
 	original.AddEntry(u.Key("M"), 1)
 	original.AddEntry(u.Key("B"), 1)
 	original.AddEntry(u.Key("D"), 1)
@@ -124,7 +124,7 @@ func TestToNetFromNetPreservesWantList(t *testing.T) {
 
 func TestToAndFromNetMessage(t *testing.T) {
 
-	original := New()
+	original := New(true)
 	original.AddBlock(blocks.NewBlock([]byte("W")))
 	original.AddBlock(blocks.NewBlock([]byte("E")))
 	original.AddBlock(blocks.NewBlock([]byte("F")))
@@ -172,7 +172,7 @@ func contains(strs []string, x string) bool {
 
 func TestDuplicates(t *testing.T) {
 	b := blocks.NewBlock([]byte("foo"))
-	msg := New()
+	msg := New(true)
 
 	msg.AddEntry(b.Key(), 1)
 	msg.AddEntry(b.Key(), 1)

--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -33,7 +33,7 @@ type Receiver interface {
 	ReceiveMessage(
 		ctx context.Context,
 		sender peer.ID,
-		incoming bsmsg.BitSwapMessage) error
+		incoming bsmsg.BitSwapMessage)
 
 	ReceiveError(error)
 

--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -23,6 +23,8 @@ type BitSwapNetwork interface {
 	// network.
 	SetDelegate(Receiver)
 
+	ConnectTo(context.Context, peer.ID) error
+
 	Routing
 }
 

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -97,6 +97,10 @@ func (bsnet *impl) SetDelegate(r Receiver) {
 	bsnet.receiver = r
 }
 
+func (bsnet *impl) ConnectTo(ctx context.Context, p peer.ID) error {
+	return bsnet.host.Connect(ctx, peer.PeerInfo{ID: p})
+}
+
 // FindProvidersAsync returns a channel of providers for the given key
 func (bsnet *impl) FindProvidersAsync(ctx context.Context, k util.Key, max int) <-chan peer.ID {
 

--- a/exchange/bitswap/peermanager.go
+++ b/exchange/bitswap/peermanager.go
@@ -1,0 +1,203 @@
+package bitswap
+
+import (
+	"sync"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	engine "github.com/ipfs/go-ipfs/exchange/bitswap/decision"
+	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
+	bsnet "github.com/ipfs/go-ipfs/exchange/bitswap/network"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	u "github.com/ipfs/go-ipfs/util"
+)
+
+type PeerManager struct {
+	receiver bsnet.Receiver
+
+	incoming   chan *msgPair
+	connect    chan peer.ID
+	disconnect chan peer.ID
+
+	peers map[peer.ID]*msgQueue
+
+	network bsnet.BitSwapNetwork
+}
+
+func NewPeerManager(network bsnet.BitSwapNetwork) *PeerManager {
+	return &PeerManager{
+		incoming:   make(chan *msgPair, 10),
+		connect:    make(chan peer.ID, 10),
+		disconnect: make(chan peer.ID, 10),
+		peers:      make(map[peer.ID]*msgQueue),
+		network:    network,
+	}
+}
+
+type msgPair struct {
+	to  peer.ID
+	msg bsmsg.BitSwapMessage
+}
+
+type cancellation struct {
+	who peer.ID
+	blk u.Key
+}
+
+type msgQueue struct {
+	p peer.ID
+
+	lk    sync.Mutex
+	wlmsg bsmsg.BitSwapMessage
+
+	work chan struct{}
+	done chan struct{}
+}
+
+func (pm *PeerManager) SendBlock(env *engine.Envelope) {
+	// Blocks need to be sent synchronously to maintain proper backpressure
+	// throughout the network stack
+	defer env.Sent()
+
+	msg := bsmsg.New()
+	msg.AddBlock(env.Block)
+	err := pm.network.SendMessage(context.TODO(), env.Peer, msg)
+	if err != nil {
+		log.Error(err)
+	}
+}
+
+func (pm *PeerManager) startPeerHandler(p peer.ID) {
+	_, ok := pm.peers[p]
+	if ok {
+		// TODO: log an error?
+		return
+	}
+
+	mq := new(msgQueue)
+	mq.done = make(chan struct{})
+	mq.work = make(chan struct{}, 1)
+	mq.p = p
+
+	pm.peers[p] = mq
+	go pm.runQueue(mq)
+}
+
+func (pm *PeerManager) stopPeerHandler(p peer.ID) {
+	pq, ok := pm.peers[p]
+	if !ok {
+		// TODO: log error?
+		return
+	}
+
+	close(pq.done)
+	delete(pm.peers, p)
+}
+
+func (pm *PeerManager) runQueue(mq *msgQueue) {
+	for {
+		select {
+		case <-mq.work: // there is work to be done
+
+			// TODO: this might not need to be done every time, figure out
+			// a good heuristic
+			err := pm.network.ConnectTo(context.TODO(), mq.p)
+			if err != nil {
+				log.Error(err)
+				// TODO: cant connect, what now?
+			}
+
+			// grab messages from queue
+			mq.lk.Lock()
+			wlm := mq.wlmsg
+			mq.wlmsg = nil
+			mq.lk.Unlock()
+
+			if wlm != nil && !wlm.Empty() {
+				// send wantlist updates
+				err = pm.network.SendMessage(context.TODO(), mq.p, wlm)
+				if err != nil {
+					log.Error("bitswap send error: ", err)
+					// TODO: what do we do if this fails?
+				}
+			}
+		case <-mq.done:
+			return
+		}
+	}
+}
+
+func (pm *PeerManager) Send(to peer.ID, msg bsmsg.BitSwapMessage) {
+	if len(msg.Blocks()) > 0 {
+		panic("no blocks here!")
+	}
+	pm.incoming <- &msgPair{to: to, msg: msg}
+}
+
+func (pm *PeerManager) Broadcast(msg bsmsg.BitSwapMessage) {
+	pm.incoming <- &msgPair{msg: msg}
+}
+
+func (pm *PeerManager) Connected(p peer.ID) {
+	pm.connect <- p
+}
+
+func (pm *PeerManager) Disconnected(p peer.ID) {
+	pm.disconnect <- p
+}
+
+// TODO: use goprocess here once i trust it
+func (pm *PeerManager) Run(ctx context.Context) {
+	for {
+		select {
+		case msgp := <-pm.incoming:
+
+			// Broadcast message to all if recipient not set
+			if msgp.to == "" {
+				for _, p := range pm.peers {
+					p.addMessage(msgp.msg)
+				}
+				continue
+			}
+
+			p, ok := pm.peers[msgp.to]
+			if !ok {
+				//TODO: decide, drop message? or dial?
+				pm.startPeerHandler(msgp.to)
+				p = pm.peers[msgp.to]
+			}
+
+			p.addMessage(msgp.msg)
+		case p := <-pm.connect:
+			pm.startPeerHandler(p)
+		case p := <-pm.disconnect:
+			pm.stopPeerHandler(p)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (mq *msgQueue) addMessage(msg bsmsg.BitSwapMessage) {
+	mq.lk.Lock()
+	defer func() {
+		mq.lk.Unlock()
+		select {
+		case mq.work <- struct{}{}:
+		default:
+		}
+	}()
+
+	if mq.wlmsg == nil || msg.Full() {
+		mq.wlmsg = msg
+		return
+	}
+
+	// TODO: add a msg.Combine(...) method
+	for _, e := range msg.Wantlist() {
+		if e.Cancel {
+			mq.wlmsg.Cancel(e.Key)
+		} else {
+			mq.wlmsg.AddEntry(e.Key, e.Priority)
+		}
+	}
+}

--- a/exchange/bitswap/peermanager.go
+++ b/exchange/bitswap/peermanager.go
@@ -7,28 +7,36 @@ import (
 	engine "github.com/ipfs/go-ipfs/exchange/bitswap/decision"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	bsnet "github.com/ipfs/go-ipfs/exchange/bitswap/network"
+	wantlist "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-type PeerManager struct {
+type WantManager struct {
 	receiver bsnet.Receiver
 
-	incoming   chan *msgPair
-	connect    chan peer.ID
+	incoming chan []*bsmsg.Entry
+
+	// notification channel for new peers connecting
+	connect chan peer.ID
+
+	// notification channel for peers disconnecting
 	disconnect chan peer.ID
 
 	peers map[peer.ID]*msgQueue
 
+	wl *wantlist.Wantlist
+
 	network bsnet.BitSwapNetwork
 }
 
-func NewPeerManager(network bsnet.BitSwapNetwork) *PeerManager {
-	return &PeerManager{
-		incoming:   make(chan *msgPair, 10),
+func NewWantManager(network bsnet.BitSwapNetwork) *WantManager {
+	return &WantManager{
+		incoming:   make(chan []*bsmsg.Entry, 10),
 		connect:    make(chan peer.ID, 10),
 		disconnect: make(chan peer.ID, 10),
 		peers:      make(map[peer.ID]*msgQueue),
+		wl:         wantlist.New(),
 		network:    network,
 	}
 }
@@ -53,37 +61,68 @@ type msgQueue struct {
 	done chan struct{}
 }
 
-func (pm *PeerManager) SendBlock(ctx context.Context, env *engine.Envelope) {
+func (pm *WantManager) WantBlocks(ks []u.Key) {
+	log.Error("WANT: ", ks)
+	pm.addEntries(ks, false)
+}
+
+func (pm *WantManager) CancelWants(ks []u.Key) {
+	log.Error("CANCEL: ", ks)
+	pm.addEntries(ks, true)
+}
+
+func (pm *WantManager) addEntries(ks []u.Key, cancel bool) {
+	var entries []*bsmsg.Entry
+	for i, k := range ks {
+		entries = append(entries, &bsmsg.Entry{
+			Cancel: cancel,
+			Entry: wantlist.Entry{
+				Key:      k,
+				Priority: kMaxPriority - i,
+			},
+		})
+	}
+	pm.incoming <- entries
+}
+
+func (pm *WantManager) SendBlock(ctx context.Context, env *engine.Envelope) {
 	// Blocks need to be sent synchronously to maintain proper backpressure
 	// throughout the network stack
 	defer env.Sent()
 
 	msg := bsmsg.New()
 	msg.AddBlock(env.Block)
+	msg.SetFull(false)
 	err := pm.network.SendMessage(ctx, env.Peer, msg)
 	if err != nil {
 		log.Error(err)
 	}
 }
 
-func (pm *PeerManager) startPeerHandler(ctx context.Context, p peer.ID) *msgQueue {
+func (pm *WantManager) startPeerHandler(ctx context.Context, p peer.ID) *msgQueue {
 	_, ok := pm.peers[p]
 	if ok {
 		// TODO: log an error?
 		return nil
 	}
 
-	mq := new(msgQueue)
-	mq.done = make(chan struct{})
-	mq.work = make(chan struct{}, 1)
-	mq.p = p
+	mq := newMsgQueue(p)
+
+	// new peer, we will want to give them our full wantlist
+	fullwantlist := bsmsg.New()
+	for _, e := range pm.wl.Entries() {
+		fullwantlist.AddEntry(e.Key, e.Priority)
+	}
+	fullwantlist.SetFull(true)
+	mq.out = fullwantlist
+	mq.work <- struct{}{}
 
 	pm.peers[p] = mq
 	go pm.runQueue(ctx, mq)
 	return mq
 }
 
-func (pm *PeerManager) stopPeerHandler(p peer.ID) {
+func (pm *WantManager) stopPeerHandler(p peer.ID) {
 	pq, ok := pm.peers[p]
 	if !ok {
 		// TODO: log error?
@@ -94,32 +133,38 @@ func (pm *PeerManager) stopPeerHandler(p peer.ID) {
 	delete(pm.peers, p)
 }
 
-func (pm *PeerManager) runQueue(ctx context.Context, mq *msgQueue) {
+func (pm *WantManager) runQueue(ctx context.Context, mq *msgQueue) {
 	for {
 		select {
 		case <-mq.work: // there is work to be done
 
-			// TODO: this might not need to be done every time, figure out
-			// a good heuristic
 			err := pm.network.ConnectTo(ctx, mq.p)
 			if err != nil {
 				log.Error(err)
 				// TODO: cant connect, what now?
 			}
 
-			// grab outgoin message
+			// grab outgoing message
 			mq.outlk.Lock()
 			wlm := mq.out
 			mq.out = nil
 			mq.outlk.Unlock()
 
-			if wlm != nil && !wlm.Empty() {
-				// send wantlist updates
-				err = pm.network.SendMessage(ctx, mq.p, wlm)
-				if err != nil {
-					log.Error("bitswap send error: ", err)
-					// TODO: what do we do if this fails?
-				}
+			// no message or empty message, continue
+			if wlm == nil {
+				log.Error("nil wantlist")
+				continue
+			}
+			if wlm.Empty() {
+				log.Error("empty wantlist")
+				continue
+			}
+
+			// send wantlist updates
+			err = pm.network.SendMessage(ctx, mq.p, wlm)
+			if err != nil {
+				log.Error("bitswap send error: ", err)
+				// TODO: what do we do if this fails?
 			}
 		case <-mq.done:
 			return
@@ -127,46 +172,38 @@ func (pm *PeerManager) runQueue(ctx context.Context, mq *msgQueue) {
 	}
 }
 
-func (pm *PeerManager) Send(to peer.ID, msg bsmsg.BitSwapMessage) {
-	if len(msg.Blocks()) > 0 {
-		panic("no blocks here!")
-	}
-	pm.incoming <- &msgPair{to: to, msg: msg}
-}
-
-func (pm *PeerManager) Broadcast(msg bsmsg.BitSwapMessage) {
-	pm.incoming <- &msgPair{msg: msg}
-}
-
-func (pm *PeerManager) Connected(p peer.ID) {
+func (pm *WantManager) Connected(p peer.ID) {
 	pm.connect <- p
 }
 
-func (pm *PeerManager) Disconnected(p peer.ID) {
+func (pm *WantManager) Disconnected(p peer.ID) {
 	pm.disconnect <- p
 }
 
 // TODO: use goprocess here once i trust it
-func (pm *PeerManager) Run(ctx context.Context) {
+func (pm *WantManager) Run(ctx context.Context) {
 	for {
 		select {
-		case msgp := <-pm.incoming:
+		case entries := <-pm.incoming:
 
-			// Broadcast message to all if recipient not set
-			if msgp.to == "" {
-				for _, p := range pm.peers {
-					p.addMessage(msgp.msg)
+			msg := bsmsg.New()
+			msg.SetFull(false)
+			// add changes to our wantlist
+			for _, e := range entries {
+				if e.Cancel {
+					pm.wl.Remove(e.Key)
+					msg.Cancel(e.Key)
+				} else {
+					pm.wl.Add(e.Key, e.Priority)
+					msg.AddEntry(e.Key, e.Priority)
 				}
-				continue
 			}
 
-			p, ok := pm.peers[msgp.to]
-			if !ok {
-				//TODO: decide, drop message? or dial?
-				p = pm.startPeerHandler(ctx, msgp.to)
+			// broadcast those wantlist changes
+			for _, p := range pm.peers {
+				p.addMessage(msg)
 			}
 
-			p.addMessage(msgp.msg)
 		case p := <-pm.connect:
 			pm.startPeerHandler(ctx, p)
 		case p := <-pm.disconnect:
@@ -175,6 +212,15 @@ func (pm *PeerManager) Run(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func newMsgQueue(p peer.ID) *msgQueue {
+	mq := new(msgQueue)
+	mq.done = make(chan struct{})
+	mq.work = make(chan struct{}, 1)
+	mq.p = p
+
+	return mq
 }
 
 func (mq *msgQueue) addMessage(msg bsmsg.BitSwapMessage) {
@@ -186,6 +232,10 @@ func (mq *msgQueue) addMessage(msg bsmsg.BitSwapMessage) {
 		default:
 		}
 	}()
+
+	if msg.Full() {
+		log.Error("GOt FULL MESSAGE")
+	}
 
 	// if we have no message held, or the one we are given is full
 	// overwrite the one we are holding
@@ -199,8 +249,10 @@ func (mq *msgQueue) addMessage(msg bsmsg.BitSwapMessage) {
 	// one passed in
 	for _, e := range msg.Wantlist() {
 		if e.Cancel {
+			log.Error("add message cancel: ", e.Key, mq.p)
 			mq.out.Cancel(e.Key)
 		} else {
+			log.Error("add message want: ", e.Key, mq.p)
 			mq.out.AddEntry(e.Key, e.Priority)
 		}
 	}

--- a/exchange/bitswap/stat.go
+++ b/exchange/bitswap/stat.go
@@ -17,8 +17,10 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	st := new(Stat)
 	st.ProvideBufLen = len(bs.newBlocks)
 	st.Wantlist = bs.GetWantlist()
+	bs.counterLk.Lock()
 	st.BlocksReceived = bs.blocksRecvd
 	st.DupBlksReceived = bs.dupBlocksRecvd
+	bs.counterLk.Unlock()
 
 	for _, p := range bs.engine.Peers() {
 		st.Peers = append(st.Peers, p.Pretty())

--- a/exchange/bitswap/testnet/network_test.go
+++ b/exchange/bitswap/testnet/network_test.go
@@ -29,19 +29,17 @@ func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
 	responder.SetDelegate(lambda(func(
 		ctx context.Context,
 		fromWaiter peer.ID,
-		msgFromWaiter bsmsg.BitSwapMessage) error {
+		msgFromWaiter bsmsg.BitSwapMessage) {
 
 		msgToWaiter := bsmsg.New()
 		msgToWaiter.AddBlock(blocks.NewBlock([]byte(expectedStr)))
 		waiter.SendMessage(ctx, fromWaiter, msgToWaiter)
-
-		return nil
 	}))
 
 	waiter.SetDelegate(lambda(func(
 		ctx context.Context,
 		fromResponder peer.ID,
-		msgFromResponder bsmsg.BitSwapMessage) error {
+		msgFromResponder bsmsg.BitSwapMessage) {
 
 		// TODO assert that this came from the correct peer and that the message contents are as expected
 		ok := false
@@ -54,9 +52,7 @@ func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
 
 		if !ok {
 			t.Fatal("Message not received from the responder")
-
 		}
-		return nil
 	}))
 
 	messageSentAsync := bsmsg.New()
@@ -71,7 +67,7 @@ func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
 }
 
 type receiverFunc func(ctx context.Context, p peer.ID,
-	incoming bsmsg.BitSwapMessage) error
+	incoming bsmsg.BitSwapMessage)
 
 // lambda returns a Receiver instance given a receiver function
 func lambda(f receiverFunc) bsnet.Receiver {
@@ -81,12 +77,12 @@ func lambda(f receiverFunc) bsnet.Receiver {
 }
 
 type lambdaImpl struct {
-	f func(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage) error
+	f func(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage)
 }
 
 func (lam *lambdaImpl) ReceiveMessage(ctx context.Context,
-	p peer.ID, incoming bsmsg.BitSwapMessage) error {
-	return lam.f(ctx, p, incoming)
+	p peer.ID, incoming bsmsg.BitSwapMessage) {
+	lam.f(ctx, p, incoming)
 }
 
 func (lam *lambdaImpl) ReceiveError(err error) {

--- a/exchange/bitswap/testnet/network_test.go
+++ b/exchange/bitswap/testnet/network_test.go
@@ -31,7 +31,7 @@ func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
 		fromWaiter peer.ID,
 		msgFromWaiter bsmsg.BitSwapMessage) {
 
-		msgToWaiter := bsmsg.New()
+		msgToWaiter := bsmsg.New(true)
 		msgToWaiter.AddBlock(blocks.NewBlock([]byte(expectedStr)))
 		waiter.SendMessage(ctx, fromWaiter, msgToWaiter)
 	}))
@@ -55,7 +55,7 @@ func TestSendMessageAsyncButWaitForResponse(t *testing.T) {
 		}
 	}))
 
-	messageSentAsync := bsmsg.New()
+	messageSentAsync := bsmsg.New(true)
 	messageSentAsync.AddBlock(blocks.NewBlock([]byte("data")))
 	errSending := waiter.SendMessage(
 		context.Background(), responderPeer.ID(), messageSentAsync)

--- a/exchange/bitswap/testnet/virtual.go
+++ b/exchange/bitswap/testnet/virtual.go
@@ -72,7 +72,8 @@ func (n *network) deliver(
 
 	n.delay.Wait()
 
-	return r.ReceiveMessage(context.TODO(), from, message)
+	r.ReceiveMessage(context.TODO(), from, message)
+	return nil
 }
 
 type networkClient struct {

--- a/exchange/bitswap/testnet/virtual.go
+++ b/exchange/bitswap/testnet/virtual.go
@@ -119,3 +119,12 @@ func (nc *networkClient) Provide(ctx context.Context, k util.Key) error {
 func (nc *networkClient) SetDelegate(r bsnet.Receiver) {
 	nc.Receiver = r
 }
+
+func (nc *networkClient) ConnectTo(_ context.Context, p peer.ID) error {
+	if !nc.network.HasPeer(p) {
+		return errors.New("no such peer in network")
+	}
+	nc.network.clients[p].PeerConnected(nc.local)
+	nc.Receiver.PeerConnected(p)
+	return nil
+}

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -178,6 +178,7 @@ func (pm *WantManager) Disconnected(p peer.ID) {
 // TODO: use goprocess here once i trust it
 func (pm *WantManager) Run() {
 	tock := time.NewTicker(rebroadcastDelay.Get())
+	defer tock.Stop()
 	for {
 		select {
 		case entries := <-pm.incoming:

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -66,6 +66,7 @@ type msgQueue struct {
 }
 
 func (pm *WantManager) WantBlocks(ks []u.Key) {
+	log.Infof("want blocks: %s", ks)
 	pm.addEntries(ks, false)
 }
 
@@ -97,6 +98,7 @@ func (pm *WantManager) SendBlock(ctx context.Context, env *engine.Envelope) {
 
 	msg := bsmsg.New(false)
 	msg.AddBlock(env.Block)
+	log.Infof("Sending block %s to %s", env.Peer, env.Block)
 	err := pm.network.SendMessage(ctx, env.Peer, msg)
 	if err != nil {
 		log.Error(err)
@@ -143,8 +145,9 @@ func (pm *WantManager) runQueue(mq *msgQueue) {
 
 			err := pm.network.ConnectTo(pm.ctx, mq.p)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("cant connect to peer %s: %s", mq.p, err)
 				// TODO: cant connect, what now?
+				continue
 			}
 
 			// grab outgoing message

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -96,7 +96,7 @@ func (pm *WantManager) SendBlock(ctx context.Context, env *engine.Envelope) {
 	log.Infof("Sending block %s to %s", env.Peer, env.Block)
 	err := pm.network.SendMessage(ctx, env.Peer, msg)
 	if err != nil {
-		log.Error(err)
+		log.Noticef("sendblock error: %s", err)
 	}
 }
 
@@ -158,7 +158,7 @@ func (mq *msgQueue) runQueue(ctx context.Context) {
 			// send wantlist updates
 			err = mq.network.SendMessage(ctx, mq.p, wlm)
 			if err != nil {
-				log.Error("bitswap send error: ", err)
+				log.Noticef("bitswap send error: %s", err)
 				// TODO: what do we do if this fails?
 			}
 		case <-mq.done:

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -42,11 +42,9 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 	}
 
 	// Start up a worker to manage periodically resending our wantlist out to peers
-	/*
-		px.Go(func(px process.Process) {
-			bs.rebroadcastWorker(ctx)
-		})
-	*/
+	px.Go(func(px process.Process) {
+		bs.rebroadcastWorker(ctx)
+	})
 
 	// Start up a worker to manage sending out provides messages
 	px.Go(func(px process.Process) {

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -46,6 +46,7 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 		bs.rebroadcastWorker(ctx)
 	})
 
+	// Start up a worker to manage sending out provides messages
 	px.Go(func(px process.Process) {
 		bs.provideCollector(ctx)
 	})
@@ -71,8 +72,7 @@ func (bs *Bitswap) taskWorker(ctx context.Context) {
 					continue
 				}
 
-				//log.Event(ctx, "deliverBlocks", envelope.Message, envelope.Peer)
-				bs.pm.SendBlock(envelope)
+				bs.pm.SendBlock(ctx, envelope)
 			case <-ctx.Done():
 				return
 			}

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -70,9 +70,9 @@ func (bs *Bitswap) taskWorker(ctx context.Context) {
 				if !ok {
 					continue
 				}
-				log.Event(ctx, "deliverBlocks", envelope.Message, envelope.Peer)
-				bs.send(ctx, envelope.Peer, envelope.Message)
-				envelope.Sent()
+
+				//log.Event(ctx, "deliverBlocks", envelope.Message, envelope.Peer)
+				bs.pm.SendBlock(envelope)
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
This PR moves all wantlist update logic into the wantmanager, this ensures that outgoing messages are synchronized and coalesced as needed. This greatly improves bitswap performance and correctness.