### PR TITLE
Get travis to test all commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 os:
   - linux
   - osx

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,11 @@ test_all_commits:
 	@echo "WARNING: this will 'git rebase --exec'."
 	@test/bin/continueyn
 	GIT_EDITOR=true git rebase -i --exec "make test" origin/master
+
+test_all_commits_travis:
+	# these are needed because travis.
+	# we don't use this yet because it takes way too long.
+	git config --global user.email "nemo@ipfs.io"
+	git config --global user.name "IPFS BOT"
+	git fetch origin master:master
+	GIT_EDITOR=true git rebase -i --exec "make test" master

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -59,6 +59,7 @@ Set the value of the 'datastore.path' key:
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("bool", "Set a boolean value"),
+		cmds.BoolOption("json", "Parse stringified JSON"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		args := req.Arguments()
@@ -74,7 +75,17 @@ Set the value of the 'datastore.path' key:
 		var output *ConfigField
 		if len(args) == 2 {
 			value := args[1]
-			if isbool, _, _ := req.Option("bool").Bool(); isbool {
+
+			if parseJson, _, _ := req.Option("json").Bool(); parseJson {
+				var jsonVal interface{}
+				if err := json.Unmarshal([]byte(value), &jsonVal); err != nil {
+					err = fmt.Errorf("failed to unmarshal json. %s", err)
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				output, err = setConfig(r, key, jsonVal)
+			} else if isbool, _, _ := req.Option("bool").Bool(); isbool {
 				output, err = setConfig(r, key, value == "true")
 			} else {
 				output, err = setConfig(r, key, value)
@@ -217,7 +228,7 @@ func getConfig(r repo.Repo, key string) (*ConfigField, error) {
 func setConfig(r repo.Repo, key string, value interface{}) (*ConfigField, error) {
 	err := r.SetConfigKey(key, value)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to set config value: %s", err)
+		return nil, fmt.Errorf("Failed to set config value: %s (maybe use --json?)", err)
 	}
 	return getConfig(r, key)
 }

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -143,6 +143,12 @@ test_init_ipfs() {
 	PORT_GWAY=$((RANDOM % 3000 + 8100))
 	ADDR_GWAY="/ip4/127.0.0.1/tcp/$PORT_GWAY"
 
+	PORT_SWARM=$((RANDOM % 3000 + 12000))
+	ADDR_SWARM="[
+  \"/ip4/0.0.0.0/tcp/$PORT_SWARM\"
+]"
+
+
 	# we set the Addresses.API config variable.
 	# the cli client knows to use it, so only need to set.
 	# todo: in the future, use env?
@@ -158,6 +164,7 @@ test_init_ipfs() {
 		test_config_set Mounts.IPNS "$(pwd)/ipns" &&
 		test_config_set Addresses.API "$ADDR_API" &&
 		test_config_set Addresses.Gateway "$ADDR_GWAY" &&
+		test_config_set --json Addresses.Swarm "$ADDR_SWARM" &&
 		ipfs bootstrap rm --all ||
 		test_fsh cat "\"$IPFS_PATH/config\""
 	'

--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -36,6 +36,17 @@ test_config_cmd_set() {
   '
 }
 
+# this is a bit brittle. the problem is we need to test
+# with something that will be forced to unmarshal as a struct.
+# (i.e. just setting 'ipfs config --json foo "[1, 2, 3]"') may
+# set it as astring instead of proper json. We leverage the
+# unmarshalling that has to happen.
+CONFIG_SET_JSON_TEST='{
+  "MDNS": {
+    "Enabled": true,
+    "Interval": 10
+  }
+}'
 
 test_config_cmd() {
   test_config_cmd_set "beep" "boop"
@@ -43,6 +54,9 @@ test_config_cmd() {
   test_config_cmd_set "beep1" "boop2"
   test_config_cmd_set "--bool" "beep2" "true"
   test_config_cmd_set "--bool" "beep2" "false"
+  test_config_cmd_set "--json" "beep3" "true"
+  test_config_cmd_set "--json" "beep3" "false"
+  test_config_cmd_set "--json" "Discovery" "$CONFIG_SET_JSON_TEST"
 
 }
 


### PR DESCRIPTION
This PR:
- config set: allow arbitrary json input
- sharness: randomize swarm address too.
- travis: use the KVM setup
- travis-ci: make test_all_commits

Ideally, after this, our travis runs:

- will randomize Swarm addr (and stop clashing \o/)
- will run faster (kvm setup)
- will test all commits.

Note: after this PR users can set arbitrary json input to config:

  ipfs config --json Addresses.Swarm '["/ip4/0.0.0.0/tcp/4002"]'

A future commit should introduce "-" as a value param (or --stdin)
to allow users to give the value in stdin.