### PR TITLE
net/p2p + secio: parallelize crypto handshake

### DIFF
--- a/p2p/net/conn/secure_conn_test.go
+++ b/p2p/net/conn/secure_conn_test.go
@@ -23,6 +23,15 @@ func upgradeToSecureConn(t *testing.T, ctx context.Context, sk ic.PrivKey, c Con
 	if err != nil {
 		return nil, err
 	}
+
+	// need to read + write, as that's what triggers the handshake.
+	h := []byte("hello")
+	if _, err := s.Write(h); err != nil {
+		return nil, err
+	}
+	if _, err := s.Read(h); err != nil {
+		return nil, err
+	}
 	return s, nil
 }
 


### PR DESCRIPTION
We had a very nasty problem: handshakes were serial so incoming
dials would wait for each other to finish handshaking. this was
particularly problematic when handshakes hung-- nodes would not
recover quickly. This led to gateways not bootstrapping peers
fast enough.

The approach taken here is to do what crypto/tls does:
defer the handshake until Read/Write[0]. There are a number of
reasons why this is _the right thing to do_:
- it delays handshaking until it is known to be necessary (doing io)
- it "accepts" before the handshake, getting the handshake out of the
  critical path entirely.
- it defers to the user's parallelization of conn handling. users
  must implement this in some way already so use that, instead of
  picking constants surely to be wrong (how many handshakes to run
  in parallel?)

[0] http://golang.org/src/crypto/tls/conn.go#L886