### PR TITLE
fix silent refs failure

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -154,7 +154,12 @@ func main() {
 	}
 
 	// everything went better than expected :)
-	io.Copy(os.Stdout, output)
+	_, err = io.Copy(os.Stdout, output)
+	if err != nil {
+		printErr(err)
+
+		os.Exit(1)
+	}
 }
 
 func (i *cmdInvocation) Run(ctx context.Context) (output io.Reader, err error) {


### PR DESCRIPTION
errors were being ignore in main.go, and on top of that, errors returned by readers cant be passed over http.