### PR TITLE
parse: fix handling of unwanted stdin

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -219,9 +219,11 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 		}
 	}
 
-	// count number of values provided by user
+	// count number of values provided by user.
+	// if there is at least one ArgDef, we can safely trigger the inputs loop
+	// below to parse stdin.
 	numInputs := len(inputs)
-	if stdin != nil {
+	if argDef := getArgDef(0, argDefs); argDef != nil && stdin != nil {
 		numInputs += 1
 	}
 

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -268,4 +268,7 @@ func TestArgumentParsing(t *testing.T) {
 	fstdin = fileToSimulateStdin(t, "stdin1")
 	test([]string{"stdinenablednotvariadic2args", "value1"}, fstdin, []string{"value1", "stdin1"})
 	test([]string{"stdinenablednotvariadic2args", "value1", "value2"}, fstdin, []string{"value1", "value2"})
+
+	fstdin = fileToSimulateStdin(t, "stdin1")
+	test([]string{"noarg"}, fstdin, []string{})
 }


### PR DESCRIPTION
There can be non-terminal (i.e. non-interactive) sessions
that are *not* a pipe, for example:

	ssh user@host ipfs version

In this case, it looks like we should read from stdin.
Parsing stdin is accomplished by deliberately triggering
the parsing loop once.

We didn't previously check whether there is an ArgDef to support
that loop iteration.