### PR TITLE
Check for nil in argument parsing

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -244,6 +244,13 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 			argDefIndex++
 			argDef = getArgDef(argDefIndex, argDefs)
 		}
+
+		// for some reason, this can be nil if
+		// ipfs is run as a node subprocess
+		if argDef == nil {
+			continue
+		}
+
 		if argDef.Required {
 			numRequired--
 		}


### PR DESCRIPTION
Ipfs crashes and burns when run as a subprocess. nil-checking solves the problem, even though i don't understand exactly what is happening.