### PR TITLE
Stdin parsing optional arg

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -223,7 +223,7 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 	// if there is at least one ArgDef, we can safely trigger the inputs loop
 	// below to parse stdin.
 	numInputs := len(inputs)
-	if argDef := getArgDef(0, argDefs); argDef != nil && stdin != nil {
+	if len(argDefs) > 0 && stdin != nil {
 		numInputs += 1
 	}
 

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -223,7 +223,7 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 	// if there is at least one ArgDef, we can safely trigger the inputs loop
 	// below to parse stdin.
 	numInputs := len(inputs)
-	if len(argDefs) > 0 && stdin != nil {
+	if len(argDefs) > 0 && argDefs[len(argDefs)-1].SupportsStdin && stdin != nil {
 		numInputs += 1
 	}
 

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -219,9 +219,11 @@ func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursi
 		}
 	}
 
-	// count number of values provided by user
+	// count number of values provided by user.
+	// if there is at least one ArgDef, we can safely trigger the inputs loop
+	// below to parse stdin.
 	numInputs := len(inputs)
-	if stdin != nil {
+	if argDef := getArgDef(0, argDefs); argDef != nil && stdin != nil {
 		numInputs += 1
 	}
 

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -144,6 +144,12 @@ func TestArgumentParsing(t *testing.T) {
 					commands.StringArg("b", false, true, "another arg"),
 				},
 			},
+			"optionalsecond": {
+				Arguments: []commands.Argument{
+					commands.StringArg("a", true, false, "some arg"),
+					commands.StringArg("b", false, false, "another arg"),
+				},
+			},
 			"reversedoptional": {
 				Arguments: []commands.Argument{
 					commands.StringArg("a", false, false, "some arg"),
@@ -213,6 +219,12 @@ func TestArgumentParsing(t *testing.T) {
 
 	test([]string{"optional", "value!"}, nil, []string{"value!"})
 	test([]string{"optional"}, nil, []string{})
+	test([]string{"optional", "value1", "value2"}, nil, []string{"value1", "value2"})
+
+	test([]string{"optionalsecond", "value!"}, nil, []string{"value!"})
+	test([]string{"optionalsecond", "value1", "value2"}, nil, []string{"value1", "value2"})
+	testFail([]string{"optionalsecond"}, "didn't provide any args, 1 required")
+	testFail([]string{"optionalsecond", "value1", "value2", "value3"}, "provided too many args, takes 2 maximum")
 
 	test([]string{"reversedoptional", "value1", "value2"}, nil, []string{"value1", "value2"})
 	test([]string{"reversedoptional", "value!"}, nil, []string{"value!"})

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -283,4 +283,7 @@ func TestArgumentParsing(t *testing.T) {
 
 	fstdin = fileToSimulateStdin(t, "stdin1")
 	test([]string{"noarg"}, fstdin, []string{})
+
+	fstdin = fileToSimulateStdin(t, "stdin1")
+	test([]string{"optionalsecond", "value1", "value2"}, fstdin, []string{"value1", "value2"})
 }

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -268,4 +268,7 @@ func TestArgumentParsing(t *testing.T) {
 	fstdin = fileToSimulateStdin(t, "stdin1")
 	test([]string{"stdinenablednotvariadic2args", "value1"}, fstdin, []string{"value1", "stdin1"})
 	test([]string{"stdinenablednotvariadic2args", "value1", "value2"}, fstdin, []string{"value1", "value2"})
+
+	fstdin = fileToSimulateStdin(t, "stdin1")
+	test([]string{"noarg"}, fstdin, []string{})
 }


### PR DESCRIPTION
This should fix issue #1260 (Ipfs crashes when run as a node subprocess).

This is based on top of @lgierth 's PR #1255 (parse: fix handling of unwanted stdin) as it modifies the same line of code.