### PR TITLE
Daemon panics if no path is given

### DIFF
--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -28,6 +28,10 @@ func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, er
 		}
 
 		seg := p.Segments()
+		if len(seg) < 2 {
+			return nil, errors.New("No path given")
+		}
+
 		extensions := seg[2:]
 		resolvable, err := path.FromSegments("/", seg[0], seg[1])
 		if err != nil {

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"strings"
+	"fmt"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
@@ -28,8 +29,9 @@ func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, er
 		}
 
 		seg := p.Segments()
-		if len(seg) < 2 {
-			return nil, errors.New("No path given")
+
+		if len(seg) < 2 || seg[1] == "" { // just "/<protocol/>" without further segments
+			return nil, fmt.Errorf("invalid path: %s", string(p))
 		}
 
 		extensions := seg[2:]

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -3,39 +3,19 @@ package core
 import (
 	"testing"
 
-	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	config "github.com/ipfs/go-ipfs/repo/config"
-	"github.com/ipfs/go-ipfs/util/testutil"
-	"github.com/ipfs/go-ipfs/repo"
 	path "github.com/ipfs/go-ipfs/path"
+	"strings"
 )
 
 func TestResolveInvalidPath(t *testing.T) {
-	ctx := context.TODO()
-	id := testIdentity
-
-	r := &repo.Mock{
-		C: config.Config{
-			Identity: id,
-			Datastore: config.Datastore{
-				Type: "memory",
-			},
-			Addresses: config.Addresses{
-				Swarm: []string{"/ip4/0.0.0.0/tcp/4001"},
-				API:   "/ip4/127.0.0.1/tcp/8000",
-			},
-		},
-		D: testutil.ThreadSafeCloserMapDatastore(),
-	}
-
-	n, err := NewIPFSNode(ctx, Standard(r, false))
+	n, err := NewMockNode()
 	if n == nil || err != nil {
-		t.Error("Should have constructed.", err)
+		t.Fatal("Should have constructed.", err)
 	}
 
-	_, err = Resolve(ctx, n, path.Path("/ipfs/"))
-	if err == nil {
-		t.Error("Should get invalid path")
+	_, err = Resolve(n.Context(), n, path.Path("/ipfs/"))
+	if !strings.HasPrefix(err.Error(), "invalid path") {
+		t.Fatal("Should get invalid path.", err)
 	}
 
 }

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"testing"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	config "github.com/ipfs/go-ipfs/repo/config"
+	"github.com/ipfs/go-ipfs/util/testutil"
+	"github.com/ipfs/go-ipfs/repo"
+	path "github.com/ipfs/go-ipfs/path"
+)
+
+func TestResolveInvalidPath(t *testing.T) {
+	ctx := context.TODO()
+	id := testIdentity
+
+	r := &repo.Mock{
+		C: config.Config{
+			Identity: id,
+			Datastore: config.Datastore{
+				Type: "memory",
+			},
+			Addresses: config.Addresses{
+				Swarm: []string{"/ip4/0.0.0.0/tcp/4001"},
+				API:   "/ip4/127.0.0.1/tcp/8000",
+			},
+		},
+		D: testutil.ThreadSafeCloserMapDatastore(),
+	}
+
+	n, err := NewIPFSNode(ctx, Standard(r, false))
+	if n == nil || err != nil {
+		t.Error("Should have constructed.", err)
+	}
+
+	_, err = Resolve(ctx, n, path.Path("/ipfs/"))
+	if err == nil {
+		t.Error("Should get invalid path")
+	}
+
+}


### PR DESCRIPTION
If no path after `/ipfs/` or `/ipns/` is given, then the daemon will
panic with a slice bounds out of range error. This checks to see if we
have anything after `ipfs` or `ipns`.