### PR TITLE
silence error log on shutdown

### DIFF
--- a/ipnsfs/system.go
+++ b/ipnsfs/system.go
@@ -80,7 +80,7 @@ func (fs *Filesystem) Close() error {
 			defer wg.Done()
 			err := r.Publish(context.TODO())
 			if err != nil {
-				log.Error(err)
+				log.Notice(err)
 				return
 			}
 		}(r)


### PR DESCRIPTION
This error always shows on shutdown, no matter what, dropping it down to a notice for now.