### PR TITLE
change pinning to happen in a callback

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -72,7 +72,7 @@ func (i *gatewayHandler) newDagFromReader(r io.Reader) (*dag.Node, error) {
 	// TODO(cryptix): change and remove this helper once PR1136 is merged
 	// return ufs.AddFromReader(i.node, r.Body)
 	return importer.BuildDagFromReader(
-		r, i.node.DAG, i.node.Pinning.GetManual(), chunk.DefaultSplitter)
+		r, i.node.DAG, chunk.DefaultSplitter, importer.BasicPinnerCB(i.node.Pinning.GetManual()))
 }
 
 // TODO(btc): break this apart into separate handlers using a more expressive muxer

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -1,7 +1,6 @@
 package coreunix
 
 import (
-	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"github.com/ipfs/go-ipfs/pin"
 	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
+	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("coreunix")
@@ -29,13 +29,10 @@ func Add(n *core.IpfsNode, r io.Reader) (string, error) {
 	dagNode, err := importer.BuildDagFromReader(
 		r,
 		n.DAG,
-		n.Pinning.GetManual(), // Fix this interface
 		chunk.DefaultSplitter,
+		importer.BasicPinnerCB(n.Pinning.GetManual()),
 	)
 	if err != nil {
-		return "", err
-	}
-	if err := n.Pinning.Flush(); err != nil {
 		return "", err
 	}
 	k, err := dagNode.Key()
@@ -53,18 +50,28 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 		return "", err
 	}
 	defer f.Close()
+
 	ff, err := files.NewSerialFile(root, f)
 	if err != nil {
 		return "", err
 	}
+
 	dagnode, err := addFile(n, ff)
 	if err != nil {
 		return "", err
 	}
+
 	k, err := dagnode.Key()
 	if err != nil {
 		return "", err
 	}
+
+	n.Pinning.GetManual().RemovePinWithMode(k, pin.Indirect)
+	err = n.Pinning.Flush()
+	if err != nil {
+		return "", err
+	}
+
 	return k.String(), nil
 }
 
@@ -87,17 +94,17 @@ func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *merkle
 }
 
 func add(n *core.IpfsNode, reader io.Reader) (*merkledag.Node, error) {
-	mp, ok := n.Pinning.(pin.ManualPinner)
-	if !ok {
-		return nil, errors.New("invalid pinner type! expected manual pinner")
-	}
+	mp := n.Pinning.GetManual()
 
-	node, err := importer.BuildDagFromReader(reader, n.DAG, mp, chunk.DefaultSplitter)
-	if err != nil {
-		return nil, err
-	}
-
-	err = n.Pinning.Flush()
+	node, err := importer.BuildDagFromReader(
+		reader,
+		n.DAG,
+		chunk.DefaultSplitter,
+		func(k u.Key, root bool) error {
+			mp.PinWithMode(k, pin.Indirect)
+			return nil
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ipfs/go-ipfs/pin"
 	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("coreunix")
@@ -100,10 +99,7 @@ func add(n *core.IpfsNode, reader io.Reader) (*merkledag.Node, error) {
 		reader,
 		n.DAG,
 		chunk.DefaultSplitter,
-		func(k u.Key, root bool) error {
-			mp.PinWithMode(k, pin.Indirect)
-			return nil
-		},
+		importer.PinIndirectCB(mp),
 	)
 	if err != nil {
 		return nil, err

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -37,7 +37,7 @@ func TestMetadata(t *testing.T) {
 	data := make([]byte, 1000)
 	u.NewTimeSeededRand().Read(data)
 	r := bytes.NewReader(data)
-	nd, err := importer.BuildDagFromReader(r, ds, nil, chunk.DefaultSplitter)
+	nd, err := importer.BuildDagFromReader(r, ds, chunk.DefaultSplitter, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -34,7 +34,7 @@ func randObj(t *testing.T, nd *core.IpfsNode, size int64) (*dag.Node, []byte) {
 	buf := make([]byte, size)
 	u.NewTimeSeededRand().Read(buf)
 	read := bytes.NewReader(buf)
-	obj, err := importer.BuildTrickleDagFromReader(read, nd.DAG, nil, chunk.DefaultSplitter)
+	obj, err := importer.BuildTrickleDagFromReader(read, nd.DAG, chunk.DefaultSplitter, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -5,6 +5,9 @@ import (
 	"github.com/ipfs/go-ipfs/pin"
 )
 
+// NodeCB is callback function for dag generation
+// the `root` flag signifies whether or not this is
+// the root of a dag.
 type NodeCB func(node *dag.Node, root bool) error
 
 var nilFunc NodeCB = func(_ *dag.Node, _ bool) error { return nil }

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -6,9 +6,10 @@ import (
 )
 
 // NodeCB is callback function for dag generation
-// the `root` flag signifies whether or not this is
-// the root of a dag.
-type NodeCB func(node *dag.Node, root bool) error
+// the `last` flag signifies whether or not this is the last
+// (top-most root) node being added. useful for things like
+// only pinning the first node recursively.
+type NodeCB func(node *dag.Node, last bool) error
 
 var nilFunc NodeCB = func(_ *dag.Node, _ bool) error { return nil }
 

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -113,8 +113,9 @@ func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
 	}
 
 	// Pin the child node indirectly
-	if db.mp != nil {
-		db.mp.PinWithMode(childkey, pin.Indirect)
+	err = db.bcb(childkey, false)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -107,13 +107,13 @@ func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
 		return err
 	}
 
-	childkey, err := db.dserv.Add(childnode)
+	_, err = db.dserv.Add(childnode)
 	if err != nil {
 		return err
 	}
 
 	// Pin the child node indirectly
-	err = db.bcb(childkey, false)
+	err = db.ncb(childnode, false)
 	if err != nil {
 		return err
 	}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -66,13 +66,13 @@ func BuildTrickleDagFromReader(r io.Reader, ds dag.DAGService, spl chunk.BlockSp
 }
 
 func BasicPinnerCB(p pin.ManualPinner) h.NodeCB {
-	return func(n *dag.Node, root bool) error {
+	return func(n *dag.Node, last bool) error {
 		k, err := n.Key()
 		if err != nil {
 			return err
 		}
 
-		if root {
+		if last {
 			p.PinWithMode(k, pin.Recursive)
 			return p.Flush()
 		} else {
@@ -83,7 +83,7 @@ func BasicPinnerCB(p pin.ManualPinner) h.NodeCB {
 }
 
 func PinIndirectCB(p pin.ManualPinner) h.NodeCB {
-	return func(n *dag.Node, root bool) error {
+	return func(n *dag.Node, last bool) error {
 		k, err := n.Key()
 		if err != nil {
 			return err

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -17,7 +17,7 @@ import (
 func getBalancedDag(t testing.TB, size int64, blksize int) (*dag.Node, dag.DAGService) {
 	ds := mdtest.Mock(t)
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
-	nd, err := BuildDagFromReader(r, ds, nil, &chunk.SizeSplitter{blksize})
+	nd, err := BuildDagFromReader(r, ds, &chunk.SizeSplitter{blksize}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func getBalancedDag(t testing.TB, size int64, blksize int) (*dag.Node, dag.DAGSe
 func getTrickleDag(t testing.TB, size int64, blksize int) (*dag.Node, dag.DAGService) {
 	ds := mdtest.Mock(t)
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
-	nd, err := BuildTrickleDagFromReader(r, ds, nil, &chunk.SizeSplitter{blksize})
+	nd, err := BuildTrickleDagFromReader(r, ds, &chunk.SizeSplitter{blksize}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestBalancedDag(t *testing.T) {
 	u.NewTimeSeededRand().Read(buf)
 	r := bytes.NewReader(buf)
 
-	nd, err := BuildDagFromReader(r, ds, nil, chunk.DefaultSplitter)
+	nd, err := BuildDagFromReader(r, ds, chunk.DefaultSplitter, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -156,7 +156,7 @@ func runBatchFetchTest(t *testing.T, read io.Reader) {
 
 	spl := &chunk.SizeSplitter{512}
 
-	root, err := imp.BuildDagFromReader(read, dagservs[0], nil, spl)
+	root, err := imp.BuildDagFromReader(read, dagservs[0], spl, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -11,6 +11,7 @@ import (
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	imp "github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	help "github.com/ipfs/go-ipfs/importer/helpers"
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
@@ -308,7 +309,7 @@ func (dm *DagModifier) appendData(node *mdag.Node, blks <-chan []byte) (*mdag.No
 	dbp := &help.DagBuilderParams{
 		Dagserv:  dm.dagserv,
 		Maxlinks: help.DefaultLinksPerBlock,
-		Pinner:   dm.mp,
+		BlockCB:  imp.BasicPinnerCB(dm.mp),
 	}
 
 	return trickle.TrickleAppend(node, dbp.New(blks))

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -309,7 +309,7 @@ func (dm *DagModifier) appendData(node *mdag.Node, blks <-chan []byte) (*mdag.No
 	dbp := &help.DagBuilderParams{
 		Dagserv:  dm.dagserv,
 		Maxlinks: help.DefaultLinksPerBlock,
-		BlockCB:  imp.BasicPinnerCB(dm.mp),
+		NodeCB:   imp.BasicPinnerCB(dm.mp),
 	}
 
 	return trickle.TrickleAppend(node, dbp.New(blks))

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -52,7 +52,7 @@ func getMockDagServAndBstore(t testing.TB) (mdag.DAGService, blockstore.Blocksto
 
 func getNode(t testing.TB, dserv mdag.DAGService, size int64, pinner pin.ManualPinner) ([]byte, *mdag.Node) {
 	in := io.LimitReader(u.NewTimeSeededRand(), size)
-	node, err := imp.BuildTrickleDagFromReader(in, dserv, pinner, &chunk.SizeSplitter{500})
+	node, err := imp.BuildTrickleDagFromReader(in, dserv, &chunk.SizeSplitter{500}, imp.BasicPinnerCB(pinner))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
this does the pinning for the add command inline (as it was intended to be) instead of after the fact. This has a significant perf improvement over the current speed of add, and that improvement increases the larger the file being added is.