### PR TITLE
t0060: expect success with stdin

### DIFF
--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -92,7 +92,7 @@ test_expect_success "'ipfs daemon' can be killed" '
   test_kill_repeat_10_sec $IPFS_PID
 '
 
-test_expect_failure "'ipfs daemon' should be able to run with a pipe attached to stdin (issue #861)" '
+test_expect_success "'ipfs daemon' should be able to run with a pipe attached to stdin (issue #861)" '
   yes | ipfs daemon --init >daemon_out 2>daemon_err &
   pollEndpoint -ep=/version -v -tout=1s -tries=10 >poll_apiout 2>poll_apierr &&
   test_kill_repeat_10_sec $! ||


### PR DESCRIPTION
This issue has been fixed by merging PR #1263 or PR #1238.
This fixes issue #861 (Strange error trying to run the daemon through supervisord).

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>