### PR TITLE
Bug/panic on empty path

### DIFF
--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"strings"
+	"fmt"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
@@ -29,8 +30,9 @@ func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, er
 		}
 
 		seg := p.Segments()
-		if len(seg) < 2 {
-			return nil, errors.New("No path given")
+
+		if len(seg) < 2 || seg[1] == "" { // just "/<protocol/>" without further segments
+			return nil, fmt.Errorf("invalid path: %s", string(p))
 		}
 
 		extensions := seg[2:]

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -3,7 +3,6 @@ package core
 import (
 	"errors"
 	"strings"
-	"fmt"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
@@ -32,7 +31,7 @@ func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, er
 		seg := p.Segments()
 
 		if len(seg) < 2 || seg[1] == "" { // just "/<protocol/>" without further segments
-			return nil, fmt.Errorf("invalid path: %s", string(p))
+			return nil, path.ErrNoComponents
 		}
 
 		extensions := seg[2:]

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -29,6 +29,10 @@ func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, er
 		}
 
 		seg := p.Segments()
+		if len(seg) < 2 {
+			return nil, errors.New("No path given")
+		}
+
 		extensions := seg[2:]
 		resolvable, err := path.FromSegments("/", seg[0], seg[1])
 		if err != nil {

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -4,18 +4,22 @@ import (
 	"testing"
 
 	path "github.com/ipfs/go-ipfs/path"
-	"strings"
 )
 
-func TestResolveInvalidPath(t *testing.T) {
+func TestResolveNoComponents(t *testing.T) {
 	n, err := NewMockNode()
 	if n == nil || err != nil {
-		t.Fatal("Should have constructed.", err)
+		t.Fatal("Should have constructed a mock node", err)
+	}
+
+	_, err = Resolve(n.Context(), n, path.Path("/ipns/"))
+	if err != path.ErrNoComponents {
+		t.Fatal("Should error with no components (/ipns/).", err)
 	}
 
 	_, err = Resolve(n.Context(), n, path.Path("/ipfs/"))
-	if !strings.HasPrefix(err.Error(), "invalid path") {
-		t.Fatal("Should get invalid path.", err)
+	if err != path.ErrNoComponents {
+		t.Fatal("Should error with no components (/ipfs/).", err)
 	}
 
 }

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -3,39 +3,19 @@ package core
 import (
 	"testing"
 
-	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	config "github.com/ipfs/go-ipfs/repo/config"
-	"github.com/ipfs/go-ipfs/util/testutil"
-	"github.com/ipfs/go-ipfs/repo"
 	path "github.com/ipfs/go-ipfs/path"
+	"strings"
 )
 
 func TestResolveInvalidPath(t *testing.T) {
-	ctx := context.TODO()
-	id := testIdentity
-
-	r := &repo.Mock{
-		C: config.Config{
-			Identity: id,
-			Datastore: config.Datastore{
-				Type: "memory",
-			},
-			Addresses: config.Addresses{
-				Swarm: []string{"/ip4/0.0.0.0/tcp/4001"},
-				API:   "/ip4/127.0.0.1/tcp/8000",
-			},
-		},
-		D: testutil.ThreadSafeCloserMapDatastore(),
-	}
-
-	n, err := NewIPFSNode(ctx, Standard(r, false))
+	n, err := NewMockNode()
 	if n == nil || err != nil {
-		t.Error("Should have constructed.", err)
+		t.Fatal("Should have constructed.", err)
 	}
 
-	_, err = Resolve(ctx, n, path.Path("/ipfs/"))
-	if err == nil {
-		t.Error("Should get invalid path")
+	_, err = Resolve(n.Context(), n, path.Path("/ipfs/"))
+	if !strings.HasPrefix(err.Error(), "invalid path") {
+		t.Fatal("Should get invalid path.", err)
 	}
 
 }

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"testing"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	config "github.com/ipfs/go-ipfs/repo/config"
+	"github.com/ipfs/go-ipfs/util/testutil"
+	"github.com/ipfs/go-ipfs/repo"
+	path "github.com/ipfs/go-ipfs/path"
+)
+
+func TestResolveInvalidPath(t *testing.T) {
+	ctx := context.TODO()
+	id := testIdentity
+
+	r := &repo.Mock{
+		C: config.Config{
+			Identity: id,
+			Datastore: config.Datastore{
+				Type: "memory",
+			},
+			Addresses: config.Addresses{
+				Swarm: []string{"/ip4/0.0.0.0/tcp/4001"},
+				API:   "/ip4/127.0.0.1/tcp/8000",
+			},
+		},
+		D: testutil.ThreadSafeCloserMapDatastore(),
+	}
+
+	n, err := NewIPFSNode(ctx, Standard(r, false))
+	if n == nil || err != nil {
+		t.Error("Should have constructed.", err)
+	}
+
+	_, err = Resolve(ctx, n, path.Path("/ipfs/"))
+	if err == nil {
+		t.Error("Should get invalid path")
+	}
+
+}

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -4,6 +4,7 @@ package path
 import (
 	"fmt"
 	"time"
+	"errors"
 
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
@@ -13,6 +14,10 @@ import (
 )
 
 var log = u.Logger("path")
+
+// Paths after a protocol must contain at least one component
+var ErrNoComponents = errors.New(
+	"path must contain at least one component")
 
 // ErrNoLink is returned when a link is not found in a path
 type ErrNoLink struct {
@@ -43,7 +48,7 @@ func SplitAbsPath(fpath Path) (mh.Multihash, []string, error) {
 
 	// if nothing, bail.
 	if len(parts) == 0 {
-		return nil, nil, fmt.Errorf("ipfs path must contain at least one component")
+		return nil, nil, ErrNoComponents
 	}
 
 	// first element in the path is a b58 hash (for now)


### PR DESCRIPTION
 If no path after `/ipfs/` or `/ipns/` is given, then the daemon will panic with a slice bounds out of range error. This checks to see if we have anything after `ipfs` or `ipns`.

Update the previous `invalid path` error to match the error returned from `SplitAbsPath`.