### PR TITLE
catch other error that means the file is locked

### DIFF
--- a/repo/fsrepo/lock/lock.go
+++ b/repo/fsrepo/lock/lock.go
@@ -34,6 +34,9 @@ func Locked(confdir string) (bool, error) {
 		if err == syscall.EAGAIN {
 			return true, nil
 		}
+		if strings.Contains(err.Error(), "can't Lock file") {
+			return true, nil
+		}
 
 		// lock fails on permissions error
 		if os.IsPermission(err) {


### PR DESCRIPTION
this should address the bug that @cryptix and @zignig ran into.

```
zignig | is anyone else getting Error: can't Lock file "/root/.ipfs/repo.lock": has non-zero size , on the latest master ?                                               
zignig | command line commands started failing.
```