### PR TITLE
sharness/t0060-daemon: don't reuse expect/actual names

### DIFF
--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -14,6 +14,7 @@ test_expect_success "setup IPFS_PATH" '
 '
 
 # NOTE: this should remove bootstrap peers (needs a flag)
+# TODO(cryptix): also default ports - might clash with local clients, failure in that case isn't clear because pollEndpoint just passes too 
 test_expect_success "ipfs daemon --init launches" '
   ipfs daemon --init >actual_daemon 2>daemon_err &
 '
@@ -28,9 +29,9 @@ test_expect_success "initialization ended" '
 # this is lifted straight from t0020-init.sh
 test_expect_success "ipfs peer id looks good" '
   PEERID=$(ipfs config Identity.PeerID) &&
-  echo $PEERID | tr -dC "[:alnum:]" | wc -c | tr -d " " >actual &&
-  echo "46" >expected &&
-  test_cmp_repeat_10_sec expected actual
+  echo $PEERID | tr -dC "[:alnum:]" | wc -c | tr -d " " >actual_id &&
+  echo "46" >expected_id &&
+  test_cmp_repeat_10_sec expected_id actual_id
 '
 
 # This is like t0020-init.sh "ipfs init output looks good"
@@ -43,15 +44,15 @@ test_expect_success "ipfs peer id looks good" '
 #
 test_expect_failure "ipfs daemon output looks good" '
   STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
-  echo "Initializing daemon..." >expected &&
-  echo "initializing ipfs node at $IPFS_PATH" >>expected &&
-  echo "generating 4096-bit RSA keypair...done" >>expected &&
-  echo "peer identity: $PEERID" >>expected &&
-  echo "to get started, enter:" >>expected &&
-  printf "\\n\\t$STARTFILE\\n\\n" >>expected &&
-  echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected &&
-  echo "Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080" >>expected &&
-  test_cmp_repeat_10_sec expected actual_daemon
+  echo "Initializing daemon..." >expected_daemon &&
+  echo "initializing ipfs node at $IPFS_PATH" >>expected_daemon &&
+  echo "generating 2048-bit RSA keypair...done" >>expected_daemon &&
+  echo "peer identity: $PEERID" >>expected_daemon &&
+  echo "to get started, enter:" >>expected_daemon &&
+  printf "\\n\\t$STARTFILE\\n\\n" >>expected_daemon &&
+  echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected_daemon &&
+  echo "Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080" >>expected_daemon &&
+  test_cmp_repeat_10_sec expected_daemon actual_daemon
 '
 
 test_expect_success ".ipfs/ has been created" '

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -14,7 +14,9 @@ test_expect_success "setup IPFS_PATH" '
 '
 
 # NOTE: this should remove bootstrap peers (needs a flag)
-# TODO(cryptix): also default ports - might clash with local clients, failure in that case isn't clear because pollEndpoint just passes too 
+# TODO(cryptix):
+#  - we won't see daemon startup failure because we put the daemon in the background - fix: fork with exit code after api listen
+#  - also default ports: might clash with local clients. Failure in that case isn't clear as well because pollEndpoint just uses the already running node 
 test_expect_success "ipfs daemon --init launches" '
   ipfs daemon --init >actual_daemon 2>daemon_err &
 '
@@ -26,9 +28,14 @@ test_expect_success "initialization ended" '
   test_fsh cat actual_daemon || test_fsh cat daemon_err || test_fsh cat poll_apierr || test_fsh cat poll_apiout
 '
 
+# this errors if daemon didnt --init $IPFS_PATH correctly
+test_expect_success "'ipfs config Identity.PeerID' works" '
+  ipfs config Identity.PeerID >config_peerId
+'
+
 # this is lifted straight from t0020-init.sh
 test_expect_success "ipfs peer id looks good" '
-  PEERID=$(ipfs config Identity.PeerID) &&
+  PEERID=$(cat config_peerId) &&
   echo $PEERID | tr -dC "[:alnum:]" | wc -c | tr -d " " >actual_id &&
   echo "46" >expected_id &&
   test_cmp_repeat_10_sec expected_id actual_id
@@ -42,7 +49,7 @@ test_expect_success "ipfs peer id looks good" '
 #
 # sometimes doesn't show up, so we cannot use test_expect_success yet.
 #
-test_expect_failure "ipfs daemon output looks good" '
+test_expect_success "ipfs daemon output looks good" '
   STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
   echo "Initializing daemon..." >expected_daemon &&
   echo "initializing ipfs node at $IPFS_PATH" >>expected_daemon &&
@@ -52,7 +59,7 @@ test_expect_failure "ipfs daemon output looks good" '
   printf "\\n\\t$STARTFILE\\n\\n" >>expected_daemon &&
   echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected_daemon &&
   echo "Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080" >>expected_daemon &&
-  test_cmp_repeat_10_sec expected_daemon actual_daemon
+  test_cmp expected_daemon actual_daemon
 '
 
 test_expect_success ".ipfs/ has been created" '
@@ -93,11 +100,11 @@ test_expect_success "'ipfs daemon' can be killed" '
   test_kill_repeat_10_sec $IPFS_PID
 '
 
-test_expect_failure "'ipfs daemon' should be able to run with a pipe attached to stdin (issue #861)" '
-  yes | ipfs daemon --init >daemon_out 2>daemon_err &
-  pollEndpoint -ep=/version -v -tout=1s -tries=10 >poll_apiout 2>poll_apierr &&
+test_expect_success "'ipfs daemon' should be able to run with a pipe attached to stdin (issue #861)" '
+  yes | ipfs daemon --init >stdin_daemon_out 2>stdin_daemon_err &
+  pollEndpoint -ep=/version -v -tout=1s -tries=10 >stdin_poll_apiout 2>stdin_poll_apierr &&
   test_kill_repeat_10_sec $! ||
-  test_fsh cat daemon_out || test_fsh cat daemon_err || test_fsh cat poll_apiout || test_fsh cat poll_apierr
+  test_fsh cat stdin_daemon_out || test_fsh cat stdin_daemon_err || test_fsh cat stdin_poll_apiout || test_fsh cat stdin_poll_apierr
 '
 
 test_done


### PR DESCRIPTION
If the names are reused, you might stare at the wrong output from another command, wondering what is going on.