### PR TITLE
WIP: discover peers from cjdns

### DIFF
--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -211,8 +211,6 @@ func toPeerInfos(bpeers []config.BootstrapPeer) []peer.PeerInfo {
 }
 
 func toPeerInfo(bp config.BootstrapPeer) peer.PeerInfo {
-	// for now, we drop the "ipfs addr" part of the multiaddr. the rest
-	// of the codebase currently uses addresses without the peerid part.
 	m := bp.Multiaddr()
 	s := ma.Split(m)
 	m = ma.Join(s[:len(s)-1]...)

--- a/core/builder.go
+++ b/core/builder.go
@@ -139,7 +139,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		if err != nil {
 			return err
 		}
-		do := setupDiscoveryOption(rcfg.Discovery)
+		do := setupDiscoveryOptions(rcfg.Discovery)
 		if err := n.startOnlineServices(ctx, cfg.Routing, cfg.Host, do); err != nil {
 			return err
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -171,7 +171,7 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 
 	// setup local discovery
 	for _, opt := range discoveryOpts {
-		if service, err := opt(n.PeerHost); err != nil {
+		if service, err := opt(ctx, n.PeerHost); err != nil {
 			return err
 		} else {
 			service.RegisterNotifee(n)
@@ -186,7 +186,7 @@ func setupDiscoveryOptions(d config.Discovery) []DiscoveryOption {
 	opts := []DiscoveryOption{}
 
 	if d.MDNS.Enabled {
-		opt := func(h p2phost.Host) (discovery.Service, error) {
+		opt := func(_ context.Context, h p2phost.Host) (discovery.Service, error) {
 			if d.MDNS.Interval == 0 {
 				d.MDNS.Interval = 5
 			}
@@ -195,11 +195,8 @@ func setupDiscoveryOptions(d config.Discovery) []DiscoveryOption {
 		opts = append(opts, opt)
 	}
 	if d.Cjdns.Enabled {
-		opt := func(h p2phost.Host) (discovery.Service, error) {
-			if d.Cjdns.Interval == 0 {
-				d.Cjdns.Interval = 5
-			}
-			return discovery.NewCjdnsService(h, time.Duration(d.Cjdns.Interval)*time.Second)
+		opt := func(ctx, context.Context, h p2phost.Host) (discovery.Service, error) {
+			return discovery.NewCjdnsService(ctx, h, d.Cjdns)
 		}
 		opts = append(opts, opt)
 	}

--- a/p2p/crypto/secio/interface.go
+++ b/p2p/crypto/secio/interface.go
@@ -2,6 +2,7 @@
 package secio
 
 import (
+	"fmt"
 	"io"
 
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
@@ -68,6 +69,7 @@ func (s *secureSession) LocalPrivateKey() ci.PrivKey {
 // RemotePeer retrieves the remote peer.
 func (s *secureSession) RemotePeer() peer.ID {
 	if err := s.Handshake(); err != nil {
+		fmt.Printf("handshake error: %s\n", err)
 		return ""
 	}
 	return s.remotePeer

--- a/p2p/discovery/cjdns.go
+++ b/p2p/discovery/cjdns.go
@@ -1,0 +1,98 @@
+package discovery
+
+// mdns introduced in https://github.com/ipfs/go-ipfs/pull/1117
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
+	"github.com/ipfs/go-ipfs/p2p/host"
+
+	"github.com/ehmry/go-cjdns/admin"
+	"github.com/ehmry/go-cjdns/key"
+)
+
+type cjdnsService struct {
+	admin    *admin.Conn
+	host     host.Host
+	lk       sync.Mutex
+	notifees []Notifee
+	interval time.Duration
+}
+
+func NewCjdnsService(host host.Host, interval time.Duration) (Service, error) {
+	cjdnsConfig := &admin.CjdnsAdminConfig{
+		Addr:     "127.0.0.1",
+		Port:     11234,
+		Password: "NONE",
+	}
+	admin, err := admin.Connect(cjdnsConfig)
+	if err != nil {
+		log.Error("cjdns connect error: ", err)
+		return nil, err
+	}
+
+	log.Debug("cjdns admin api connected")
+
+	service := &cjdnsService{
+		admin:    admin,
+		host:     host,
+		interval: interval,
+	}
+
+	go service.pollPeerStats()
+
+	return service, nil
+}
+
+func (cjdns *cjdnsService) Close() error {
+	return nil
+}
+
+func (cjdns *cjdnsService) pollPeerStats() {
+	ticker := time.NewTicker(cjdns.interval)
+	for {
+		select {
+		case <-ticker.C:
+			results, err := cjdns.admin.InterfaceController_peerStats()
+			if err != nil {
+				log.Error("cjdns peerstats error: ", err)
+			}
+
+			for _, peer := range results {
+				k, err := key.DecodePublic(peer.PublicKey.String())
+				if err != nil {
+					log.Error("malformed cjdns key: [%s] %s", peer.PublicKey.String(), err)
+				}
+				maddr, err := manet.FromNetAddr(&net.TCPAddr{IP: k.IP(), Port: 4001})
+				if err != nil {
+					log.Error("corrupt multiaddr: %s", err)
+				}
+				log.Debugf("possible cjdns peer: %s", maddr.String())
+			}
+		}
+	}
+}
+
+func (c *cjdnsService) RegisterNotifee(n Notifee) {
+	c.lk.Lock()
+	c.notifees = append(c.notifees, n)
+	c.lk.Unlock()
+}
+
+func (c *cjdnsService) UnregisterNotifee(n Notifee) {
+	c.lk.Lock()
+	found := -1
+	for i, notif := range c.notifees {
+		if notif == n {
+			found = i
+			break
+		}
+	}
+	if found != -1 {
+		c.notifees = append(c.notifees[:found], c.notifees[found+1:]...)
+	}
+	c.lk.Unlock()
+}

--- a/p2p/discovery/cjdns.go
+++ b/p2p/discovery/cjdns.go
@@ -1,112 +1,210 @@
 package discovery
 
 import (
-	"io"
+	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
-	"github.com/ipfs/go-ipfs/p2p/host"
-	swarm "github.com/ipfs/go-ipfs/p2p/net/swarm"
-
-	"github.com/ehmry/go-cjdns/admin"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	host "github.com/ipfs/go-ipfs/p2p/host"
+	swarm "github.com/ipfs/go-ipfs/p2p/net/swarm"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	// TODO: kill this dependency
+	config "github.com/ipfs/go-ipfs/repo/config"
+
+	cjdns "github.com/ehmry/go-cjdns/admin"
 )
 
 type cjdnsService struct {
-	admin    *admin.Conn
 	host     host.Host
+	dialed   map[ma.Multiaddr]bool
+	ctx      context.Context
 	lk       sync.Mutex
 	notifees []Notifee
-	interval time.Duration
 }
 
-func NewCjdnsService(host host.Host, interval time.Duration) (Service, error) {
-	cjdnsConfig := &admin.CjdnsAdminConfig{
-		Addr:     "127.0.0.1",
-		Port:     11234,
-		Password: "NONE",
+func NewCjdnsService(ctx context.Context, host host.Host, cfg config.Cjdns) (Service, error) {
+	s := &cjdnsService{
+		host:   host,
+		dialed: map[ma.Multiaddr]bool{},
+		ctx:    ctx,
 	}
-	admin, err := admin.Connect(cjdnsConfig)
+
+	admin, err := cjdnsAdmin(cfg)
 	if err != nil {
-		log.Error("cjdns connect error: ", err)
-		return nil, err
-	}
-
-	log.Debug("cjdns admin api connected")
-
-	service := &cjdnsService{
-		admin:    admin,
-		host:     host,
-		interval: interval,
+		log.Errorf("cjdns admin error: %s", err)
+	} else {
+		s.Discover(admin)
 	}
 
 	go func() {
-		for {
-			service.pollPeerStats()
-			log.Fatal("quit here")
+		s.Discover(admin)
+		ticker := time.NewTicker(time.Duration(cfg.Interval) * time.Second)
+		rticker := time.NewTicker(time.Duration(cfg.RefreshInterval) * time.Second)
+		select {
+		case <-ticker.C:
+			admin, err := cjdnsAdmin(cfg)
+			if err != nil {
+				log.Errorf("cjdns admin error: %s", err)
+			} else {
+				s.Discover(admin)
+			}
+		case <-rticker.C:
+			s.dialed = map[ma.Multiaddr]bool{}
+		case <-s.ctx.Done():
+			ticker.Stop()
+			rticker.Stop()
+			return
 		}
 	}()
 
-	return service, nil
+	return s, nil
 }
 
-func (cjdns *cjdnsService) Close() error {
+// TODO is this right?
+func (s *cjdnsService) Close() error {
+	s.ctx.Done()
 	return nil
 }
 
-func (cjdns *cjdnsService) pollPeerStats() {
-	peerstats, err := cjdns.admin.InterfaceController_peerStats()
+func (s *cjdnsService) Discover(admin *cjdns.Conn) {
+	nodes, err := knownCjdnsNodes(admin)
 	if err != nil {
-		log.Errorf("cjdns peerstats error: %s", err)
+		log.Errorf("known cjdns nodes error: %s", err)
 		return
 	}
 
-	for _, peer := range peerstats {
-		ipaddr := peer.PublicKey.IP()
-		maddr, err := manet.FromNetAddr(&net.TCPAddr{IP: ipaddr, Port: 4001})
+	for _, maddr := range nodes {
+		if _, dialed := s.dialed[maddr]; dialed {
+			continue
+		}
+		id, err := s.dial(maddr)
 		if err != nil {
-			log.Errorf("corrupt multiaddr: [%s] %s", ipaddr, err)
+			log.Debugf("dial error: %s", err)
 			continue
 		}
 
-		p2pnet := cjdns.host.Network()
-		swnet := p2pnet.(*swarm.Network)
-		conn, err := swnet.Swarm().Dialer().Dial(context.TODO(), maddr, "")
+		str := maddr.String() + "/ipfs/" + id.Pretty()
+		maddrid, err := ma.NewMultiaddr(str)
 		if err != nil {
-			log.Debugf("dial failed: [%s] %s", maddr.String(), err)
+			log.Errorf("multiaddr error: [%s] %s", str, err)
 			continue
 		}
 
-		rp := conn.RemotePeer().Pretty()
-		if len(rp) == 0 {
-			log.Errorf("handshake failed with %s", maddr.String())
-			continue
-		}
-		maddr = ma.NewMultiaddr(maddr.String() + "/ipfs/" + rp)
-		log.Debugf("possible cjdns peer: %s", maddr)
+		s.dialed[maddr] = true
+		log.Infof("discovered %s", str)
+		s.emit(id, maddrid)
 	}
 }
 
-func (c *cjdnsService) RegisterNotifee(n Notifee) {
-	c.lk.Lock()
-	c.notifees = append(c.notifees, n)
-	c.lk.Unlock()
+func (s *cjdnsService) dial(maddr ma.Multiaddr) (peer.ID, error) {
+	p2pnet := s.host.Network()
+	swnet := p2pnet.(*swarm.Network)
+	conn, err := swnet.Swarm().Dialer().Dial(s.ctx, maddr, "")
+	if err != nil {
+		return "", err
+	}
+
+	id := conn.RemotePeer()
+	if len(id) == 0 {
+		return "", fmt.Debugf("handshake failed with %s", maddr.String())
+	}
+
+	return id, nil
 }
 
-func (c *cjdnsService) UnregisterNotifee(n Notifee) {
-	c.lk.Lock()
+func (s *cjdnsService) emit(id peer.ID, maddr ma.Multiaddr) {
+	pi := peer.PeerInfo{
+		ID:    id,
+		Addrs: []ma.Multiaddr{maddr},
+	}
+
+	s.lk.Lock()
+	for _, n := range s.notifees {
+		n.HandlePeerFound(pi)
+	}
+	s.lk.Unlock()
+}
+
+func knownCjdnsNodes(admin *cjdns.Conn) ([]ma.Multiaddr, error) {
+	nodes := []ma.Multiaddr{}
+
+	peers, err := admin.InterfaceController_peerStats()
+	if err != nil {
+		return nil, err
+	}
+	for _, peer := range peers {
+		maddr, err := fromCjdnsIP(peer.PublicKey.IP())
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, maddr)
+	}
+
+	nodestore, err := admin.NodeStore_dumpTable()
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodestore {
+		maddr, err := fromCjdnsIP(*node.IP)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, maddr)
+	}
+
+	return nodes, nil
+}
+
+func fromCjdnsIP(ip net.IP) (ma.Multiaddr, error) {
+	return manet.FromNetAddr(&net.TCPAddr{IP: ip, Port: 4001})
+}
+
+func cjdnsAdmin(cfg config.Cjdns) (*cjdns.Conn, error) {
+	maddr, err := ma.NewMultiaddr(cfg.AdminAddress)
+	if err != nil {
+		panic(fmt.Errorf("invalid Cjdns.AdminAddress: %s", err))
+	}
+	p := strings.Split(maddr.String(), "/")[1:]
+	if p[2] != "udp" {
+		panic(fmt.Errorf("non-udp Cjdns.AdminAddress: %s", p[2]))
+	}
+
+	port, _ := strconv.ParseInt(p[3], 10, 16)
+	c := &cjdns.CjdnsAdminConfig{
+		Addr:     p[1],
+		Port:     int(port),
+		Password: "NONE",
+	}
+	admin, err := cjdns.Connect(c)
+	if err != nil {
+		return nil, err
+	}
+	return admin, nil
+}
+
+func (s *cjdnsService) RegisterNotifee(n Notifee) {
+	s.lk.Lock()
+	s.notifees = append(s.notifees, n)
+	s.lk.Unlock()
+}
+
+func (s *cjdnsService) UnregisterNotifee(n Notifee) {
+	s.lk.Lock()
 	found := -1
-	for i, notif := range c.notifees {
+	for i, notif := range s.notifees {
 		if notif == n {
 			found = i
 			break
 		}
 	}
 	if found != -1 {
-		c.notifees = append(c.notifees[:found], c.notifees[found+1:]...)
+		s.notifees = append(s.notifees[:found], s.notifees[found+1:]...)
 	}
-	c.lk.Unlock()
+	s.lk.Unlock()
 }

--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -1,0 +1,20 @@
+package discovery
+
+import (
+	"io"
+
+	"github.com/ipfs/go-ipfs/p2p/peer"
+	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
+)
+
+var log = logging.Logger("discovery")
+
+type Service interface {
+	io.Closer
+	RegisterNotifee(Notifee)
+	UnregisterNotifee(Notifee)
+}
+
+type Notifee interface {
+	HandlePeerFound(peer.PeerInfo)
+}

--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"errors"
-	"io"
 	"io/ioutil"
 	golog "log"
 	"net"
@@ -15,22 +14,9 @@ import (
 
 	"github.com/ipfs/go-ipfs/p2p/host"
 	"github.com/ipfs/go-ipfs/p2p/peer"
-	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
 )
 
-var log = logging.Logger("mdns")
-
 const ServiceTag = "discovery.ipfs.io"
-
-type Service interface {
-	io.Closer
-	RegisterNotifee(Notifee)
-	UnregisterNotifee(Notifee)
-}
-
-type Notifee interface {
-	HandlePeerFound(peer.PeerInfo)
-}
 
 type mdnsService struct {
 	server  *mdns.Server

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -170,6 +170,11 @@ func (s *Swarm) Close() error {
 	return s.proc.Close()
 }
 
+// Dialer returns the p2p/net dialer of this swarm
+func (s *Swarm) Dialer() *conn.Dialer {
+	return s.dialer
+}
+
 // StreamSwarm returns the underlying peerstream.Swarm
 func (s *Swarm) StreamSwarm() *ps.Swarm {
 	return s.swarm

--- a/repo/config/discovery.go
+++ b/repo/config/discovery.go
@@ -1,12 +1,18 @@
 package config
 
 type Discovery struct {
-	MDNS MDNS
+	MDNS  MDNS
+	Cjdns Cjdns
 }
 
 type MDNS struct {
 	Enabled bool
 
 	// Time in seconds between discovery rounds
+	Interval int
+}
+
+type Cjdns struct {
+	Enabled  bool
 	Interval int
 }

--- a/repo/config/discovery.go
+++ b/repo/config/discovery.go
@@ -13,6 +13,10 @@ type MDNS struct {
 }
 
 type Cjdns struct {
-	Enabled  bool
-	Interval int
+	Enabled         bool
+	DialTimeout     int
+	Interval        int    // 10m0s
+	RefreshInterval int    // 24h0m0s
+	AdminAddress    string // /ip4/127.0.0.1/udp/11234
+	Password        string // NONE
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -55,8 +55,11 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 				Interval: 10,
 			},
 			Cjdns{
-				Enabled:  true,
-				Interval: 10,
+				Enabled:         true,
+				Interval:        3600,
+				RefreshInterval: 24 * 3600,
+				AdminAddress:    "/ip4/127.0.0.1/udp/11234",
+				Password:        "NONE",
 			}},
 
 		// setup the node mount points.

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -49,10 +49,15 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		SupernodeRouting: *snr,
 		Datastore:        *ds,
 		Identity:         identity,
-		Discovery: Discovery{MDNS{
-			Enabled:  true,
-			Interval: 10,
-		}},
+		Discovery: Discovery{
+			MDNS{
+				Enabled:  true,
+				Interval: 10,
+			},
+			Cjdns{
+				Enabled:  true,
+				Interval: 10,
+			}},
 
 		// setup the node mount points.
 		Mounts: Mounts{


### PR DESCRIPTION
Cjdns provides a private and authenticated IPv6 network on top of UDP or Ethernet. We can use its peer list ("peerstats") or routing table ("nodestore") to discover peers and assume IPFS might be running on port 4001.

This PR introduces a discovery service analogous to MDNS, which polls cjdns' admin API and then dials each of the possible peers.

It already discovers peers, but does not yet dial them, since dialing requires the peer ID. A little refactoring of swarm_dial.go will enable dialing without a peer ID. An idea for that will follow in a comment.