### PR TITLE
move util.Key into its own package under blocks

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
@@ -35,8 +36,8 @@ func NewBlockWithHash(data []byte, h mh.Multihash) (*Block, error) {
 }
 
 // Key returns the block's Multihash as a Key value.
-func (b *Block) Key() u.Key {
-	return u.Key(b.Multihash)
+func (b *Block) Key() key.Key {
+	return key.Key(b.Multihash)
 }
 
 func (b *Block) String() string {

--- a/blocks/blockstore/blockstore_test.go
+++ b/blocks/blockstore/blockstore_test.go
@@ -11,14 +11,14 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	blocks "github.com/ipfs/go-ipfs/blocks"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 // TODO(brian): TestGetReturnsNil
 
 func TestGetWhenKeyNotPresent(t *testing.T) {
 	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
-	_, err := bs.Get(u.Key("not present"))
+	_, err := bs.Get(key.Key("not present"))
 
 	if err != nil {
 		t.Log("As expected, block is not present")
@@ -45,13 +45,13 @@ func TestPutThenGetBlock(t *testing.T) {
 	}
 }
 
-func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []u.Key) {
+func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []key.Key) {
 	if d == nil {
 		d = ds.NewMapDatastore()
 	}
 	bs := NewBlockstore(ds_sync.MutexWrap(d))
 
-	keys := make([]u.Key, N)
+	keys := make([]key.Key, N)
 	for i := 0; i < N; i++ {
 		block := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
 		err := bs.Put(block)
@@ -63,8 +63,8 @@ func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []u
 	return bs, keys
 }
 
-func collect(ch <-chan u.Key) []u.Key {
-	var keys []u.Key
+func collect(ch <-chan key.Key) []key.Key {
+	var keys []key.Key
 	for k := range ch {
 		keys = append(keys, k)
 	}
@@ -219,7 +219,7 @@ func TestValueTypeMismatch(t *testing.T) {
 	}
 }
 
-func expectMatches(t *testing.T, expect, actual []u.Key) {
+func expectMatches(t *testing.T, expect, actual []key.Key) {
 
 	if len(expect) != len(actual) {
 		t.Errorf("expect and actual differ: %d != %d", len(expect), len(actual))

--- a/blocks/blockstore/write_cache.go
+++ b/blocks/blockstore/write_cache.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/hashicorp/golang-lru"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/ipfs/go-ipfs/blocks"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 // WriteCached returns a blockstore that caches up to |size| unique writes (bs.Put).
@@ -21,19 +21,19 @@ type writecache struct {
 	blockstore Blockstore
 }
 
-func (w *writecache) DeleteBlock(k u.Key) error {
+func (w *writecache) DeleteBlock(k key.Key) error {
 	w.cache.Remove(k)
 	return w.blockstore.DeleteBlock(k)
 }
 
-func (w *writecache) Has(k u.Key) (bool, error) {
+func (w *writecache) Has(k key.Key) (bool, error) {
 	if _, ok := w.cache.Get(k); ok {
 		return true, nil
 	}
 	return w.blockstore.Has(k)
 }
 
-func (w *writecache) Get(k u.Key) (*blocks.Block, error) {
+func (w *writecache) Get(k key.Key) (*blocks.Block, error) {
 	return w.blockstore.Get(k)
 }
 
@@ -45,6 +45,6 @@ func (w *writecache) Put(b *blocks.Block) error {
 	return w.blockstore.Put(b)
 }
 
-func (w *writecache) AllKeysChan(ctx context.Context) (<-chan u.Key, error) {
+func (w *writecache) AllKeysChan(ctx context.Context) (<-chan key.Key, error) {
 	return w.blockstore.AllKeysChan(ctx)
 }

--- a/blocks/key/key.go
+++ b/blocks/key/key.go
@@ -1,4 +1,4 @@
-package util
+package key
 
 import (
 	"encoding/json"
@@ -104,40 +104,6 @@ func (b58KeyConverter) InvertKey(dsk ds.Key) ds.Key {
 		k = k.ChildString(string(b58.Decode(n)))
 	}
 	return k
-}
-
-// Hash is the global IPFS hash function. uses multihash SHA2_256, 256 bits
-func Hash(data []byte) mh.Multihash {
-	h, err := mh.Sum(data, mh.SHA2_256, -1)
-	if err != nil {
-		// this error can be safely ignored (panic) because multihash only fails
-		// from the selection of hash function. If the fn + length are valid, it
-		// won't error.
-		panic("multihash failed to hash using SHA2_256.")
-	}
-	return h
-}
-
-// IsValidHash checks whether a given hash is valid (b58 decodable, len > 0)
-func IsValidHash(s string) bool {
-	out := b58.Decode(s)
-	if out == nil || len(out) == 0 {
-		return false
-	}
-	_, err := mh.Cast(out)
-	if err != nil {
-		return false
-	}
-	return true
-}
-
-// XOR takes two byte slices, XORs them together, returns the resulting slice.
-func XOR(a, b []byte) []byte {
-	c := make([]byte, len(a))
-	for i := 0; i < len(a); i++ {
-		c[i] = a[i] ^ b[i]
-	}
-	return c
 }
 
 // KeySlice is used for sorting Keys

--- a/blocks/key/key_set.go
+++ b/blocks/key/key_set.go
@@ -1,4 +1,4 @@
-package util
+package key
 
 import (
 	"sync"

--- a/blocks/key/key_test.go
+++ b/blocks/key/key_test.go
@@ -1,0 +1,28 @@
+package key
+
+import (
+	"bytes"
+	"testing"
+
+	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
+)
+
+func TestKey(t *testing.T) {
+
+	h1, err := mh.Sum([]byte("beep boop"), mh.SHA2_256, -1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	k1 := Key(h1)
+	h2 := mh.Multihash(k1)
+	k2 := Key(h2)
+
+	if !bytes.Equal(h1, h2) {
+		t.Error("Multihashes not equal.")
+	}
+
+	if k1 != k2 {
+		t.Error("Keys not equal.")
+	}
+}

--- a/blocks/set/dbset.go
+++ b/blocks/set/dbset.go
@@ -3,7 +3,7 @@ package set
 import (
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	"github.com/ipfs/go-ipfs/blocks/bloom"
-	"github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 type datastoreBlockSet struct {
@@ -19,7 +19,7 @@ func NewDBWrapperSet(d ds.Datastore, bset BlockSet) BlockSet {
 	}
 }
 
-func (d *datastoreBlockSet) AddBlock(k util.Key) {
+func (d *datastoreBlockSet) AddBlock(k key.Key) {
 	err := d.dstore.Put(k.DsKey(), []byte{})
 	if err != nil {
 		log.Debugf("blockset put error: %s", err)
@@ -28,14 +28,14 @@ func (d *datastoreBlockSet) AddBlock(k util.Key) {
 	d.bset.AddBlock(k)
 }
 
-func (d *datastoreBlockSet) RemoveBlock(k util.Key) {
+func (d *datastoreBlockSet) RemoveBlock(k key.Key) {
 	d.bset.RemoveBlock(k)
 	if !d.bset.HasKey(k) {
 		d.dstore.Delete(k.DsKey())
 	}
 }
 
-func (d *datastoreBlockSet) HasKey(k util.Key) bool {
+func (d *datastoreBlockSet) HasKey(k key.Key) bool {
 	return d.bset.HasKey(k)
 }
 
@@ -43,6 +43,6 @@ func (d *datastoreBlockSet) GetBloomFilter() bloom.Filter {
 	return d.bset.GetBloomFilter()
 }
 
-func (d *datastoreBlockSet) GetKeys() []util.Key {
+func (d *datastoreBlockSet) GetKeys() []key.Key {
 	return d.bset.GetKeys()
 }

--- a/blocks/set/set.go
+++ b/blocks/set/set.go
@@ -3,6 +3,7 @@ package set
 
 import (
 	"github.com/ipfs/go-ipfs/blocks/bloom"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/util"
 )
 
@@ -10,16 +11,16 @@ var log = util.Logger("blockset")
 
 // BlockSet represents a mutable set of keyed blocks
 type BlockSet interface {
-	AddBlock(util.Key)
-	RemoveBlock(util.Key)
-	HasKey(util.Key) bool
+	AddBlock(key.Key)
+	RemoveBlock(key.Key)
+	HasKey(key.Key) bool
 	GetBloomFilter() bloom.Filter
 
-	GetKeys() []util.Key
+	GetKeys() []key.Key
 }
 
-func SimpleSetFromKeys(keys []util.Key) BlockSet {
-	sbs := &simpleBlockSet{blocks: make(map[util.Key]struct{})}
+func SimpleSetFromKeys(keys []key.Key) BlockSet {
+	sbs := &simpleBlockSet{blocks: make(map[key.Key]struct{})}
 	for _, k := range keys {
 		sbs.blocks[k] = struct{}{}
 	}
@@ -27,22 +28,22 @@ func SimpleSetFromKeys(keys []util.Key) BlockSet {
 }
 
 func NewSimpleBlockSet() BlockSet {
-	return &simpleBlockSet{blocks: make(map[util.Key]struct{})}
+	return &simpleBlockSet{blocks: make(map[key.Key]struct{})}
 }
 
 type simpleBlockSet struct {
-	blocks map[util.Key]struct{}
+	blocks map[key.Key]struct{}
 }
 
-func (b *simpleBlockSet) AddBlock(k util.Key) {
+func (b *simpleBlockSet) AddBlock(k key.Key) {
 	b.blocks[k] = struct{}{}
 }
 
-func (b *simpleBlockSet) RemoveBlock(k util.Key) {
+func (b *simpleBlockSet) RemoveBlock(k key.Key) {
 	delete(b.blocks, k)
 }
 
-func (b *simpleBlockSet) HasKey(k util.Key) bool {
+func (b *simpleBlockSet) HasKey(k key.Key) bool {
 	_, has := b.blocks[k]
 	return has
 }
@@ -55,8 +56,8 @@ func (b *simpleBlockSet) GetBloomFilter() bloom.Filter {
 	return f
 }
 
-func (b *simpleBlockSet) GetKeys() []util.Key {
-	var out []util.Key
+func (b *simpleBlockSet) GetKeys() []key.Key {
+	var out []key.Key
 	for k := range b.blocks {
 		out = append(out, k)
 	}

--- a/blockservice/blocks_test.go
+++ b/blockservice/blocks_test.go
@@ -11,6 +11,7 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -30,7 +31,7 @@ func TestBlocks(t *testing.T) {
 		t.Error("Block Multihash and data multihash not equal")
 	}
 
-	if b.Key() != u.Key(h) {
+	if b.Key() != key.Key(h) {
 		t.Error("Block key and data multihash key not equal")
 	}
 
@@ -68,7 +69,7 @@ func TestGetBlocksSequential(t *testing.T) {
 	bg := blocksutil.NewBlockGenerator()
 	blks := bg.Blocks(50)
 
-	var keys []u.Key
+	var keys []key.Key
 	for _, blk := range blks {
 		keys = append(keys, blk.Key())
 		servs[0].AddBlock(blk)
@@ -79,7 +80,7 @@ func TestGetBlocksSequential(t *testing.T) {
 	for i := 1; i < len(servs); i++ {
 		ctx, _ := context.WithTimeout(context.TODO(), time.Second*50)
 		out := servs[i].GetBlocks(ctx, keys)
-		gotten := make(map[u.Key]*blocks.Block)
+		gotten := make(map[key.Key]*blocks.Block)
 		for blk := range out {
 			if _, ok := gotten[blk.Key()]; ok {
 				t.Fatal("Got duplicate block!")

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -10,6 +10,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	worker "github.com/ipfs/go-ipfs/blockservice/worker"
 	exchange "github.com/ipfs/go-ipfs/exchange"
 	u "github.com/ipfs/go-ipfs/util"
@@ -64,7 +65,7 @@ func New(bs blockstore.Blockstore, rem exchange.Interface) (*BlockService, error
 
 // AddBlock adds a particular block to the service, Putting it into the datastore.
 // TODO pass a context into this if the remote.HasBlock is going to remain here.
-func (s *BlockService) AddBlock(b *blocks.Block) (u.Key, error) {
+func (s *BlockService) AddBlock(b *blocks.Block) (key.Key, error) {
 	k := b.Key()
 	err := s.Blockstore.Put(b)
 	if err != nil {
@@ -78,7 +79,7 @@ func (s *BlockService) AddBlock(b *blocks.Block) (u.Key, error) {
 
 // GetBlock retrieves a particular block from the service,
 // Getting it from the datastore using the key (hash).
-func (s *BlockService) GetBlock(ctx context.Context, k u.Key) (*blocks.Block, error) {
+func (s *BlockService) GetBlock(ctx context.Context, k key.Key) (*blocks.Block, error) {
 	log.Debugf("BlockService GetBlock: '%s'", k)
 	block, err := s.Blockstore.Get(k)
 	if err == nil {
@@ -101,11 +102,11 @@ func (s *BlockService) GetBlock(ctx context.Context, k u.Key) (*blocks.Block, er
 // GetBlocks gets a list of blocks asynchronously and returns through
 // the returned channel.
 // NB: No guarantees are made about order.
-func (s *BlockService) GetBlocks(ctx context.Context, ks []u.Key) <-chan *blocks.Block {
+func (s *BlockService) GetBlocks(ctx context.Context, ks []key.Key) <-chan *blocks.Block {
 	out := make(chan *blocks.Block, 0)
 	go func() {
 		defer close(out)
-		var misses []u.Key
+		var misses []key.Key
 		for _, k := range ks {
 			hit, err := s.Blockstore.Get(k)
 			if err != nil {
@@ -138,7 +139,7 @@ func (s *BlockService) GetBlocks(ctx context.Context, ks []u.Key) <-chan *blocks
 }
 
 // DeleteBlock deletes a block in the blockservice from the datastore
-func (s *BlockService) DeleteBlock(k u.Key) error {
+func (s *BlockService) DeleteBlock(k key.Key) error {
 	return s.Blockstore.DeleteBlock(k)
 }
 

--- a/blockservice/worker/worker.go
+++ b/blockservice/worker/worker.go
@@ -9,6 +9,7 @@ import (
 	process "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	ratelimit "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess/ratelimit"
 	blocks "github.com/ipfs/go-ipfs/blocks"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	exchange "github.com/ipfs/go-ipfs/exchange"
 	waitable "github.com/ipfs/go-ipfs/thirdparty/waitable"
 	util "github.com/ipfs/go-ipfs/util"
@@ -141,12 +142,12 @@ func (w *Worker) start(c Config) {
 
 type BlockList struct {
 	list    list.List
-	uniques map[util.Key]*list.Element
+	uniques map[key.Key]*list.Element
 }
 
 func (s *BlockList) PushFront(b *blocks.Block) {
 	if s.uniques == nil {
-		s.uniques = make(map[util.Key]*list.Element)
+		s.uniques = make(map[key.Key]*list.Element)
 	}
 	_, ok := s.uniques[b.Key()]
 	if !ok {
@@ -157,7 +158,7 @@ func (s *BlockList) PushFront(b *blocks.Block) {
 
 func (s *BlockList) Push(b *blocks.Block) {
 	if s.uniques == nil {
-		s.uniques = make(map[util.Key]*list.Element)
+		s.uniques = make(map[key.Key]*list.Element)
 	}
 	_, ok := s.uniques[b.Key()]
 	if !ok {

--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -10,6 +10,7 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	assets "github.com/ipfs/go-ipfs/assets"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
@@ -17,7 +18,6 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 const nBitsForKeypairDefault = 2048
@@ -177,7 +177,7 @@ func addDefaultAssets(out io.Writer, repoRoot string) error {
 			return err
 		}
 
-		k := u.B58KeyDecode(s)
+		k := key.B58KeyDecode(s)
 		if err := dirb.AddChild(fname, k); err != nil {
 			return err
 		}

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -11,6 +11,7 @@ import (
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/ipfs/go-ipfs/blocks"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -161,22 +162,22 @@ It reads from stdin, and <key> is a base58 encoded multihash.
 	Type: BlockStat{},
 }
 
-func getBlockForKey(req cmds.Request, key string) (*blocks.Block, error) {
+func getBlockForKey(req cmds.Request, skey string) (*blocks.Block, error) {
 	n, err := req.Context().GetNode()
 	if err != nil {
 		return nil, err
 	}
 
-	if !u.IsValidHash(key) {
+	if !u.IsValidHash(skey) {
 		return nil, errors.New("Not a valid hash")
 	}
 
-	h, err := mh.FromB58String(key)
+	h, err := mh.FromB58String(skey)
 	if err != nil {
 		return nil, err
 	}
 
-	k := u.Key(h)
+	k := key.Key(h)
 	b, err := n.Blocks.GetBlock(context.TODO(), k)
 	if err != nil {
 		return nil, err

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"time"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	notif "github.com/ipfs/go-ipfs/notifications"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
@@ -59,7 +60,7 @@ var queryDhtCmd = &cmds.Command{
 		events := make(chan *notif.QueryEvent)
 		ctx := notif.RegisterForQueryEvents(req.Context().Context, events)
 
-		closestPeers, err := dht.GetClosestPeers(ctx, u.Key(req.Arguments()[0]))
+		closestPeers, err := dht.GetClosestPeers(ctx, key.Key(req.Arguments()[0]))
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -171,7 +172,7 @@ FindProviders will return a list of peers who are able to provide the value requ
 		events := make(chan *notif.QueryEvent)
 		ctx := notif.RegisterForQueryEvents(req.Context().Context, events)
 
-		pchan := dht.FindProvidersAsync(ctx, u.B58KeyDecode(req.Arguments()[0]), numProviders)
+		pchan := dht.FindProvidersAsync(ctx, key.B58KeyDecode(req.Arguments()[0]), numProviders)
 		go func() {
 			defer close(outChan)
 			for e := range events {
@@ -401,7 +402,7 @@ GetValue will return the value stored in the dht at the given key.
 
 		go func() {
 			defer close(events)
-			val, err := dht.GetValue(ctx, u.B58KeyDecode(req.Arguments()[0]))
+			val, err := dht.GetValue(ctx, key.B58KeyDecode(req.Arguments()[0]))
 			if err != nil {
 				notif.PublishQueryEvent(ctx, &notif.QueryEvent{
 					Type:  notif.QueryError,
@@ -500,7 +501,7 @@ PutValue will store the given key value pair in the dht.
 		events := make(chan *notif.QueryEvent)
 		ctx := notif.RegisterForQueryEvents(req.Context().Context, events)
 
-		key := u.B58KeyDecode(req.Arguments()[0])
+		key := key.B58KeyDecode(req.Arguments()[0])
 		data := req.Arguments()[1]
 
 		go func() {

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	u "github.com/ipfs/go-ipfs/util"
@@ -23,7 +24,7 @@ var PinCmd = &cmds.Command{
 }
 
 type PinOutput struct {
-	Pinned []u.Key
+	Pinned []key.Key
 }
 
 var addPinCmd = &cmds.Command{

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -8,11 +8,11 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
 	crypto "github.com/ipfs/go-ipfs/p2p/crypto"
 	path "github.com/ipfs/go-ipfs/path"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var errNotOnline = errors.New("This command must be run in online mode. Try running 'ipfs daemon' first.")
@@ -128,7 +128,7 @@ func publish(ctx context.Context, n *core.IpfsNode, k crypto.PrivKey, ref path.P
 	}
 
 	return &IpnsEntry{
-		Name:  u.Key(hash).String(),
+		Name:  key.Key(hash).String(),
 		Value: ref.String(),
 	}, nil
 }

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	dag "github.com/ipfs/go-ipfs/merkledag"
@@ -17,7 +18,7 @@ import (
 
 // KeyList is a general type for outputting lists of keys
 type KeyList struct {
-	Keys []u.Key
+	Keys []key.Key
 }
 
 // KeyListTextMarshaler outputs a KeyList as plaintext, one key per line
@@ -214,7 +215,7 @@ type RefWriter struct {
 	PrintEdge bool
 	PrintFmt  string
 
-	seen map[u.Key]struct{}
+	seen map[key.Key]struct{}
 }
 
 // WriteRefs writes refs of the given object to the underlying writer.
@@ -238,7 +239,7 @@ func (rw *RefWriter) writeRefsRecursive(n *dag.Node) (int, error) {
 
 	var count int
 	for i, ng := range rw.DAG.GetDAG(rw.Ctx, n) {
-		lk := u.Key(n.Links[i].Hash)
+		lk := key.Key(n.Links[i].Hash)
 		if rw.skip(lk) {
 			continue
 		}
@@ -273,7 +274,7 @@ func (rw *RefWriter) writeRefsSingle(n *dag.Node) (int, error) {
 
 	count := 0
 	for _, l := range n.Links {
-		lk := u.Key(l.Hash)
+		lk := key.Key(l.Hash)
 
 		if rw.skip(lk) {
 			continue
@@ -288,13 +289,13 @@ func (rw *RefWriter) writeRefsSingle(n *dag.Node) (int, error) {
 }
 
 // skip returns whether to skip a key
-func (rw *RefWriter) skip(k u.Key) bool {
+func (rw *RefWriter) skip(k key.Key) bool {
 	if !rw.Unique {
 		return false
 	}
 
 	if rw.seen == nil {
-		rw.seen = make(map[u.Key]struct{})
+		rw.seen = make(map[key.Key]struct{})
 	}
 
 	_, found := rw.seen[k]
@@ -305,7 +306,7 @@ func (rw *RefWriter) skip(k u.Key) bool {
 }
 
 // Write one edge
-func (rw *RefWriter) WriteEdge(from, to u.Key, linkname string) error {
+func (rw *RefWriter) WriteEdge(from, to key.Key, linkname string) error {
 	if rw.Ctx != nil {
 		select {
 		case <-rw.Ctx.Done(): // just in case.

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
@@ -19,7 +20,6 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	"github.com/ipfs/go-ipfs/routing"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 const (
@@ -304,7 +304,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	tctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	// TODO(cryptix): could this be core.Resolve() too?
-	rootnd, err := i.node.Resolver.DAG.Get(tctx, u.Key(h))
+	rootnd, err := i.node.Resolver.DAG.Get(tctx, key.Key(h))
 	if err != nil {
 		webError(w, "Could not resolve root object", err, http.StatusBadRequest)
 		return
@@ -374,7 +374,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	tctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
-	rootnd, err := i.node.Resolver.DAG.Get(tctx, u.Key(h))
+	rootnd, err := i.node.Resolver.DAG.Get(tctx, key.Key(h))
 	if err != nil {
 		webError(w, "Could not resolve root object", err, http.StatusBadRequest)
 		return

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -2,8 +2,8 @@ package corerepo
 
 import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/core"
-	u "github.com/ipfs/go-ipfs/util"
 
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 )
@@ -11,7 +11,7 @@ import (
 var log = eventlog.Logger("corerepo")
 
 type KeyRemoved struct {
-	Key u.Key
+	Key key.Key
 }
 
 func GarbageCollect(n *core.IpfsNode, ctx context.Context) error {

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -19,13 +19,13 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
-func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
+func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]key.Key, error) {
 	// TODO(cryptix): do we want a ctx as first param for (Un)Pin() as well, just like core.Resolve?
 	ctx := n.Context()
 
@@ -38,7 +38,7 @@ func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 		dagnodes = append(dagnodes, dagnode)
 	}
 
-	var out []u.Key
+	var out []key.Key
 	for _, dagnode := range dagnodes {
 		k, err := dagnode.Key()
 		if err != nil {
@@ -62,7 +62,7 @@ func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 	return out, nil
 }
 
-func Unpin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
+func Unpin(n *core.IpfsNode, paths []string, recursive bool) ([]key.Key, error) {
 	// TODO(cryptix): do we want a ctx as first param for (Un)Pin() as well, just like core.Resolve?
 	ctx := n.Context()
 
@@ -75,7 +75,7 @@ func Unpin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 		dagnodes = append(dagnodes, dagnode)
 	}
 
-	var unpinned []u.Key
+	var unpinned []key.Key
 	for _, dagnode := range dagnodes {
 		k, _ := dagnode.Key()
 

--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -5,14 +5,14 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
-func AddMetadataTo(n *core.IpfsNode, key string, m *ft.Metadata) (string, error) {
-	ukey := u.B58KeyDecode(key)
+func AddMetadataTo(n *core.IpfsNode, skey string, m *ft.Metadata) (string, error) {
+	ukey := key.B58KeyDecode(skey)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
 	defer cancel()
@@ -41,8 +41,8 @@ func AddMetadataTo(n *core.IpfsNode, key string, m *ft.Metadata) (string, error)
 	return nk.B58String(), nil
 }
 
-func Metadata(n *core.IpfsNode, key string) (*ft.Metadata, error) {
-	ukey := u.B58KeyDecode(key)
+func Metadata(n *core.IpfsNode, skey string) (*ft.Metadata, error) {
+	ukey := key.B58KeyDecode(skey)
 
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
 	defer cancel()

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -10,6 +10,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	core "github.com/ipfs/go-ipfs/core"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
@@ -66,7 +67,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("something went wrong in conversion: '%s' != '%s'", rec.MimeType, m.MimeType)
 	}
 
-	retnode, err := ds.Get(context.Background(), u.B58KeyDecode(mdk))
+	retnode, err := ds.Get(context.Background(), key.B58KeyDecode(mdk))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -12,11 +12,11 @@ import (
 
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	tn "github.com/ipfs/go-ipfs/exchange/bitswap/testnet"
 	p2ptestutil "github.com/ipfs/go-ipfs/p2p/test/util"
 	mockrouting "github.com/ipfs/go-ipfs/routing/mock"
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 // FIXME the tests are really sensitive to the network delay. fix them to work
@@ -155,7 +155,7 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 
 	t.Log("Give the blocks to the first instance")
 
-	var blkeys []u.Key
+	var blkeys []key.Key
 	first := instances[0]
 	for _, b := range blocks {
 		blkeys = append(blkeys, b.Key())
@@ -227,7 +227,7 @@ func TestSendToWantingPeer(t *testing.T) {
 	alpha := bg.Next()
 	// peerA requests and waits for block alpha
 	ctx, _ := context.WithTimeout(context.TODO(), waitTime)
-	alphaPromise, err := peerA.Exchange.GetBlocks(ctx, []u.Key{alpha.Key()})
+	alphaPromise, err := peerA.Exchange.GetBlocks(ctx, []key.Key{alpha.Key()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchange/bitswap/decision/bench_test.go
+++ b/exchange/bitswap/decision/bench_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	"github.com/ipfs/go-ipfs/p2p/peer"
-	"github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
 )
 
@@ -21,6 +21,6 @@ func BenchmarkTaskQueuePush(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		q.Push(wantlist.Entry{Key: util.Key(i), Priority: math.MaxInt32}, peers[i%len(peers)])
+		q.Push(wantlist.Entry{Key: key.Key(i), Priority: math.MaxInt32}, peers[i%len(peers)])
 	}
 }

--- a/exchange/bitswap/decision/ledger.go
+++ b/exchange/bitswap/decision/ledger.go
@@ -3,20 +3,20 @@ package decision
 import (
 	"time"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	wl "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 // keySet is just a convenient alias for maps of keys, where we only care
 // access/lookups.
-type keySet map[u.Key]struct{}
+type keySet map[key.Key]struct{}
 
 func newLedger(p peer.ID) *ledger {
 	return &ledger{
 		wantList:   wl.New(),
 		Partner:    p,
-		sentToPeer: make(map[u.Key]time.Time),
+		sentToPeer: make(map[key.Key]time.Time),
 	}
 }
 
@@ -43,7 +43,7 @@ type ledger struct {
 
 	// sentToPeer is a set of keys to ensure we dont send duplicate blocks
 	// to a given peer
-	sentToPeer map[u.Key]time.Time
+	sentToPeer map[key.Key]time.Time
 }
 
 type debtRatio struct {
@@ -68,16 +68,16 @@ func (l *ledger) ReceivedBytes(n int) {
 }
 
 // TODO: this needs to be different. We need timeouts.
-func (l *ledger) Wants(k u.Key, priority int) {
+func (l *ledger) Wants(k key.Key, priority int) {
 	log.Debugf("peer %s wants %s", l.Partner, k)
 	l.wantList.Add(k, priority)
 }
 
-func (l *ledger) CancelWant(k u.Key) {
+func (l *ledger) CancelWant(k key.Key) {
 	l.wantList.Remove(k)
 }
 
-func (l *ledger) WantListContains(k u.Key) (wl.Entry, bool) {
+func (l *ledger) WantListContains(k key.Key) (wl.Entry, bool) {
 	return l.wantList.Contains(k)
 }
 

--- a/exchange/bitswap/decision/peer_request_queue_test.go
+++ b/exchange/bitswap/decision/peer_request_queue_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
-	"github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
 )
 
@@ -41,10 +41,10 @@ func TestPushPop(t *testing.T) {
 	for _, index := range rand.Perm(len(alphabet)) { // add blocks for all letters
 		letter := alphabet[index]
 		t.Log(partner.String())
-		prq.Push(wantlist.Entry{Key: util.Key(letter), Priority: math.MaxInt32 - index}, partner)
+		prq.Push(wantlist.Entry{Key: key.Key(letter), Priority: math.MaxInt32 - index}, partner)
 	}
 	for _, consonant := range consonants {
-		prq.Remove(util.Key(consonant), partner)
+		prq.Remove(key.Key(consonant), partner)
 	}
 
 	var out []string
@@ -76,10 +76,10 @@ func TestPeerRepeats(t *testing.T) {
 	// Have each push some blocks
 
 	for i := 0; i < 5; i++ {
-		prq.Push(wantlist.Entry{Key: util.Key(i)}, a)
-		prq.Push(wantlist.Entry{Key: util.Key(i)}, b)
-		prq.Push(wantlist.Entry{Key: util.Key(i)}, c)
-		prq.Push(wantlist.Entry{Key: util.Key(i)}, d)
+		prq.Push(wantlist.Entry{Key: key.Key(i)}, a)
+		prq.Push(wantlist.Entry{Key: key.Key(i)}, b)
+		prq.Push(wantlist.Entry{Key: key.Key(i)}, c)
+		prq.Push(wantlist.Entry{Key: key.Key(i)}, d)
 	}
 
 	// now, pop off four entries, there should be one from each

--- a/exchange/bitswap/message/message_test.go
+++ b/exchange/bitswap/message/message_test.go
@@ -7,14 +7,14 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 
 	blocks "github.com/ipfs/go-ipfs/blocks"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	pb "github.com/ipfs/go-ipfs/exchange/bitswap/message/internal/pb"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 func TestAppendWanted(t *testing.T) {
 	const str = "foo"
 	m := New(true)
-	m.AddEntry(u.Key(str), 1)
+	m.AddEntry(key.Key(str), 1)
 
 	if !wantlistContains(m.ToProto().GetWantlist(), str) {
 		t.Fail()
@@ -63,7 +63,7 @@ func TestWantlist(t *testing.T) {
 	keystrs := []string{"foo", "bar", "baz", "bat"}
 	m := New(true)
 	for _, s := range keystrs {
-		m.AddEntry(u.Key(s), 1)
+		m.AddEntry(key.Key(s), 1)
 	}
 	exported := m.Wantlist()
 
@@ -86,7 +86,7 @@ func TestCopyProtoByValue(t *testing.T) {
 	const str = "foo"
 	m := New(true)
 	protoBeforeAppend := m.ToProto()
-	m.AddEntry(u.Key(str), 1)
+	m.AddEntry(key.Key(str), 1)
 	if wantlistContains(protoBeforeAppend.GetWantlist(), str) {
 		t.Fail()
 	}
@@ -94,11 +94,11 @@ func TestCopyProtoByValue(t *testing.T) {
 
 func TestToNetFromNetPreservesWantList(t *testing.T) {
 	original := New(true)
-	original.AddEntry(u.Key("M"), 1)
-	original.AddEntry(u.Key("B"), 1)
-	original.AddEntry(u.Key("D"), 1)
-	original.AddEntry(u.Key("T"), 1)
-	original.AddEntry(u.Key("F"), 1)
+	original.AddEntry(key.Key("M"), 1)
+	original.AddEntry(key.Key("B"), 1)
+	original.AddEntry(key.Key("D"), 1)
+	original.AddEntry(key.Key("T"), 1)
+	original.AddEntry(key.Key("F"), 1)
 
 	buf := new(bytes.Buffer)
 	if err := original.ToNet(buf); err != nil {
@@ -110,7 +110,7 @@ func TestToNetFromNetPreservesWantList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	keys := make(map[u.Key]bool)
+	keys := make(map[key.Key]bool)
 	for _, k := range copied.Wantlist() {
 		keys[k.Key] = true
 	}
@@ -140,7 +140,7 @@ func TestToAndFromNetMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	keys := make(map[u.Key]bool)
+	keys := make(map[key.Key]bool)
 	for _, b := range m2.Blocks() {
 		keys[b.Key()] = true
 	}

--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -2,10 +2,10 @@ package network
 
 import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var ProtocolBitswap protocol.ID = "/ipfs/bitswap"
@@ -44,8 +44,8 @@ type Receiver interface {
 
 type Routing interface {
 	// FindProvidersAsync returns a channel of providers for the given key
-	FindProvidersAsync(context.Context, u.Key, int) <-chan peer.ID
+	FindProvidersAsync(context.Context, key.Key, int) <-chan peer.ID
 
 	// Provide provides the key to the network
-	Provide(context.Context, u.Key) error
+	Provide(context.Context, key.Key) error
 }

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -3,13 +3,13 @@ package network
 import (
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	host "github.com/ipfs/go-ipfs/p2p/host"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	util "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("bitswap_network")
@@ -102,7 +102,7 @@ func (bsnet *impl) ConnectTo(ctx context.Context, p peer.ID) error {
 }
 
 // FindProvidersAsync returns a channel of providers for the given key
-func (bsnet *impl) FindProvidersAsync(ctx context.Context, k util.Key, max int) <-chan peer.ID {
+func (bsnet *impl) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.ID {
 
 	// Since routing queries are expensive, give bitswap the peers to which we
 	// have open connections. Note that this may cause issues if bitswap starts
@@ -138,7 +138,7 @@ func (bsnet *impl) FindProvidersAsync(ctx context.Context, k util.Key, max int) 
 }
 
 // Provide provides the key to the network
-func (bsnet *impl) Provide(ctx context.Context, k util.Key) error {
+func (bsnet *impl) Provide(ctx context.Context, k key.Key) error {
 	return bsnet.routing.Provide(ctx, k)
 }
 

--- a/exchange/bitswap/notifications/notifications.go
+++ b/exchange/bitswap/notifications/notifications.go
@@ -4,14 +4,14 @@ import (
 	pubsub "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/briantigerchow/pubsub"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 const bufferSize = 16
 
 type PubSub interface {
 	Publish(block *blocks.Block)
-	Subscribe(ctx context.Context, keys ...u.Key) <-chan *blocks.Block
+	Subscribe(ctx context.Context, keys ...key.Key) <-chan *blocks.Block
 	Shutdown()
 }
 
@@ -35,7 +35,7 @@ func (ps *impl) Shutdown() {
 // Subscribe returns a channel of blocks for the given |keys|. |blockChannel|
 // is closed if the |ctx| times out or is cancelled, or after sending len(keys)
 // blocks.
-func (ps *impl) Subscribe(ctx context.Context, keys ...u.Key) <-chan *blocks.Block {
+func (ps *impl) Subscribe(ctx context.Context, keys ...key.Key) <-chan *blocks.Block {
 
 	blocksCh := make(chan *blocks.Block, len(keys))
 	valuesCh := make(chan interface{}, len(keys)) // provide our own channel to control buffer, prevent blocking
@@ -71,7 +71,7 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...u.Key) <-chan *blocks.Blo
 	return blocksCh
 }
 
-func toStrings(keys []u.Key) []string {
+func toStrings(keys []key.Key) []string {
 	strs := make([]string, 0)
 	for _, key := range keys {
 		strs = append(strs, string(key))

--- a/exchange/bitswap/notifications/notifications_test.go
+++ b/exchange/bitswap/notifications/notifications_test.go
@@ -8,7 +8,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
-	"github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 func TestDuplicates(t *testing.T) {
@@ -131,8 +131,8 @@ func TestDoesNotDeadLockIfContextCancelledBeforePublish(t *testing.T) {
 
 	t.Log("generate a large number of blocks. exceed default buffer")
 	bs := g.Blocks(1000)
-	ks := func() []util.Key {
-		var keys []util.Key
+	ks := func() []key.Key {
+		var keys []key.Key
 		for _, b := range bs {
 			keys = append(keys, b.Key())
 		}

--- a/exchange/bitswap/stat.go
+++ b/exchange/bitswap/stat.go
@@ -1,13 +1,13 @@
 package bitswap
 
 import (
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"sort"
 )
 
 type Stat struct {
 	ProvideBufLen   int
-	Wantlist        []u.Key
+	Wantlist        []key.Key
 	Peers           []string
 	BlocksReceived  int
 	DupBlksReceived int

--- a/exchange/bitswap/testnet/virtual.go
+++ b/exchange/bitswap/testnet/virtual.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	bsnet "github.com/ipfs/go-ipfs/exchange/bitswap/network"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	mockrouting "github.com/ipfs/go-ipfs/routing/mock"
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
-	util "github.com/ipfs/go-ipfs/util"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 )
 
@@ -91,7 +91,7 @@ func (nc *networkClient) SendMessage(
 }
 
 // FindProvidersAsync returns a channel of providers for the given key
-func (nc *networkClient) FindProvidersAsync(ctx context.Context, k util.Key, max int) <-chan peer.ID {
+func (nc *networkClient) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.ID {
 
 	// NB: this function duplicates the PeerInfo -> ID transformation in the
 	// bitswap network adapter. Not to worry. This network client will be
@@ -113,7 +113,7 @@ func (nc *networkClient) FindProvidersAsync(ctx context.Context, k util.Key, max
 }
 
 // Provide provides the key to the network
-func (nc *networkClient) Provide(ctx context.Context, k util.Key) error {
+func (nc *networkClient) Provide(ctx context.Context, k key.Key) error {
 	return nc.routing.Provide(ctx, k)
 }
 

--- a/exchange/bitswap/wantlist/wantlist.go
+++ b/exchange/bitswap/wantlist/wantlist.go
@@ -3,7 +3,7 @@
 package wantlist
 
 import (
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"sort"
 	"sync"
 )
@@ -15,14 +15,14 @@ type ThreadSafe struct {
 
 // not threadsafe
 type Wantlist struct {
-	set map[u.Key]Entry
+	set map[key.Key]Entry
 	// TODO provide O(1) len accessor if cost becomes an issue
 }
 
 type Entry struct {
 	// TODO consider making entries immutable so they can be shared safely and
 	// slices can be copied efficiently.
-	Key      u.Key
+	Key      key.Key
 	Priority int
 }
 
@@ -40,25 +40,25 @@ func NewThreadSafe() *ThreadSafe {
 
 func New() *Wantlist {
 	return &Wantlist{
-		set: make(map[u.Key]Entry),
+		set: make(map[key.Key]Entry),
 	}
 }
 
-func (w *ThreadSafe) Add(k u.Key, priority int) {
+func (w *ThreadSafe) Add(k key.Key, priority int) {
 	// TODO rm defer for perf
 	w.lk.Lock()
 	defer w.lk.Unlock()
 	w.Wantlist.Add(k, priority)
 }
 
-func (w *ThreadSafe) Remove(k u.Key) {
+func (w *ThreadSafe) Remove(k key.Key) {
 	// TODO rm defer for perf
 	w.lk.Lock()
 	defer w.lk.Unlock()
 	w.Wantlist.Remove(k)
 }
 
-func (w *ThreadSafe) Contains(k u.Key) (Entry, bool) {
+func (w *ThreadSafe) Contains(k key.Key) (Entry, bool) {
 	// TODO rm defer for perf
 	w.lk.RLock()
 	defer w.lk.RUnlock()
@@ -87,7 +87,7 @@ func (w *Wantlist) Len() int {
 	return len(w.set)
 }
 
-func (w *Wantlist) Add(k u.Key, priority int) {
+func (w *Wantlist) Add(k key.Key, priority int) {
 	if _, ok := w.set[k]; ok {
 		return
 	}
@@ -97,11 +97,11 @@ func (w *Wantlist) Add(k u.Key, priority int) {
 	}
 }
 
-func (w *Wantlist) Remove(k u.Key) {
+func (w *Wantlist) Remove(k key.Key) {
 	delete(w.set, k)
 }
 
-func (w *Wantlist) Contains(k u.Key) (Entry, bool) {
+func (w *Wantlist) Contains(k key.Key) (Entry, bool) {
 	e, ok := w.set[k]
 	return e, ok
 }

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	engine "github.com/ipfs/go-ipfs/exchange/bitswap/decision"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	bsnet "github.com/ipfs/go-ipfs/exchange/bitswap/network"
 	wantlist "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 type WantManager struct {
@@ -46,7 +46,7 @@ type msgPair struct {
 
 type cancellation struct {
 	who peer.ID
-	blk u.Key
+	blk key.Key
 }
 
 type msgQueue struct {
@@ -60,16 +60,16 @@ type msgQueue struct {
 	done chan struct{}
 }
 
-func (pm *WantManager) WantBlocks(ks []u.Key) {
+func (pm *WantManager) WantBlocks(ks []key.Key) {
 	log.Infof("want blocks: %s", ks)
 	pm.addEntries(ks, false)
 }
 
-func (pm *WantManager) CancelWants(ks []u.Key) {
+func (pm *WantManager) CancelWants(ks []key.Key) {
 	pm.addEntries(ks, true)
 }
 
-func (pm *WantManager) addEntries(ks []u.Key, cancel bool) {
+func (pm *WantManager) addEntries(ks []key.Key, cancel bool) {
 	var entries []*bsmsg.Entry
 	for i, k := range ks {
 		entries = append(entries, &bsmsg.Entry{

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -7,7 +7,7 @@ import (
 
 	process "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 var TaskWorkerCount = 8
@@ -104,9 +104,9 @@ func (bs *Bitswap) provideWorker(ctx context.Context) {
 
 func (bs *Bitswap) provideCollector(ctx context.Context) {
 	defer close(bs.provideKeys)
-	var toProvide []u.Key
-	var nextKey u.Key
-	var keysOut chan u.Key
+	var toProvide []key.Key
+	var nextKey key.Key
+	var keysOut chan key.Key
 
 	for {
 		select {

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -6,16 +6,16 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 // Any type that implements exchange.Interface may be used as an IPFS block
 // exchange protocol.
 type Interface interface {
 	// GetBlock returns the block associated with a given key.
-	GetBlock(context.Context, u.Key) (*blocks.Block, error)
+	GetBlock(context.Context, key.Key) (*blocks.Block, error)
 
-	GetBlocks(context.Context, []u.Key) (<-chan *blocks.Block, error)
+	GetBlocks(context.Context, []key.Key) (<-chan *blocks.Block, error)
 
 	// TODO Should callers be concerned with whether the block was made
 	// available on the network?

--- a/exchange/offline/offline.go
+++ b/exchange/offline/offline.go
@@ -6,8 +6,8 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	exchange "github.com/ipfs/go-ipfs/exchange"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 func Exchange(bs blockstore.Blockstore) exchange.Interface {
@@ -23,7 +23,7 @@ type offlineExchange struct {
 // GetBlock returns nil to signal that a block could not be retrieved for the
 // given key.
 // NB: This function may return before the timeout expires.
-func (e *offlineExchange) GetBlock(_ context.Context, k u.Key) (*blocks.Block, error) {
+func (e *offlineExchange) GetBlock(_ context.Context, k key.Key) (*blocks.Block, error) {
 	return e.bs.Get(k)
 }
 
@@ -39,11 +39,11 @@ func (_ *offlineExchange) Close() error {
 	return nil
 }
 
-func (e *offlineExchange) GetBlocks(ctx context.Context, ks []u.Key) (<-chan *blocks.Block, error) {
+func (e *offlineExchange) GetBlocks(ctx context.Context, ks []key.Key) (<-chan *blocks.Block, error) {
 	out := make(chan *blocks.Block, 0)
 	go func() {
 		defer close(out)
-		var misses []u.Key
+		var misses []key.Key
 		for _, k := range ks {
 			hit, err := e.bs.Get(k)
 			if err != nil {

--- a/exchange/offline/offline_test.go
+++ b/exchange/offline/offline_test.go
@@ -9,12 +9,12 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
 	"github.com/ipfs/go-ipfs/blocks/blocksutil"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
 func TestBlockReturnsErr(t *testing.T) {
 	off := Exchange(bstore())
-	_, err := off.GetBlock(context.Background(), u.Key("foo"))
+	_, err := off.GetBlock(context.Background(), key.Key("foo"))
 	if err != nil {
 		return // as desired
 	}
@@ -49,8 +49,8 @@ func TestGetBlocks(t *testing.T) {
 		}
 	}
 
-	request := func() []u.Key {
-		var ks []u.Key
+	request := func() []key.Key {
+		var ks []key.Key
 
 		for _, b := range expected {
 			ks = append(ks, b.Key())

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -15,12 +15,12 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	nsfs "github.com/ipfs/go-ipfs/ipnsfs"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	ft "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("fuse/ipns")
@@ -76,7 +76,7 @@ func CreateRoot(ipfs *core.IpfsNode, keys []ci.PrivKey, ipfspath, ipnspath strin
 		if err != nil {
 			return nil, err
 		}
-		name := u.Key(pkh).B58String()
+		name := key.Key(pkh).B58String()
 		root, err := ipfs.IpnsFs.GetRoot(name)
 		if err != nil {
 			return nil, err
@@ -194,7 +194,7 @@ func (r *Root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 			continue
 		}
 		ent := fuse.Dirent{
-			Name: u.Key(hash).Pretty(),
+			Name: key.Key(hash).Pretty(),
 			Type: fuse.DT_Dir,
 		}
 		listing = append(listing, ent)

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -14,6 +14,7 @@ import (
 
 	fstest "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse/fs/fstestutil"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
 	coremock "github.com/ipfs/go-ipfs/core/mock"
@@ -112,7 +113,7 @@ func TestIpfsStressRead(t *testing.T) {
 	nd, mnt := setupIpfsTest(t, nil)
 	defer mnt.Close()
 
-	var ks []u.Key
+	var ks []key.Key
 	var paths []string
 
 	nobj := 50

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 // BlockSizeLimit specifies the maximum size an imported block can have.
@@ -123,7 +123,7 @@ func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
 
 // Removes the child node at the given index
 func (n *UnixfsNode) RemoveChild(index int, dbh *DagBuilderHelper) {
-	k := u.Key(n.node.Links[index].Hash)
+	k := key.Key(n.node.Links[index].Hash)
 	if dbh.mp != nil {
 		dbh.mp.RemovePinWithMode(k, pin.Indirect)
 	}

--- a/ipnsfs/system.go
+++ b/ipnsfs/system.go
@@ -17,13 +17,13 @@ import (
 	"sync"
 	"time"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	path "github.com/ipfs/go-ipfs/path"
 	pin "github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
@@ -66,7 +66,7 @@ func NewFilesystem(ctx context.Context, ds dag.DAGService, nsys namesys.NameSyst
 		if err != nil {
 			return nil, err
 		}
-		roots[u.Key(pkh).Pretty()] = root
+		roots[key.Key(pkh).Pretty()] = root
 	}
 
 	return fs, nil
@@ -141,7 +141,7 @@ func (fs *Filesystem) newKeyRoot(parent context.Context, k ci.PrivKey) (*KeyRoot
 		return nil, err
 	}
 
-	name := "/ipns/" + u.Key(hash).String()
+	name := "/ipns/" + key.Key(hash).String()
 
 	root := new(KeyRoot)
 	root.key = k

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -16,15 +17,15 @@ var ErrNotFound = fmt.Errorf("merkledag: not found")
 
 // DAGService is an IPFS Merkle DAG service.
 type DAGService interface {
-	Add(*Node) (u.Key, error)
+	Add(*Node) (key.Key, error)
 	AddRecursive(*Node) error
-	Get(context.Context, u.Key) (*Node, error)
+	Get(context.Context, key.Key) (*Node, error)
 	Remove(*Node) error
 
 	// GetDAG returns, in order, all the single leve child
 	// nodes of the passed in node.
 	GetDAG(context.Context, *Node) []NodeGetter
-	GetNodes(context.Context, []u.Key) []NodeGetter
+	GetNodes(context.Context, []key.Key) []NodeGetter
 }
 
 func NewDAGService(bs *bserv.BlockService) DAGService {
@@ -41,7 +42,7 @@ type dagService struct {
 }
 
 // Add adds a node to the dagService, storing the block in the BlockService
-func (n *dagService) Add(nd *Node) (u.Key, error) {
+func (n *dagService) Add(nd *Node) (key.Key, error) {
 	if n == nil { // FIXME remove this assertion. protect with constructor invariant
 		return "", fmt.Errorf("dagService is nil")
 	}
@@ -82,7 +83,7 @@ func (n *dagService) AddRecursive(nd *Node) error {
 }
 
 // Get retrieves a node from the dagService, fetching the block in the BlockService
-func (n *dagService) Get(ctx context.Context, k u.Key) (*Node, error) {
+func (n *dagService) Get(ctx context.Context, k key.Key) (*Node, error) {
 	if n == nil {
 		return nil, fmt.Errorf("dagService is nil")
 	}
@@ -148,7 +149,7 @@ func FetchGraph(ctx context.Context, root *Node, serv DAGService) chan struct{} 
 
 // FindLinks searches this nodes links for the given key,
 // returns the indexes of any links pointing to it
-func FindLinks(links []u.Key, k u.Key, start int) []int {
+func FindLinks(links []key.Key, k key.Key, start int) []int {
 	var out []int
 	for i, lnk_k := range links[start:] {
 		if k == lnk_k {
@@ -162,9 +163,9 @@ func FindLinks(links []u.Key, k u.Key, start int) []int {
 // It returns a channel of nodes, which the caller can receive
 // all the child nodes of 'root' on, in proper order.
 func (ds *dagService) GetDAG(ctx context.Context, root *Node) []NodeGetter {
-	var keys []u.Key
+	var keys []key.Key
 	for _, lnk := range root.Links {
-		keys = append(keys, u.Key(lnk.Hash))
+		keys = append(keys, key.Key(lnk.Hash))
 	}
 
 	return ds.GetNodes(ctx, keys)
@@ -172,7 +173,7 @@ func (ds *dagService) GetDAG(ctx context.Context, root *Node) []NodeGetter {
 
 // GetNodes returns an array of 'NodeGetter' promises, with each corresponding
 // to the key with the same index as the passed in keys
-func (ds *dagService) GetNodes(ctx context.Context, keys []u.Key) []NodeGetter {
+func (ds *dagService) GetNodes(ctx context.Context, keys []key.Key) []NodeGetter {
 
 	// Early out if no work to do
 	if len(keys) == 0 {
@@ -219,9 +220,9 @@ func (ds *dagService) GetNodes(ctx context.Context, keys []u.Key) []NodeGetter {
 }
 
 // Remove duplicates from a list of keys
-func dedupeKeys(ks []u.Key) []u.Key {
-	kmap := make(map[u.Key]struct{})
-	var out []u.Key
+func dedupeKeys(ks []key.Key) []key.Key {
+	kmap := make(map[key.Key]struct{})
+	var out []key.Key
 	for _, k := range ks {
 		if _, ok := kmap[k]; !ok {
 			kmap[k] = struct{}{}

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -12,6 +12,7 @@ import (
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	blockservice "github.com/ipfs/go-ipfs/blockservice"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
@@ -81,7 +82,7 @@ func TestNode(t *testing.T) {
 		k, err := n.Key()
 		if err != nil {
 			t.Error(err)
-		} else if k != u.Key(h) {
+		} else if k != key.Key(h) {
 			t.Error("Key is not equivalent to multihash")
 		} else {
 			fmt.Println("key: ", k)

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -6,13 +6,8 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 )
-
-// NodeMap maps u.Keys to Nodes.
-// We cannot use []byte/Multihash for keys :(
-// so have to convert Multihash bytes to string (u.Key)
-type NodeMap map[u.Key]*Node
 
 // Node represents a node in the IPFS Merkle DAG.
 // nodes have opaque data and a set of navigable links.
@@ -84,7 +79,7 @@ func (l *Link) GetNode(ctx context.Context, serv DAGService) (*Node, error) {
 		return l.Node, nil
 	}
 
-	return serv.Get(ctx, u.Key(l.Hash))
+	return serv.Get(ctx, key.Key(l.Hash))
 }
 
 // AddNodeLink adds a link to another node.
@@ -227,7 +222,7 @@ func (n *Node) Multihash() (mh.Multihash, error) {
 }
 
 // Key returns the Multihash as a key, for maps.
-func (n *Node) Key() (u.Key, error) {
+func (n *Node) Key() (key.Key, error) {
 	h, err := n.Multihash()
-	return u.Key(h), err
+	return key.Key(h), err
 }

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	pb "github.com/ipfs/go-ipfs/namesys/internal/pb"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
@@ -55,7 +56,7 @@ func (p *ipnsPublisher) Publish(ctx context.Context, k ci.PrivKey, value path.Pa
 	}
 
 	nameb := u.Hash(pkbytes)
-	namekey := u.Key("/pk/" + string(nameb))
+	namekey := key.Key("/pk/" + string(nameb))
 
 	log.Debugf("Storing pubkey at: %s", namekey)
 	// Store associated public key
@@ -65,7 +66,7 @@ func (p *ipnsPublisher) Publish(ctx context.Context, k ci.PrivKey, value path.Pa
 		return err
 	}
 
-	ipnskey := u.Key("/ipns/" + string(nameb))
+	ipnskey := key.Key("/ipns/" + string(nameb))
 
 	log.Debugf("Storing ipns entry at: %s", ipnskey)
 	// Store ipns entry at "/ipns/"+b58(h(pubkey))
@@ -110,7 +111,7 @@ var IpnsRecordValidator = &record.ValidChecker{
 
 // ValidateIpnsRecord implements ValidatorFunc and verifies that the
 // given 'val' is an IpnsEntry and that that entry is valid.
-func ValidateIpnsRecord(k u.Key, val []byte) error {
+func ValidateIpnsRecord(k key.Key, val []byte) error {
 	entry := new(pb.IpnsEntry)
 	err := proto.Unmarshal(val, entry)
 	if err != nil {

--- a/namesys/resolve_test.go
+++ b/namesys/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	path "github.com/ipfs/go-ipfs/path"
 	mockrouting "github.com/ipfs/go-ipfs/routing/mock"
 	u "github.com/ipfs/go-ipfs/util"
@@ -33,7 +34,7 @@ func TestRoutingResolve(t *testing.T) {
 	}
 
 	pkhash := u.Hash(pubkb)
-	res, err := resolver.Resolve(context.Background(), u.Key(pkhash).Pretty())
+	res, err := resolver.Resolve(context.Background(), key.Key(pkhash).Pretty())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -7,6 +7,7 @@ import (
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	pb "github.com/ipfs/go-ipfs/namesys/internal/pb"
 	path "github.com/ipfs/go-ipfs/path"
 	routing "github.com/ipfs/go-ipfs/routing"
@@ -64,7 +65,7 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 	// /ipns/<name>
 	h := []byte("/ipns/" + string(hash))
 
-	ipnsKey := u.Key(h)
+	ipnsKey := key.Key(h)
 	val, err := r.routing.GetValue(ctx, ipnsKey)
 	if err != nil {
 		log.Warning("RoutingResolve get failed.")
@@ -84,7 +85,7 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 	}
 
 	hsh, _ := pubkey.Hash()
-	log.Debugf("pk hash = %s", u.Key(hsh))
+	log.Debugf("pk hash = %s", key.Key(hsh))
 
 	// check sig with pk
 	if ok, err := pubkey.Verify(ipnsEntryDataForSig(entry), entry.GetSignature()); err != nil || !ok {
@@ -101,6 +102,6 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 	} else {
 		// Its an old style multihash record
 		log.Warning("Detected old style multihash record")
-		return path.FromKey(u.Key(valh)), nil
+		return path.FromKey(key.Key(valh)), nil
 	}
 }

--- a/p2p/net/conn/conn.go
+++ b/p2p/net/conn/conn.go
@@ -157,7 +157,7 @@ func ID(c Conn) string {
 	lh := u.Hash([]byte(l))
 	rh := u.Hash([]byte(r))
 	ch := u.XOR(lh, rh)
-	return u.Key(ch).Pretty()
+	return peer.ID(ch).Pretty()
 }
 
 // String returns the user-friendly String representation of a conn

--- a/p2p/net/conn/interface.go
+++ b/p2p/net/conn/interface.go
@@ -5,9 +5,9 @@ import (
 	"net"
 	"time"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	ic "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 
 	msgio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-msgio"
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
@@ -15,7 +15,7 @@ import (
 )
 
 // Map maps Keys (Peer.IDs) to Connections.
-type Map map[u.Key]Conn
+type Map map[key.Key]Conn
 
 type PeerConn interface {
 	io.Closer

--- a/p2p/peer/queue/distance.go
+++ b/p2p/peer/queue/distance.go
@@ -5,9 +5,9 @@ import (
 	"math/big"
 	"sync"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	ks "github.com/ipfs/go-ipfs/routing/keyspace"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 // peerMetric tracks a peer and its distance to something else.
@@ -93,7 +93,7 @@ func (pq *distancePQ) Dequeue() peer.ID {
 // NewXORDistancePQ returns a PeerQueue which maintains its peers sorted
 // in terms of their distances to each other in an XORKeySpace (i.e. using
 // XOR as a metric of distance).
-func NewXORDistancePQ(fromKey u.Key) PeerQueue {
+func NewXORDistancePQ(fromKey key.Key) PeerQueue {
 	return &distancePQ{
 		from: ks.XORKeySpace.Key([]byte(fromKey)),
 		heap: peerMetricHeap{},

--- a/p2p/peer/queue/queue_test.go
+++ b/p2p/peer/queue/queue_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	u "github.com/ipfs/go-ipfs/util"
 
@@ -27,7 +28,7 @@ func TestQueue(t *testing.T) {
 	// [78 135 26 216 178 181 224 181 234 117 2 248 152 115 255 103 244 34 4 152 193 88 9 225 8 127 216 158 226 8 236 246]
 	// [125 135 124 6 226 160 101 94 192 57 39 12 18 79 121 140 190 154 147 55 44 83 101 151 63 255 94 179 51 203 241 51]
 
-	pq := NewXORDistancePQ(u.Key("11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31"))
+	pq := NewXORDistancePQ(key.Key("11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31"))
 	pq.Enqueue(p3)
 	pq.Enqueue(p1)
 	pq.Enqueue(p2)
@@ -81,7 +82,7 @@ func TestSyncQueue(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	pq := NewXORDistancePQ(u.Key("11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31"))
+	pq := NewXORDistancePQ(key.Key("11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31"))
 	cq := NewChanQueue(ctx, pq)
 	wg := sync.WaitGroup{}
 

--- a/path/path.go
+++ b/path/path.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"strings"
 
-	u "github.com/ipfs/go-ipfs/util"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 
 	b58 "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-base58"
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
@@ -24,7 +24,7 @@ func FromString(s string) Path {
 }
 
 // FromKey safely converts a Key type to a Path type
-func FromKey(k u.Key) Path {
+func FromKey(k key.Key) Path {
 	return Path("/ipfs/" + k.String())
 }
 
@@ -86,7 +86,7 @@ func ParseKeyToPath(txt string) (Path, error) {
 	if err != nil {
 		return "", err
 	}
-	return FromKey(u.Key(chk)), nil
+	return FromKey(key.Key(chk)), nil
 }
 
 func (p *Path) IsValid() error {

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -2,13 +2,14 @@
 package path
 
 import (
+	"errors"
 	"fmt"
 	"time"
-	"errors"
 
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -83,7 +84,7 @@ func (s *Resolver) ResolvePathComponents(ctx context.Context, fpath Path) ([]*me
 	log.Debug("Resolve dag get.")
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
-	nd, err := s.DAG.Get(ctx, u.Key(h))
+	nd, err := s.DAG.Get(ctx, key.Key(h))
 	if err != nil {
 		return nil, err
 	}
@@ -107,12 +108,12 @@ func (s *Resolver) ResolveLinks(ctx context.Context, ndd *merkledag.Node, names 
 	// for each of the path components
 	for _, name := range names {
 
-		var next u.Key
+		var next key.Key
 		var nlink *merkledag.Link
 		// for each of the links in nd, the current object
 		for _, link := range nd.Links {
 			if link.Name == name {
-				next = u.Key(link.Hash)
+				next = key.Key(link.Hash)
 				nlink = link
 				break
 			}

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	blockservice "github.com/ipfs/go-ipfs/blockservice"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
@@ -16,7 +17,7 @@ import (
 	util "github.com/ipfs/go-ipfs/util"
 )
 
-func randNode() (*merkledag.Node, util.Key) {
+func randNode() (*merkledag.Node, key.Key) {
 	node := new(merkledag.Node)
 	node.Data = make([]byte, 32)
 	util.NewTimeSeededRand().Read(node.Data)

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -9,13 +9,14 @@ import (
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bs "github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/exchange/offline"
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/util"
 )
 
-func randNode() (*mdag.Node, util.Key) {
+func randNode() (*mdag.Node, key.Key) {
 	nd := new(mdag.Node)
 	nd.Data = make([]byte, 32)
 	util.NewTimeSeededRand().Read(nd.Data)

--- a/routing/dht/ext_test.go
+++ b/routing/dht/ext_test.go
@@ -12,6 +12,7 @@ import (
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	mocknet "github.com/ipfs/go-ipfs/p2p/net/mock"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
@@ -37,7 +38,6 @@ func TestGetFailures(t *testing.T) {
 	d := NewDHT(ctx, hosts[0], tsds)
 	d.Update(ctx, hosts[1].ID())
 
-	// u.POut("NotFound Test\n")
 	// Reply with failures to every message
 	hosts[1].SetStreamHandler(ProtocolDHT, func(s inet.Stream) {
 		defer s.Close()
@@ -45,9 +45,8 @@ func TestGetFailures(t *testing.T) {
 	})
 
 	// This one should time out
-	// u.POut("Timout Test\n")
 	ctx1, _ := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	if _, err := d.GetValue(ctx1, u.Key("test")); err != nil {
+	if _, err := d.GetValue(ctx1, key.Key("test")); err != nil {
 		if merr, ok := err.(u.MultiErr); ok && len(merr) > 0 {
 			err = merr[0]
 		}
@@ -87,7 +86,7 @@ func TestGetFailures(t *testing.T) {
 	// (was 3 seconds before which should be _plenty_ of time, but maybe
 	// travis machines really have a hard time...)
 	ctx2, _ := context.WithTimeout(context.Background(), 20*time.Second)
-	_, err = d.GetValue(ctx2, u.Key("test"))
+	_, err = d.GetValue(ctx2, key.Key("test"))
 	if err != nil {
 		if merr, ok := err.(u.MultiErr); ok && len(merr) > 0 {
 			err = merr[0]
@@ -111,7 +110,7 @@ func TestGetFailures(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rec, err := record.MakePutRecord(sk, u.Key(str), []byte("blah"), true)
+		rec, err := record.MakePutRecord(sk, key.Key(str), []byte("blah"), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +120,6 @@ func TestGetFailures(t *testing.T) {
 			Record: rec,
 		}
 
-		// u.POut("handleGetValue Test\n")
 		s, err := hosts[1].NewStream(ProtocolDHT, hosts[0].ID())
 		if err != nil {
 			t.Fatal(err)
@@ -205,7 +203,7 @@ func TestNotFound(t *testing.T) {
 
 	// long timeout to ensure timing is not at play.
 	ctx, _ = context.WithTimeout(ctx, time.Second*20)
-	v, err := d.GetValue(ctx, u.Key("hello"))
+	v, err := d.GetValue(ctx, key.Key("hello"))
 	log.Debugf("get value got %v", v)
 	if err != nil {
 		if merr, ok := err.(u.MultiErr); ok && len(merr) > 0 {
@@ -277,7 +275,7 @@ func TestLessThanKResponses(t *testing.T) {
 	}
 
 	ctx, _ = context.WithTimeout(ctx, time.Second*30)
-	if _, err := d.GetValue(ctx, u.Key("hello")); err != nil {
+	if _, err := d.GetValue(ctx, key.Key("hello")); err != nil {
 		switch err {
 		case routing.ErrNotFound:
 			//Success!

--- a/routing/dht/lookup.go
+++ b/routing/dht/lookup.go
@@ -2,10 +2,10 @@ package dht
 
 import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	notif "github.com/ipfs/go-ipfs/notifications"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	kb "github.com/ipfs/go-ipfs/routing/kbucket"
-	u "github.com/ipfs/go-ipfs/util"
 	pset "github.com/ipfs/go-ipfs/util/peerset"
 )
 
@@ -21,7 +21,7 @@ func pointerizePeerInfos(pis []peer.PeerInfo) []*peer.PeerInfo {
 
 // Kademlia 'node lookup' operation. Returns a channel of the K closest peers
 // to the given key
-func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key u.Key) (<-chan peer.ID, error) {
+func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key key.Key) (<-chan peer.ID, error) {
 	e := log.EventBegin(ctx, "getClosestPeers", &key)
 	tablepeers := dht.routingTable.NearestPeers(kb.ConvertKey(key), AlphaValue)
 	if len(tablepeers) == 0 {
@@ -88,7 +88,7 @@ func (dht *IpfsDHT) GetClosestPeers(ctx context.Context, key u.Key) (<-chan peer
 	return out, nil
 }
 
-func (dht *IpfsDHT) closerPeersSingle(ctx context.Context, key u.Key, p peer.ID) ([]peer.ID, error) {
+func (dht *IpfsDHT) closerPeersSingle(ctx context.Context, key key.Key, p peer.ID) ([]peer.ID, error) {
 	pmes, err := dht.findPeerSingle(ctx, p, peer.ID(key))
 	if err != nil {
 		return nil, err

--- a/routing/dht/pb/message.go
+++ b/routing/dht/pb/message.go
@@ -3,10 +3,10 @@ package dht_pb
 import (
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	util "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("dht.pb")
@@ -143,7 +143,7 @@ func (m *Message) Loggable() map[string]interface{} {
 	return map[string]interface{}{
 		"message": map[string]string{
 			"type": m.Type.String(),
-			"key":  util.Key(m.GetKey()).Pretty(),
+			"key":  key.Key(m.GetKey()).Pretty(),
 		},
 	}
 }

--- a/routing/dht/providers.go
+++ b/routing/dht/providers.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	ctxgroup "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
@@ -16,10 +16,10 @@ type providerInfo struct {
 }
 
 type ProviderManager struct {
-	providers map[u.Key][]*providerInfo
-	local     map[u.Key]struct{}
+	providers map[key.Key][]*providerInfo
+	local     map[key.Key]struct{}
 	lpeer     peer.ID
-	getlocal  chan chan []u.Key
+	getlocal  chan chan []key.Key
 	newprovs  chan *addProv
 	getprovs  chan *getProv
 	period    time.Duration
@@ -27,12 +27,12 @@ type ProviderManager struct {
 }
 
 type addProv struct {
-	k   u.Key
+	k   key.Key
 	val peer.ID
 }
 
 type getProv struct {
-	k    u.Key
+	k    key.Key
 	resp chan []peer.ID
 }
 
@@ -40,9 +40,9 @@ func NewProviderManager(ctx context.Context, local peer.ID) *ProviderManager {
 	pm := new(ProviderManager)
 	pm.getprovs = make(chan *getProv)
 	pm.newprovs = make(chan *addProv)
-	pm.providers = make(map[u.Key][]*providerInfo)
-	pm.getlocal = make(chan chan []u.Key)
-	pm.local = make(map[u.Key]struct{})
+	pm.providers = make(map[key.Key][]*providerInfo)
+	pm.getlocal = make(chan chan []key.Key)
+	pm.local = make(map[key.Key]struct{})
 	pm.ContextGroup = ctxgroup.WithContext(ctx)
 
 	pm.Children().Add(1)
@@ -76,7 +76,7 @@ func (pm *ProviderManager) run() {
 			gp.resp <- parr
 
 		case lc := <-pm.getlocal:
-			var keys []u.Key
+			var keys []key.Key
 			for k := range pm.local {
 				keys = append(keys, k)
 			}
@@ -99,7 +99,7 @@ func (pm *ProviderManager) run() {
 	}
 }
 
-func (pm *ProviderManager) AddProvider(ctx context.Context, k u.Key, val peer.ID) {
+func (pm *ProviderManager) AddProvider(ctx context.Context, k key.Key, val peer.ID) {
 	prov := &addProv{
 		k:   k,
 		val: val,
@@ -110,7 +110,7 @@ func (pm *ProviderManager) AddProvider(ctx context.Context, k u.Key, val peer.ID
 	}
 }
 
-func (pm *ProviderManager) GetProviders(ctx context.Context, k u.Key) []peer.ID {
+func (pm *ProviderManager) GetProviders(ctx context.Context, k key.Key) []peer.ID {
 	gp := &getProv{
 		k:    k,
 		resp: make(chan []peer.ID, 1), // buffered to prevent sender from blocking
@@ -128,8 +128,8 @@ func (pm *ProviderManager) GetProviders(ctx context.Context, k u.Key) []peer.ID 
 	}
 }
 
-func (pm *ProviderManager) GetLocal() []u.Key {
-	resp := make(chan []u.Key)
+func (pm *ProviderManager) GetLocal() []key.Key {
+	resp := make(chan []key.Key)
 	pm.getlocal <- resp
 	return <-resp
 }

--- a/routing/dht/providers_test.go
+++ b/routing/dht/providers_test.go
@@ -3,8 +3,8 @@ package dht
 import (
 	"testing"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
@@ -13,7 +13,7 @@ func TestProviderManager(t *testing.T) {
 	ctx := context.Background()
 	mid := peer.ID("testing")
 	p := NewProviderManager(ctx, mid)
-	a := u.Key("test")
+	a := key.Key("test")
 	p.AddProvider(ctx, a, peer.ID("testingprovider"))
 	resp := p.GetProviders(ctx, a)
 	if len(resp) != 1 {

--- a/routing/dht/query.go
+++ b/routing/dht/query.go
@@ -3,6 +3,7 @@ package dht
 import (
 	"sync"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	notif "github.com/ipfs/go-ipfs/notifications"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	queue "github.com/ipfs/go-ipfs/p2p/peer/queue"
@@ -21,7 +22,7 @@ var maxQueryConcurrency = AlphaValue
 
 type dhtQuery struct {
 	dht         *IpfsDHT
-	key         u.Key     // the key we're querying for
+	key         key.Key   // the key we're querying for
 	qfunc       queryFunc // the function to execute per peer
 	concurrency int       // the concurrency parameter
 }
@@ -35,7 +36,7 @@ type dhtQueryResult struct {
 }
 
 // constructs query
-func (dht *IpfsDHT) newQuery(k u.Key, f queryFunc) *dhtQuery {
+func (dht *IpfsDHT) newQuery(k key.Key, f queryFunc) *dhtQuery {
 	return &dhtQuery{
 		key:         k,
 		dht:         dht,

--- a/routing/kbucket/util.go
+++ b/routing/kbucket/util.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	ks "github.com/ipfs/go-ipfs/routing/keyspace"
 	u "github.com/ipfs/go-ipfs/util"
@@ -45,13 +46,13 @@ func ConvertPeerID(id peer.ID) ID {
 }
 
 // ConvertKey creates a DHT ID by hashing a local key (String)
-func ConvertKey(id u.Key) ID {
+func ConvertKey(id key.Key) ID {
 	hash := sha256.Sum256([]byte(id))
 	return hash[:]
 }
 
 // Closer returns true if a is closer to key than b is
-func Closer(a, b peer.ID, key u.Key) bool {
+func Closer(a, b peer.ID, key key.Key) bool {
 	aid := ConvertPeerID(a)
 	bid := ConvertPeerID(b)
 	tgt := ConvertKey(key)

--- a/routing/mock/centralized_client.go
+++ b/routing/mock/centralized_client.go
@@ -7,6 +7,7 @@ import (
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	u "github.com/ipfs/go-ipfs/util"
@@ -22,13 +23,13 @@ type client struct {
 }
 
 // FIXME(brian): is this method meant to simulate putting a value into the network?
-func (c *client) PutValue(ctx context.Context, key u.Key, val []byte) error {
+func (c *client) PutValue(ctx context.Context, key key.Key, val []byte) error {
 	log.Debugf("PutValue: %s", key)
 	return c.datastore.Put(key.DsKey(), val)
 }
 
 // FIXME(brian): is this method meant to simulate getting a value from the network?
-func (c *client) GetValue(ctx context.Context, key u.Key) ([]byte, error) {
+func (c *client) GetValue(ctx context.Context, key key.Key) ([]byte, error) {
 	log.Debugf("GetValue: %s", key)
 	v, err := c.datastore.Get(key.DsKey())
 	if err != nil {
@@ -43,7 +44,7 @@ func (c *client) GetValue(ctx context.Context, key u.Key) ([]byte, error) {
 	return data, nil
 }
 
-func (c *client) FindProviders(ctx context.Context, key u.Key) ([]peer.PeerInfo, error) {
+func (c *client) FindProviders(ctx context.Context, key key.Key) ([]peer.PeerInfo, error) {
 	return c.server.Providers(key), nil
 }
 
@@ -52,7 +53,7 @@ func (c *client) FindPeer(ctx context.Context, pid peer.ID) (peer.PeerInfo, erro
 	return peer.PeerInfo{}, nil
 }
 
-func (c *client) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-chan peer.PeerInfo {
+func (c *client) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.PeerInfo {
 	out := make(chan peer.PeerInfo)
 	go func() {
 		defer close(out)
@@ -72,7 +73,7 @@ func (c *client) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-cha
 
 // Provide returns once the message is on the network. Value is not necessarily
 // visible yet.
-func (c *client) Provide(_ context.Context, key u.Key) error {
+func (c *client) Provide(_ context.Context, key key.Key) error {
 	info := peer.PeerInfo{
 		ID:    c.peer.ID(),
 		Addrs: []ma.Multiaddr{c.peer.Address()},

--- a/routing/mock/centralized_server.go
+++ b/routing/mock/centralized_server.go
@@ -7,15 +7,15 @@ import (
 
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
 )
 
 // server is the mockrouting.Client's private interface to the routing server
 type server interface {
-	Announce(peer.PeerInfo, u.Key) error
-	Providers(u.Key) []peer.PeerInfo
+	Announce(peer.PeerInfo, key.Key) error
+	Providers(key.Key) []peer.PeerInfo
 
 	Server
 }
@@ -25,7 +25,7 @@ type s struct {
 	delayConf DelayConfig
 
 	lock      sync.RWMutex
-	providers map[u.Key]map[peer.ID]providerRecord
+	providers map[key.Key]map[peer.ID]providerRecord
 }
 
 type providerRecord struct {
@@ -33,7 +33,7 @@ type providerRecord struct {
 	Created time.Time
 }
 
-func (rs *s) Announce(p peer.PeerInfo, k u.Key) error {
+func (rs *s) Announce(p peer.PeerInfo, k key.Key) error {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()
 
@@ -48,7 +48,7 @@ func (rs *s) Announce(p peer.PeerInfo, k u.Key) error {
 	return nil
 }
 
-func (rs *s) Providers(k u.Key) []peer.PeerInfo {
+func (rs *s) Providers(k key.Key) []peer.PeerInfo {
 	rs.delayConf.Query.Wait() // before locking
 
 	rs.lock.RLock()

--- a/routing/mock/centralized_test.go
+++ b/routing/mock/centralized_test.go
@@ -5,16 +5,16 @@ import (
 	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
-	u "github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
 )
 
 func TestKeyNotFound(t *testing.T) {
 
 	var pi = testutil.RandIdentityOrFatal(t)
-	var key = u.Key("mock key")
+	var key = key.Key("mock key")
 	var ctx = context.Background()
 
 	rs := NewServer()
@@ -30,7 +30,7 @@ func TestClientFindProviders(t *testing.T) {
 	rs := NewServer()
 	client := rs.Client(pi)
 
-	k := u.Key("hello")
+	k := key.Key("hello")
 	err := client.Provide(context.Background(), k)
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +40,7 @@ func TestClientFindProviders(t *testing.T) {
 	time.Sleep(time.Millisecond * 300)
 	max := 100
 
-	providersFromClient := client.FindProvidersAsync(context.Background(), u.Key("hello"), max)
+	providersFromClient := client.FindProvidersAsync(context.Background(), key.Key("hello"), max)
 	isInClient := false
 	for pi := range providersFromClient {
 		if pi.ID == pi.ID {
@@ -54,7 +54,7 @@ func TestClientFindProviders(t *testing.T) {
 
 func TestClientOverMax(t *testing.T) {
 	rs := NewServer()
-	k := u.Key("hello")
+	k := key.Key("hello")
 	numProvidersForHelloKey := 100
 	for i := 0; i < numProvidersForHelloKey; i++ {
 		pi := testutil.RandIdentityOrFatal(t)
@@ -81,7 +81,7 @@ func TestClientOverMax(t *testing.T) {
 // TODO does dht ensure won't receive self as a provider? probably not.
 func TestCanceledContext(t *testing.T) {
 	rs := NewServer()
-	k := u.Key("hello")
+	k := key.Key("hello")
 
 	// avoid leaking goroutine, without using the context to signal
 	// (we want the goroutine to keep trying to publish on a
@@ -139,7 +139,7 @@ func TestCanceledContext(t *testing.T) {
 func TestValidAfter(t *testing.T) {
 
 	pi := testutil.RandIdentityOrFatal(t)
-	var key = u.Key("mock key")
+	var key = key.Key("mock key")
 	var ctx = context.Background()
 	conf := DelayConfig{
 		ValueVisibility: delay.Fixed(1 * time.Hour),

--- a/routing/mock/interface.go
+++ b/routing/mock/interface.go
@@ -7,10 +7,10 @@ package mockrouting
 import (
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
-	u "github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
 )
 
@@ -22,7 +22,7 @@ type Server interface {
 
 // Client implements IpfsRouting
 type Client interface {
-	FindProviders(context.Context, u.Key) ([]peer.PeerInfo, error)
+	FindProviders(context.Context, key.Key) ([]peer.PeerInfo, error)
 	routing.IpfsRouting
 }
 
@@ -37,7 +37,7 @@ func NewServer() Server {
 // NewServerWithDelay returns a mockrouting Server with a delay!
 func NewServerWithDelay(conf DelayConfig) Server {
 	return &s{
-		providers: make(map[u.Key]map[peer.ID]providerRecord),
+		providers: make(map[key.Key]map[peer.ID]providerRecord),
 		delayConf: conf,
 	}
 }

--- a/routing/offline/offline.go
+++ b/routing/offline/offline.go
@@ -7,13 +7,13 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	"github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	record "github.com/ipfs/go-ipfs/routing/record"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("offlinerouting")
@@ -35,7 +35,7 @@ type offlineRouting struct {
 	sk        ci.PrivKey
 }
 
-func (c *offlineRouting) PutValue(ctx context.Context, key u.Key, val []byte) error {
+func (c *offlineRouting) PutValue(ctx context.Context, key key.Key, val []byte) error {
 	rec, err := record.MakePutRecord(c.sk, key, val, false)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (c *offlineRouting) PutValue(ctx context.Context, key u.Key, val []byte) er
 	return c.datastore.Put(key.DsKey(), data)
 }
 
-func (c *offlineRouting) GetValue(ctx context.Context, key u.Key) ([]byte, error) {
+func (c *offlineRouting) GetValue(ctx context.Context, key key.Key) ([]byte, error) {
 	v, err := c.datastore.Get(key.DsKey())
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (c *offlineRouting) GetValue(ctx context.Context, key u.Key) ([]byte, error
 	return rec.GetValue(), nil
 }
 
-func (c *offlineRouting) FindProviders(ctx context.Context, key u.Key) ([]peer.PeerInfo, error) {
+func (c *offlineRouting) FindProviders(ctx context.Context, key key.Key) ([]peer.PeerInfo, error) {
 	return nil, ErrOffline
 }
 
@@ -75,13 +75,13 @@ func (c *offlineRouting) FindPeer(ctx context.Context, pid peer.ID) (peer.PeerIn
 	return peer.PeerInfo{}, ErrOffline
 }
 
-func (c *offlineRouting) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-chan peer.PeerInfo {
+func (c *offlineRouting) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.PeerInfo {
 	out := make(chan peer.PeerInfo)
 	close(out)
 	return out
 }
 
-func (c *offlineRouting) Provide(_ context.Context, key u.Key) error {
+func (c *offlineRouting) Provide(_ context.Context, key key.Key) error {
 	return ErrOffline
 }
 

--- a/routing/record/record.go
+++ b/routing/record/record.go
@@ -5,16 +5,16 @@ import (
 
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("routing/record")
 
 // MakePutRecord creates and signs a dht record for the given key/value pair
-func MakePutRecord(sk ci.PrivKey, key u.Key, value []byte, sign bool) (*pb.Record, error) {
+func MakePutRecord(sk ci.PrivKey, key key.Key, value []byte, sign bool) (*pb.Record, error) {
 	record := new(pb.Record)
 
 	record.Key = proto.String(string(key))

--- a/routing/record/validation.go
+++ b/routing/record/validation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	u "github.com/ipfs/go-ipfs/util"
@@ -12,7 +13,7 @@ import (
 
 // ValidatorFunc is a function that is called to validate a given
 // type of DHTRecord.
-type ValidatorFunc func(u.Key, []byte) error
+type ValidatorFunc func(key.Key, []byte) error
 
 // ErrBadRecord is returned any time a dht record is found to be
 // incorrectly formatted or signed.
@@ -38,7 +39,7 @@ func (v Validator) VerifyRecord(r *pb.Record) error {
 	// Now, check validity func
 	parts := strings.Split(r.GetKey(), "/")
 	if len(parts) < 3 {
-		log.Infof("Record key does not have validator: %s", u.Key(r.GetKey()))
+		log.Infof("Record key does not have validator: %s", key.Key(r.GetKey()))
 		return nil
 	}
 
@@ -48,10 +49,10 @@ func (v Validator) VerifyRecord(r *pb.Record) error {
 		return ErrInvalidRecordType
 	}
 
-	return val.Func(u.Key(r.GetKey()), r.GetValue())
+	return val.Func(key.Key(r.GetKey()), r.GetValue())
 }
 
-func (v Validator) IsSigned(k u.Key) (bool, error) {
+func (v Validator) IsSigned(k key.Key) (bool, error) {
 	// Now, check validity func
 	parts := strings.Split(string(k), "/")
 	if len(parts) < 3 {
@@ -71,7 +72,7 @@ func (v Validator) IsSigned(k u.Key) (bool, error) {
 // ValidatePublicKeyRecord implements ValidatorFunc and
 // verifies that the passed in record value is the PublicKey
 // that matches the passed in key.
-func ValidatePublicKeyRecord(k u.Key, val []byte) error {
+func ValidatePublicKeyRecord(k key.Key, val []byte) error {
 	keyparts := bytes.Split([]byte(k), []byte("/"))
 	if len(keyparts) < 3 {
 		return errors.New("invalid key")

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 // ErrNotFound is returned when a search fails to find anything
@@ -17,21 +17,21 @@ var ErrNotFound = errors.New("routing: not found")
 // IpfsRouting is the routing module interface
 // It is implemented by things like DHTs, etc.
 type IpfsRouting interface {
-	FindProvidersAsync(context.Context, u.Key, int) <-chan peer.PeerInfo
+	FindProvidersAsync(context.Context, key.Key, int) <-chan peer.PeerInfo
 
 	// Basic Put/Get
 
 	// PutValue adds value corresponding to given Key.
-	PutValue(context.Context, u.Key, []byte) error
+	PutValue(context.Context, key.Key, []byte) error
 
 	// GetValue searches for the value corresponding to given Key.
-	GetValue(context.Context, u.Key) ([]byte, error)
+	GetValue(context.Context, key.Key) ([]byte, error)
 
 	// Value provider layer of indirection.
 	// This is what DSHTs (Coral and MainlineDHT) do to store large values in a DHT.
 
 	// Announce that this node can provide value for given key
-	Provide(context.Context, u.Key) error
+	Provide(context.Context, key.Key) error
 
 	// Find specific Peer
 	// FindPeer searches for a peer with given ID, returns a peer.PeerInfo
@@ -54,8 +54,8 @@ type PubKeyFetcher interface {
 
 // KeyForPublicKey returns the key used to retrieve public keys
 // from the dht.
-func KeyForPublicKey(id peer.ID) u.Key {
-	return u.Key("/pk/" + string(id))
+func KeyForPublicKey(id peer.ID) key.Key {
+	return key.Key("/pk/" + string(id))
 }
 
 func GetPublicKey(r IpfsRouting, ctx context.Context, pkhash []byte) (ci.PubKey, error) {
@@ -63,7 +63,7 @@ func GetPublicKey(r IpfsRouting, ctx context.Context, pkhash []byte) (ci.PubKey,
 		// If we have a DHT as our routing system, use optimized fetcher
 		return dht.GetPublicKey(ctx, peer.ID(pkhash))
 	} else {
-		key := u.Key("/pk/" + string(pkhash))
+		key := key.Key("/pk/" + string(pkhash))
 		pkval, err := r.GetValue(ctx, key)
 		if err != nil {
 			return nil, err

--- a/routing/supernode/client.go
+++ b/routing/supernode/client.go
@@ -8,13 +8,13 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/p2p/host"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	proxy "github.com/ipfs/go-ipfs/routing/supernode/proxy"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 var log = eventlog.Logger("supernode")
@@ -36,7 +36,7 @@ func NewClient(px proxy.Proxy, h host.Host, ps peer.Peerstore, local peer.ID) (*
 	}, nil
 }
 
-func (c *Client) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-chan peer.PeerInfo {
+func (c *Client) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.PeerInfo {
 	ctx = eventlog.ContextWithLoggable(ctx, eventlog.Uuid("findProviders"))
 	defer log.EventBegin(ctx, "findProviders", &k).Done()
 	ch := make(chan peer.PeerInfo)
@@ -60,7 +60,7 @@ func (c *Client) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-cha
 	return ch
 }
 
-func (c *Client) PutValue(ctx context.Context, k u.Key, v []byte) error {
+func (c *Client) PutValue(ctx context.Context, k key.Key, v []byte) error {
 	defer log.EventBegin(ctx, "putValue", &k).Done()
 	r, err := makeRecord(c.peerstore, c.local, k, v)
 	if err != nil {
@@ -71,7 +71,7 @@ func (c *Client) PutValue(ctx context.Context, k u.Key, v []byte) error {
 	return c.proxy.SendMessage(ctx, pmes) // wrap to hide the remote
 }
 
-func (c *Client) GetValue(ctx context.Context, k u.Key) ([]byte, error) {
+func (c *Client) GetValue(ctx context.Context, k key.Key) ([]byte, error) {
 	defer log.EventBegin(ctx, "getValue", &k).Done()
 	msg := pb.NewMessage(pb.Message_GET_VALUE, string(k), 0)
 	response, err := c.proxy.SendRequest(ctx, msg) // TODO wrap to hide the remote
@@ -81,7 +81,7 @@ func (c *Client) GetValue(ctx context.Context, k u.Key) ([]byte, error) {
 	return response.Record.GetValue(), nil
 }
 
-func (c *Client) Provide(ctx context.Context, k u.Key) error {
+func (c *Client) Provide(ctx context.Context, k key.Key) error {
 	defer log.EventBegin(ctx, "provide", &k).Done()
 	msg := pb.NewMessage(pb.Message_ADD_PROVIDER, string(k), 0)
 	// FIXME how is connectedness defined for the local node
@@ -113,7 +113,7 @@ func (c *Client) FindPeer(ctx context.Context, id peer.ID) (peer.PeerInfo, error
 }
 
 // creates and signs a record for the given key/value pair
-func makeRecord(ps peer.Peerstore, p peer.ID, k u.Key, v []byte) (*pb.Record, error) {
+func makeRecord(ps peer.Peerstore, p peer.ID, k key.Key, v []byte) (*pb.Record, error) {
 	blob := bytes.Join([][]byte{[]byte(k), v, []byte(p)}, []byte{})
 	sig, err := ps.PrivKey(p).Sign(blob)
 	if err != nil {

--- a/routing/supernode/proxy/standard.go
+++ b/routing/supernode/proxy/standard.go
@@ -6,13 +6,13 @@ import (
 	ggio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/io"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	host "github.com/ipfs/go-ipfs/p2p/host"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	dhtpb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	kbucket "github.com/ipfs/go-ipfs/routing/kbucket"
 	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	util "github.com/ipfs/go-ipfs/util"
 )
 
 const ProtocolSNR = "/ipfs/supernoderouting"
@@ -162,7 +162,7 @@ func (px *standard) sendRequest(ctx context.Context, m *dhtpb.Message, remote pe
 	return response, nil
 }
 
-func sortedByKey(peers []peer.ID, key string) []peer.ID {
-	target := kbucket.ConvertKey(util.Key(key))
+func sortedByKey(peers []peer.ID, skey string) []peer.ID {
+	target := kbucket.ConvertKey(key.Key(skey))
 	return kbucket.SortClosestPeers(peers, target)
 }

--- a/routing/supernode/server.go
+++ b/routing/supernode/server.go
@@ -8,11 +8,11 @@ import (
 	datastore "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	dhtpb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	record "github.com/ipfs/go-ipfs/routing/record"
 	proxy "github.com/ipfs/go-ipfs/routing/supernode/proxy"
-	util "github.com/ipfs/go-ipfs/util"
 )
 
 // Server handles routing queries using a database backend
@@ -53,7 +53,7 @@ func (s *Server) handleMessage(
 	switch req.GetType() {
 
 	case dhtpb.Message_GET_VALUE:
-		rawRecord, err := getRoutingRecord(s.routingBackend, util.Key(req.GetKey()))
+		rawRecord, err := getRoutingRecord(s.routingBackend, key.Key(req.GetKey()))
 		if err != nil {
 			return "", nil
 		}
@@ -67,7 +67,7 @@ func (s *Server) handleMessage(
 		// 	log.Event(ctx, "validationFailed", req, p)
 		// 	return "", nil
 		// }
-		putRoutingRecord(s.routingBackend, util.Key(req.GetKey()), req.GetRecord())
+		putRoutingRecord(s.routingBackend, key.Key(req.GetKey()), req.GetRecord())
 		return p, req
 
 	case dhtpb.Message_FIND_NODE:
@@ -87,7 +87,7 @@ func (s *Server) handleMessage(
 			if providerID == p {
 				store := []*dhtpb.Message_Peer{provider}
 				storeProvidersToPeerstore(s.peerstore, p, store)
-				if err := putRoutingProviders(s.routingBackend, util.Key(req.GetKey()), store); err != nil {
+				if err := putRoutingProviders(s.routingBackend, key.Key(req.GetKey()), store); err != nil {
 					return "", nil
 				}
 			} else {
@@ -97,7 +97,7 @@ func (s *Server) handleMessage(
 		return "", nil
 
 	case dhtpb.Message_GET_PROVIDERS:
-		providers, err := getRoutingProviders(s.routingBackend, util.Key(req.GetKey()))
+		providers, err := getRoutingProviders(s.routingBackend, key.Key(req.GetKey()))
 		if err != nil {
 			return "", nil
 		}
@@ -114,7 +114,7 @@ func (s *Server) handleMessage(
 var _ proxy.RequestHandler = &Server{}
 var _ proxy.Proxy = &Server{}
 
-func getRoutingRecord(ds datastore.Datastore, k util.Key) (*dhtpb.Record, error) {
+func getRoutingRecord(ds datastore.Datastore, k key.Key) (*dhtpb.Record, error) {
 	dskey := k.DsKey()
 	val, err := ds.Get(dskey)
 	if err != nil {
@@ -131,7 +131,7 @@ func getRoutingRecord(ds datastore.Datastore, k util.Key) (*dhtpb.Record, error)
 	return &record, nil
 }
 
-func putRoutingRecord(ds datastore.Datastore, k util.Key, value *dhtpb.Record) error {
+func putRoutingRecord(ds datastore.Datastore, k key.Key, value *dhtpb.Record) error {
 	data, err := proto.Marshal(value)
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func putRoutingRecord(ds datastore.Datastore, k util.Key, value *dhtpb.Record) e
 	return nil
 }
 
-func putRoutingProviders(ds datastore.Datastore, k util.Key, newRecords []*dhtpb.Message_Peer) error {
+func putRoutingProviders(ds datastore.Datastore, k key.Key, newRecords []*dhtpb.Message_Peer) error {
 	log.Event(context.Background(), "putRoutingProviders", &k)
 	oldRecords, err := getRoutingProviders(ds, k)
 	if err != nil {
@@ -183,7 +183,7 @@ func storeProvidersToPeerstore(ps peer.Peerstore, p peer.ID, providers []*dhtpb.
 	}
 }
 
-func getRoutingProviders(ds datastore.Datastore, k util.Key) ([]*dhtpb.Message_Peer, error) {
+func getRoutingProviders(ds datastore.Datastore, k key.Key) ([]*dhtpb.Message_Peer, error) {
 	e := log.EventBegin(context.Background(), "getProviders", &k)
 	defer e.Done()
 	var providers []*dhtpb.Message_Peer
@@ -199,7 +199,7 @@ func getRoutingProviders(ds datastore.Datastore, k util.Key) ([]*dhtpb.Message_P
 	return providers, nil
 }
 
-func providerKey(k util.Key) datastore.Key {
+func providerKey(k key.Key) datastore.Key {
 	return datastore.KeyWithNamespaces([]string{"routing", "providers", k.String()})
 }
 

--- a/routing/supernode/server_test.go
+++ b/routing/supernode/server_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	datastore "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	dhtpb "github.com/ipfs/go-ipfs/routing/dht/pb"
-	"github.com/ipfs/go-ipfs/util"
 )
 
 func TestPutProviderDoesntResultInDuplicates(t *testing.T) {
 	routingBackend := datastore.NewMapDatastore()
-	k := util.Key("foo")
+	k := key.Key("foo")
 	put := []*dhtpb.Message_Peer{
 		convPeer("bob", "127.0.0.1/tcp/4001"),
 		convPeer("alice", "10.0.0.10/tcp/4001"),

--- a/test/integration/grandcentral_test.go
+++ b/test/integration/grandcentral_test.go
@@ -12,6 +12,7 @@ import (
 	syncds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/corerouting"
 	"github.com/ipfs/go-ipfs/core/coreunix"
@@ -19,7 +20,6 @@ import (
 	"github.com/ipfs/go-ipfs/p2p/peer"
 	"github.com/ipfs/go-ipfs/thirdparty/iter"
 	"github.com/ipfs/go-ipfs/thirdparty/unit"
-	"github.com/ipfs/go-ipfs/util"
 	ds2 "github.com/ipfs/go-ipfs/util/datastore2"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 )
@@ -166,7 +166,7 @@ func RunSupernodePutRecordGetRecord(conf testutil.LatencyConfig) error {
 	putter := clients[0]
 	getter := clients[1]
 
-	k := util.Key("key")
+	k := key.Key("key")
 	note := []byte("a note from putter")
 
 	if err := putter.Routing.PutValue(ctx, k, note); err != nil {

--- a/unixfs/io/dirbuilder.go
+++ b/unixfs/io/dirbuilder.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	format "github.com/ipfs/go-ipfs/unixfs"
-	u "github.com/ipfs/go-ipfs/util"
 )
 
 type directoryBuilder struct {
@@ -29,7 +29,7 @@ func NewDirectory(dserv mdag.DAGService) *directoryBuilder {
 }
 
 // AddChild adds a (name, key)-pair to the root node.
-func (d *directoryBuilder) AddChild(name string, k u.Key) error {
+func (d *directoryBuilder) AddChild(name string, k key.Key) error {
 	// TODO(cryptix): consolidate context managment
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
 	defer cancel()

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -11,6 +11,7 @@ import (
 	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	imp "github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	help "github.com/ipfs/go-ipfs/importer/helpers"
@@ -226,7 +227,7 @@ func (dm *DagModifier) Sync() error {
 // modifyDag writes the data in 'data' over the data in 'node' starting at 'offset'
 // returns the new key of the passed in node and whether or not all the data in the reader
 // has been consumed.
-func (dm *DagModifier) modifyDag(node *mdag.Node, offset uint64, data io.Reader) (u.Key, bool, error) {
+func (dm *DagModifier) modifyDag(node *mdag.Node, offset uint64, data io.Reader) (key.Key, bool, error) {
 	f, err := ft.FromBytes(node.Data)
 	if err != nil {
 		return "", false, err
@@ -266,7 +267,7 @@ func (dm *DagModifier) modifyDag(node *mdag.Node, offset uint64, data io.Reader)
 		// We found the correct child to write into
 		if cur+bs > offset {
 			// Unpin block
-			ckey := u.Key(node.Links[i].Hash)
+			ckey := key.Key(node.Links[i].Hash)
 			dm.mp.RemovePinWithMode(ckey, pin.Indirect)
 
 			child, err := node.Links[i].GetNode(dm.ctx, dm.dagserv)

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
+	key "github.com/ipfs/go-ipfs/blocks/key"
 	bs "github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/exchange/offline"
 	imp "github.com/ipfs/go-ipfs/importer"
@@ -574,10 +575,10 @@ func TestCorrectPinning(t *testing.T) {
 
 }
 
-func enumerateChildren(t *testing.T, nd *mdag.Node, ds mdag.DAGService) []u.Key {
-	var out []u.Key
+func enumerateChildren(t *testing.T, nd *mdag.Node, ds mdag.DAGService) []key.Key {
+	var out []key.Key
 	for _, lnk := range nd.Links {
-		out = append(out, u.Key(lnk.Hash))
+		out = append(out, key.Key(lnk.Hash))
 		child, err := lnk.GetNode(context.Background(), ds)
 		if err != nil {
 			t.Fatal(err)

--- a/util/util.go
+++ b/util/util.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"time"
 
+	b58 "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-base58"
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 )
@@ -125,4 +127,38 @@ func RPartition(subject string, sep string) (string, string, string) {
 	} else {
 		return subject, "", ""
 	}
+}
+
+// Hash is the global IPFS hash function. uses multihash SHA2_256, 256 bits
+func Hash(data []byte) mh.Multihash {
+	h, err := mh.Sum(data, mh.SHA2_256, -1)
+	if err != nil {
+		// this error can be safely ignored (panic) because multihash only fails
+		// from the selection of hash function. If the fn + length are valid, it
+		// won't error.
+		panic("multihash failed to hash using SHA2_256.")
+	}
+	return h
+}
+
+// IsValidHash checks whether a given hash is valid (b58 decodable, len > 0)
+func IsValidHash(s string) bool {
+	out := b58.Decode(s)
+	if out == nil || len(out) == 0 {
+		return false
+	}
+	_, err := mh.Cast(out)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// XOR takes two byte slices, XORs them together, returns the resulting slice.
+func XOR(a, b []byte) []byte {
+	c := make([]byte, len(a))
+	for i := 0; i < len(a); i++ {
+		c[i] = a[i] ^ b[i]
+	}
+	return c
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -3,29 +3,7 @@ package util
 import (
 	"bytes"
 	"testing"
-
-	mh "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 )
-
-func TestKey(t *testing.T) {
-
-	h1, err := mh.Sum([]byte("beep boop"), mh.SHA2_256, -1)
-	if err != nil {
-		t.Error(err)
-	}
-
-	k1 := Key(h1)
-	h2 := mh.Multihash(k1)
-	k2 := Key(h2)
-
-	if !bytes.Equal(h1, h2) {
-		t.Error("Multihashes not equal.")
-	}
-
-	if k1 != k2 {
-		t.Error("Keys not equal.")
-	}
-}
 
 func TestXOR(t *testing.T) {
 	cases := [][3][]byte{


### PR DESCRIPTION
make util.Key into its own package. This clears up the dependency graph a bit and makes it easier to start modularizing and extracting the ipfs packages.