### PR TITLE
Text under `ipfs name --help` incorrect

### DIFF
--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -40,12 +40,12 @@ Publish an <ipfs-path> to another public key:
 Resolve the value of your identity:
 
   > ipfs name resolve
-  /ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Resolve the value of another name:
 
   > ipfs name resolve QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n
-  /ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 `,
 	},


### PR DESCRIPTION
Change help text to display proper results from an `ipfs name resolve`.