### PR TITLE
Fully resolve ipfs paths down to its final hash

### DIFF
--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -84,6 +84,23 @@ Resolve the value of another name recursively:
 			return
 		}
 
+		if len(output.Segments()) > 2 {
+			merkNode, err := n.Resolver.ResolvePath(n.Context(), output)
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			k, err := merkNode.Key()
+
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			output = path.Path("/ipfs/" + k.Pretty())
+		}
+
 		res.SetOutput(&ResolvedPath{output})
 	},
 	Marshalers: cmds.MarshalerMap{


### PR DESCRIPTION
Given an ipfs path, this will resolve it down to it's furthest point.

Tests to come.