### PR TITLE
Do not merge: Spec for adder APIs

### DIFF
--- a/add-api.md
+++ b/add-api.md
@@ -1,0 +1,104 @@
+A clear picture of the intended adder API is blocking some of the
+later commits in #1136.  This issue floats my first pass at an adder
+API that I think strikes a good balance between power and simplicity
+(mostly by offloading the complicated bits to a per-DAG-node
+callback).
+
+# Where it lives
+
+I'd suggest moving `core/coreunix` to `core/unixfs` to match
+`unixfs/` and `shell/unixfs/`.
+
+# High-level UI (shell/unixfs/)
+
+    // NodeCallback is called after each DAG node is created.  The
+    // arguments are:
+    //
+    //   nIn: The just-created node
+    //   p: The path from the add root to the just-created node.  This
+    //     is empty for the root node.  For large files and
+    //     directories that are chunked and trickled, each chunk and
+    //     fanout node will have the same path argument.
+    //   f: A File reference for the file used to create nIn.  Don't
+    //     seek this (which could throw off the chunker), but you can
+    //     use it to extract metadata about the visited file including
+    //     its name, permissions, etc.  This will be nil for
+    //     io.Reader-based adders.
+    //   top: Whether or not nIn is the tip of a trickle DAG or an
+    //     unchunked object.  This allows you to distinguish those
+    //     nodes (which are referenced from a link with a user-visible
+    //     name)
+    //
+    // The returned values are:
+    //
+    //   nOut: The node to insert into the constructed DAG.  Return nIn
+    //     to use the just-created node without changes or nil to drop
+    //     the just-created node.  You're also free to return another
+    //     node of your choosing (e.g. a new node wrapping the
+    //     just-created node or a completely independent node).
+    //   err: Any errors serious enough to abort the addition.
+    type NodeCallback func(nIn *dag.Node, p *path.Path, f *os.File, top bool) (nOut *dag.Node, err error)
+
+    // Add recursively adds files from a File type, which can point to
+    // either a directory or a file.  The arguments are:
+    //
+    //   ctx: A Context for cancelling or timing out a recursive
+    //     addition.
+    //   n: And IPFS node for storing newly-created DAG nodes.
+    //   f: An open file pointing at the root of the filesystem to be
+    //     added.
+    //   cb: An optional hook for post-DAG-node processing.  Set to nil
+    //     if you don't need it.
+    //
+    // The returned values are:
+    //
+    //   root: The root of the just-added DAG.
+    //   err: Any errors serious enough to abort the addition.
+    Add(ctx context.Context, n *core.IpfsNode, f *os.File, cb *NodeCallback) (root *dag.Node, err error)
+
+    // AddFromReader recursively adds a file from an io.Reader.  It is
+    // otherwise identical to Add().
+    AddFromReader(ctx context.Context, n *core.IpfsNode, r io.Reader, cb *NodeCallback) (root *dag.Node, err error)
+
+Most additions will be recursive and load data from a [*File][File]
+(which can be a directory or a file).  Alternatively, the
+`*FromReader` variants accept a [Reader][2].
+
+We need a way to get information about progress of a running addition
+back to other goroutines.  Choices for this include [the channel
+messages proposed in #1121][channel] or additional arguments to [a
+per-chunk callback like that proposed in #1274][callback].  The main
+difference between a callback and a channel is whether or not we want
+synchronous collaboration between the adder and the hook.  Since I
+think we want the option for synchronous collaboration
+(e.g. optionally inserting a metadata node on top of each file node).
+For situations where asynchronous communication makes more sense, the
+user can provide a synchronous callback that just pushes a message to
+a channel (so the callback-based API supports the channel-based
+workflow).
+
+Actions like wrapping an added file in another Merkle object to hold a
+filename is left to the caller and the callback API.
+
+# Low-level UI (core/unixfs/)
+
+These should look just like the high-level API, except instead of
+passing in an IpfsNode and using that node's default DAG service,
+trickler, and splitter, we pass each of those in explicitly:
+
+    Add(ctx context.Context, ds dag.DAGService, t trickle.Trickler, s chunk.BlockSplitter, f *os.File, cb *NodeCallback) (root *dag.Node, err error)
+    AddFromReader(ctx context.Context, ds dag.DAGService, t trickle.Trickler, s chunk.BlockSplitter, r io.Reader, cb *NodeCallback) (root *dag.Node, error)
+
+We don't currently have a public `Trickler` interface, but I think we should
+add one so folks can easily plug in alternative trickler implementations.
+
+I'm not familiar enough with Go at the moment to know which arguments
+are best passed by reference and which should be passed by value.  If
+I was writing this in C, everything except the Boolean `top` would be
+passed by reference, but I'll have to read around to figure out what's
+idiomatic in Go.
+
+[File]: https://golang.org/pkg/os/#File
+[Reader]: https://golang.org/pkg/io/#Reader
+[channel]: https://github.com/ipfs/go-ipfs/issues/1121#issuecomment-104073727
+[callback]: https://github.com/ipfs/go-ipfs/pull/1274

--- a/add-api.md
+++ b/add-api.md
@@ -74,21 +74,12 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
     //   node: And IPFS node for storing newly-created DAG nodes.
     //   file: An open file pointing at the root of the filesystem to be
     //     added.
-    //   preNodeCallBacks: An optional slice of hooks for pre-DAG-node
-    //     checks (e.g. ignoring boring paths).  Before adding a path,
-    //     Add will iterate through the preNodeCallbacks and ignore
-    //     the path (and stop further preNodeCallbacks iteration) if
-    //     any of the callbacks set ignore to true.  Set to nil if you
-    //     don't need it.
-    //   postNodeCallBacks: An optional slice of hooks for
-    //     post-DAG-node processing (e.g. altering or wrapping the
-    //     newly-created nodes).  After creating a node, Add will
-    //     iterate through the postNodeCallbacks, passing nodeOut from
-    //     earlier callbacks in as nodeIn to the next callback.  For
-    //     example, if Add internally creates node1, the first
-    //     callback will get node1 as nodeIn.  If that callback
-    //     returns node2 (possibly nil), the second callback will get
-    //     node2 as nodeIn.  Set to nil if you don't need it.
+    //   preNodeCallBack: An optional hook for pre-DAG-node checks
+    //     (e.g. ignoring boring paths).  Set to nil if you don't need
+    //     it.
+    //   postNodeCallBack: An optional hook for post-DAG-node
+    //     processing (e.g. altering or wrapping the newly-created
+    //     nodes).  Set to nil if you don't need it.
     //
     // The returned values are:
     //
@@ -98,8 +89,8 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
         ctx context.Context,
         node *core.IpfsNode,
         file *os.File,
-        preNodeCallBacks []*PreNodeCallback,
-        postNodeCallbacks []*PostNodeCallback
+        preNodeCallBack *PreNodeCallback,
+        postNodeCallback *PostNodeCallback
         ) (root *dag.Node, err error)
 
     // AddFromReader adds a file from an io.Reader.  It is otherwise
@@ -108,8 +99,8 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
         ctx context.Context,
         node *core.IpfsNode,
         reader io.Reader,
-        preNodeCallBacks []*PreNodeCallback,
-        postNodeCallbacks []*PostNodeCallback
+        preNodeCallBack *PreNodeCallback,
+        postNodeCallback *PostNodeCallback
         ) (root *dag.Node, err error)
 
 Most additions will be recursive and load data from a [*File][File]
@@ -144,8 +135,8 @@ layout, and splitter, we pass each of those in explicitly:
         layout _layout.Layout,
         splitter chunk.BlockSplitter,
         file *os.File,
-        preNodeCallBacks []*PreNodeCallback,
-        postNodeCallbacks []*PostNodeCallback
+        preNodeCallBack *PreNodeCallback,
+        postNodeCallback *PostNodeCallback
         ) (root *dag.Node, err error)
     AddFromReader(
         ctx context.Context,
@@ -153,8 +144,8 @@ layout, and splitter, we pass each of those in explicitly:
         layout _layout.Layout,
         splitter chunk.BlockSplitter,
         reader io.Reader,
-        preNodeCallBacks []*PreNodeCallback,
-        postNodeCallbacks []*PostNodeCallback
+        preNodeCallBack *PreNodeCallback,
+        postNodeCallback *PostNodeCallback
         ) (root *dag.Node, error)
 
 We don't currently have a public `Layout` interface, but I think we

--- a/add-api.md
+++ b/add-api.md
@@ -74,12 +74,21 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
     //   node: And IPFS node for storing newly-created DAG nodes.
     //   file: An open file pointing at the root of the filesystem to be
     //     added.
-    //   preNodeCallBack: An optional hook for pre-DAG-node checks
-    //     (e.g. ignoring boring paths).  Set to nil if you don't need
-    //     it.
-    //   postNodeCallBack: An optional hook for post-DAG-node
-    //     processing (e.g. altering or wrapping the newly-created
-    //     nodes).  Set to nil if you don't need it.
+    //   preNodeCallBacks: An optional slice of hooks for pre-DAG-node
+    //     checks (e.g. ignoring boring paths).  Before adding a path,
+    //     Add will iterate through the preNodeCallbacks and ignore
+    //     the path (and stop further preNodeCallbacks iteration) if
+    //     any of the callbacks set ignore to true.  Set to nil if you
+    //     don't need it.
+    //   postNodeCallBacks: An optional slice of hooks for
+    //     post-DAG-node processing (e.g. altering or wrapping the
+    //     newly-created nodes).  After creating a node, Add will
+    //     iterate through the postNodeCallbacks, passing nodeOut from
+    //     earlier callbacks in as nodeIn to the next callback.  For
+    //     example, if Add internally creates node1, the first
+    //     callback will get node1 as nodeIn.  If that callback
+    //     returns node2 (possibly nil), the second callback will get
+    //     node2 as nodeIn.  Set to nil if you don't need it.
     //
     // The returned values are:
     //
@@ -89,8 +98,8 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
         ctx context.Context,
         node *core.IpfsNode,
         file *os.File,
-        preNodeCallBack *PreNodeCallback,
-        postNodeCallback *PostNodeCallback
+        preNodeCallBacks []*PreNodeCallback,
+        postNodeCallbacks []*PostNodeCallback
         ) (root *dag.Node, err error)
 
     // AddFromReader adds a file from an io.Reader.  It is otherwise
@@ -99,8 +108,8 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
         ctx context.Context,
         node *core.IpfsNode,
         reader io.Reader,
-        preNodeCallBack *PreNodeCallback,
-        postNodeCallback *PostNodeCallback
+        preNodeCallBacks []*PreNodeCallback,
+        postNodeCallbacks []*PostNodeCallback
         ) (root *dag.Node, err error)
 
 Most additions will be recursive and load data from a [*File][File]
@@ -135,8 +144,8 @@ layout, and splitter, we pass each of those in explicitly:
         layout _layout.Layout,
         splitter chunk.BlockSplitter,
         file *os.File,
-        preNodeCallBack *PreNodeCallback,
-        postNodeCallback *PostNodeCallback
+        preNodeCallBacks []*PreNodeCallback,
+        postNodeCallbacks []*PostNodeCallback
         ) (root *dag.Node, err error)
     AddFromReader(
         ctx context.Context,
@@ -144,8 +153,8 @@ layout, and splitter, we pass each of those in explicitly:
         layout _layout.Layout,
         splitter chunk.BlockSplitter,
         reader io.Reader,
-        preNodeCallBack *PreNodeCallback,
-        postNodeCallback *PostNodeCallback
+        preNodeCallBacks []*PreNodeCallback,
+        postNodeCallbacks []*PostNodeCallback
         ) (root *dag.Node, error)
 
 We don't currently have a public `Layout` interface, but I think we

--- a/add-api.md
+++ b/add-api.md
@@ -16,7 +16,7 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
     //
     //   p: The path from the add root to the just-created node.  This
     //     is empty for the root node.  For large files and
-    //     directories that are chunked and trickled, each chunk and
+    //     directories that are chunked and laid-out, each chunk and
     //     fanout node will have the same path argument.
     //   f: A File reference for the file used to create nIn.  Don't
     //     seek this (which could throw off the chunker), but you can
@@ -36,14 +36,14 @@ I'd suggest moving `core/coreunix` to `core/unixfs` to match
     //   nIn: The just-created node
     //   p: The path from the add root to the just-created node.  This
     //     is empty for the root node.  For large files and
-    //     directories that are chunked and trickled, each chunk and
+    //     directories that are chunked and laid-out, each chunk and
     //     fanout node will have the same path argument.
     //   f: A File reference for the file used to create nIn.  Don't
     //     seek this (which could throw off the chunker), but you can
     //     use it to extract metadata about the visited file including
     //     its name, permissions, etc.  This will be nil for
     //     io.Reader-based adders.
-    //   top: Whether or not nIn is the tip of a trickle DAG or an
+    //   top: Whether or not nIn is the tip of a layout DAG or an
     //     unchunked object.  This allows you to distinguish those
     //     nodes (which are referenced from a link with a user-visible
     //     name)
@@ -103,13 +103,14 @@ filename is left to the caller and the callback API.
 
 These should look just like the high-level API, except instead of
 passing in an IpfsNode and using that node's default DAG service,
-trickler, and splitter, we pass each of those in explicitly:
+layout, and splitter, we pass each of those in explicitly:
 
-    Add(ctx context.Context, ds dag.DAGService, t trickle.Trickler, s chunk.BlockSplitter, f *os.File, preNodeCallBack *PreNodeCallback, postNodeCallback *PostNodeCallback) (root *dag.Node, err error)
-    AddFromReader(ctx context.Context, ds dag.DAGService, t trickle.Trickler, s chunk.BlockSplitter, r io.Reader, preNodeCallBack *PreNodeCallback, postNodeCallback *PostNodeCallback) (root *dag.Node, error)
+    Add(ctx context.Context, ds dag.DAGService, layout _layout.Layout, s chunk.BlockSplitter, f *os.File, preNodeCallBack *PreNodeCallback, postNodeCallback *PostNodeCallback) (root *dag.Node, err error)
+    AddFromReader(ctx context.Context, ds dag.DAGService, layout _layout.Layout, s chunk.BlockSplitter, r io.Reader, preNodeCallBack *PreNodeCallback, postNodeCallback *PostNodeCallback) (root *dag.Node, error)
 
-We don't currently have a public `Trickler` interface, but I think we should
-add one so folks can easily plug in alternative trickler implementations.
+We don't currently have a public `Layout` interface, but I think we
+should add one so folks can easily plug in alternative layout
+implementations.
 
 I'm not familiar enough with Go at the moment to know which arguments
 are best passed by reference and which should be passed by value.  If


### PR DESCRIPTION
Spun off from #1291, since I wanted a way to track the spec's
evolution and allow for inline comments.  This PR has the spec in an
orphan branch to support that, but once we settle on a spec we'll just
grab the bits from this file and incorporate them in interface
definitions in the master branch (instead of merging this branch).