### PR TITLE
experimental concurrent add

### DIFF
--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -107,18 +107,7 @@ func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
 		return err
 	}
 
-	_, err = db.dserv.Add(childnode)
-	if err != nil {
-		return err
-	}
-
-	// Pin the child node indirectly
-	err = db.ncb(childnode, false)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return db.Store(childnode)
 }
 
 // Removes the child node at the given index


### PR DESCRIPTION
This PR is an experimental concurrent pipeline for "ipfs add"
The idea is to decouple the various cpu / io intensive parts of storing a block into separate stages with a configurable number of workers for each stage.

I would appreciate if some people with different os/fs/physical storage could benchmark this by adding a single large file (~500-1000 MB) and time it against master.
If it turns out to generally improve performance, the implementation could be cleaned up and extended to handle each add operation rather than individual files.

My results on linux/ext4/single hdd (626MB):
master:
```
% time ipfs add archlinux-2015.05.01-dual.iso 
added Qmb1cWYzczBZz4d8HoSmxhU9GY8QuVq7sUvD6ZCQBkvmU2 archlinux-2015.05.01-dual.iso
ipfs add archlinux-2015.05.01-dual.iso  0.62s user 1.10s system 0% cpu 3:08.60 total
```
concurrent:
```
% time ipfs add archlinux-2015.05.01-dual.iso
added Qmb1cWYzczBZz4d8HoSmxhU9GY8QuVq7sUvD6ZCQBkvmU2 archlinux-2015.05.01-dual.iso
ipfs add archlinux-2015.05.01-dual.iso  0.34s user 0.80s system 4% cpu 26.576 total
```

