### PR TITLE
Do not merge - protocol change discussion

### DIFF
--- a/p2p/net/conn/conn_test.go
+++ b/p2p/net/conn/conn_test.go
@@ -8,17 +8,25 @@ import (
 	"testing"
 	"time"
 
+	msgio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-msgio"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	travis "github.com/ipfs/go-ipfs/util/testutil/ci/travis"
 )
 
+func msgioWrap(c Conn) msgio.ReadWriter {
+	return msgio.NewReadWriter(c)
+}
+
 func testOneSendRecv(t *testing.T, c1, c2 Conn) {
+	mc1 := msgioWrap(c1)
+	mc2 := msgioWrap(c2)
+
 	log.Debugf("testOneSendRecv from %s to %s", c1.LocalPeer(), c2.LocalPeer())
 	m1 := []byte("hello")
-	if err := c1.WriteMsg(m1); err != nil {
+	if err := mc1.WriteMsg(m1); err != nil {
 		t.Fatal(err)
 	}
-	m2, err := c2.ReadMsg()
+	m2, err := mc2.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,11 +36,14 @@ func testOneSendRecv(t *testing.T, c1, c2 Conn) {
 }
 
 func testNotOneSendRecv(t *testing.T, c1, c2 Conn) {
+	mc1 := msgioWrap(c1)
+	mc2 := msgioWrap(c2)
+
 	m1 := []byte("hello")
-	if err := c1.WriteMsg(m1); err == nil {
+	if err := mc1.WriteMsg(m1); err == nil {
 		t.Fatal("write should have failed", err)
 	}
-	_, err := c2.ReadMsg()
+	_, err := mc2.ReadMsg()
 	if err == nil {
 		t.Fatal("read should have failed", err)
 	}
@@ -72,10 +83,13 @@ func TestCloseLeak(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		c1, c2, _, _ := setupSingleConn(t, ctx)
 
+		mc1 := msgioWrap(c1)
+		mc2 := msgioWrap(c2)
+
 		for i := 0; i < num; i++ {
 			b1 := []byte(fmt.Sprintf("beep%d", i))
-			c1.WriteMsg(b1)
-			b2, err := c2.ReadMsg()
+			mc1.WriteMsg(b1)
+			b2, err := mc2.ReadMsg()
 			if err != nil {
 				panic(err)
 			}
@@ -84,8 +98,8 @@ func TestCloseLeak(t *testing.T) {
 			}
 
 			b2 = []byte(fmt.Sprintf("boop%d", i))
-			c2.WriteMsg(b2)
-			b1, err = c1.ReadMsg()
+			mc2.WriteMsg(b2)
+			b1, err = mc1.ReadMsg()
 			if err != nil {
 				panic(err)
 			}

--- a/p2p/net/conn/dial_test.go
+++ b/p2p/net/conn/dial_test.go
@@ -161,10 +161,10 @@ func testDialer(t *testing.T, secure bool) {
 	}
 
 	// fmt.Println("sending")
-	c.WriteMsg([]byte("beep"))
-	c.WriteMsg([]byte("boop"))
-
-	out, err := c.ReadMsg()
+	mc := msgioWrap(c)
+	mc.WriteMsg([]byte("beep"))
+	mc.WriteMsg([]byte("boop"))
+	out, err := mc.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func testDialer(t *testing.T, secure bool) {
 		t.Error("unexpected conn output", data)
 	}
 
-	out, err = c.ReadMsg()
+	out, err = mc.ReadMsg()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/net/conn/interface.go
+++ b/p2p/net/conn/interface.go
@@ -9,7 +9,6 @@ import (
 	ic "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 
-	msgio "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-msgio"
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
 )
@@ -45,8 +44,8 @@ type Conn interface {
 	SetReadDeadline(t time.Time) error
 	SetWriteDeadline(t time.Time) error
 
-	msgio.Reader
-	msgio.Writer
+	io.Reader
+	io.Writer
 }
 
 // Dialer is an object that can open connections. We could have a "convenience"

--- a/p2p/net/conn/secure_conn.go
+++ b/p2p/net/conn/secure_conn.go
@@ -119,20 +119,6 @@ func (c *secureConn) Write(buf []byte) (int, error) {
 	return c.secure.ReadWriter().Write(buf)
 }
 
-func (c *secureConn) NextMsgLen() (int, error) {
-	return c.secure.ReadWriter().NextMsgLen()
-}
-
-// ReadMsg reads data, net.Conn style
-func (c *secureConn) ReadMsg() ([]byte, error) {
-	return c.secure.ReadWriter().ReadMsg()
-}
-
-// WriteMsg writes data, net.Conn style
-func (c *secureConn) WriteMsg(buf []byte) error {
-	return c.secure.ReadWriter().WriteMsg(buf)
-}
-
 // ReleaseMsg releases a buffer
 func (c *secureConn) ReleaseMsg(m []byte) {
 	c.secure.ReadWriter().ReleaseMsg(m)

--- a/p2p/net/conn/secure_conn_test.go
+++ b/p2p/net/conn/secure_conn_test.go
@@ -145,13 +145,16 @@ func TestSecureCloseLeak(t *testing.T) {
 	}
 
 	runPair := func(c1, c2 Conn, num int) {
+		mc1 := msgioWrap(c1)
+		mc2 := msgioWrap(c2)
+
 		log.Debugf("runPair %d", num)
 
 		for i := 0; i < num; i++ {
 			log.Debugf("runPair iteration %d", i)
 			b1 := []byte("beep")
-			c1.WriteMsg(b1)
-			b2, err := c2.ReadMsg()
+			mc1.WriteMsg(b1)
+			b2, err := mc2.ReadMsg()
 			if err != nil {
 				panic(err)
 			}
@@ -160,8 +163,8 @@ func TestSecureCloseLeak(t *testing.T) {
 			}
 
 			b2 = []byte("beep")
-			c2.WriteMsg(b2)
-			b1, err = c1.ReadMsg()
+			mc2.WriteMsg(b2)
+			b1, err = mc1.ReadMsg()
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
This branch contains the code from #1065 as well as the change from #1304. without this change, the times for an ipfs ping were at least double that of a unix ping, with these changes, they are quite close.

```
whyrusleeping@csg-gate:~$ ipfs swarm connect /ip4/192.241.194.199/tcp/4001/ipfs/QmTmyCBwHEu7zHFemLvw18HQBnK3jupWfVPg86VGPZ1jLS
connect QmTmyCBwHEu7zHFemLvw18HQBnK3jupWfVPg86VGPZ1jLS success
whyrusleeping@csg-gate:~$ ipfs ping QmTmyCBwHEu7zHFemLvw18HQBnK3jupWfVPg86VGPZ1jLS
PING QmTmyCBwHEu7zHFemLvw18HQBnK3jupWfVPg86VGPZ1jLS.
Pong received: time=31.90 ms
Pong received: time=31.88 ms
Pong received: time=31.13 ms
Pong received: time=31.77 ms
Pong received: time=31.87 ms
Pong received: time=31.18 ms
Pong received: time=31.31 ms
Pong received: time=31.13 ms
Pong received: time=32.20 ms
Pong received: time=31.93 ms
Average latency: 31.63ms
whyrusleeping@csg-gate:~$ ping 192.241.194.199
PING 192.241.194.199 (192.241.194.199) 56(84) bytes of data.
64 bytes from 192.241.194.199: icmp_req=1 ttl=49 time=28.4 ms
64 bytes from 192.241.194.199: icmp_req=2 ttl=49 time=28.4 ms
64 bytes from 192.241.194.199: icmp_req=3 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=4 ttl=49 time=28.5 ms
64 bytes from 192.241.194.199: icmp_req=5 ttl=49 time=28.5 ms
64 bytes from 192.241.194.199: icmp_req=6 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=7 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=8 ttl=49 time=28.5 ms
64 bytes from 192.241.194.199: icmp_req=9 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=10 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=11 ttl=49 time=28.3 ms
64 bytes from 192.241.194.199: icmp_req=12 ttl=49 time=28.5 ms
^C
--- 192.241.194.199 ping statistics ---
12 packets transmitted, 12 received, 0% packet loss, time 11016ms
rtt min/avg/max/mdev = 28.300/28.416/28.577/0.180 ms
```