### PR TITLE
Add DCO and commit-message.md

### DIFF
--- a/commit-message.md
+++ b/commit-message.md
@@ -1,0 +1,36 @@
+# Guidelines to create great commit messages
+
+
+We use [GitCop](https://gitcop.com) to check that commit messages are
+properly written. The rules are the following:
+
+* The first line of a commit message, called the subject line should
+  not be more than 80 characters long.
+
+* The commit message should end with the following trailers:
+
+  ```
+  Licence: MIT
+  Signed-off-by: User Name <email@address>
+  ```
+
+  where "User Name" is the author's real name and email@address one of
+  the author's valid email addresses.
+
+  These trailers mean that the author agrees with the following
+  document (which comes from http://developercertificate.org/):
+
+  [developer-certificate-of-origin](./developer-certificate-of-origin)
+
+  and with licensing the work under the MIT license available in the
+  following file:
+
+  [LICENSE](./LICENSE)
+
+  To help you automatically add these trailers, you can run the
+  following script:
+
+  [setup_commit_msg_hook.sh](./setup_commit_msg_hook.sh)
+
+  which will setup a Git commit-msg hook that will add the above
+  trailers to all the commit messages you write.

--- a/developer-certificate-of-origin
+++ b/developer-certificate-of-origin
@@ -1,0 +1,35 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/setup_commit_msg_hook.sh
+++ b/setup_commit_msg_hook.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cat >.git/hooks/commit-msg <<'EOF'
+#!/bin/sh
+
+grep "^License:" "$1" || {
+        echo >>"$1"
+        echo "License: MIT" >>"$1"
+        echo "Signed-off-by: $(git config user.name) <$(git config user.email)>" >>"$1"
+}
+EOF
+chmod +x .git/hooks/commit-msg
+


### PR DESCRIPTION
These are documents we might want to add if we use GitCop. I will perhaps add them to another PR instead of this one. So please don't merge for now.