### PR TITLE
Better symmetric NAT avoidance.

### DIFF
--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -256,7 +256,7 @@ func (ids *IDService) consumeObservedAddress(observed []byte, c inet.Conn) {
 
 	// ok! we have the observed version of one of our ListenAddresses!
 	log.Debugf("added own observed listen addr: %s --> %s", c.LocalMultiaddr(), maddr)
-	ids.observedAddrs.Add(maddr)
+	ids.observedAddrs.Add(maddr, c.RemoteMultiaddr())
 }
 
 func addrInAddrs(a ma.Multiaddr, as []ma.Multiaddr) bool {

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -85,9 +85,23 @@ func (oas *ObservedAddrSet) Add(addr ma.Multiaddr, observer ma.Multiaddr) {
 		oas.addrs[s] = oa
 	}
 
-	// Add current observer.
-	oa.SeenBy[observer.String()] = struct{}{}
+	// mark the observer
+	oa.SeenBy[observerGroup(observer)] = struct{}{}
 	oa.LastSeen = time.Now()
+}
+
+// observerGroup is a function that determines what part of
+// a multiaddr counts as a different observer. for example,
+// two ipfs nodes at the same IP/TCP transport would get
+// the exact same NAT mapping; they would count as the
+// same observer. This may protect against NATs who assign
+// different ports to addresses at different IP hosts, but
+// not TCP ports.
+//
+// Here, we use the root multiaddr address. This is mostly
+// IP addresses. In practice, this is what we want.
+func observerGroup(m ma.Multiaddr) string {
+	return ma.Split(m)[0].String()
 }
 
 func (oas *ObservedAddrSet) SetTTL(ttl time.Duration) {

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -38,7 +38,8 @@ func TestObsAddrSet(t *testing.T) {
 	a3 := m("/ip4/1.2.3.4/tcp/1233")
 	a4 := m("/ip4/1.2.3.4/tcp/1234")
 	a5 := m("/ip4/1.2.3.4/tcp/1235")
-	a6 := m("/ip4/1.2.3.4/tcp/1236")
+	a6 := m("/ip4/1.2.3.6/tcp/1236")
+	a7 := m("/ip4/1.2.3.7/tcp/1237")
 
 	oas := ObservedAddrSet{}
 
@@ -63,7 +64,15 @@ func TestObsAddrSet(t *testing.T) {
 		t.Error("addrs should _still_ be empty (same obs)")
 	}
 
+	// different observer, but same observer group.
 	oas.Add(a1, a5)
+	oas.Add(a2, a5)
+	oas.Add(a3, a5)
+	if !addrsMarch(oas.Addrs(), nil) {
+		t.Error("addrs should _still_ be empty (same obs group)")
+	}
+
+	oas.Add(a1, a6)
 	if !addrsMarch(oas.Addrs(), []ma.Multiaddr{a1}) {
 		t.Error("addrs should only have a1")
 	}
@@ -74,6 +83,9 @@ func TestObsAddrSet(t *testing.T) {
 	oas.Add(a2, a6)
 	oas.Add(a1, a6)
 	oas.Add(a1, a6)
+	oas.Add(a2, a7)
+	oas.Add(a1, a7)
+	oas.Add(a1, a7)
 	if !addrsMarch(oas.Addrs(), []ma.Multiaddr{a1, a2}) {
 		t.Error("addrs should only have a1, a2")
 	}

--- a/p2p/protocol/identify/obsaddr_test.go
+++ b/p2p/protocol/identify/obsaddr_test.go
@@ -36,6 +36,9 @@ func TestObsAddrSet(t *testing.T) {
 	a1 := m("/ip4/1.2.3.4/tcp/1231")
 	a2 := m("/ip4/1.2.3.4/tcp/1232")
 	a3 := m("/ip4/1.2.3.4/tcp/1233")
+	a4 := m("/ip4/1.2.3.4/tcp/1234")
+	a5 := m("/ip4/1.2.3.4/tcp/1235")
+	a6 := m("/ip4/1.2.3.4/tcp/1236")
 
 	oas := ObservedAddrSet{}
 
@@ -43,23 +46,34 @@ func TestObsAddrSet(t *testing.T) {
 		t.Error("addrs should be empty")
 	}
 
-	oas.Add(a1)
-	oas.Add(a2)
-	oas.Add(a3)
+	oas.Add(a1, a4)
+	oas.Add(a2, a4)
+	oas.Add(a3, a4)
 
 	// these are all different so we should not yet get them.
 	if !addrsMarch(oas.Addrs(), nil) {
 		t.Error("addrs should _still_ be empty (once)")
 	}
 
-	oas.Add(a1)
+	// same observer, so should not yet get them.
+	oas.Add(a1, a4)
+	oas.Add(a2, a4)
+	oas.Add(a3, a4)
+	if !addrsMarch(oas.Addrs(), nil) {
+		t.Error("addrs should _still_ be empty (same obs)")
+	}
+
+	oas.Add(a1, a5)
 	if !addrsMarch(oas.Addrs(), []ma.Multiaddr{a1}) {
 		t.Error("addrs should only have a1")
 	}
 
-	oas.Add(a2)
-	oas.Add(a1)
-	oas.Add(a1)
+	oas.Add(a2, a5)
+	oas.Add(a1, a5)
+	oas.Add(a1, a5)
+	oas.Add(a2, a6)
+	oas.Add(a1, a6)
+	oas.Add(a1, a6)
 	if !addrsMarch(oas.Addrs(), []ma.Multiaddr{a1, a2}) {
 		t.Error("addrs should only have a1, a2")
 	}


### PR DESCRIPTION
p2p/protocol/identify: dont double count observers

If the same peer observed the same address twice, it would be double
counted as different observations. This change adds a map to make sure
we're counting each observer once.

This is easily extended to require more than two observations, but i have
not yet encountered NATs for whom this is relevant.

p2p/net/identify: clump addr observers into groups

Different mutliaddrs is not enough. Nodes may share transports. NAT port
mappings will likely only work on the base IP/TCP port pair. We go one step
further, and require different root (IP) addrs. Just in case some NATs
group by IP. In practice, this is what we want: use addresses only if hosts
that are on different parts of the network have seen this address.