### PR TITLE
core/commands/ls: Remove trailing tabs

### DIFF
--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -116,13 +116,13 @@ it contains, with the following format:
 					fmt.Fprintf(w, "%s:\n", object.Hash)
 				}
 				if headers {
-					fmt.Fprintln(w, "Hash\tSize\tName\t")
+					fmt.Fprintln(w, "Hash\tSize\tName")
 				}
 				for _, link := range object.Links {
 					if link.Type == unixfspb.Data_Directory {
 						link.Name += "/"
 					}
-					fmt.Fprintf(w, "%s\t%v\t%s\t\n", link.Hash, link.Size, link.Name)
+					fmt.Fprintf(w, "%s\t%v\t%s\n", link.Hash, link.Size, link.Name)
 				}
 				if len(output.Objects) > 1 {
 					fmt.Fprintln(w)

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -45,18 +45,18 @@ test_ls_cmd() {
 	test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
 		cat <<-\EOF >expected_ls &&
 			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
-			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/ 
-			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/ 
-			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1  
-			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2  
+			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/
+			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/
+			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1
+			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2
 	
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
-			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024 
-			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a    
+			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024
+			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a
 	
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139 128 
-			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14  a   
+			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139 128
+			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14  a
 	
 		EOF
 		test_cmp expected_ls actual_ls
@@ -69,21 +69,21 @@ test_ls_cmd() {
 	test_expect_success "'ipfs ls --headers  <three dir hashes>' output looks good" '
 		cat <<-\EOF >expected_ls_headers &&
 			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
-			Hash                                           Size Name 
-			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/  
-			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/  
-			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1   
-			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2   
+			Hash                                           Size Name
+			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/
+			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/
+			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1
+			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2
 	
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
-			Hash                                           Size Name 
-			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024 
-			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a    
+			Hash                                           Size Name
+			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024
+			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a
 	
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-			Hash                                           Size Name 
-			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128  
-			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a    
+			Hash                                           Size Name
+			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128
+			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a
 	
 		EOF
 		test_cmp expected_ls_headers actual_ls_headers

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -105,7 +105,7 @@ test_object_cmd() {
 	'
 
 	test_expect_success "output looks good" '
-		echo "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn 4 foo/ " > patched_exp &&
+		echo "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn 4 foo/" > patched_exp &&
 		test_cmp patched_exp patched_output
 	'
 


### PR DESCRIPTION
Since 607468a9 (beautify 'ipfs ls' and 'ipfs object links', #833)
we've had these.  That pull request was about [text/tabwriter][1] and
[elastic tabstops][2], but we don't need a column separator at the end
of each line.

[1]: https://golang.org/pkg/text/tabwriter/
[2]: http://nickgravgaard.com/elastic-tabstops/index.html