### PR TITLE
Make sure to stop progressbar on exit

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -55,6 +55,7 @@ it contains.
 
 		reader := bar.NewProxyReader(res.Output().(io.Reader))
 		res.SetOutput(reader)
+		defer bar.Finish()
 	},
 }
 


### PR DESCRIPTION
Can't reproduce #1345. Maybe this will do?

> progress bar sometimes lingers after exit

This could mean either the progress bar keeps adding up even after exit or it hangs there after exit.

> (b) clear the line before

The line is to be cleared (with '\b') after exit? But the elapsed time is useful info.
curl/wget retains the progress stat.