### PR TITLE
Add 'ipfs file ls …'

### DIFF
--- a/commands/response.go
+++ b/commands/response.go
@@ -15,8 +15,9 @@ type ErrorType uint
 
 // ErrorTypes convey what category of error ocurred
 const (
-	ErrNormal ErrorType = iota // general errors
-	ErrClient                  // error was caused by the client, (e.g. invalid CLI usage)
+	ErrNormal         ErrorType = iota // general errors
+	ErrClient                          // error was caused by the client, (e.g. invalid CLI usage)
+	ErrImplementation                  // programmer error in the server
 	// TODO: add more types of errors for better error-specific handling
 )
 

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -36,7 +36,7 @@ DATA STRUCTURE COMMANDS
 
     block         Interact with raw blocks in the datastore
     object        Interact with raw dag nodes
-    unixfs        Interact with Unix filesystem objects
+    file          Interact with Unix filesystem objects
 
 ADVANCED COMMANDS
 
@@ -104,7 +104,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"stats":     StatsCmd,
 	"swarm":     SwarmCmd,
 	"tour":      tourCmd,
-	"unixfs":    unixfs.UnixFSCmd,
+	"file":      unixfs.UnixFSCmd,
 	"update":    UpdateCmd,
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
+	unixfs "github.com/ipfs/go-ipfs/core/commands/unixfs"
 	evlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 )
 
@@ -35,6 +36,7 @@ DATA STRUCTURE COMMANDS
 
     block         Interact with raw blocks in the datastore
     object        Interact with raw dag nodes
+    unixfs        Interact with Unix filesystem objects
 
 ADVANCED COMMANDS
 
@@ -102,6 +104,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"stats":     StatsCmd,
 	"swarm":     SwarmCmd,
 	"tour":      tourCmd,
+	"unixfs":    unixfs.UnixFSCmd,
 	"update":    UpdateCmd,
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -94,7 +94,7 @@ directories, the child size is the IPFS link size.
 			case unixfspb.Data_Directory:
 				output[i].Links = make([]LsLink, len(merkleNode.Links))
 				for j, link := range merkleNode.Links {
-					getCtx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+					getCtx, cancel := context.WithTimeout(ctx, time.Minute)
 					defer cancel()
 					link.Node, err = link.GetNode(getCtx, node.DAG)
 					if err != nil {

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -72,7 +72,7 @@ directories, the child size is the IPFS link size.
 				return
 			}
 
-			output[i] = &LsObject{}
+			output[i] = &LsObject{Argument: fpath}
 
 			t := unixFSNode.GetType()
 			switch t {
@@ -92,7 +92,6 @@ directories, the child size is the IPFS link size.
 					Size: unixFSNode.GetFilesize(),
 				}}
 			case unixfspb.Data_Directory:
-				output[i].Argument = fpath
 				output[i].Links = make([]LsLink, len(merkleNode.Links))
 				for j, link := range merkleNode.Links {
 					getCtx, cancel := context.WithTimeout(context.TODO(), time.Minute)
@@ -132,7 +131,9 @@ directories, the child size is the IPFS link size.
 			w := tabwriter.NewWriter(buf, 1, 2, 1, ' ', 0)
 			lastObjectDirHeader := false
 			for i, object := range output.Objects {
-				if len(output.Objects) > 1 && object.Argument != "" {
+				singleObject := (len(object.Links) == 1 &&
+					object.Links[0].Name == object.Argument)
+				if len(output.Objects) > 1 && !singleObject {
 					if i > 0 {
 						fmt.Fprintln(w)
 					}

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -19,7 +19,7 @@ import (
 type LsLink struct {
 	Name, Hash string
 	Size       uint64
-	Type       unixfspb.Data_DataType
+	Type       string
 }
 
 type LsObject struct {
@@ -88,7 +88,7 @@ directories, the child size is the IPFS link size.
 				output[i].Links = []LsLink{LsLink{
 					Name: fpath,
 					Hash: key.String(),
-					Type: t,
+					Type: t.String(),
 					Size: unixFSNode.GetFilesize(),
 				}}
 			case unixfspb.Data_Directory:
@@ -106,12 +106,13 @@ directories, the child size is the IPFS link size.
 						res.SetError(err, cmds.ErrNormal)
 						return
 					}
+					t := d.GetType()
 					lsLink := LsLink{
 						Name: link.Name,
 						Hash: link.Hash.B58String(),
-						Type: d.GetType(),
+						Type: t.String(),
 					}
-					if lsLink.Type == unixfspb.Data_File {
+					if t == unixfspb.Data_File {
 						lsLink.Size = d.GetFilesize()
 					} else {
 						lsLink.Size = link.Size

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -59,40 +59,66 @@ directories, the child size is the IPFS link size.
 
 		output := make([]*LsObject, len(paths))
 		for i, fpath := range paths {
-			dagnode, err := core.Resolve(req.Context().Context, node, path.Path(fpath))
+			ctx := req.Context().Context
+			merkleNode, err := core.Resolve(ctx, node, path.Path(fpath))
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
 
-			output[i] = &LsObject{
-				Argument: fpath,
-				Links:    make([]LsLink, len(dagnode.Links)),
+			unixFSNode, err := unixfs.FromBytes(merkleNode.Data)
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
 			}
-			for j, link := range dagnode.Links {
-				ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
-				defer cancel()
-				link.Node, err = link.GetNode(ctx, node.DAG)
+
+			output[i] = &LsObject{}
+
+			t := unixFSNode.GetType()
+			switch t {
+			default:
+				res.SetError(fmt.Errorf("unrecognized type: %s", t), cmds.ErrImplementation)
+				return
+			case unixfspb.Data_File:
+				key, err := merkleNode.Key()
 				if err != nil {
 					res.SetError(err, cmds.ErrNormal)
 					return
 				}
-				d, err := unixfs.FromBytes(link.Node.Data)
-				if err != nil {
-					res.SetError(err, cmds.ErrNormal)
-					return
+				output[i].Links = []LsLink{LsLink{
+					Name: fpath,
+					Hash: key.String(),
+					Type: t,
+					Size: unixFSNode.GetFilesize(),
+				}}
+			case unixfspb.Data_Directory:
+				output[i].Argument = fpath
+				output[i].Links = make([]LsLink, len(merkleNode.Links))
+				for j, link := range merkleNode.Links {
+					getCtx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+					defer cancel()
+					link.Node, err = link.GetNode(getCtx, node.DAG)
+					if err != nil {
+						res.SetError(err, cmds.ErrNormal)
+						return
+					}
+					d, err := unixfs.FromBytes(link.Node.Data)
+					if err != nil {
+						res.SetError(err, cmds.ErrNormal)
+						return
+					}
+					lsLink := LsLink{
+						Name: link.Name,
+						Hash: link.Hash.B58String(),
+						Type: d.GetType(),
+					}
+					if lsLink.Type == unixfspb.Data_File {
+						lsLink.Size = d.GetFilesize()
+					} else {
+						lsLink.Size = link.Size
+					}
+					output[i].Links[j] = lsLink
 				}
-				lsLink := LsLink{
-					Name: link.Name,
-					Hash: link.Hash.B58String(),
-					Type: d.GetType(),
-				}
-				if lsLink.Type == unixfspb.Data_File {
-					lsLink.Size = d.GetFilesize()
-				} else {
-					lsLink.Size = link.Size
-				}
-				output[i].Links[j] = lsLink
 			}
 		}
 
@@ -104,15 +130,22 @@ directories, the child size is the IPFS link size.
 			output := res.Output().(*LsOutput)
 			buf := new(bytes.Buffer)
 			w := tabwriter.NewWriter(buf, 1, 2, 1, ' ', 0)
-			for _, object := range output.Objects {
-				if len(output.Objects) > 1 {
+			lastObjectDirHeader := false
+			for i, object := range output.Objects {
+				if len(output.Objects) > 1 && object.Argument != "" {
+					if i > 0 {
+						fmt.Fprintln(w)
+					}
 					fmt.Fprintf(w, "%s:\n", object.Argument)
+					lastObjectDirHeader = true
+				} else {
+					if lastObjectDirHeader {
+						fmt.Fprintln(w)
+					}
+					lastObjectDirHeader = false
 				}
 				for _, link := range object.Links {
 					fmt.Fprintf(w, "%s\n", link.Name)
-				}
-				if len(output.Objects) > 1 {
-					fmt.Fprintln(w)
 				}
 			}
 			w.Flush()

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -184,9 +184,11 @@ directories, the child size is the IPFS link size.
 				if i > 0 || len(nonDirectories) > 0 {
 					fmt.Fprintln(w)
 				}
-				for _, arg := range directories[i:] {
-					if output.Arguments[arg] == hash {
-						fmt.Fprintf(w, "%s:\n", arg)
+				if len(output.Arguments) > 1 {
+					for _, arg := range directories[i:] {
+						if output.Arguments[arg] == hash {
+							fmt.Fprintf(w, "%s:\n", arg)
+						}
 					}
 				}
 				for _, link := range object.Links {

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -1,0 +1,124 @@
+package unixfs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	core "github.com/ipfs/go-ipfs/core"
+	path "github.com/ipfs/go-ipfs/path"
+	unixfs "github.com/ipfs/go-ipfs/unixfs"
+	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
+)
+
+type LsLink struct {
+	Name, Hash string
+	Size       uint64
+	Type       unixfspb.Data_DataType
+}
+
+type LsObject struct {
+	Argument string
+	Links    []LsLink
+}
+
+type LsOutput struct {
+	Objects []*LsObject
+}
+
+var LsCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "List directory contents for Unix-filesystem objects",
+		ShortDescription: `
+Retrieves the object named by <ipfs-or-ipns-path> and displays the
+contents with the following format:
+
+  <hash> <type> <size> <name>
+
+For files, the child size is the total size of the file contents.  For
+directories, the child size is the IPFS link size.
+`,
+	},
+
+	Arguments: []cmds.Argument{
+		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to list links from").EnableStdin(),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		node, err := req.Context().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		paths := req.Arguments()
+
+		output := make([]*LsObject, len(paths))
+		for i, fpath := range paths {
+			dagnode, err := core.Resolve(req.Context().Context, node, path.Path(fpath))
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			output[i] = &LsObject{
+				Argument: fpath,
+				Links:    make([]LsLink, len(dagnode.Links)),
+			}
+			for j, link := range dagnode.Links {
+				ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+				defer cancel()
+				link.Node, err = link.GetNode(ctx, node.DAG)
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+				d, err := unixfs.FromBytes(link.Node.Data)
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+				lsLink := LsLink{
+					Name: link.Name,
+					Hash: link.Hash.B58String(),
+					Type: d.GetType(),
+				}
+				if lsLink.Type == unixfspb.Data_File {
+					lsLink.Size = d.GetFilesize()
+				} else {
+					lsLink.Size = link.Size
+				}
+				output[i].Links[j] = lsLink
+			}
+		}
+
+		res.SetOutput(&LsOutput{Objects: output})
+	},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+
+			output := res.Output().(*LsOutput)
+			buf := new(bytes.Buffer)
+			w := tabwriter.NewWriter(buf, 1, 2, 1, ' ', 0)
+			for _, object := range output.Objects {
+				if len(output.Objects) > 1 {
+					fmt.Fprintf(w, "%s:\n", object.Argument)
+				}
+				for _, link := range object.Links {
+					fmt.Fprintf(w, "%s\n", link.Name)
+				}
+				if len(output.Objects) > 1 {
+					fmt.Fprintln(w)
+				}
+			}
+			w.Flush()
+
+			return buf, nil
+		},
+	},
+	Type: LsOutput{},
+}

--- a/core/commands/unixfs/unixfs.go
+++ b/core/commands/unixfs/unixfs.go
@@ -1,0 +1,21 @@
+package unixfs
+
+import cmds "github.com/ipfs/go-ipfs/commands"
+
+var UnixFSCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Interact with ipfs objects representing Unix filesystems",
+		ShortDescription: `
+'ipfs unixfs' provides a familar interface to filesystems represtented
+by IPFS objects that hides IPFS-implementation details like layout
+objects (e.g. fanout and chunking).
+`,
+		Synopsis: `
+ipfs unixfs ls <path>...  - List directory contents for <path>...
+`,
+	},
+
+	Subcommands: map[string]*cmds.Command{
+		"ls": LsCmd,
+	},
+}

--- a/core/commands/unixfs/unixfs.go
+++ b/core/commands/unixfs/unixfs.go
@@ -6,12 +6,12 @@ var UnixFSCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Interact with ipfs objects representing Unix filesystems",
 		ShortDescription: `
-'ipfs unixfs' provides a familar interface to filesystems represtented
+'ipfs file' provides a familar interface to filesystems represtented
 by IPFS objects that hides IPFS-implementation details like layout
 objects (e.g. fanout and chunking).
 `,
 		Synopsis: `
-ipfs unixfs ls <path>...  - List directory contents for <path>...
+ipfs file ls <path>...  - List directory contents for <path>...
 `,
 	},
 

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -88,7 +88,7 @@ test_ls_cmd() {
 			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
 			          "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
 			          "Size": 1024,
-			          "Type": 2
+			          "Type": "File"
 			        }
 			      ]
 			    }

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -72,6 +72,32 @@ test_ls_cmd() {
 		EOF
 		test_cmp expected_ls_file actual_ls_file
 	'
+
+	test_expect_success "'ipfs --encoding=json file ls <file hashes>' succeeds" '
+		ipfs --encoding=json file ls /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 >actual_json_ls_file
+	'
+
+	test_expect_success "'ipfs --encoding=json file ls <file hashes>' output looks good" '
+		cat <<-\EOF >expected_json_ls_file_trailing_newline &&
+			{
+			  "Objects": [
+			    {
+			      "Argument": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
+			      "Links": [
+			        {
+			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
+			          "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			          "Size": 1024,
+			          "Type": 2
+			        }
+			      ]
+			    }
+			  ]
+			}
+		EOF
+		printf %s "$(cat expected_json_ls_file_trailing_newline)" >expected_json_ls_file &&
+		test_cmp expected_json_ls_file actual_json_ls_file
+	'
 }
 
 

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -57,9 +57,20 @@ test_ls_cmd() {
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 			128
 			a
-
 		EOF
 		test_cmp expected_ls actual_ls
+	'
+
+	test_expect_success "'ipfs unixfs ls <file hashes>' succeeds" '
+		ipfs unixfs ls /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe >actual_ls_file
+	'
+
+	test_expect_success "'ipfs unixfs ls <file hashes>' output looks good" '
+		cat <<-\EOF >expected_ls_file &&
+			/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024
+			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe
+		EOF
+		test_cmp expected_ls_file actual_ls_file
 	'
 }
 

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -38,12 +38,24 @@ test_ls_cmd() {
 		test_cmp expected_add actual_add
 	'
 
+	test_expect_success "'ipfs file ls <dir>' succeeds" '
+		ipfs file ls QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy >actual_ls_one_directory
+	'
+
+	test_expect_success "'ipfs file ls <dir>' output looks good" '
+		cat <<-\EOF >expected_ls_one_directory &&
+			1024
+			a
+		EOF
+		test_cmp expected_ls_one_directory actual_ls_one_directory
+	'
+
 	test_expect_success "'ipfs file ls <three dir hashes>' succeeds" '
-		ipfs file ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+		ipfs file ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_three_directories
 	'
 
 	test_expect_success "'ipfs file ls <three dir hashes>' output looks good" '
-		cat <<-\EOF >expected_ls &&
+		cat <<-\EOF >expected_ls_three_directories &&
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
 			1024
 			a
@@ -58,7 +70,7 @@ test_ls_cmd() {
 			f1
 			f2
 		EOF
-		test_cmp expected_ls actual_ls
+		test_cmp expected_ls_three_directories actual_ls_three_directories
 	'
 
 	test_expect_success "'ipfs file ls <file hashes>' succeeds" '

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test unixfs ls command"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_ls_cmd() {
+
+	test_expect_success "'ipfs add -r testData' succeeds" '
+		mkdir -p testData testData/d1 testData/d2 &&
+		echo "test" >testData/f1 &&
+		echo "data" >testData/f2 &&
+		echo "hello" >testData/d1/a &&
+		random 128 42 >testData/d1/128 &&
+		echo "world" >testData/d2/a &&
+		random 1024 42 >testData/d2/1024 &&
+		ipfs add -r testData >actual_add
+	'
+
+	test_expect_success "'ipfs add' output looks good" '
+		cat <<-\EOF >expected_add &&
+			added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
+			added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
+			added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
+			added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
+			added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
+			added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
+			added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
+			added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
+			added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
+		EOF
+		test_cmp expected_add actual_add
+	'
+
+	test_expect_success "'ipfs unixfs ls <three dir hashes>' succeeds" '
+		ipfs unixfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+	'
+
+	test_expect_success "'ipfs unixfs ls <three dir hashes>' output looks good" '
+		cat <<-\EOF >expected_ls &&
+			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+			d1
+			d2
+			f1
+			f2
+
+			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+			1024
+			a
+
+			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+			128
+			a
+
+		EOF
+		test_cmp expected_ls actual_ls
+	'
+}
+
+
+# should work offline
+test_ls_cmd
+
+# should work online
+test_launch_ipfs_daemon
+test_ls_cmd
+test_kill_ipfs_daemon
+
+test_done

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -114,14 +114,10 @@ test_ls_cmd() {
 			  },
 			  "Objects": {
 			    "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd": {
-			      "Links": [
-			        {
-			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
-			          "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
-			          "Size": 1024,
-			          "Type": "File"
-			        }
-			      ]
+			      "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			      "Size": 1024,
+			      "Type": "File",
+			      "Links": null
 			    }
 			  }
 			}
@@ -145,6 +141,9 @@ test_ls_cmd() {
 			  },
 			  "Objects": {
 			    "QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss": {
+			      "Hash": "QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss",
+			      "Size": 0,
+			      "Type": "Directory",
 			      "Links": [
 			        {
 			          "Name": "128",
@@ -161,14 +160,10 @@ test_ls_cmd() {
 			      ]
 			    },
 			    "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd": {
-			      "Links": [
-			        {
-			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
-			          "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
-			          "Size": 1024,
-			          "Type": "File"
-			        }
-			      ]
+			      "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			      "Size": 1024,
+			      "Type": "File",
+			      "Links": null
 			    }
 			  }
 			}

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -4,7 +4,7 @@
 # MIT Licensed; see the LICENSE file in this repository.
 #
 
-test_description="Test unixfs ls command"
+test_description="Test file ls command"
 
 . lib/test-lib.sh
 
@@ -38,11 +38,11 @@ test_ls_cmd() {
 		test_cmp expected_add actual_add
 	'
 
-	test_expect_success "'ipfs unixfs ls <three dir hashes>' succeeds" '
-		ipfs unixfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+	test_expect_success "'ipfs file ls <three dir hashes>' succeeds" '
+		ipfs file ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
 	'
 
-	test_expect_success "'ipfs unixfs ls <three dir hashes>' output looks good" '
+	test_expect_success "'ipfs file ls <three dir hashes>' output looks good" '
 		cat <<-\EOF >expected_ls &&
 			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
 			d1
@@ -61,11 +61,11 @@ test_ls_cmd() {
 		test_cmp expected_ls actual_ls
 	'
 
-	test_expect_success "'ipfs unixfs ls <file hashes>' succeeds" '
-		ipfs unixfs ls /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe >actual_ls_file
+	test_expect_success "'ipfs file ls <file hashes>' succeeds" '
+		ipfs file ls /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe >actual_ls_file
 	'
 
-	test_expect_success "'ipfs unixfs ls <file hashes>' output looks good" '
+	test_expect_success "'ipfs file ls <file hashes>' output looks good" '
 		cat <<-\EOF >expected_ls_file &&
 			/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024
 			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -44,12 +44,6 @@ test_ls_cmd() {
 
 	test_expect_success "'ipfs file ls <three dir hashes>' output looks good" '
 		cat <<-\EOF >expected_ls &&
-			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
-			d1
-			d2
-			f1
-			f2
-
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
 			1024
 			a
@@ -57,6 +51,12 @@ test_ls_cmd() {
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 			128
 			a
+
+			QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+			d1
+			d2
+			f1
+			f2
 		EOF
 		test_cmp expected_ls actual_ls
 	'
@@ -73,6 +73,23 @@ test_ls_cmd() {
 		test_cmp expected_ls_file actual_ls_file
 	'
 
+	test_expect_success "'ipfs file ls <duplicates>' succeeds" '
+		ipfs file ls /ipfs/QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj/d1 /ipfs/QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 /ipfs/QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd >actual_ls_duplicates_file
+	'
+
+	test_expect_success "'ipfs file ls <duplicates>' output looks good" '
+		cat <<-\EOF >expected_ls_duplicates_file &&
+			/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024
+			/ipfs/QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd
+
+			/ipfs/QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+			/ipfs/QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj/d1:
+			128
+			a
+		EOF
+		test_cmp expected_ls_duplicates_file actual_ls_duplicates_file
+	'
+
 	test_expect_success "'ipfs --encoding=json file ls <file hashes>' succeeds" '
 		ipfs --encoding=json file ls /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 >actual_json_ls_file
 	'
@@ -80,9 +97,11 @@ test_ls_cmd() {
 	test_expect_success "'ipfs --encoding=json file ls <file hashes>' output looks good" '
 		cat <<-\EOF >expected_json_ls_file_trailing_newline &&
 			{
-			  "Objects": [
-			    {
-			      "Argument": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
+			  "Arguments": {
+			    "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd"
+			  },
+			  "Objects": {
+			    "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd": {
 			      "Links": [
 			        {
 			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
@@ -92,11 +111,58 @@ test_ls_cmd() {
 			        }
 			      ]
 			    }
-			  ]
+			  }
 			}
 		EOF
 		printf %s "$(cat expected_json_ls_file_trailing_newline)" >expected_json_ls_file &&
 		test_cmp expected_json_ls_file actual_json_ls_file
+	'
+
+	test_expect_success "'ipfs --encoding=json file ls <duplicates>' succeeds" '
+		ipfs --encoding=json file ls /ipfs/QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj/d1 /ipfs/QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss /ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024 /ipfs/QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd >actual_json_ls_duplicates_file
+	'
+
+	test_expect_success "'ipfs --encoding=json file ls <duplicates>' output looks good" '
+		cat <<-\EOF >expected_json_ls_duplicates_file_trailing_newline &&
+			{
+			  "Arguments": {
+			    "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			    "/ipfs/QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss": "QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss",
+			    "/ipfs/QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			    "/ipfs/QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj/d1": "QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss"
+			  },
+			  "Objects": {
+			    "QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss": {
+			      "Links": [
+			        {
+			          "Name": "128",
+			          "Hash": "QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe",
+			          "Size": 128,
+			          "Type": "File"
+			        },
+			        {
+			          "Name": "a",
+			          "Hash": "QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN",
+			          "Size": 6,
+			          "Type": "File"
+			        }
+			      ]
+			    },
+			    "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd": {
+			      "Links": [
+			        {
+			          "Name": "/ipfs/QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy/1024",
+			          "Hash": "QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd",
+			          "Size": 1024,
+			          "Type": "File"
+			        }
+			      ]
+			    }
+			  }
+			}
+		EOF
+		printf %s "$(cat expected_json_ls_duplicates_file_trailing_newline)" >expected_json_ls_duplicates_file &&
+		test_cmp expected_json_ls_duplicates_file actual_json_ls_duplicates_file
 	'
 }
 


### PR DESCRIPTION
This is mostly to get an interface for listing the file-sizes for Unix
files (vs. the Merkle-ancestor sizes listed by `ipfs ls …`).  For
background, see #543.  For details on the individual commits, see the
commit messages.

The intended space for `ipfs unixfs …` is for folks operating with
Unix-filesystem trees (obviously), so the API should tranparently
resolve any fanout.  The current Merkle-level commands (`ipfs ls …`,
etc.) on the other hand should be operating below the UnixFS level.
They probably shouldn't handle fanout, and they almost certainly
shouldn't be converting Merkle nodes to UnixFS nodes.  For example,
`ipfs cat …` might print the appended set of all constituent chunks,
but it shouldn't be stripping the magic Data wrappers (`Type`,
`Filesize`, `Blocksizes`, … in `unixfs_pb.Data`), because ‘ipfs cat …’
might be used to access non-UnixFS nodes.

I think there is space between the really-low-level `ipfs object …`
API and the UnixFS API we're starting here for commands that only add
fanout and typing to the base Merkle objects.  Then the UnixFS
implementation can build on that.  For example, the `ipfs unixfs ls …`
implementation here doesn't currently handle fanned-out directories.
Blocking issues for building such an intermediate API include generic
typing (vs. the Protobuf magic in `unixfs_pb.Data`, see ipfs/ipfs#36)
and generic fanout (see ipfs/specs#10).

There are a few consistency issues with the exising `ipfs ls …` that I
point out in the commit messages, and we'll want to resolve those
before merging this PR.