### PR TITLE
core/commands: Catch ErrResolveRecursion in non-recursive resolution

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -63,7 +63,7 @@ The resolver will give:
 			depth = namesys.DefaultDepthLimit
 		}
 		output, err := resolver.ResolveN(req.Context().Context, name, depth)
-		if err != nil {
+		if err != nil && (err != namesys.ErrResolveRecursion || depth > 1) {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}

--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -82,7 +82,7 @@ Resolve the value of another name:
 
 		resolver := namesys.NewRoutingResolver(n.Routing)
 		output, err := resolver.ResolveN(n.Context(), name, depth)
-		if err != nil {
+		if err != nil && (err != namesys.ErrResolveRecursion || depth > 1) {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -79,7 +79,7 @@ Resolve the value of another name recursively:
 		}
 
 		output, err := n.Namesys.ResolveN(n.Context(), name, depth)
-		if err != nil {
+		if err != nil && (err != namesys.ErrResolveRecursion || depth > 1) {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}


### PR DESCRIPTION
For depth-1, getting `ErrResolveRecursion` means the resolution was
successful and we hit our depth limit.  That's what we want for
non-recursive resolution, so don't die with:

    Error: could not resolve name (recursion limit exceeded).

in this case.

Fixes part of #1350.  The rest of the resolution issue reported there
is #1307.