### PR TITLE
Assume config value to be json-formatted in cli

### DIFF
--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -110,8 +110,6 @@ func TestOptionParsing(t *testing.T) {
 	test("-bs foo", kvs{"b": "", "s": "foo"}, words{})
 	test("-sb", kvs{"s": "b"}, words{})
 	test("-b foo", kvs{"b": ""}, words{"foo"})
-	test("--bool foo", kvs{"bool": ""}, words{"foo"})
-	testFail("--bool=foo")
 	testFail("--string")
 	test("--string foo", kvs{"string": "foo"}, words{})
 	test("--string=foo", kvs{"string": "foo"}, words{})

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -181,7 +181,7 @@ variable set to your preferred text editor.
 
 var configReplaceCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Replaces the config with `file>",
+		Tagline: "Replaces the config with <file>",
 		ShortDescription: `
 Make sure to back up the config file first if neccessary, this operation
 can't be undone.

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -75,21 +75,14 @@ Set the value of the 'datastore.path' key:
 		var output *ConfigField
 		if len(args) == 2 {
 			value := args[1]
-
-			if parseJson, _, _ := req.Option("json").Bool(); parseJson {
-				var jsonVal interface{}
-				if err := json.Unmarshal([]byte(value), &jsonVal); err != nil {
-					err = fmt.Errorf("failed to unmarshal json. %s", err)
-					res.SetError(err, cmds.ErrNormal)
-					return
-				}
-
-				output, err = setConfig(r, key, jsonVal)
-			} else if isbool, _, _ := req.Option("bool").Bool(); isbool {
-				output, err = setConfig(r, key, value == "true")
-			} else {
-				output, err = setConfig(r, key, value)
+			var jsonVal interface{}
+			if err := json.Unmarshal([]byte(value), &jsonVal); err != nil {
+				err = fmt.Errorf("failed to unmarshal json. %s", err)
+				res.SetError(err, cmds.ErrNormal)
+				return
 			}
+
+			output, err = setConfig(r, key, jsonVal)
 		} else {
 			output, err = getConfig(r, key)
 		}
@@ -228,7 +221,7 @@ func getConfig(r repo.Repo, key string) (*ConfigField, error) {
 func setConfig(r repo.Repo, key string, value interface{}) (*ConfigField, error) {
 	err := r.SetConfigKey(key, value)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to set config value: %s (maybe use --json?)", err)
+		return nil, fmt.Errorf("Failed to set config value: %s", err)
 	}
 	return getConfig(r, key)
 }

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -65,7 +65,7 @@ ipfs daemon --mount
 If you wish to allow other users to use the mount points, use the following:
 
 ```sh
-ipfs config Mounts.FuseAllowOther --bool true
+ipfs config Mounts.FuseAllowOther true
 ipfs daemon --mount
 ```
 

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -100,7 +100,7 @@ test_wait_open_tcp_port_10_sec() {
 # was setting really weird things and am not sure why.
 test_config_set() {
 
-	# grab flags (like --bool in "ipfs config --bool")
+	# grab flags (like --json in "ipfs config --json")
 	test_cfg_flags="" # unset in case.
 	test "$#" = 3 && { test_cfg_flags=$1; shift; }
 
@@ -186,7 +186,7 @@ test_config_ipfs_gateway_writable() {
 	test_config_ipfs_gateway_readonly $1
 
 	test_expect_success "prepare config -- gateway writable" '
-		test_config_set --bool Gateway.Writable true ||
+		test_config_set Gateway.Writable true ||
 		test_fsh cat "\"$IPFS_PATH/config\""
 	'
 }

--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -7,7 +7,7 @@ test_description="Test config command"
 # we use a function so that we can run it both offline + online
 test_config_cmd_set() {
 
-  # flags (like --bool in "ipfs config --bool")
+  # flags (like --json in "ipfs config --json")
   cfg_flags="" # unset in case.
   test "$#" = 3 && { cfg_flags=$1; shift; }
 
@@ -52,11 +52,9 @@ test_config_cmd() {
   test_config_cmd_set "beep" "boop"
   test_config_cmd_set "beep1" "boop2"
   test_config_cmd_set "beep1" "boop2"
-  test_config_cmd_set "--bool" "beep2" "true"
-  test_config_cmd_set "--bool" "beep2" "false"
-  test_config_cmd_set "--json" "beep3" "true"
-  test_config_cmd_set "--json" "beep3" "false"
-  test_config_cmd_set "--json" "Discovery" "$CONFIG_SET_JSON_TEST"
+  test_config_cmd_set "beep2" "true"
+  test_config_cmd_set "beep2" "false"
+  test_config_cmd_set "Discovery" "$CONFIG_SET_JSON_TEST"
 
 }
 


### PR DESCRIPTION
This deprecates explicit '--bool' and '--json' flag.
The reason is, if explicit type has to be specified, then '--integer',
'--float' also need to be implemented. But json parser already knows how
to handle these types, so why not just reuse it.
ref: #740