### PR TITLE
prevent wantmanager from leaking goroutines (and memory)

### DIFF
--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -137,33 +137,46 @@ func (mq *msgQueue) runQueue(ctx context.Context) {
 	for {
 		select {
 		case <-mq.work: // there is work to be done
-
-			err := mq.network.ConnectTo(ctx, mq.p)
-			if err != nil {
-				log.Noticef("cant connect to peer %s: %s", mq.p, err)
-				// TODO: cant connect, what now?
-				continue
-			}
-
-			// grab outgoing message
-			mq.outlk.Lock()
-			wlm := mq.out
-			if wlm == nil || wlm.Empty() {
-				mq.outlk.Unlock()
-				continue
-			}
-			mq.out = nil
-			mq.outlk.Unlock()
-
-			// send wantlist updates
-			err = mq.network.SendMessage(ctx, mq.p, wlm)
-			if err != nil {
-				log.Noticef("bitswap send error: %s", err)
-				// TODO: what do we do if this fails?
-			}
+			mq.doWork(ctx)
 		case <-mq.done:
 			return
 		}
+	}
+}
+
+func (mq *msgQueue) doWork(ctx context.Context) {
+	// allow a minute for connections
+	// this includes looking them up in the dht
+	// dialing them, and handshaking
+	conctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	err := mq.network.ConnectTo(conctx, mq.p)
+	if err != nil {
+		log.Noticef("cant connect to peer %s: %s", mq.p, err)
+		// TODO: cant connect, what now?
+		return
+	}
+
+	// grab outgoing message
+	mq.outlk.Lock()
+	wlm := mq.out
+	mq.out = nil
+	mq.outlk.Unlock()
+
+	if wlm == nil || wlm.Empty() {
+		return
+	}
+
+	sendctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	// send wantlist updates
+	err = mq.network.SendMessage(sendctx, mq.p, wlm)
+	if err != nil {
+		log.Noticef("bitswap send error: %s", err)
+		// TODO: what do we do if this fails?
+		return
 	}
 }
 


### PR DESCRIPTION
got tired of not being able to figure out the spdy problem. So I went to something that I could solve.

the context for the runQueue is actually just the context for the entire wantmanager. It never really gets cancelled before the daemon shuts down. I added a timeout to the Connect and Send calls within the runQueue to prevent this from happening.

This still leaves one problem unsolved, what do we do if we cannot connect to a given peer, but bitswap insists on sending them a message? (line 157)