### PR TITLE
Added nofuse tag for windows builds

### DIFF
--- a/cmd/ipfs/.gobuilder.yml
+++ b/cmd/ipfs/.gobuilder.yml
@@ -1,4 +1,9 @@
 ---
+build_matrix:
+  all:
+  windows:
+    build_tags:
+      - nofuse
 artifacts:
   - dist/README.md
   - dist/LICENSE


### PR DESCRIPTION
This configuration is supported since GoBuilder 1.16.0 so now we should be able to build windows binaries in GoBuilder