### PR TITLE
cancel contexts if http connections closes

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -121,6 +121,13 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	i.ctx.Context = ctx
 	req.SetContext(i.ctx)
 
+	if cn, ok := w.(http.CloseNotifier); ok {
+		go func() {
+			<-cn.CloseNotify()
+			cancel()
+		}()
+	}
+
 	// call the command
 	res := i.root.Call(req)
 

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -215,51 +215,17 @@ func flushCopy(w http.ResponseWriter, out io.Reader) error {
 // Copies from an io.Reader to a http.ResponseWriter.
 // Flushes chunks over HTTP stream as they are read (if supported by transport).
 func copyChunks(contentType string, w http.ResponseWriter, out io.Reader) error {
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		return errors.New("Could not create hijacker")
+	if contentType != "" {
+		w.Header().Set(contentTypeHeader, contentType)
 	}
-	conn, writer, err := hijacker.Hijack()
+
+	w.Header().Set(transferEncodingHeader, "chunked")
+	w.Header().Set(channelHeader, "1")
+
+	_, err := io.Copy(w, out)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-
-	writer.WriteString("HTTP/1.1 200 OK\r\n")
-	if contentType != "" {
-		writer.WriteString(contentTypeHeader + ": " + contentType + "\r\n")
-	}
-	writer.WriteString(transferEncodingHeader + ": chunked\r\n")
-	writer.WriteString(channelHeader + ": 1\r\n\r\n")
-
-	buf := make([]byte, 32*1024)
-
-	for {
-		n, err := out.Read(buf)
-
-		if n > 0 {
-			length := fmt.Sprintf("%x\r\n", n)
-			writer.WriteString(length)
-
-			_, err := writer.Write(buf[0:n])
-			if err != nil {
-				return err
-			}
-
-			writer.WriteString("\r\n")
-			writer.Flush()
-		}
-
-		if err != nil && err != io.EOF {
-			return err
-		}
-		if err == io.EOF {
-			break
-		}
-	}
-
-	writer.WriteString("0\r\n\r\n")
-	writer.Flush()
 
 	return nil
 }

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -123,8 +123,11 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if cn, ok := w.(http.CloseNotifier); ok {
 		go func() {
-			<-cn.CloseNotify()
-			cancel()
+			select {
+			case <-cn.CloseNotify():
+				cancel()
+			case <-ctx.Done():
+			}
 		}()
 	}
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -77,22 +77,32 @@ func (i *gatewayHandler) newDagFromReader(r io.Reader) (*dag.Node, error) {
 
 // TODO(btc): break this apart into separate handlers using a more expressive muxer
 func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithCancel(i.node.Context())
+	defer cancel()
+
+	if cn, ok := w.(http.CloseNotifier); ok {
+		go func() {
+			<-cn.CloseNotify()
+			cancel()
+		}()
+	}
+
 	if i.config.Writable {
 		switch r.Method {
 		case "POST":
-			i.postHandler(w, r)
+			i.postHandler(ctx, w, r)
 			return
 		case "PUT":
-			i.putHandler(w, r)
+			i.putHandler(ctx, w, r)
 			return
 		case "DELETE":
-			i.deleteHandler(w, r)
+			i.deleteHandler(ctx, w, r)
 			return
 		}
 	}
 
 	if r.Method == "GET" || r.Method == "HEAD" {
-		i.getOrHeadHandler(w, r)
+		i.getOrHeadHandler(ctx, w, r)
 		return
 	}
 
@@ -108,10 +118,7 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Error(errmsg) // TODO(cryptix): log errors until we have a better way to expose these (counter metrics maybe)
 }
 
-func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithCancel(i.node.Context())
-	defer cancel()
-
+func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	urlPath := r.URL.Path
 
 	if i.config.BlockList != nil && i.config.BlockList.ShouldBlock(urlPath) {
@@ -220,7 +227,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
-func (i *gatewayHandler) postHandler(w http.ResponseWriter, r *http.Request) {
+func (i *gatewayHandler) postHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	nd, err := i.newDagFromReader(r.Body)
 	if err != nil {
 		internalWebError(w, err)
@@ -250,7 +257,7 @@ func (i *gatewayHandler) putEmptyDirHandler(w http.ResponseWriter, r *http.Reque
 	http.Redirect(w, r, ipfsPathPrefix+key.String()+"/", http.StatusCreated)
 }
 
-func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
+func (i *gatewayHandler) putHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	// TODO(cryptix): either ask mildred about the flow of this or rewrite it
 	webErrorWithCode(w, "Sorry, PUT is bugged right now, closing request", errors.New("handler disabled"), http.StatusInternalServerError)
 	return
@@ -348,10 +355,8 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, ipfsPathPrefix+key.String()+"/"+strings.Join(components, "/"), http.StatusCreated)
 }
 
-func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
+func (i *gatewayHandler) deleteHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	urlPath := r.URL.Path
-	ctx, cancel := context.WithCancel(i.node.Context())
-	defer cancel()
 
 	ipfsNode, err := core.Resolve(ctx, i.node, path.Path(urlPath))
 	if err != nil {

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -82,8 +82,11 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if cn, ok := w.(http.CloseNotifier); ok {
 		go func() {
-			<-cn.CloseNotify()
-			cancel()
+			select {
+			case <-cn.CloseNotify():
+				cancel()
+			case <-ctx.Done():
+			}
 		}()
 	}
 


### PR DESCRIPTION
thanks @cryptix for pointing this functionality out.

This will cancel gateway requests when the http client closes the connection.

Closes #1387 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>