### PR TITLE
Add readonly api to gateway

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -281,7 +281,7 @@ func serveHTTPApi(req cmds.Request) (error, <-chan error) {
 	var opts = []corehttp.ServeOption{
 		corehttp.CommandsOption(*req.Context()),
 		corehttp.WebUIOption,
-		apiGw.ServeOption(),
+		apiGw.ServeOption(nil),
 		corehttp.VersionOption(),
 		defaultMux("/debug/vars"),
 		defaultMux("/debug/pprof/"),
@@ -339,7 +339,7 @@ func serveHTTPGateway(req cmds.Request) (error, <-chan error) {
 	var opts = []corehttp.ServeOption{
 		corehttp.VersionOption(),
 		corehttp.IPNSHostnameOption(),
-		corehttp.GatewayOption(writable),
+		corehttp.GatewayOption(writable, req.Context()),
 	}
 
 	if len(cfg.Gateway.RootRedirect) > 0 {

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -76,13 +76,13 @@ func run(ipfsPath, watchPath string) error {
 		return err
 	}
 	defer node.Close()
-
+	cmd_ctx := cmdCtx(node, ipfsPath)
 	if *http {
 		addr := "/ip4/127.0.0.1/tcp/5001"
 		var opts = []corehttp.ServeOption{
-			corehttp.GatewayOption(true),
+			corehttp.GatewayOption(true, &cmd_ctx),
 			corehttp.WebUIOption,
-			corehttp.CommandsOption(cmdCtx(node, ipfsPath)),
+			corehttp.CommandsOption(cmd_ctx),
 		}
 		proc.Go(func(p process.Process) {
 			if err := corehttp.ListenAndServe(node, addr, opts...); err != nil {

--- a/commands/command.go
+++ b/commands/command.go
@@ -64,8 +64,9 @@ type Command struct {
 	// the Run Function.
 	//
 	// ie. If command Run returns &Block{}, then Command.Type == &Block{}
-	Type        interface{}
-	Subcommands map[string]*Command
+	Type          interface{}
+	Subcommands   map[string]*Command
+	GatewayAccess bool
 }
 
 // ErrNotCallable signals a command that cannot be called.

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -97,8 +97,6 @@ func NewReadOnlyHandler(ctx cmds.Context, root *cmds.Command, allowedOrigin stri
 		},
 	})
 
-	fmt.Println("Read Only API")
-
 	// Wrap the internal handler with CORS handling-middleware.
 	return &Handler{internal, c.Handler(internal)}
 }

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -12,7 +12,6 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	commands "github.com/ipfs/go-ipfs/core/commands"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
@@ -47,10 +46,6 @@ var mimeTypes = map[string]string{
 	cmds.JSON: "application/json",
 	cmds.XML:  "application/xml",
 	cmds.Text: "text/plain",
-}
-
-var readOnlyCmds = map[*cmds.Command]bool{
-	commands.RefsCmd: true,
 }
 
 func NewHandler(ctx cmds.Context, root *cmds.Command, allowedOrigin string, commandList map[*cmds.Command]bool) *Handler {

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -43,6 +43,7 @@ multihash.
 }
 
 var blockStatCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Print information of a raw IPFS block",
 		ShortDescription: `
@@ -80,6 +81,7 @@ on raw ipfs blocks. It outputs the following to stdout:
 }
 
 var blockGetCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Get a raw IPFS block",
 		ShortDescription: `

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -15,6 +15,7 @@ import (
 const progressBarMinSize = 1024 * 1024 * 8 // show progress bar for outputs > 8MiB
 
 var CatCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Show IPFS object data",
 		ShortDescription: `

--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -11,6 +11,7 @@ import (
 )
 
 var ipnsCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Gets the value currently published at an IPNS name",
 		ShortDescription: `

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -33,6 +33,7 @@ type LsOutput struct {
 }
 
 var LsCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "List links from an object.",
 		ShortDescription: `

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -72,6 +72,7 @@ ipfs object patch <args>    - Create new object from old ones
 }
 
 var objectDataCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Outputs the raw bytes in an IPFS object",
 		ShortDescription: `
@@ -110,6 +111,7 @@ output is the raw data of the object.
 }
 
 var objectLinksCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Outputs the links pointed to by the specified object",
 		ShortDescription: `
@@ -159,6 +161,7 @@ multihash.
 }
 
 var objectGetCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Get and serialize the DAG node named by <key>",
 		ShortDescription: `
@@ -230,6 +233,7 @@ This command outputs data in the following encodings:
 }
 
 var objectStatCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Get stats for the DAG node named by <key>",
 		ShortDescription: `

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -32,6 +32,7 @@ func KeyListTextMarshaler(res cmds.Response) (io.Reader, error) {
 }
 
 var RefsCmd = &cmds.Command{
+	GatewayAccess: true,
 	Helptext: cmds.HelpText{
 		Tagline: "Lists links (references) from an object",
 		ShortDescription: `

--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -16,9 +16,15 @@ const (
 )
 
 func CommandsOption(cctx commands.Context) ServeOption {
+	commandList := map[*commands.Command]bool{}
+
+	for _, cmd := range corecommands.Root.Subcommands {
+		commandList[cmd] = true
+	}
+
 	return func(n *core.IpfsNode, mux *http.ServeMux) (*http.ServeMux, error) {
 		origin := os.Getenv(originEnvKey)
-		cmdHandler := cmdsHttp.NewHandler(cctx, corecommands.Root, origin)
+		cmdHandler := cmdsHttp.NewHandler(cctx, corecommands.Root, origin, commandList)
 		mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
 		return mux, nil
 	}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -30,6 +30,12 @@ func NewGateway(conf GatewayConfig) *Gateway {
 }
 
 func (g *Gateway) ServeOption(cctx * commands.Context) ServeOption {
+	var commandList = map[*commands.Command]bool{}
+
+	for _, cmd := range corecommands.Root.Subcommands {
+		commandList[cmd] = cmd.GatewayAccess
+	}
+
 	return func(n *core.IpfsNode, mux *http.ServeMux) (*http.ServeMux, error) {
 		gateway, err := newGatewayHandler(n, g.Config)
 		if err != nil {
@@ -40,7 +46,7 @@ func (g *Gateway) ServeOption(cctx * commands.Context) ServeOption {
 
 		if cctx != nil {
 			origin := os.Getenv(originEnvKey)
-			cmdHandler := cmdsHttp.NewReadOnlyHandler(*cctx, corecommands.Root, origin)
+			cmdHandler := cmdsHttp.NewHandler(*cctx, corecommands.Root, origin, commandList)
 			mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
 		}
 		return mux, nil

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -17,6 +17,7 @@ import (
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
+	commands "github.com/ipfs/go-ipfs/commands"
 )
 
 type mockNamesys map[string]path.Path
@@ -65,9 +66,10 @@ func TestGatewayGet(t *testing.T) {
 	}
 	ns["example.com"] = path.FromString("/ipfs/" + k)
 
+	cmd_ctx := commands.Context{}
 	h, err := makeHandler(n,
 		IPNSHostnameOption(),
-		GatewayOption(false),
+		GatewayOption(false, &cmd_ctx),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -106,9 +106,10 @@ func run() error {
 	}
 	defer node.Close()
 
+	cmd_ctx := cmdCtx(node, repoPath)
 	opts := []corehttp.ServeOption{
-		corehttp.CommandsOption(cmdCtx(node, repoPath)),
-		corehttp.GatewayOption(false),
+		corehttp.CommandsOption(cmd_ctx),
+		corehttp.GatewayOption(false, &cmd_ctx),
 	}
 
 	if *cat {


### PR DESCRIPTION
Issue #1322

Added the ability to expose individual commands to a read-only style
handler that can be used on any http interface.

Added the read-only handler to the gateway.

Tests to come