### PR TITLE
fix fuse mount error in linux

### DIFF
--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -24,6 +24,9 @@ const mountTimeout = time.Second
 // fuseNoDirectory used to check the returning fuse error
 const fuseNoDirectory = "fusermount: failed to access mountpoint"
 
+// fuseExitStatus1 used to check the returning fuse error
+const fuseExitStatus1 = "fusermount: exit status 1"
+
 // platformFuseChecks can get overridden by arch-specific files
 // to run fuse checks (like checking the OSXFUSE version)
 var platformFuseChecks = func(*core.IpfsNode) error {
@@ -181,11 +184,15 @@ func Mount(node *core.IpfsNode, fsdir, nsdir string) error {
 }
 
 func doMount(node *core.IpfsNode, fsdir, nsdir string) error {
-	fmtFuseErr := func(err error) error {
+	fmtFuseErr := func(err error, mountpoint string) error {
 		s := err.Error()
 		if strings.Contains(s, fuseNoDirectory) {
 			s = strings.Replace(s, `fusermount: "fusermount:`, "", -1)
 			s = strings.Replace(s, `\n", exit status 1`, "", -1)
+			return cmds.ClientError(s)
+		}
+		if s == fuseExitStatus1 {
+			s = fmt.Sprintf("fuse failed to access mountpoint %s", mountpoint)
 			return cmds.ClientError(s)
 		}
 		return err
@@ -222,9 +229,9 @@ func doMount(node *core.IpfsNode, fsdir, nsdir string) error {
 		}
 
 		if err1 != nil {
-			return fmtFuseErr(err1)
+			return fmtFuseErr(err1, fsdir)
 		}
-		return fmtFuseErr(err2)
+		return fmtFuseErr(err2, nsdir)
 	}
 
 	// setup node state, so that it can be cancelled


### PR DESCRIPTION
There has been a regression such that ./t0030-mount.sh fails on

  'ipfs mount' fails when there is no mount dir

The issue was a change in how fuse errors are reported to the client
process. We have introduced an optimistic categorization that hides
the obscure fusermount error and replaces it with something a bit
more helpful.

Fixes: #1369

@chriscool: I tested this on linux, but would you mind testing
as well to confirm it is fixed for you too?