### PR TITLE
core/commands: Make IpnsCmd and PublishCmd public

### DIFF
--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -10,7 +10,7 @@ import (
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-var ipnsCmd = &cmds.Command{
+var IpnsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Gets the value currently published at an IPNS name",
 		ShortDescription: `

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -51,7 +51,7 @@ Resolve the value of another name:
 	},
 
 	Subcommands: map[string]*cmds.Command{
-		"publish": publishCmd,
-		"resolve": ipnsCmd,
+		"publish": PublishCmd,
+		"resolve": IpnsCmd,
 	},
 }

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -17,7 +17,7 @@ import (
 
 var errNotOnline = errors.New("This command must be run in online mode. Try running 'ipfs daemon' first.")
 
-var publishCmd = &cmds.Command{
+var PublishCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Publish an object to IPNS",
 		ShortDescription: `


### PR DESCRIPTION
[ipfs-shell][1] accesses the Command objects directly to construct
requests for an external IPFS daemon API.  This isn't a terribly
robust approach, because it doesn't handle version differences between
the version of go-ipfs used to build the daemon and the version used
to build the ipfs-shell-consuming application.  But for cases where
you can get those APIs to match it works well.  Making these two
commands public allows us to write ipfs-shell wrappers for them.
Until we figure out how to get ipfs-shell working without access to
core/commands, I think the best approach is to make future command
objects and their returned structures public, and to go back and
expose existing commands/structures on an as-needed basis.

In this case, I need the public PublishCmd for the Docker-registry
storage driver, and I made the IpnsCmd public at the same time to stay
consistent for both `ipfs name ...` sub-commands.

[1]: https://github.com/whyrusleeping/ipfs-shell