### PR TITLE
core/commands/publish: Allow explicit local node ID

### DIFF
--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -72,16 +72,19 @@ Publish an <ipfs-path> to another public key (not implemented):
 			return
 		}
 
+		var name string
 		var pstr string
 
 		switch len(args) {
 		case 2:
-			// name = args[0]
+			name = args[0]
 			pstr = args[1]
-			res.SetError(errors.New("keychains not yet implemented"), cmds.ErrNormal)
-			return
+			if name != n.Identity.Pretty() {
+				res.SetError(errors.New("keychains not yet implemented"), cmds.ErrNormal)
+				return
+			}
 		case 1:
-			// name = n.Identity.ID.String()
+			// name = n.Identity.Pretty()
 			pstr = args[0]
 		}
 

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -52,4 +52,16 @@ test_expect_success "resolve output looks good" '
 	test_cmp output expected4
 '
 
+# publish with an explicit node ID
+
+test_expect_success "'ipfs name publish <local-id> <hash>' succeeds" '
+	PEERID=`ipfs id --format="<id>"` &&
+	ipfs name publish "${PEERID}" "/ipfs/$HASH_WELCOME_DOCS" >actual_node_id_publish
+'
+
+test_expect_success "publish with our explicit node ID looks good" '
+	echo "Published to ${PEERID}: /ipfs/$HASH_WELCOME_DOCS" >expected_node_id_publish &&
+	test_cmp expected_node_id_publish actual_node_id_publish
+'
+
 test_done


### PR DESCRIPTION
Instead of raising "keychains not yet implemented" whenever we have an
explicit node ID, only raise the error when the given node ID isn't
the local node.  This allows folks to use the more-general
explicit-node-ID form in scripts and such now, as long as they use the
local node name when calling those scripts.

Also add a test for this case, and update the comment for the
one-argument case to match the current syntax for extracting a
multihash name string.

License: MIT
Signed-off-by: W. Trevor King <wking@tremily.us>