### PR TITLE
Swarm Addrs, Disable secio opt, + tests

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -179,6 +180,8 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		return
 	}
 
+	printSwarmAddrs(node)
+
 	defer func() {
 		// We wait for the node to close first, as the node has children
 		// that it will wait for before closing, such as the API server.
@@ -303,6 +306,19 @@ func serveHTTPApi(req cmds.Request) (error, <-chan error) {
 		close(errc)
 	}()
 	return nil, errc
+}
+
+// printSwarmAddrs prints the addresses of the host
+func printSwarmAddrs(node *core.IpfsNode) {
+	var addrs []string
+	for _, addr := range node.PeerHost.Addrs() {
+		addrs = append(addrs, addr.String())
+	}
+	sort.Sort(sort.StringSlice(addrs))
+
+	for _, addr := range addrs {
+		fmt.Printf("Swarm listening on %s\n", addr)
+	}
 }
 
 // serveHTTPGateway collects options, creates listener, prints status message and starts serving requests

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -46,6 +46,7 @@ ipfs id supports the format option for output with the following keys:
 <aver>: agent version
 <pver>: protocol version
 <pubkey>: public key
+<addrs>: addresses (newline delimited)
 `,
 	},
 	Arguments: []cmds.Argument{
@@ -119,6 +120,9 @@ ipfs id supports the format option for output with the following keys:
 				output = strings.Replace(output, "<aver>", val.AgentVersion, -1)
 				output = strings.Replace(output, "<pver>", val.ProtocolVersion, -1)
 				output = strings.Replace(output, "<pubkey>", val.PublicKey, -1)
+				output = strings.Replace(output, "<addrs>", strings.Join(val.Addresses, "\n"), -1)
+				output = strings.Replace(output, "\\n", "\n", -1)
+				output = strings.Replace(output, "\\t", "\t", -1)
 				return strings.NewReader(output), nil
 			} else {
 

--- a/p2p/net/conn/dial.go
+++ b/p2p/net/conn/dial.go
@@ -60,7 +60,7 @@ func (d *Dialer) Dial(ctx context.Context, raddr ma.Multiaddr, remote peer.ID) (
 			return
 		}
 
-		if d.PrivateKey == nil {
+		if d.PrivateKey == nil || EncryptConnections == false {
 			log.Warning("dialer %s dialing INSECURELY %s at %s!", d, remote, raddr)
 			connOut = c
 			return

--- a/p2p/net/conn/interface.go
+++ b/p2p/net/conn/interface.go
@@ -93,3 +93,11 @@ type Listener interface {
 	// Any blocked Accept operations will be unblocked and return errors.
 	Close() error
 }
+
+// EncryptConnections is a global parameter because it should either be
+// enabled or _completely disabled_. I.e. a node should only be able to talk
+// to proper (encrypted) networks if it is encrypting all its transports.
+// Running a node with disabled transport encryption is useful to debug the
+// protocols, achieve implementation interop, or for private networks which
+// -- for whatever reason -- _must_ run unencrypted.
+var EncryptConnections = true

--- a/p2p/net/conn/listen.go
+++ b/p2p/net/conn/listen.go
@@ -107,7 +107,7 @@ func (l *listener) Accept() (net.Conn, error) {
 			return nil, err
 		}
 
-		if l.privk == nil {
+		if l.privk == nil || EncryptConnections == false {
 			log.Warning("listener %s listening INSECURELY!", l)
 			return c, nil
 		}

--- a/p2p/net/mock/mock_notif_test.go
+++ b/p2p/net/mock/mock_notif_test.go
@@ -43,24 +43,30 @@ func TestNotifications(t *testing.T) {
 	for i, s := range nets {
 		n := notifiees[i]
 		for _, s2 := range nets {
-			cos := s.ConnsToPeer(s2.LocalPeer())
-			func() {
-				for i := 0; i < len(cos); i++ {
-					var c inet.Conn
-					select {
-					case c = <-n.connected:
-					case <-time.After(timeout):
-						t.Fatal("timeout")
+			var actual []inet.Conn
+			for len(s.ConnsToPeer(s2.LocalPeer())) != len(actual) {
+				select {
+				case c := <-n.connected:
+					actual = append(actual, c)
+				case <-time.After(timeout):
+					t.Fatal("timeout")
+				}
+			}
+
+			expect := s.ConnsToPeer(s2.LocalPeer())
+			for _, c1 := range actual {
+				found := false
+				for _, c2 := range expect {
+					if c1 == c2 {
+						found = true
+						break
 					}
-					for _, c2 := range cos {
-						if c == c2 {
-							t.Log("got notif for conn")
-							return
-						}
-					}
+				}
+				if !found {
 					t.Error("connection not found")
 				}
-			}()
+			}
+
 		}
 	}
 

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -325,6 +325,6 @@ func TestFilterBounds(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("should have gotten connection")
 	case <-conns:
-		fmt.Println("got connect")
+		t.Log("got connect")
 	}
 }

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -193,8 +193,10 @@ test_config_ipfs_gateway_writable() {
 
 test_launch_ipfs_daemon() {
 
+	args=$1
+
 	test_expect_success "'ipfs daemon' succeeds" '
-		ipfs daemon >actual_daemon 2>daemon_err &
+		ipfs daemon $args >actual_daemon 2>daemon_err &
 	'
 
 	# we say the daemon is ready when the API server is ready.

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -8,6 +8,8 @@ test_description="Test daemon command"
 
 . lib/test-lib.sh
 
+# TODO: randomize ports here once we add --config to ipfs daemon
+
 # this needs to be in a different test than "ipfs daemon --init" below
 test_expect_success "setup IPFS_PATH" '
   IPFS_PATH="$(pwd)/.ipfs" &&
@@ -89,6 +91,16 @@ test_expect_success "ipfs help output looks good" '
 	cat help.txt | egrep -i "^Usage:" >/dev/null &&
 	cat help.txt | egrep "ipfs .* <command>" >/dev/null ||
 	test_fsh cat help.txt
+'
+
+# check transport is encrypted
+
+test_expect_success 'transport should be encrypted' '
+  nc localhost 4001 >swarmnc &
+  go-sleep 0.1s &&
+  grep -q "AES-256,AES-128" swarmnc &&
+  ! grep -q "/ipfs/identify" swarmnc ||
+	test_fsh cat swarmnc
 '
 
 # end same as in t0010

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -36,6 +36,11 @@ test_expect_success "'ipfs config Identity.PeerID' works" '
   ipfs config Identity.PeerID >config_peerId
 '
 
+test_expect_success "'ipfs swarm addrs local' works" '
+  ipfs swarm addrs local >local_addrs
+'
+
+
 # this is lifted straight from t0020-init.sh
 test_expect_success "ipfs peer id looks good" '
   PEERID=$(cat config_peerId) &&
@@ -60,6 +65,7 @@ test_expect_success "ipfs daemon output looks good" '
   echo "peer identity: $PEERID" >>expected_daemon &&
   echo "to get started, enter:" >>expected_daemon &&
   printf "\\n\\t$STARTFILE\\n\\n" >>expected_daemon &&
+  cat local_addrs | sed "s/^/Swarm listening on /" >>expected_daemon &&
   echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected_daemon &&
   echo "Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080" >>expected_daemon &&
   test_cmp expected_daemon actual_daemon

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -19,7 +19,7 @@ test_expect_success "setup IPFS_PATH" '
 # NOTE: this should remove bootstrap peers (needs a flag)
 # TODO(cryptix):
 #  - we won't see daemon startup failure because we put the daemon in the background - fix: fork with exit code after api listen
-#  - also default ports: might clash with local clients. Failure in that case isn't clear as well because pollEndpoint just uses the already running node 
+#  - also default ports: might clash with local clients. Failure in that case isn't clear as well because pollEndpoint just uses the already running node
 test_expect_success "ipfs daemon --init launches" '
   ipfs daemon --init >actual_daemon 2>daemon_err &
 '
@@ -102,10 +102,9 @@ test_expect_success "ipfs help output looks good" '
 # check transport is encrypted
 
 test_expect_success 'transport should be encrypted' '
-  nc localhost 4001 >swarmnc &
-  go-sleep 0.1s &&
+  nc -w 5 localhost 4001 >swarmnc &&
   grep -q "AES-256,AES-128" swarmnc &&
-  ! grep -q "/ipfs/identify" swarmnc ||
+  test_must_fail grep -q "/ipfs/identify" swarmnc ||
 	test_fsh cat swarmnc
 '
 

--- a/test/sharness/t0061-daemon-opts.sh
+++ b/test/sharness/t0061-daemon-opts.sh
@@ -26,10 +26,9 @@ test_expect_success 'api gateway should be unrestricted' '
 '
 
 # Odd. this fails here, but the inverse works on t0060-daemon.
-test_expect_failure 'transport should be unencrypted' '
-  nc 127.0.0.1 "$PORT_SWARM" >swarmnc &
-  go-sleep 0.1s &&
-  ! grep -q "AES-256,AES-128" swarmnc &&
+test_expect_success 'transport should be unencrypted' '
+  go-sleep 0.5s | nc localhost "$PORT_SWARM" >swarmnc &&
+  test_must_fail grep -q "AES-256,AES-128" swarmnc &&
   grep -q "/ipfs/identify" swarmnc ||
   test_fsh cat swarmnc
 '

--- a/test/sharness/t0061-daemon-opts.sh
+++ b/test/sharness/t0061-daemon-opts.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Juan Batiz-Benet
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test daemon command"
+
+. lib/test-lib.sh
+
+
+test_init_ipfs
+
+test_launch_ipfs_daemon '--unrestricted-api --disable-transport-encryption'
+
+gwyport=$PORT_GWAY
+apiport=$PORT_API
+
+test_expect_success 'api gateway should be unrestricted' '
+  echo "hello mars :$gwyport :$apiport" >expected &&
+  HASH=$(ipfs add -q expected) &&
+  curl -sfo actual1 "http://127.0.0.1:$gwyport/ipfs/$HASH" &&
+  curl -sfo actual2 "http://127.0.0.1:$apiport/ipfs/$HASH" &&
+  test_cmp expected actual1 &&
+  test_cmp expected actual2
+'
+
+# Odd. this fails here, but the inverse works on t0060-daemon.
+test_expect_failure 'transport should be unencrypted' '
+  nc 127.0.0.1 "$PORT_SWARM" >swarmnc &
+  go-sleep 0.1s &&
+  ! grep -q "AES-256,AES-128" swarmnc &&
+  grep -q "/ipfs/identify" swarmnc ||
+  test_fsh cat swarmnc
+'
+
+test_kill_ipfs_daemon
+
+test_done

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -33,6 +33,10 @@ test_expect_success "GET IPFS path output looks good" '
   rm actual
 '
 
+test_expect_success "GET IPFS path on API forbidden" '
+  test_curl_resp_http_code "http://127.0.0.1:$apiport/ipfs/$HASH" "HTTP/1.1 403 Forbidden"
+'
+
 test_expect_success "GET IPFS directory path succeeds" '
   mkdir dir &&
   echo "12345" >dir/test &&

--- a/test/sharness/t0140-swarm.sh
+++ b/test/sharness/t0140-swarm.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test ipfs swarm command"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_launch_ipfs_daemon
+
+test_expect_success 'disconnected: peers is empty' '
+	ipfs swarm peers >actual &&
+	test_must_be_empty actual
+'
+
+test_expect_success 'disconnected: addrs local has localhost' '
+	ipfs swarm addrs local >actual &&
+	grep "/ip4/127.0.0.1" actual
+'
+
+test_expect_success 'disconnected: addrs local matches ipfs id' '
+	ipfs id -f="<addrs>\\n" | sort >expected &&
+	ipfs swarm addrs local --id | sort >actual &&
+	test_cmp expected actual
+'
+
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
This PR adds:

- `ipfs swarm addrs local` - command to list out local addresses
- `ipfs id -f=<addrs>` - format to print out addrs too
- `ipfs id -f=\n\t` - handle `\n` and `\t` correctly
- test for daemon that checks encryption is on
- `--disable-transport-encryption` daemon option (see below)
- test for restricted api
- test for `--unrestricted-api`

Left TODO:
- [ ] fix the 'transport should be unencrypted' test


Changes:

```
commit f0d3d19d9dcb6c793a251d1c7836229de08b8440
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 05:53:00 2015 -0700

    added sharness/t0061-daemon-opts

    Test odd daemon options, like:
    - unrestricted-api
    - disable-transport-encryption (known breakage atm)

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit a763bb7d74f129b68f949c7a741a669f2d998f8b
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 03:05:50 2015 -0700

    daemon option to optionally disable secio

    This commit adds an option to turn off all encryption. This is a mode
    used for tests, debugging, achieving protocol implementation interop,
    learning about how the protocol works (nc ftw), and worst case
    networks which _demand_ to be able to snoop on all the traffic.
    (sadly, there are some private intranets like this...). (We should
    consider at least _signing_ all this traffic.)

    Because of the severity of this sort of thing, this is an
    all-or-nothing deal. Either encryption is ON or OFF _fully_.
    This way, partially unencrypted nodes cannot be accidentally left
    running without the user's understanding. Nodes without encrypted
    connections will simply not be able to speak to any of the global
    bootstrap nodes, or anybody in the public network.

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit 0b2f1dd774c79006433a63caa57dd0aad3a283e1
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 03:21:01 2015 -0700

    daemon output includes swarm addresses

    daemon output now includes initial swarm addresses. this is not a
    full solution, as a change in network will not trigger re-printing.
    We need a good way to do that.

    This made me re-think how we're outputting these messages, perhaps
    we should be throwing them as log.Events, and capturing some with
    a special keyword to output to the user on stdout. Things like
    network addresses being rebound, NATs being holepunched, external
    network addresses being figured out, connections established, etc
    may be valuable events to show the user. Of course, these should be
    very few, as a noisy daemon is an annoying daemon.

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit 767b2b1ec195a230f38afad5e8401d11f0469e80
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 04:20:43 2015 -0700

    ipfs swarm addrs local - show local addrs

    Add a command to return local addresses.

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit 62f316971cd4c6b17e98af3480bdd35a8a814144
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 04:47:52 2015 -0700

    ipfs id -f=<addrs> and \n \t

    - added <addrs> field to `ipfs id -f`
    - added \n and \t conversion in `ipfs id -f`

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit a098cabc40f2d5732b7fd99fa916ef09576bf6b2
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Fri Jun 19 05:13:04 2015 -0700

    t0060-daemon: test transport is encrypted

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>
```