### PR TITLE
Assorted 'ipfs object patch' cleanups

### DIFF
--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -577,19 +577,15 @@ func rmLinkCaller(req cmds.Request, root *dag.Node) (key.Key, error) {
 		return "", err
 	}
 
-	name := req.Arguments()[2]
+	ctx := req.Context().Context
+	path := req.Arguments()[2]
+	parts := strings.Split(path, "/")
 
-	err = root.RemoveNodeLink(name)
+	newRoot, err := insertNodeAtPath(ctx, nd.DAG, root, parts, nil)
 	if err != nil {
 		return "", err
 	}
-
-	newkey, err := nd.DAG.Add(root)
-	if err != nil {
-		return "", err
-	}
-
-	return newkey, nil
+	return newRoot.Key()
 }
 
 func addLinkCaller(req cmds.Request, root *dag.Node) (key.Key, error) {

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -431,9 +431,31 @@ var objectPatchCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Create a new merkledag object based on an existing one",
 		ShortDescription: `
-'ipfs object patch <root> [add-link|rm-link] <args>' is a plumbing command used to
-build custom DAG objects. It adds and removes links from objects, creating a new
-object as a result. This is the merkle-dag version of modifying an object.
+'ipfs object patch <root> [action] <args>' is a plumbing command used
+to build custom DAG objects. It adds and removes links from objects or
+manipulates their data, creating new objects as a result. This is the
+merkle-dag version of modifying an object.
+
+Actions and their expected arguments:
+
+    * add-link PATH LINK_HASH
+      Creates a new link referencing LINK_HASH named after the final
+      segment of PATH and bubbles the Merkle node changes up the path
+      to return the new root. If some intermediate nodes in PATH are
+      missing, add-link will automatically create new nodes for them.
+    * rm-link PATH
+      Removes any links named after the final segment of PATH and
+      bubbles the Merkle node changes up the path to return the new
+      root.
+    * set-data BINARY_DATA
+      Set the root node's data to BINARY_DATA.
+    * append-data BINARY_DATA
+      Append BINARY_DATA to the root node's existing data.
+
+The nodes auto-created by add-link are basic Merkle nodes, not the
+directory nodes used for filesystem entries.  To auto-create those
+you'd need a filesystem-level version of the patch command (which
+hasn't been written yet).
 
 Examples:
 
@@ -529,7 +551,7 @@ resulting object hash.
 
 func appendDataCaller(req cmds.Request, root *dag.Node) (key.Key, error) {
 	if len(req.Arguments()) < 3 {
-		return "", fmt.Errorf("not enough arguments for set-data")
+		return "", fmt.Errorf("not enough arguments for append-data")
 	}
 
 	nd, err := req.Context().GetNode()

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -655,7 +655,7 @@ func addLinkCaller(ctx context.Context, ds dag.DAGService, root *dag.Node, path 
 func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, path []string, toinsert *dag.Node, write bool) (*dag.Node, error) {
 	if len(path) == 1 {
 		if toinsert == nil {
-			err := root.RemoveNodeLink(path[0])
+			err := root.RemoveNodeLinks(path[0])
 			if err != nil {
 				return nil, err
 			}
@@ -690,7 +690,7 @@ func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, pa
 		return nil, err
 	}
 
-	err = root.RemoveNodeLink(path[0])
+	err = root.RemoveNodeLinks(path[0])
 	if err != nil && err != dag.ErrNotFound {
 		return nil, err
 	}

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -137,6 +137,23 @@ func (n *Node) RemoveNodeLink(name string) error {
 	return ErrNotFound
 }
 
+// Remove all links on this node by the given name
+func (n *Node) RemoveNodeLinks(name string) error {
+	n.encoded = nil
+	found := false
+	for i := len(n.Links) - 1; i >= 0; i-- {
+		link := n.Links[i]
+		if link.Name == name {
+			n.Links = append(n.Links[:i], n.Links[i+1:]...)
+			found = true
+		}
+	}
+	if found {
+		return nil
+	}
+	return ErrNotFound
+}
+
 // Return a copy of the link with given name
 func (n *Node) GetNodeLink(name string) (*Link, error) {
 	for _, l := range n.Links {

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -118,6 +118,22 @@ test_object_cmd() {
 		test_cmp rmlink_exp rmlink_output
 	'
 
+	test_expect_success "'ipfs object patch set-data' should work" '
+		EMPTY=$(ipfs object new) &&
+		printf %s "hello world" >set_data_expected &&
+		PATCHED=$(ipfs object patch $EMPTY set-data "$(<set_data_expected)") &&
+		ipfs object data $PATCHED >set_data &&
+		test_cmp set_data_expected set_data
+	'
+
+	test_expect_success "'ipfs object patch set-data' should overwrite existing data" '
+		EMPTY_DIR=$(ipfs object new unixfs-dir) &&
+		printf %s "hello world" >set_data_overwrite_expected &&
+		PATCHED=$(ipfs object patch $EMPTY_DIR set-data "$(<set_data_overwrite_expected)") &&
+		ipfs object data $PATCHED >set_data_overwrite &&
+		test_cmp set_data_overwrite_expected set_data_overwrite
+	'
+
 	test_expect_success "multilayer patch add-link auto-creates directories" '
 		echo "hello world" > hwfile &&
 		FILE=$(ipfs add -q hwfile) &&

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -109,6 +109,60 @@ test_object_cmd() {
 		test_cmp patched_exp patched_output
 	'
 
+	test_expect_success "object patch add-link can create links with existing names" '
+		EMPTY=$(ipfs object new) &&
+		P1=$(ipfs object patch $EMPTY add-link foo $EMPTY) &&
+		ipfs object patch $P1 add-link foo $EMPTY >multiple_add_links
+	'
+
+	test_expect_success "object patch add-link with existing names looks good" '
+		cat <<-\EOF >multiple_add_links_expected_newline &&
+			{
+			  "Links": [
+			    {
+			      "Name": "foo",
+			      "Hash": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+			      "Size": 0
+			    },
+			    {
+			      "Name": "foo",
+			      "Hash": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+			      "Size": 0
+			    }
+			  ],
+			  "Data": ""
+			}
+		EOF
+		printf %s "$(<multiple_add_links_expected_newline)" >multiple_add_links_expected &&
+		ipfs object get $(<multiple_add_links) >multiple_add_links_output &&
+		test_cmp multiple_add_links_expected multiple_add_links_output
+	'
+
+	test_expect_success "object patch replace-link overwrites existing names" '
+		EMPTY=$(ipfs object new) &&
+		EMPTY_DIR=$(ipfs object new unixfs-dir) &&
+		P1=$(ipfs object patch $EMPTY replace-link foo $EMPTY_DIR) &&
+		ipfs object patch $P1 replace-link foo $EMPTY >multiple_replace_links
+	'
+
+	test_expect_success "object patch replace-link with existing names looks good" '
+		cat <<-\EOF >multiple_replace_links_expected_newline &&
+			{
+			  "Links": [
+			    {
+			      "Name": "foo",
+			      "Hash": "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+			      "Size": 0
+			    }
+			  ],
+			  "Data": ""
+			}
+		EOF
+		printf %s "$(<multiple_replace_links_expected_newline)" >multiple_replace_links_expected &&
+		ipfs object get $(<multiple_replace_links) >multiple_replace_links_output &&
+		test_cmp multiple_replace_links_expected multiple_replace_links_output
+	'
+
 	test_expect_success "can remove the directory" '
 		ipfs object patch $OUTPUT rm-link foo > rmlink_output
 	'

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -118,6 +118,36 @@ test_object_cmd() {
 		test_cmp rmlink_exp rmlink_output
 	'
 
+	test_expect_success "multilayer patch add-link auto-creates directories" '
+		echo "hello world" > hwfile &&
+		FILE=$(ipfs add -q hwfile) &&
+		EMPTY=$(ipfs object new unixfs-dir) &&
+		ipfs object patch $EMPTY add-link a/b/c $FILE >multi_patch_add_auto_create_directories
+	'
+
+	test_expect_success "multilayer patch add-link auto-create leaf looks good" '
+		ipfs cat $(<multi_patch_add_auto_create_directories)/a/b/c >multi_patch_add_auto_create_leaf &&
+		test_cmp hwfile multi_patch_add_auto_create_leaf
+	'
+
+	test_expect_success "multilayer patch add-link auto-create intermediate looks good" '
+		cat <<-\EOF >multi_patch_add_auto_create_intermediate_expected_newline &&
+			{
+			  "Links": [
+			    {
+			      "Name": "c",
+			      "Hash": "QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o",
+			      "Size": 20
+			    }
+			  ],
+			  "Data": ""
+			}
+		EOF
+		printf %s "$(<multi_patch_add_auto_create_intermediate_expected_newline)" >multi_patch_add_auto_create_intermediate_expected &&
+		ipfs object get $(<multi_patch_add_auto_create_directories)/a/b >multi_patch_add_auto_create_intermediate &&
+		test_cmp multi_patch_add_auto_create_intermediate_expected multi_patch_add_auto_create_intermediate
+	'
+
 	test_expect_success "multilayer ipfs patch works" '
 		echo "hello world" > hwfile &&
 		FILE=$(ipfs add -q hwfile) &&
@@ -128,7 +158,7 @@ test_object_cmd() {
 	'
 
 	test_expect_success "output looks good" '
-		ipfs cat $(cat multi_patch)/a/b/c > hwfile_out &&
+		ipfs cat $(<multi_patch)/a/b/c > hwfile_out &&
 		test_cmp hwfile hwfile_out
 	'
 }

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -100,20 +100,6 @@ test_object_cmd() {
 		OUTPUT=$(ipfs object patch $EMPTY_DIR add-link foo $EMPTY_DIR)
 	'
 
-	test_expect_success "multilayer ipfs patch works" '
-		echo "hello world" > hwfile &&
-		FILE=$(ipfs add -q hwfile) &&
-		EMPTY=$(ipfs object new unixfs-dir) &&
-		ONE=$(ipfs object patch $EMPTY add-link b $EMPTY) &&
-		TWO=$(ipfs object patch $EMPTY add-link a $ONE) &&
-		ipfs object patch $TWO add-link a/b/c $FILE > multi_patch
-	'
-
-	test_expect_success "output looks good" '
-		ipfs cat $(cat multi_patch)/a/b/c > hwfile_out &&
-		test_cmp hwfile hwfile_out
-	'
-
 	test_expect_success "should have created dir within a dir" '
 		ipfs ls $OUTPUT > patched_output
 	'
@@ -130,6 +116,20 @@ test_object_cmd() {
 	test_expect_success "output should be empty" '
 		echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn > rmlink_exp &&
 		test_cmp rmlink_exp rmlink_output
+	'
+
+	test_expect_success "multilayer ipfs patch works" '
+		echo "hello world" > hwfile &&
+		FILE=$(ipfs add -q hwfile) &&
+		EMPTY=$(ipfs object new unixfs-dir) &&
+		ONE=$(ipfs object patch $EMPTY add-link b $EMPTY) &&
+		TWO=$(ipfs object patch $EMPTY add-link a $ONE) &&
+		ipfs object patch $TWO add-link a/b/c $FILE > multi_patch
+	'
+
+	test_expect_success "output looks good" '
+		ipfs cat $(cat multi_patch)/a/b/c > hwfile_out &&
+		test_cmp hwfile hwfile_out
 	'
 }
 

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -172,6 +172,25 @@ test_object_cmd() {
 		test_cmp rmlink_exp rmlink_output
 	'
 
+	test_expect_success "object patch rm-link removes multiple links" '
+		EMPTY=$(ipfs object new) &&
+		P1=$(ipfs object patch $EMPTY add-link foo $EMPTY) &&
+		P2=$(ipfs object patch $P1 add-link foo $EMPTY) &&
+		ipfs object patch $P2 rm-link foo >rm_multiple_links
+	'
+
+	test_expect_success "object patch rm-link multi-link removal looks good" '
+		cat <<-\EOF >rm_multiple_links_expected_newline &&
+			{
+			  "Links": [],
+			  "Data": ""
+			}
+		EOF
+		printf %s "$(<rm_multiple_links_expected_newline)" >rm_multiple_links_expected &&
+		ipfs object get $(<rm_multiple_links) >rm_multiple_links_actual &&
+		test_cmp rm_multiple_links_expected rm_multiple_links_actual
+	'
+
 	test_expect_success "'ipfs object patch set-data' should work" '
 		EMPTY=$(ipfs object new) &&
 		printf %s "hello world" >set_data_expected &&

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -134,6 +134,23 @@ test_object_cmd() {
 		test_cmp set_data_overwrite_expected set_data_overwrite
 	'
 
+	test_expect_success "'ipfs object patch append-data' should work" '
+		EMPTY=$(ipfs object new) &&
+		printf %s "hello world" >empty_append_data_expected &&
+		PATCHED=$(ipfs object patch $EMPTY append-data "$(<empty_append_data_expected)") &&
+		ipfs object data $PATCHED >empty_append_data &&
+		test_cmp empty_append_data_expected empty_append_data
+	'
+
+	test_expect_success "'ipfs object patch append-data' should append to existing data" '
+		EMPTY=$(ipfs object new) &&
+		printf %s "hello world" >append_data_expected &&
+		P1=$(ipfs object patch $EMPTY append-data "hello") &&
+		P2=$(ipfs object patch $P1 append-data " world") &&
+		ipfs object data $P2 >append_data &&
+		test_cmp append_data_expected append_data_expected
+	'
+
 	test_expect_success "multilayer patch add-link auto-creates directories" '
 		echo "hello world" > hwfile &&
 		FILE=$(ipfs add -q hwfile) &&


### PR DESCRIPTION
Lots of detail and motivation in the commit messages themselves.
Major changes:

* New replace-link action.
* Both add-link and replace-link auto-create nodes for any missing
  intermediate paths (more on this below).
* rm-link now removes all links matching a name (not just the first).
* Docs and tests for all the actions :).

I expect most of this to be fairly non-controversial (although I've
been wrong about that sort of thing before ;).  The main UI thing we
need to work out is auto-creating intermediate nodes.  Talking about
this on IRC, @whyrusleeping expressed concern about auto-creation as
part of the object-patch command (see [1] through [2]).  Options I
see:

a. Keep the auto-creation as it's currently implemented in this PR
   (i.e. just do it).  Folks who typo paths may end up accidentally
   creating a few DAG entries, but that's not a big deal (we don't
   even pin the stuff made by `object patch` as far as I can tell).
   Folks who want a different intermediate node can either patch the
   auto-created node, or build their indentded intermediate node first
   and then run the bubbling patch through that node (or any of its
   ancestors).

b. Add a flag enabling auto-creation (like `mkdir`'s `-p` /
   `--parents`).  This lets folks like me (who don't want them)
   opt-out of typo'ed path checks, but keeps the checks in place for
   users who haven't thought about what they want (and who may
   therefore expect errors in the missing-intermediate case).  This
   approach almost ties with (a) for me, since `-p` isn't that hard to
   type (and I could always alias it), with the main drawback being an
   extra knob that I don't really think we need.  This option still
   doesn't give the control @whyrusleeping apparently desires over the
   auto-created objects themselves.

c. Add a flag (`-t` / `--template`?) that accepts all the strings
   understood by `ipfs object new`.  Then we use the same logic
   internally when auto-creating intermediates.  This gives some
   control over the auto-created objects, which may satisfy
   @whyrusleeping.  On the other hand, the only template there is
   currently unixfs-new, and for creating intermediates that are
   Unix-FS directories I think we should really be looking at an `ipfs
   file patch …` command that auto-creates directories by default.  It
   would also handle things like transparent sharding, chunking, and
   shard/chunk-transparent Path resolution (e.g. an `a/b/c` path would
   work even if the Merkle representation was:

        {a-shard-root}→{a-shard}→{b-shard-root}→{b-shard}→{c-chunk-root}→[{c-chunks}…]

d. Create some new command that handles the auto-creation in a
   separate step.  But then folks like me that can (with this PR) run:

        $ ipfs object patch $ROOT replace-link a/b/c $CONTENT

   would need to run something like:

        $ if ipfs object ls $ROOT/a/b >/dev/null 2>&1
        > then  # parent already exists
        >   ipfs object patch $ROOT replace-link a/b/c $CONTENT
        > else
        >   ipfs object mkdir -p $ROOT/a/b &&
        >   ipfs object patch $ROOT add-link a/b/c $CONTENT
        > fi

   and that seems like useless hoop-jumping.

[1]: https://botbot.me/freenode/ipfs/2015-06-20/?msg=42439389&page=4
[2]: https://botbot.me/freenode/ipfs/2015-06-20/?msg=42445602&page=5