### PR TITLE
add test for only-hash to ensure no blocks are added to datastore

### DIFF
--- a/test/sharness/t0041-add-cat-offline.sh
+++ b/test/sharness/t0041-add-cat-offline.sh
@@ -45,4 +45,12 @@ test_expect_success "output looks good" '
 	test_cmp afile out_2
 '
 
+test_expect_success "ipfs add --only-hash succeeds" '
+	echo "unknown content for only-hash" | ipfs add --only-hash -q > oh_hash
+'
+
+test_expect_success "ipfs cat file fails" '
+	test_must_fail ipfs cat $(cat oh_hash)
+'
+
 test_done


### PR DESCRIPTION
A test that should have made it into #1417 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>