### PR TITLE
swarm: fix peers_total metric

### DIFF
--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -289,11 +289,11 @@ func (n *ps2netNotifee) ClosedStream(s *ps.Stream) {
 type metricsNotifiee Swarm
 
 func (nn *metricsNotifiee) Connected(n inet.Network, v inet.Conn) {
-	peersTotalGauge(n.LocalPeer()).Inc()
+	peersTotalGauge(n.LocalPeer()).Set(float64(len(n.Conns())))
 }
 
 func (nn *metricsNotifiee) Disconnected(n inet.Network, v inet.Conn) {
-	peersTotalGauge(n.LocalPeer()).Dec()
+	peersTotalGauge(n.LocalPeer()).Set(float64(len(n.Conns())))
 }
 
 func (nn *metricsNotifiee) OpenedStream(n inet.Network, v inet.Stream) {}

--- a/p2p/net/swarm/swarm_net.go
+++ b/p2p/net/swarm/swarm_net.go
@@ -58,12 +58,12 @@ func (n *Network) LocalPeer() peer.ID {
 	return n.Swarm().LocalPeer()
 }
 
-// Peers returns the connected peers
+// Peers returns the known peer IDs from the Peerstore
 func (n *Network) Peers() []peer.ID {
 	return n.Swarm().Peers()
 }
 
-// Peers returns the connected peers
+// Peers returns the Peerstore, which tracks known peers
 func (n *Network) Peerstore() peer.Peerstore {
 	return n.Swarm().peers
 }


### PR DESCRIPTION
Connection notifications tend to not fire exactly-once, so we always update the metric with the total number, instead of incrementing/decrementing.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>