### PR TITLE
Assert and convert config value into predefined struct

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -181,7 +181,7 @@ variable set to your preferred text editor.
 
 var configReplaceCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Replaces the config with `file>",
+		Tagline: "Replaces the config with <file>",
 		ShortDescription: `
 Make sure to back up the config file first if neccessary, this operation
 can't be undone.

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -65,7 +65,7 @@ ipfs daemon --mount
 If you wish to allow other users to use the mount points, use the following:
 
 ```sh
-ipfs config Mounts.FuseAllowOther --bool true
+ipfs config Mounts.FuseAllowOther true
 ipfs daemon --mount
 ```
 


### PR DESCRIPTION
Basically with this PR, 'true' is parsed as boolean, making explicit '--bool'/'--number'/'--string' optional if there is already config struct.

Lower dose version of https://github.com/ipfs/go-ipfs/pull/1355 that doesn't break backward compatibility.