### PR TITLE
Allow CORS for gateway handler.

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -133,6 +133,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Set("X-IPFS-Path", urlPath)
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	// Suborigin header, sandboxes apps from each other in the browser (even
 	// though they are served from the same gateway domain). NOTE: This is not


### PR DESCRIPTION
The gateway endpoint is read-only anyway. This enables gateways to service other sites on the regular internet.