### PR TITLE
core/commands/unixfs/ls: Drop multi-column example from --help

### DIFF
--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -40,12 +40,11 @@ var LsCmd = &cmds.Command{
 		Tagline: "List directory contents for Unix-filesystem objects",
 		ShortDescription: `
 Retrieves the object named by <ipfs-or-ipns-path> and displays the
-contents with the following format:
+contents.
 
-  <hash> <type> <size> <name>
-
-For files, the child size is the total size of the file contents.  For
-directories, the child size is the IPFS link size.
+The JSON output contains size information.  For files, the child size
+is the total size of the file contents.  For directories, the child
+size is the IPFS link size.
 `,
 	},
 


### PR DESCRIPTION
The old text belonged to an earlier iteration that didn't land in the
rebased 434871ba (core/commands/unixfs: Add 'ipfs unixfs ls ...',
2015-06-09).