### PR TITLE
Add locking interface to blockstore

### DIFF
--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -4,6 +4,7 @@ package blockstore
 
 import (
 	"errors"
+	"sync"
 
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	dsns "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace"
@@ -34,7 +35,14 @@ type Blockstore interface {
 	AllKeysChan(ctx context.Context) (<-chan key.Key, error)
 }
 
-func NewBlockstore(d ds.ThreadSafeDatastore) Blockstore {
+type GCBlockstore interface {
+	Blockstore
+
+	Lock() func()
+	RLock() func()
+}
+
+func NewBlockstore(d ds.ThreadSafeDatastore) *blockstore {
 	dd := dsns.Wrap(d, BlockPrefix)
 	return &blockstore{
 		datastore: dd,
@@ -45,6 +53,8 @@ type blockstore struct {
 	datastore ds.Datastore
 	// cant be ThreadSafeDatastore cause namespace.Datastore doesnt support it.
 	// we do check it on `NewBlockstore` though.
+
+	lk sync.RWMutex
 }
 
 func (bs *blockstore) Get(k key.Key) (*blocks.Block, error) {
@@ -150,4 +160,14 @@ func (bs *blockstore) AllKeysChan(ctx context.Context) (<-chan key.Key, error) {
 	}()
 
 	return output, nil
+}
+
+func (bs *blockstore) Lock() func() {
+	bs.lk.Lock()
+	return bs.lk.Unlock
+}
+
+func (bs *blockstore) RLock() func() {
+	bs.lk.RLock()
+	return bs.lk.RUnlock
 }

--- a/blocks/blockstore/write_cache.go
+++ b/blocks/blockstore/write_cache.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WriteCached returns a blockstore that caches up to |size| unique writes (bs.Put).
-func WriteCached(bs Blockstore, size int) (Blockstore, error) {
+func WriteCached(bs Blockstore, size int) (*writecache, error) {
 	c, err := lru.New(size)
 	if err != nil {
 		return nil, err
@@ -47,4 +47,12 @@ func (w *writecache) Put(b *blocks.Block) error {
 
 func (w *writecache) AllKeysChan(ctx context.Context) (<-chan key.Key, error) {
 	return w.blockstore.AllKeysChan(ctx)
+}
+
+func (w *writecache) Lock() func() {
+	return w.blockstore.(GCBlockstore).Lock()
+}
+
+func (w *writecache) RLock() func() {
+	return w.blockstore.(GCBlockstore).RLock()
 }

--- a/blocks/blockstore/write_cache.go
+++ b/blocks/blockstore/write_cache.go
@@ -49,10 +49,10 @@ func (w *writecache) AllKeysChan(ctx context.Context) (<-chan key.Key, error) {
 	return w.blockstore.AllKeysChan(ctx)
 }
 
-func (w *writecache) Lock() func() {
-	return w.blockstore.(GCBlockstore).Lock()
+func (w *writecache) GCLock() func() {
+	return w.blockstore.(GCBlockstore).GCLock()
 }
 
-func (w *writecache) RLock() func() {
-	return w.blockstore.(GCBlockstore).RLock()
+func (w *writecache) PinLock() func() {
+	return w.blockstore.(GCBlockstore).PinLock()
 }

--- a/blocks/key/key_set.go
+++ b/blocks/key/key_set.go
@@ -1,46 +1,39 @@
 package key
 
-import (
-	"sync"
-)
-
 type KeySet interface {
 	Add(Key)
+	Has(Key) bool
 	Remove(Key)
 	Keys() []Key
 }
 
-type ks struct {
-	lock sync.RWMutex
-	data map[Key]struct{}
+type keySet struct {
+	keys map[Key]struct{}
 }
 
 func NewKeySet() KeySet {
-	return &ks{
-		data: make(map[Key]struct{}),
+	return &keySet{make(map[Key]struct{})}
+}
+
+func (gcs *keySet) Add(k Key) {
+	gcs.keys[k] = struct{}{}
+}
+
+func (gcs *keySet) Has(k Key) bool {
+	_, has := gcs.keys[k]
+	return has
+}
+
+func (ks *keySet) Keys() []Key {
+	var out []Key
+	for k, _ := range ks.keys {
+		out = append(out, k)
 	}
+	return out
 }
 
-func (wl *ks) Add(k Key) {
-	wl.lock.Lock()
-	defer wl.lock.Unlock()
-
-	wl.data[k] = struct{}{}
+func (ks *keySet) Remove(k Key) {
+	delete(ks.keys, k)
 }
 
-func (wl *ks) Remove(k Key) {
-	wl.lock.Lock()
-	defer wl.lock.Unlock()
-
-	delete(wl.data, k)
-}
-
-func (wl *ks) Keys() []Key {
-	wl.lock.RLock()
-	defer wl.lock.RUnlock()
-	keys := make([]Key, 0)
-	for k := range wl.data {
-		keys = append(keys, k)
-	}
-	return keys
-}
+// TODO: implement disk-backed keyset for working with massive DAGs

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -111,7 +111,7 @@ remains to be implemented.
 			defer close(outChan)
 
 			// lock blockstore to prevent rogue GC
-			unlock := n.Blockstore.RLock()
+			unlock := n.Blockstore.PinLock()
 			defer unlock()
 
 			for {

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -110,6 +110,10 @@ remains to be implemented.
 		go func() {
 			defer close(outChan)
 
+			// lock blockstore to prevent rogue GC
+			unlock := n.Blockstore.RLock()
+			defer unlock()
+
 			for {
 				file, err := req.Files().NextFile()
 				if err != nil && err != io.EOF {

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -50,6 +50,9 @@ on disk.
 			return
 		}
 
+		unlock := n.Blockstore.RLock()
+		defer unlock()
+
 		// set recursive flag
 		recursive, found, err := req.Option("recursive").Bool()
 		if err != nil {

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -50,7 +50,7 @@ on disk.
 			return
 		}
 
-		unlock := n.Blockstore.RLock()
+		unlock := n.Blockstore.PinLock()
 		defer unlock()
 
 		// set recursive flag

--- a/core/core.go
+++ b/core/core.go
@@ -87,7 +87,7 @@ type IpfsNode struct {
 
 	// Services
 	Peerstore  peer.Peerstore       // storage for other Peer instances
-	Blockstore bstore.Blockstore    // the block store (lower level)
+	Blockstore bstore.GCBlockstore  // the block store (lower level)
 	Blocks     *bserv.BlockService  // the block service, get/add blocks.
 	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
 	Resolver   *path.Resolver       // the path resolution system

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -24,7 +24,7 @@ var log = eventlog.Logger("coreunix")
 // Add builds a merkledag from the a reader, pinning all objects to the local
 // datastore. Returns a key representing the root node.
 func Add(n *core.IpfsNode, r io.Reader) (string, error) {
-	unlock := n.Blockstore.RLock()
+	unlock := n.Blockstore.PinLock()
 	defer unlock()
 
 	// TODO more attractive function signature importer.BuildDagFromReader
@@ -47,7 +47,7 @@ func Add(n *core.IpfsNode, r io.Reader) (string, error) {
 
 // AddR recursively adds files in |path|.
 func AddR(n *core.IpfsNode, root string) (key string, err error) {
-	unlock := n.Blockstore.RLock()
+	unlock := n.Blockstore.PinLock()
 	defer unlock()
 
 	f, err := os.Open(root)
@@ -85,7 +85,7 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 // Returns the path of the added file ("<dir hash>/filename"), the DAG node of
 // the directory, and and error if any.
 func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *merkledag.Node, error) {
-	unlock := n.Blockstore.RLock()
+	unlock := n.Blockstore.PinLock()
 	defer unlock()
 
 	file := files.NewReaderFile(filename, ioutil.NopCloser(r), nil)

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -24,6 +24,9 @@ var log = eventlog.Logger("coreunix")
 // Add builds a merkledag from the a reader, pinning all objects to the local
 // datastore. Returns a key representing the root node.
 func Add(n *core.IpfsNode, r io.Reader) (string, error) {
+	unlock := n.Blockstore.RLock()
+	defer unlock()
+
 	// TODO more attractive function signature importer.BuildDagFromReader
 	dagNode, err := importer.BuildDagFromReader(
 		r,
@@ -44,6 +47,9 @@ func Add(n *core.IpfsNode, r io.Reader) (string, error) {
 
 // AddR recursively adds files in |path|.
 func AddR(n *core.IpfsNode, root string) (key string, err error) {
+	unlock := n.Blockstore.RLock()
+	defer unlock()
+
 	f, err := os.Open(root)
 	if err != nil {
 		return "", err
@@ -79,6 +85,9 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 // Returns the path of the added file ("<dir hash>/filename"), the DAG node of
 // the directory, and and error if any.
 func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *merkledag.Node, error) {
+	unlock := n.Blockstore.RLock()
+	defer unlock()
+
 	file := files.NewReaderFile(filename, ioutil.NopCloser(r), nil)
 	dir := files.NewSliceFile("", []files.File{file})
 	dagnode, err := addDir(n, dir)

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -3,7 +3,6 @@ package merkledag
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
@@ -110,41 +109,86 @@ func (n *dagService) Remove(nd *Node) error {
 	return n.Blocks.DeleteBlock(k)
 }
 
-// FetchGraph asynchronously fetches all nodes that are children of the given
-// node, and returns a channel that may be waited upon for the fetch to complete
-func FetchGraph(ctx context.Context, root *Node, serv DAGService) chan struct{} {
-	log.Warning("Untested.")
-	var wg sync.WaitGroup
-	done := make(chan struct{})
+// FetchGraph fetches all nodes that are children of the given node
+func FetchGraph(ctx context.Context, root *Node, serv DAGService) error {
+	toprocess := make(chan []key.Key, 8)
+	nodes := make(chan *Node, 8)
+	errs := make(chan error, 1)
 
-	for _, l := range root.Links {
-		wg.Add(1)
-		go func(lnk *Link) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer close(toprocess)
 
-			// Signal child is done on way out
-			defer wg.Done()
-			select {
-			case <-ctx.Done():
-				return
+	go fetchNodes(ctx, serv, toprocess, nodes, errs)
+
+	nodes <- root
+	live := 1
+
+	for {
+		select {
+		case nd, ok := <-nodes:
+			if !ok {
+				return nil
 			}
 
-			nd, err := lnk.GetNode(ctx, serv)
-			if err != nil {
-				log.Debug(err)
-				return
+			var keys []key.Key
+			for _, lnk := range nd.Links {
+				keys = append(keys, key.Key(lnk.Hash))
+			}
+			keys = dedupeKeys(keys)
+
+			// keep track of open request, when zero, we're done
+			live += len(keys) - 1
+
+			if live == 0 {
+				return nil
 			}
 
-			// Wait for children to finish
-			<-FetchGraph(ctx, nd, serv)
-		}(l)
+			if len(keys) > 0 {
+				select {
+				case toprocess <- keys:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		case err := <-errs:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
+}
 
-	go func() {
-		wg.Wait()
-		done <- struct{}{}
-	}()
+func fetchNodes(ctx context.Context, ds DAGService, in <-chan []key.Key, out chan<- *Node, errs chan<- error) {
+	defer close(out)
+	for {
+		select {
+		case ks, ok := <-in:
+			if !ok {
+				return
+			}
 
-	return done
+			ng := ds.GetNodes(ctx, ks)
+			for _, g := range ng {
+				go func(g NodeGetter) {
+					nd, err := g.Get(ctx)
+					if err != nil {
+						select {
+						case errs <- err:
+						case <-ctx.Done():
+						}
+						return
+					}
+
+					select {
+					case out <- nd:
+					case <-ctx.Done():
+						return
+					}
+				}(g)
+			}
+		}
+	}
 }
 
 // FindLinks searches this nodes links for the given key,
@@ -268,4 +312,25 @@ func (np *nodePromise) Get(ctx context.Context) (*Node, error) {
 		return nil, ctx.Err()
 	}
 	return np.cache, nil
+}
+
+// EnumerateChildren will walk the dag below the given root node and add all
+// unseen children to the passed in set.
+// TODO: parallelize to avoid disk latency perf hits?
+func EnumerateChildren(ctx context.Context, ds DAGService, root *Node, set key.KeySet) error {
+	for _, lnk := range root.Links {
+		k := key.Key(lnk.Hash)
+		if !set.Has(k) {
+			set.Add(k)
+			child, err := ds.Get(ctx, k)
+			if err != nil {
+				return err
+			}
+			err = EnumerateChildren(ctx, ds, child, set)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -111,84 +111,7 @@ func (n *dagService) Remove(nd *Node) error {
 
 // FetchGraph fetches all nodes that are children of the given node
 func FetchGraph(ctx context.Context, root *Node, serv DAGService) error {
-	toprocess := make(chan []key.Key, 8)
-	nodes := make(chan *Node, 8)
-	errs := make(chan error, 1)
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	defer close(toprocess)
-
-	go fetchNodes(ctx, serv, toprocess, nodes, errs)
-
-	nodes <- root
-	live := 1
-
-	for {
-		select {
-		case nd, ok := <-nodes:
-			if !ok {
-				return nil
-			}
-
-			var keys []key.Key
-			for _, lnk := range nd.Links {
-				keys = append(keys, key.Key(lnk.Hash))
-			}
-			keys = dedupeKeys(keys)
-
-			// keep track of open request, when zero, we're done
-			live += len(keys) - 1
-
-			if live == 0 {
-				return nil
-			}
-
-			if len(keys) > 0 {
-				select {
-				case toprocess <- keys:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			}
-		case err := <-errs:
-			return err
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func fetchNodes(ctx context.Context, ds DAGService, in <-chan []key.Key, out chan<- *Node, errs chan<- error) {
-	defer close(out)
-	for {
-		select {
-		case ks, ok := <-in:
-			if !ok {
-				return
-			}
-
-			ng := ds.GetNodes(ctx, ks)
-			for _, g := range ng {
-				go func(g NodeGetter) {
-					nd, err := g.Get(ctx)
-					if err != nil {
-						select {
-						case errs <- err:
-						case <-ctx.Done():
-						}
-						return
-					}
-
-					select {
-					case out <- nd:
-					case <-ctx.Done():
-						return
-					}
-				}(g)
-			}
-		}
-	}
+	return EnumerateChildrenAsync(ctx, serv, root, key.NewKeySet())
 }
 
 // FindLinks searches this nodes links for the given key,
@@ -333,4 +256,84 @@ func EnumerateChildren(ctx context.Context, ds DAGService, root *Node, set key.K
 		}
 	}
 	return nil
+}
+
+func EnumerateChildrenAsync(ctx context.Context, ds DAGService, root *Node, set key.KeySet) error {
+	toprocess := make(chan []key.Key, 8)
+	nodes := make(chan *Node, 8)
+	errs := make(chan error, 1)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer close(toprocess)
+
+	go fetchNodes(ctx, ds, toprocess, nodes, errs)
+
+	nodes <- root
+	live := 1
+
+	for {
+		select {
+		case nd, ok := <-nodes:
+			if !ok {
+				return nil
+			}
+			// a node has been fetched
+			live--
+
+			var keys []key.Key
+			for _, lnk := range nd.Links {
+				k := key.Key(lnk.Hash)
+				if !set.Has(k) {
+					set.Add(k)
+					live++
+					keys = append(keys, k)
+				}
+			}
+
+			if live == 0 {
+				return nil
+			}
+
+			if len(keys) > 0 {
+				select {
+				case toprocess <- keys:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		case err := <-errs:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func fetchNodes(ctx context.Context, ds DAGService, in <-chan []key.Key, out chan<- *Node, errs chan<- error) {
+	defer close(out)
+
+	get := func(g NodeGetter) {
+		nd, err := g.Get(ctx)
+		if err != nil {
+			select {
+			case errs <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		select {
+		case out <- nd:
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	for ks := range in {
+		ng := ds.GetNodes(ctx, ks)
+		for _, g := range ng {
+			go get(g)
+		}
+	}
 }

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -216,26 +216,9 @@ func runBatchFetchTest(t *testing.T, read io.Reader) {
 }
 
 func TestFetchGraph(t *testing.T) {
-	bsi := bstest.Mocks(t, 1)[0]
-	ds := NewDAGService(bsi)
-
-	read := io.LimitReader(u.NewTimeSeededRand(), 1024*32)
-	spl := &chunk.SizeSplitter{512}
-
-	root, err := imp.BuildDagFromReader(read, ds, spl, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = FetchGraph(context.TODO(), root, ds)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestFetchGraphOther(t *testing.T) {
 	var dservs []DAGService
-	for _, bsi := range bstest.Mocks(t, 2) {
+	bsis := bstest.Mocks(t, 2)
+	for _, bsi := range bsis {
 		dservs = append(dservs, NewDAGService(bsi))
 	}
 
@@ -248,6 +231,20 @@ func TestFetchGraphOther(t *testing.T) {
 	}
 
 	err = FetchGraph(context.TODO(), root, dservs[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create an offline dagstore and ensure all blocks were fetched
+	bs, err := bserv.New(bsis[1].Blockstore, offline.Exchange(bsis[1].Blockstore))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	offline_ds := NewDAGService(bs)
+	ks := key.NewKeySet()
+
+	err = EnumerateChildren(context.Background(), offline_ds, root, ks)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The addition of a locking interface to the blockstore allows us to
perform atomic operations on the underlying datastore without having to
worry about different operations happening in the background, such as
garbage collection.

Also implement a few merkledag package changes.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>