### PR TITLE
fix race introduced in bitswap

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -228,13 +228,13 @@ func (bs *Bitswap) HasBlock(ctx context.Context, blk *blocks.Block) error {
 	default:
 	}
 
-	bs.notifications.Publish(blk)
-
 	err := bs.tryPutBlock(blk, 4) // attempt to store block up to four times
 	if err != nil {
 		log.Errorf("Error writing block to datastore: %s", err)
 		return err
 	}
+
+	bs.notifications.Publish(blk)
 
 	select {
 	case bs.newBlocks <- blk:


### PR DESCRIPTION
Doing the publish before the `blockstore.Put` would cause a race where callers of `GetBlock` (in tests) would finish, and then immediately try to read the blocks from the blockstore to verify that the block was received, and the block hadnt quite made it to disk yet by the time that call was made.

repro was running:
```
while go test ./exchange/bitswap -run=TestLargeFile; end
```

for a few minutes, before the fix would fail within a minute, after the fix, ran for ten minutes before i got bored and killed it.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>