### PR TITLE
fix parsing for paths of format <hash>/path

### DIFF
--- a/path/path.go
+++ b/path/path.go
@@ -56,16 +56,19 @@ func ParsePath(txt string) (Path, error) {
 			return kp, nil
 		}
 	}
-	if len(parts) < 3 {
-		return "", ErrBadPath
-	}
 
+	// if the path doesnt being with a '/'
+	// we expect this to start with a hash, and be an 'ipfs' path
 	if parts[0] != "" {
 		if _, err := ParseKeyToPath(parts[0]); err != nil {
 			return "", ErrBadPath
 		}
 		// The case when the path starts with hash without a protocol prefix
 		return Path("/ipfs/" + txt), nil
+	}
+
+	if len(parts) < 3 {
+		return "", ErrBadPath
 	}
 
 	if parts[1] == "ipfs" {

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -1,0 +1,30 @@
+package path
+
+import (
+	"testing"
+)
+
+func TestPathParsing(t *testing.T) {
+	cases := map[string]bool{
+		"/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n":             true,
+		"/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a":           true,
+		"/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f": true,
+		"/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f": true,
+		"/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n":             true,
+		"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f":       true,
+		"QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n":                   true,
+		"/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n":                  false,
+		"/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a":                false,
+		"/ipfs/": false,
+		"ipfs/":  false,
+		"ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n": false,
+	}
+
+	for p, expected := range cases {
+		_, err := ParsePath(p)
+		valid := (err == nil)
+		if valid != expected {
+			t.Fatalf("expected %s to have valid == %s", p, expected)
+		}
+	}
+}

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -114,6 +114,19 @@ test_object_cmd() {
 		test_cmp hwfile hwfile_out
 	'
 
+	test_expect_success "ipfs object stat path succeeds" '
+		ipfs object stat $(cat multi_patch)/a/b/c > obj_stat_out
+	'
+
+	test_expect_success "ipfs object stat output looks good" '
+		echo NumLinks: 0 > obj_stat_exp && 
+		echo BlockSize: 20 >> obj_stat_exp && 
+		echo LinksSize: 2 >> obj_stat_exp && 
+		echo DataSize: 18 >> obj_stat_exp && 
+		echo CumulativeSize: 20 >> obj_stat_exp && 
+		test_cmp obj_stat_out obj_stat_exp
+	'
+
 	test_expect_success "should have created dir within a dir" '
 		ipfs ls $OUTPUT > patched_output
 	'

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -115,15 +115,16 @@ test_object_cmd() {
 	'
 
 	test_expect_success "ipfs object stat path succeeds" '
-		ipfs object stat $(cat multi_patch)/a/b/c > obj_stat_out
+		ipfs object stat $(cat multi_patch)/a > obj_stat_out
 	'
 
 	test_expect_success "ipfs object stat output looks good" '
-		echo NumLinks: 0 > obj_stat_exp && 
-		echo BlockSize: 20 >> obj_stat_exp && 
-		echo LinksSize: 2 >> obj_stat_exp && 
-		echo DataSize: 18 >> obj_stat_exp && 
-		echo CumulativeSize: 20 >> obj_stat_exp && 
+		echo NumLinks: 1 > obj_stat_exp &&
+		echo BlockSize: 47 >> obj_stat_exp &&
+		echo LinksSize: 45 >> obj_stat_exp &&
+		echo DataSize: 2 >> obj_stat_exp &&
+		echo CumulativeSize: 114 >> obj_stat_exp &&
+
 		test_cmp obj_stat_out obj_stat_exp
 	'
 


### PR DESCRIPTION
with this we can now do
```
ipfs object stat <hash>/a/b/c
```

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>