### PR TITLE
include hash of resolved object in object stat output

### DIFF
--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -109,12 +109,19 @@ func SubtestNodeStat(t *testing.T, n *Node) {
 		return
 	}
 
+	k, err := n.Key()
+	if err != nil {
+		t.Error("n.Key() failed")
+		return
+	}
+
 	expected := NodeStat{
 		NumLinks:       len(n.Links),
 		BlockSize:      len(enc),
 		LinksSize:      len(enc) - len(n.Data), // includes framing.
 		DataSize:       len(n.Data),
 		CumulativeSize: int(cumSize),
+		Hash:           k.B58String(),
 	}
 
 	actual, err := n.Stat()
@@ -124,7 +131,7 @@ func SubtestNodeStat(t *testing.T, n *Node) {
 	}
 
 	if expected != *actual {
-		t.Error("n.Stat incorrect.\nexpect: %s\nactual: %s", expected, actual)
+		t.Errorf("n.Stat incorrect.\nexpect: %s\nactual: %s", expected, actual)
 	} else {
 		fmt.Printf("n.Stat correct: %s\n", actual)
 	}

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -23,6 +23,7 @@ type Node struct {
 
 // NodeStat is a statistics object for a Node. Mostly sizes.
 type NodeStat struct {
+	Hash           string
 	NumLinks       int // number of links in link table
 	BlockSize      int // size of the raw, encoded data
 	LinksSize      int // size of the links segment
@@ -201,7 +202,13 @@ func (n *Node) Stat() (*NodeStat, error) {
 		return nil, err
 	}
 
+	key, err := n.Key()
+	if err != nil {
+		return nil, err
+	}
+
 	return &NodeStat{
+		Hash:           key.B58String(),
 		NumLinks:       len(n.Links),
 		BlockSize:      len(enc),
 		LinksSize:      len(enc) - len(n.Data), // includes framing.


### PR DESCRIPTION
this way i can do: `ipfs object stat a/b/c/d/e/f/g` and get the hash of `g`. Essentially exposing core.Resolve through the API.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>