### PR TITLE
Implement http trailers for error handling

### DIFF
--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -34,6 +34,9 @@ type client struct {
 }
 
 func NewClient(address string) Client {
+	// We cannot use the default transport because of a bug in go's connection reuse
+	// code. It causes random failures in the connection including io.EOF and connection
+	// refused on 'client.Do'
 	return &client{
 		serverAddress: address,
 		httpClient: http.Client{

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -242,6 +242,8 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 	return res, nil
 }
 
+// read json objects off of the given stream, and write the objects out to
+// the 'out' channel
 func readStreamedJson(req cmds.Request, httpRes *http.Response, out chan<- interface{}) {
 	defer close(out)
 	dec := json.NewDecoder(&httpResponseReader{httpRes})
@@ -270,6 +272,8 @@ func readStreamedJson(req cmds.Request, httpRes *http.Response, out chan<- inter
 	}
 }
 
+// decode a value of the given type, if the type is nil, attempt to decode into
+// an interface{} anyways
 func decodeTypedVal(t reflect.Type, dec *json.Decoder) (interface{}, error) {
 	var v interface{}
 	var err error
@@ -283,6 +287,9 @@ func decodeTypedVal(t reflect.Type, dec *json.Decoder) (interface{}, error) {
 	return v, err
 }
 
+// httpResponseReader reads from the response body, and checks for an error
+// in the http trailer upon EOF, this error if present is returned instead
+// of the EOF.
 type httpResponseReader struct {
 	resp *http.Response
 }

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -36,10 +36,14 @@ const (
 	StreamErrHeader        = "X-Stream-Error"
 	streamHeader           = "X-Stream-Output"
 	channelHeader          = "X-Chunked-Output"
+	uaHeader               = "User-Agent"
 	contentTypeHeader      = "Content-Type"
 	contentLengthHeader    = "Content-Length"
+	contentDispHeader      = "Content-Disposition"
 	transferEncodingHeader = "Transfer-Encoding"
 	applicationJson        = "application/json"
+	applicationOctetStream = "application/octet-stream"
+	plainText              = "text/plain"
 )
 
 var mimeTypes = map[string]string{
@@ -156,7 +160,7 @@ func sendResponse(w http.ResponseWriter, req cmds.Request, res cmds.Response) {
 		return
 	}
 
-	status := 200
+	status := http.StatusOK
 	// if response contains an error, write an HTTP error status code
 	if e := res.Error(); e != nil {
 		if e.Code == cmds.ErrClient {

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -193,6 +193,7 @@ func sendResponse(w http.ResponseWriter, req cmds.Request, res cmds.Response) {
 			mime = applicationJson
 		}
 	}
+
 	if mime != "" {
 		h.Set(contentTypeHeader, mime)
 	}
@@ -207,6 +208,7 @@ func sendResponse(w http.ResponseWriter, req cmds.Request, res cmds.Response) {
 // Copies from an io.Reader to a http.ResponseWriter.
 // Flushes chunks over HTTP stream as they are read (if supported by transport).
 func copyChunks(status int, w http.ResponseWriter, out io.Reader) error {
+	// hijack the connection so we can write our own chunked output and trailers
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		log.Error("Failed to create hijacker! cannot continue!")

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -166,19 +166,14 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	streamChans, _, _ := req.Option("stream-channels").Bool()
 	if isChan && streamChans {
-		// w.WriteString(transferEncodingHeader + ": chunked\r\n")
-		// w.Header().Set(channelHeader, "1")
-		// w.WriteHeader(200)
-		err = copyChunks(applicationJson, w, out)
-		if err != nil {
-			log.Debug("copy chunks error: ", err)
+		if err := copyChunks(applicationJson, w, out); err != nil {
+			log.Error("error while writing stream", err)
 		}
 		return
 	}
 
-	err = flushCopy(w, out)
-	if err != nil {
-		log.Debug("Flush copy returned an error: ", err)
+	if err := flushCopy(w, out); err != nil {
+		log.Error("error while writing stream", err)
 	}
 }
 

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -120,8 +120,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			bar.Start()
 			defer bar.Finish()
 
-			_, err = io.Copy(file, pbReader)
-			if err != nil {
+			if _, err := io.Copy(file, pbReader); err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
@@ -140,10 +139,8 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 
 		bar.Start()
 		defer bar.Finish()
-
 		extractor := &tar.Extractor{outPath}
-		err = extractor.Extract(reader)
-		if err != nil {
+		if err := extractor.Extract(reader); err != nil {
 			res.SetError(err, cmds.ErrNormal)
 		}
 	},
@@ -169,7 +166,7 @@ func get(ctx context.Context, node *core.IpfsNode, p path.Path, compression int)
 		return nil, err
 	}
 
-	return utar.NewReader(p, node.DAG, dagnode, compression)
+	return utar.NewReader(ctx, p, node.DAG, dagnode, compression)
 }
 
 // getZip is equivalent to `ipfs getdag $hash | gzip`

--- a/thirdparty/tar/extractor.go
+++ b/thirdparty/tar/extractor.go
@@ -39,15 +39,13 @@ func (te *Extractor) Extract(reader io.Reader) error {
 		}
 
 		if header.Typeflag == tar.TypeDir {
-			err = te.extractDir(header, i, exists)
-			if err != nil {
+			if err := te.extractDir(header, i, exists); err != nil {
 				return err
 			}
 			continue
 		}
 
-		err = te.extractFile(header, tarReader, i, exists, pathIsDir)
-		if err != nil {
+		if err := te.extractFile(header, tarReader, i, exists, pathIsDir); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR started off as a quick fix for the get command, but turned into a moderately large refactor of the http commands library.