### PR TITLE
set identity on core mock to fix ipns tests

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -130,8 +130,12 @@ func NewIPFSNode(ctx context.Context, option ConfigOption) (*IpfsNode, error) {
 		return nil, err
 	}
 
-	node.proc = goprocessctx.WithContextAndTeardown(ctx, node.teardown)
-	node.ctx = ctx
+	if node.ctx == nil {
+		node.ctx = ctx
+	}
+	if node.proc == nil {
+		node.proc = goprocessctx.WithContextAndTeardown(node.ctx, node.teardown)
+	}
 
 	success := false // flip to true after all sub-system inits succeed
 	defer func() {
@@ -216,6 +220,9 @@ func standardWithRouting(r repo.Repo, online bool, routingOption RoutingOption, 
 			}(),
 			Repo: r,
 		}
+
+		n.ctx = ctx
+		n.proc = goprocessctx.WithContextAndTeardown(ctx, n.teardown)
 
 		// setup Peerstore
 		n.Peerstore = peer.NewPeerstore()

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -55,6 +55,7 @@ func NewMockNode() (*core.IpfsNode, error) {
 	nd.Peerstore = peer.NewPeerstore()
 	nd.Peerstore.AddPrivKey(p, ident.PrivateKey())
 	nd.Peerstore.AddPubKey(p, ident.PublicKey())
+	nd.Identity = p
 
 	nd.PeerHost, err = mocknet.New(ctx).AddPeer(ident.PrivateKey(), ident.Address()) // effectively offline
 	if err != nil {

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	syncds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
 	blockservice "github.com/ipfs/go-ipfs/blockservice"
 	commands "github.com/ipfs/go-ipfs/commands"
@@ -24,7 +25,7 @@ import (
 
 // TODO this is super sketch. Deprecate and initialize one that shares code
 // with the actual core constructor. Lots of fields aren't initialized.
-// Additionally, the context group isn't wired up. This is as good as broken.
+// "This is as good as broken." --- is it?
 
 // NewMockNode constructs an IpfsNode for use in tests.
 func NewMockNode() (*core.IpfsNode, error) {
@@ -57,7 +58,7 @@ func NewMockNode() (*core.IpfsNode, error) {
 	nd.Peerstore.AddPubKey(p, ident.PublicKey())
 	nd.Identity = p
 
-	nd.PeerHost, err = mocknet.New(ctx).AddPeer(ident.PrivateKey(), ident.Address()) // effectively offline
+	nd.PeerHost, err = mocknet.New(nd.Context()).AddPeer(ident.PrivateKey(), ident.Address()) // effectively offline
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The fuse tests were failing because the mock node didnt have the identity set.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>