### PR TITLE
Fix refs u

### DIFF
--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -232,10 +232,6 @@ func (rw *RefWriter) writeRefsRecursive(n *dag.Node) (int, error) {
 		return 0, err
 	}
 
-	if rw.skip(nkey) {
-		return 0, nil
-	}
-
 	var count int
 	for i, ng := range rw.DAG.GetDAG(rw.Ctx, n) {
 		lk := key.Key(n.Links[i].Hash)

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -187,6 +187,29 @@ test_expect_success "'ipfs refs --unique --recursive' is correct" '
 	test_cmp expected line_count
 '
 
+test_expect_success "'ipfs refs --recursive (bigger)'" '
+	mkdir -p b/c/d/e &&
+	echo "content1" >b/f &&
+	echo "content1" >b/c/f1 &&
+	echo "content1" >b/c/d/f2 &&
+	echo "content2" >b/c/f2 &&
+	echo "content2" >b/c/d/f1 &&
+	echo "content2" >b/c/d/e/f &&
+	cp -r b b2 && mv b2 b/b2 &&
+	cp -r b b3 && mv b3 b/b3 &&
+	cp -r b b4 && mv b4 b/b4 &&
+	hash=$(ipfs add -r -q b | tail -n1) &&
+	ipfs refs -r "$hash" | wc -l | sed "s/^ *//g" >actual &&
+	echo "79" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "'ipfs refs --unique --recursive (bigger)'" '
+	ipfs refs -r "$hash" | sort | uniq >expected &&
+	ipfs refs -r -u "$hash" | sort >actual &&
+	test_cmp expected actual
+'
+
 test_kill_ipfs_daemon
 
 test_done

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -66,6 +66,7 @@ test_expect_success "file no longer pinned" '
 '
 
 test_expect_success "recursively pin afile" '
+	HASH=`ipfs add -q afile` &&
 	ipfs pin add -r "$HASH"
 '
 

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -163,6 +163,30 @@ test_expect_success "'ipfs pin ls --type=all --quiet' is correct" '
 	test_sort_cmp allpins_uniq_hashes actual_allpins
 '
 
+test_expect_success "'ipfs refs --unique' is correct" '
+	mkdir -p uniques &&
+	cd uniques &&
+	echo "content1" > file1 &&
+	echo "content1" > file2 &&
+	ROOT=$(ipfs add -r -q . | tail -n1) &&
+	ipfs refs --unique $ROOT >expected &&
+	ipfs add -q file1 >unique_hash &&
+	test_cmp expected unique_hash
+'
+
+test_expect_success "'ipfs refs --unique --recursive' is correct" '
+	mkdir -p a/b/c &&
+	echo "c1" > a/f1 &&
+	echo "c1" > a/b/f1 &&
+	echo "c1" > a/b/c/f1 &&
+	echo "c2" > a/b/c/f2 &&
+	ROOT=$(ipfs add -r -q a | tail -n1) &&
+	ipfs refs --unique --recursive $ROOT >refs_output &&
+	wc -l refs_output | sed "s/^ *//g" >line_count &&
+	echo "4 refs_output" >expected &&
+	test_cmp expected line_count
+'
+
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
commit 490ed41c454184aa01b0a6a1d534c88d6997ad5f
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Tue Jul 28 06:13:27 2015 -0700

    sharness/ipfs refs bigger tests

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

commit 8fe7d2f571ea3f7c68e34f1b4d9867a2ba3d4e4c
Author: gatesvp <gatesvp@gmail.com>
Date:   Tue Jul 28 03:05:01 2015 -0400

    Fix refs -r -u for #1211

    License: MIT
    Signed-off-by: Gaetan Voyer-Perrault <gatesvp@gmail.com>

commit a5521fcc765f391616b58beb91ea05ffe5652869
Author: Juan Batiz-Benet <juan@benet.ai>
Date:   Tue Jul 28 05:56:14 2015 -0700

    sharness/repo: fix pinning test

    looks like the test was broken by GC-ing everything.
    the pin expects $HASH to still be there.

    License: MIT
    Signed-off-by: Juan Batiz-Benet <juan@benet.ai>