### PR TITLE
ipfs add -w directories (and FUSE fixes)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -187,6 +187,10 @@
 			"Rev": "cd535bd25356746b9b1e824871dda7da932460e2"
 		},
 		{
+			"ImportPath": "github.com/jbenet/go-random-files",
+			"Rev": "737479700b40b4b50e914e963ce8d9d44603e3c8"
+		},
+		{
 			"ImportPath": "github.com/jbenet/go-reuseport",
 			"Rev": "48959f1fad204b6cf2c0e8d086ef69f03f2de961"
 		},

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -204,7 +204,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/goprocess",
-			"Rev": "788dcf5ca3517f243d276394545ca6b3b4ac32d5"
+			"Rev": "4562d0c5780b8f060df2b84a8945bb8678bfc023"
 		},
 		{
 			"ImportPath": "github.com/kardianos/osext",

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/LICENSE
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Juan Batiz-Benet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/Makefile
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/Makefile
@@ -1,0 +1,5 @@
+build:
+	cd random-files && go build
+
+install:
+	cd random-files && go install

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/README.md
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/README.md
@@ -1,0 +1,108 @@
+# go-random-files - create random fs hierarchies
+
+Useful for testing filesystems.
+
+
+```
+# library
+go get -u github.com/jbenet/go-random-files
+
+# binary
+go get -u github.com/jbenet/go-random-files/random-files
+```
+
+### Library godoc: https://godoc.org/github.com/jbenet/go-random-files
+
+# random-files - create random fs hierarchies
+
+See more about the binary at: github.com/jbenet/go-random-files/tree/master/random-files
+
+Useful for testing filesystems.
+
+## Install
+
+```
+go get -u github.com/jbenet/go-random-files/random-files
+```
+
+## Usage
+
+```sh
+> random-files --help
+usage: random-files [options] <path>...
+Write a random filesystem hierarchy to each <path>
+
+Options:
+  -alphabet="easy": alphabet for filenames {easy, hard}
+  -depth=2: fanout depth - how deep the hierarchy goes
+  -dirs=5: fanout dirs - number of dirs per dir (or max)
+  -files=10: fanout files - number of files per dir (or max
+  -filesize=4096: filesize - how big to make each file (or max)
+  -q=false: quiet output
+  -random-crypto=false: use cryptographic randomness for files
+  -random-fanout=false: randomize fanout numbers
+  -random-size=true: randomize filesize
+  -seed=0: random seed - 0 for current time
+```
+
+### Examples
+
+```sh
+> random-files --depth=2 --files=3 foo
+foo/h20uo3jrpihb
+foo/x6tef1
+foo/jh0c2vdci
+foo/fden012m368
+foo/fden012m368/p6n0chy4kg
+foo/fden012m368/h92_
+foo/fden012m368/kvjiya98p3
+foo/e_i6hwav1tb
+foo/e_i6hwav1tb/oj0-a
+foo/e_i6hwav1tb/1-pfgvim
+foo/e_i6hwav1tb/s_unf
+foo/bgvy8x-_hsm
+foo/bgvy8x-_hsm/98zcoz-9ng
+foo/bgvy8x-_hsm/j0see3qv
+foo/bgvy8x-_hsm/qntuf0r
+foo/6zjkw3ejm2awwt
+foo/6zjkw3ejm2awwt/iba52dh1lhnewh
+foo/6zjkw3ejm2awwt/n1bwcv5zpe
+foo/6zjkw3ejm2awwt/o8k89cc
+foo/efp_6
+foo/efp_6/qfap2
+foo/efp_6/v_kl_wlefsaa
+foo/efp_6/r7sdbph
+```
+
+It made:
+
+```
+> tree foo
+foo
+├── 6zjkw3ejm2awwt
+│   ├── iba52dh1lhnewh
+│   ├── n1bwcv5zpe
+│   └── o8k89cc
+├── bgvy8x-_hsm
+│   ├── 98zcoz-9ng
+│   ├── j0see3qv
+│   └── qntuf0r
+├── e_i6hwav1tb
+│   ├── 1-pfgvim
+│   ├── oj0-a
+│   └── s_unf
+├── efp_6
+│   ├── qfap2
+│   ├── r7sdbph
+│   └── v_kl_wlefsaa
+├── fden012m368
+│   ├── h92_
+│   ├── kvjiya98p3
+│   └── p6n0chy4kg
+├── h20uo3jrpihb
+├── jh0c2vdci
+└── x6tef1
+
+5 directories, 18 files
+```
+

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/lib.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/lib.go
@@ -1,0 +1,110 @@
+package randomfiles
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path"
+)
+
+type Options struct {
+	Out    io.Writer // output progress
+	Source io.Reader // randomness source
+
+	FileSize int    // the size per file.
+	Alphabet []rune // for filenames
+
+	FanoutDepth int // how deep the hierarchy goes
+	FanoutFiles int // how many files per dir
+	FanoutDirs  int // how many dirs per dir
+
+	RandomSeed   int64 // use a random seed. if 0, use a random seed
+	RandomSize   bool  // randomize file sizes
+	RandomFanout bool  // randomize fanout numbers
+}
+
+func WriteRandomFiles(root string, depth int, opts *Options) error {
+
+	numfiles := opts.FanoutFiles
+	if opts.RandomFanout {
+		numfiles = rand.Intn(numfiles) + 1
+	}
+
+	for i := 0; i < numfiles; i++ {
+		if err := WriteRandomFile(root, opts); err != nil {
+			return err
+		}
+	}
+
+	if depth+1 <= opts.FanoutDepth {
+		numdirs := opts.FanoutDirs
+		if opts.RandomFanout {
+			numdirs = rand.Intn(numdirs) + 1
+		}
+
+		for i := 0; i < numdirs; i++ {
+			if err := WriteRandomDir(root, depth+1, opts); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+var FilenameSize = 16
+var RunesEasy = []rune("abcdefghijklmnopqrstuvwxyz01234567890-_")
+var RunesHard = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890!@#$%^&*()-_+= ;.,<>'\"[]{}() ")
+
+func RandomFilename(length int, alphabet []rune) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+func WriteRandomFile(root string, opts *Options) error {
+	filesize := int64(opts.FileSize)
+	if opts.RandomSize {
+		filesize = rand.Int63n(filesize) + 1
+	}
+
+	n := rand.Intn(FilenameSize-4) + 4
+	name := RandomFilename(n, opts.Alphabet)
+	filepath := path.Join(root, name)
+	f, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.CopyN(f, opts.Source, filesize); err != nil {
+		return err
+	}
+
+	if opts.Out != nil {
+		fmt.Fprintln(opts.Out, filepath)
+	}
+
+	return f.Close()
+}
+
+func WriteRandomDir(root string, depth int, opts *Options) error {
+	if depth > opts.FanoutDepth {
+		return nil
+	}
+
+	n := rand.Intn(FilenameSize-4) + 4
+	name := RandomFilename(n, opts.Alphabet)
+	root = path.Join(root, name)
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return err
+	}
+
+	if opts.Out != nil {
+		fmt.Fprintln(opts.Out, root)
+	}
+
+	return WriteRandomFiles(root, depth, opts)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/.gitignore
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/.gitignore
@@ -1,0 +1,1 @@
+random-files

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/README.md
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/README.md
@@ -1,0 +1,90 @@
+# random-files - create random fs hierarchies
+
+random-files creates random fs hierarchies. Useful for testing filesystems.
+
+## Install
+
+```
+go get -u github.com/jbenet/go-random-files/random-files
+```
+
+## Usage
+
+```sh
+> random-files --help
+usage: random-files [options] <path>...
+Write a random filesystem hierarchy to each <path>
+
+Options:
+  -alphabet="easy": alphabet for filenames {easy, hard}
+  -depth=2: fanout depth - how deep the hierarchy goes
+  -dirs=5: fanout dirs - number of dirs per dir (or max)
+  -files=10: fanout files - number of files per dir (or max
+  -filesize=4096: filesize - how big to make each file (or max)
+  -q=false: quiet output
+  -random-crypto=false: use cryptographic randomness for files
+  -random-fanout=false: randomize fanout numbers
+  -random-size=true: randomize filesize
+  -seed=0: random seed - 0 for current time
+```
+
+## Examples
+
+```sh
+> random-files --depth=2 --files=3 foo
+foo/h20uo3jrpihb
+foo/x6tef1
+foo/jh0c2vdci
+foo/fden012m368
+foo/fden012m368/p6n0chy4kg
+foo/fden012m368/h92_
+foo/fden012m368/kvjiya98p3
+foo/e_i6hwav1tb
+foo/e_i6hwav1tb/oj0-a
+foo/e_i6hwav1tb/1-pfgvim
+foo/e_i6hwav1tb/s_unf
+foo/bgvy8x-_hsm
+foo/bgvy8x-_hsm/98zcoz-9ng
+foo/bgvy8x-_hsm/j0see3qv
+foo/bgvy8x-_hsm/qntuf0r
+foo/6zjkw3ejm2awwt
+foo/6zjkw3ejm2awwt/iba52dh1lhnewh
+foo/6zjkw3ejm2awwt/n1bwcv5zpe
+foo/6zjkw3ejm2awwt/o8k89cc
+foo/efp_6
+foo/efp_6/qfap2
+foo/efp_6/v_kl_wlefsaa
+foo/efp_6/r7sdbph
+```
+
+It made:
+
+```
+> tree foo
+foo
+├── 6zjkw3ejm2awwt
+│   ├── iba52dh1lhnewh
+│   ├── n1bwcv5zpe
+│   └── o8k89cc
+├── bgvy8x-_hsm
+│   ├── 98zcoz-9ng
+│   ├── j0see3qv
+│   └── qntuf0r
+├── e_i6hwav1tb
+│   ├── 1-pfgvim
+│   ├── oj0-a
+│   └── s_unf
+├── efp_6
+│   ├── qfap2
+│   ├── r7sdbph
+│   └── v_kl_wlefsaa
+├── fden012m368
+│   ├── h92_
+│   ├── kvjiya98p3
+│   └── p6n0chy4kg
+├── h20uo3jrpihb
+├── jh0c2vdci
+└── x6tef1
+
+5 directories, 18 files
+```

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/main.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/random-files/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	crand "crypto/rand"
+	"errors"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	randomfiles "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random-files"
+	ringreader "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random-files/ringreader"
+)
+
+var usage = `usage: %s [options] <path>...
+Write a random filesystem hierarchy to each <path>
+
+Options:
+`
+
+// flags
+var opts randomfiles.Options
+var quiet bool
+var alphabet string
+var paths []string
+var cryptorand bool
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, usage, os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.BoolVar(&quiet, "q", false, "quiet output")
+	flag.BoolVar(&cryptorand, "random-crypto", false, "use cryptographic randomness for files")
+	flag.StringVar(&alphabet, "alphabet", "easy", "alphabet for filenames {easy, hard}")
+	flag.IntVar(&opts.FileSize, "filesize", 4096, "filesize - how big to make each file (or max)")
+
+	flag.IntVar(&opts.FanoutDepth, "depth", 2, "fanout depth - how deep the hierarchy goes")
+	flag.IntVar(&opts.FanoutDirs, "dirs", 5, "fanout dirs - number of dirs per dir (or max)")
+	flag.IntVar(&opts.FanoutFiles, "files", 10, "fanout files - number of files per dir (or max")
+
+	flag.Int64Var(&opts.RandomSeed, "seed", 0, "random seed - 0 for current time")
+	flag.BoolVar(&opts.RandomFanout, "random-fanout", false, "randomize fanout numbers")
+	flag.BoolVar(&opts.RandomSize, "random-size", true, "randomize filesize")
+}
+
+func parseArgs() error {
+	flag.Parse()
+
+	switch alphabet {
+	case "easy":
+		opts.Alphabet = randomfiles.RunesEasy
+	case "hard":
+		opts.Alphabet = randomfiles.RunesHard
+	default:
+		return errors.New("alphabet must be one of: easy, hard")
+	}
+
+	paths = flag.Args()
+	if len(paths) < 1 {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	if !quiet {
+		opts.Out = os.Stdout
+	}
+
+	switch opts.RandomSeed {
+	case 0:
+		rand.Seed(time.Now().UnixNano())
+	default:
+		rand.Seed(opts.RandomSeed)
+	}
+
+	// prepare randomn source.
+	if cryptorand {
+		opts.Source = crand.Reader
+	} else {
+		// if not crypto, we don't need a lot of random
+		// data. we just need to sample from a sequence.
+		s := 16777216 // 16MB
+		r, err := ringreader.NewReader(s)
+		if err != nil {
+			return err
+		}
+		opts.Source = r
+	}
+
+	return nil
+}
+
+func run() error {
+	if err := parseArgs(); err != nil {
+		return err
+	}
+
+	for _, root := range paths {
+		if err := os.MkdirAll(root, 0755); err != nil {
+			return err
+		}
+
+		err := randomfiles.WriteRandomFiles(root, 1, &opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/ringreader/ringreader.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/ringreader/ringreader.go
@@ -1,0 +1,40 @@
+package ringreader
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+
+	random "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random"
+)
+
+type Reader struct {
+	Buf []byte
+}
+
+func NewReader(bufsize int) (*Reader, error) {
+	buf := bytes.NewBuffer(nil)
+	err := random.WritePseudoRandomBytes(int64(bufsize), buf, rand.Int63())
+	return &Reader{Buf: buf.Bytes()}, err
+}
+
+func (r *Reader) Read(buf []byte) (n int, err error) {
+	ibufl := len(r.Buf)
+	left := len(buf)
+	copied := 0
+
+	for copied < left {
+		pos1 := rand.Intn(len(r.Buf))
+		pos2 := pos1 + left
+		if pos2 > ibufl {
+			pos2 = ibufl
+		}
+		copied += copy(buf[copied:], r.Buf[pos1:pos2])
+	}
+
+	if copied != left {
+		err := fmt.Errorf("copied a different ammount: %d != %d", copied, left)
+		panic(err.Error())
+	}
+	return copied, nil
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-random-files/ringreader/ringreader_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-random-files/ringreader/ringreader_test.go
@@ -1,0 +1,22 @@
+package ringreader
+
+import (
+	"testing"
+)
+
+func TestRingReader(t *testing.T) {
+	r, _ := NewReader(256)
+	t.Log("buffer:", r.Buf)
+
+	for i := 1; i < 1048576; i = i * 2 {
+		buf := make([]byte, i)
+		n, err := r.Read(buf)
+		if err != nil {
+			t.Error(err)
+		}
+		if n != len(buf) {
+			t.Error("did not read %d bytes", n)
+		}
+		t.Log("read:", buf)
+	}
+}

--- a/Godeps/_workspace/src/github.com/jbenet/goprocess/goprocess.go
+++ b/Godeps/_workspace/src/github.com/jbenet/goprocess/goprocess.go
@@ -145,8 +145,6 @@ type Process interface {
 // lifecycle of a Process.
 type TeardownFunc func() error
 
-var nilTeardownFunc = func() error { return nil }
-
 // ProcessFunc is a function that takes a process. Its main use case is goprocess.Go,
 // which spawns a ProcessFunc in its own goroutine, and returns a corresponding
 // Process object.

--- a/Godeps/_workspace/src/github.com/jbenet/goprocess/goprocess_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/goprocess/goprocess_test.go
@@ -300,13 +300,11 @@ func TestAddChild(t *testing.T) {
 	testNone(t, Q)
 
 	go b.Close()
-	testNone(t, Q)
 	d.Close()
 	testStrs(t, Q, "b", "d")
 	testStrs(t, Q, "b", "d")
 
 	go a.Close()
-	testNone(t, Q)
 	c.Close()
 	testStrs(t, Q, "a", "c")
 	testStrs(t, Q, "a", "c")

--- a/commands/files/multipartfile.go
+++ b/commands/files/multipartfile.go
@@ -68,6 +68,10 @@ func (f *MultipartFile) NextFile() (File, error) {
 }
 
 func (f *MultipartFile) FileName() string {
+	if f == nil || f.Part == nil {
+		return ""
+	}
+
 	filename, err := url.QueryUnescape(f.Part.FileName())
 	if err != nil {
 		// if there is a unescape error, just treat the name as unescaped

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -216,7 +216,7 @@ func doMount(node *core.IpfsNode, fsdir, nsdir string) error {
 	<-done
 
 	if err1 != nil || err2 != nil {
-		log.Infof("error mounting: %s %s", err1, err2)
+		log.Errorf("error mounting: %s %s", err1, err2)
 		if fsmount != nil {
 			fsmount.Unmount()
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -382,6 +382,13 @@ func (n *IpfsNode) teardown() error {
 		n.Repo,
 	}
 
+	if n.Mounts.Ipfs != nil {
+		closers = append(closers, mount.Closer(n.Mounts.Ipfs))
+	}
+	if n.Mounts.Ipns != nil {
+		closers = append(closers, mount.Closer(n.Mounts.Ipns))
+	}
+
 	// Filesystem needs to be closed before network, dht, and blockservice
 	// so it can use them as its shutting down
 	if n.IpnsFs != nil {

--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -96,7 +96,7 @@ func (m *mount) unmount() error {
 	if err == nil {
 		return nil
 	}
-	log.Debug("fuse unmount err: %s", err)
+	log.Warningf("fuse unmount err: %s", err)
 
 	// try closing the fuseConn
 	err = m.fuseConn.Close()
@@ -104,7 +104,7 @@ func (m *mount) unmount() error {
 		return nil
 	}
 	if err != nil {
-		log.Debug("fuse conn error: %s", err)
+		log.Warningf("fuse conn error: %s", err)
 	}
 
 	// try mount.ForceUnmountManyTimes

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,7 @@ BINS = bin/random bin/multihash bin/ipfs bin/pollEndpoint bin/iptb bin/go-sleep
 IPFS_ROOT = ../
 IPFS_CMD = ../cmd/ipfs
 RANDOM_SRC = ../Godeps/_workspace/src/github.com/jbenet/go-random
+RANDOM_FILES_SRC = ../Godeps/_workspace/src/github.com/jbenet/go-random-files
 MULTIHASH_SRC = ../Godeps/_workspace/src/github.com/jbenet/go-multihash
 IPTB_SRC = ../Godeps/_workspace/src/github.com/whyrusleeping/iptb
 POLLENDPOINT_SRC= ../thirdparty/pollEndpoint
@@ -25,6 +26,10 @@ find_go_files = $(shell find $(1) -name "*.go")
 bin/random: $(call find_go_files, $(RANDOM_SRC)) IPFS-BUILD-OPTIONS
 	@echo "*** installing $@ ***"
 	go build $(GOFLAGS) -o bin/random $(RANDOM_SRC)/random
+
+bin/random-files:
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/random-files $(RANDOM_FILES_SRC)/random-files
 
 bin/multihash: $(call find_go_files, $(MULTIHASH_SRC)) IPFS-BUILD-OPTIONS
 	@echo "*** installing $@ ***"

--- a/test/sharness/Makefile
+++ b/test/sharness/Makefile
@@ -8,7 +8,7 @@
 
 T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
 BINS = bin/random bin/multihash bin/ipfs bin/pollEndpoint \
-	   bin/iptb bin/go-sleep
+	   bin/iptb bin/go-sleep bin/random-files
 SHARNESS = lib/sharness/sharness.sh
 IPFS_ROOT = ../..
 

--- a/test/sharness/lib/random-dep.go
+++ b/test/sharness/lib/random-dep.go
@@ -5,4 +5,5 @@ package randomdep
 
 import (
 	_ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random"
+	_ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random-files"
 )

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -212,28 +212,6 @@ test_expect_success "'ipfs cat' output looks good" '
 	test_cmp mountdir/bigfile actual
 '
 
-test_expect_success "ipfs add -w succeeds" '
-	ipfs add -w mountdir/hello.txt >actual
-'
-
-test_expect_success "ipfs add -w output looks good" '
-	HASH_W1="QmVr26fY1tKyspEJBniVhqxQeEjhF78XerGiqWAwraVLQH" &&
-	HASH_W2="QmVJfrqd4ogGZME6LWkkikAGddYgh9dBs2U14DHZZUBk7W" &&
-	echo "added $HASH_W1 mountdir/hello.txt" >expected &&
-	echo "added $HASH_W2 " >>expected &&
-	test_cmp expected actual
-'
-
-test_expect_success "ipfs add -w succeeds (dir)" '
-	ipfs add -r -w mountdir | tail -n1 >actual
-'
-
-test_expect_success "ipfs add -w output looks good (dir)" '
-	HASH_W="Qmc341yGztU1o8n3c1u5xTYF3uE3zPPP2NYemG9MKz775V" &&
-	echo "added $HASH_W " >expected &&
-	test_cmp expected actual
-'
-
 test_expect_success FUSE "cat ipfs/bigfile succeeds" '
 	cat "ipfs/$HASH" >actual
 '

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -212,6 +212,28 @@ test_expect_success "'ipfs cat' output looks good" '
 	test_cmp mountdir/bigfile actual
 '
 
+test_expect_success "ipfs add -w succeeds" '
+	ipfs add -w mountdir/hello.txt >actual
+'
+
+test_expect_success "ipfs add -w output looks good" '
+	HASH_W1="QmVr26fY1tKyspEJBniVhqxQeEjhF78XerGiqWAwraVLQH" &&
+	HASH_W2="QmVJfrqd4ogGZME6LWkkikAGddYgh9dBs2U14DHZZUBk7W" &&
+	echo "added $HASH_W1 mountdir/hello.txt" >expected &&
+	echo "added $HASH_W2 " >>expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "ipfs add -w succeeds (dir)" '
+	ipfs add -r -w mountdir | tail -n1 >actual
+'
+
+test_expect_success "ipfs add -w output looks good (dir)" '
+	HASH_W="Qmc341yGztU1o8n3c1u5xTYF3uE3zPPP2NYemG9MKz775V" &&
+	echo "added $HASH_W " >expected &&
+	test_cmp expected actual
+'
+
 test_expect_success FUSE "cat ipfs/bigfile succeeds" '
 	cat "ipfs/$HASH" >actual
 '
@@ -260,16 +282,6 @@ test_expect_success FUSE,EXPENSIVE "cat ipfs/bigfile succeeds" '
 
 test_expect_success FUSE,EXPENSIVE "cat ipfs/bigfile looks good" '
 	test_cmp sha1_expected sha1_actual
-'
-
-test_expect_success "ipfs add -w succeeds" '
-	ipfs add -w mountdir/hello.txt >actual
-'
-
-test_expect_success "ipfs add -w output looks good" '
-	HASH="QmVJfrqd4ogGZME6LWkkikAGddYgh9dBs2U14DHZZUBk7W" &&
-	echo "added $HASH/hello.txt mountdir/hello.txt" >expected &&
-	test_cmp expected actual
 '
 
 test_kill_ipfs_daemon

--- a/test/sharness/t0043-add-w.sh
+++ b/test/sharness/t0043-add-w.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test add -w"
+
+add_w_m='QmazHkwx6mPmmCEi1jR5YzjjQd1g5XzKfYQLzRAg7x5uUk'
+
+add_w_1='added Qme987pqNBhZZXy4ckeXiR7zaRQwBabB7fTgHurW2yJfNu m/4r93
+added Qmf82PSsMpUHcrqxa69KG6Qp5yeK7K9BTizXgG3nvzWcNG '
+
+add_w_12='added Qme987pqNBhZZXy4ckeXiR7zaRQwBabB7fTgHurW2yJfNu m/4r93
+added QmVb4ntSZZnT2J2zvCmXKMJc52cmZYH6AB37MzeYewnkjs m/4u6ead
+added QmZPASVB6EsADrLN8S2sak34zEHL8mx4TAVsPJU9cNnQQJ '
+
+add_w_21='added QmVb4ntSZZnT2J2zvCmXKMJc52cmZYH6AB37MzeYewnkjs m/4u6ead
+added Qme987pqNBhZZXy4ckeXiR7zaRQwBabB7fTgHurW2yJfNu m/4r93
+added QmZPASVB6EsADrLN8S2sak34zEHL8mx4TAVsPJU9cNnQQJ '
+
+add_w_d1='added QmPcaX84tDiTfzdTn8GQxexodgeWH6mHjSss5Zfr5ojssb m/t_1wp-8a2/_jo7/-s782qgs
+added QmaVBqquUuXKjkyWHXaXfsaQUxAnsCKS95VRDHU8PzGA4K m/t_1wp-8a2/_jo7/15totauzkak-
+added QmaAHFG8cmhW3WLjofx5siSp44VV25ETN6ThzrU8iAqpkR m/t_1wp-8a2/_jo7/galecuirrj4r
+added QmeuSfhJNKwBESp1W9H8cfoMdBfW3AeHQDWXbNXQJYWp53 m/t_1wp-8a2/_jo7/mzo50r-1xidf5zx
+added QmYC3u5jGWuyFwvTxtvLYm2K3SpWZ31tg3NjpVVvh9cJaJ m/t_1wp-8a2/_jo7/wzvsihy
+added QmQkib3f9XNX5sj6WEahLUPFpheTcwSRJwUCSvjcv8b9by m/t_1wp-8a2/_jo7
+added QmNQoesMj1qp8ApE51NbtTjFYksyzkezPD4cat7V2kzbKN '
+
+add_w_d2='added QmVaKAt2eVftNKFfKhiBV7Mu5HjCugffuLqWqobSSFgiA7 m/t_1wp-8a2/h3qpecj0
+added QmU9Jqks8TPu4vFr6t7EKkAKQrSJuEujNj1AkzoCeTEDFJ m/ha6f0x7su6/gnz66h/1k0xpx34
+added QmSLYZycXAufRw3ePMVH2brbtYWCcWsmksGLbHcT8ia9Ke m/ha6f0x7su6/gnz66h/9cwudvacx
+added QmfYmpCCAMU9nLe7xbrYsHf5z2R2GxeQnsm4zavUhX9vq2 m/ha6f0x7su6/gnz66h/9ximv51cbo8
+added QmWgEE4e2kfx3b8HZcBk5cLrfhoi8kTMQP2MipgPhykuV3 m/ha6f0x7su6/gnz66h/b54ygh6gs
+added QmcLbqEqhREGednc6mrVtanee4WHKp5JnUfiwTTHCJwuDf m/ha6f0x7su6/gnz66h/lbl5
+added QmVPwNy8pZegpsNmsjjZvdTQn4uCeuZgtzhgWhRSQWjK9x m/ha6f0x7su6/gnz66h
+added QmPcaX84tDiTfzdTn8GQxexodgeWH6mHjSss5Zfr5ojssb m/t_1wp-8a2/_jo7/-s782qgs
+added QmaVBqquUuXKjkyWHXaXfsaQUxAnsCKS95VRDHU8PzGA4K m/t_1wp-8a2/_jo7/15totauzkak-
+added QmaAHFG8cmhW3WLjofx5siSp44VV25ETN6ThzrU8iAqpkR m/t_1wp-8a2/_jo7/galecuirrj4r
+added QmeuSfhJNKwBESp1W9H8cfoMdBfW3AeHQDWXbNXQJYWp53 m/t_1wp-8a2/_jo7/mzo50r-1xidf5zx
+added QmYC3u5jGWuyFwvTxtvLYm2K3SpWZ31tg3NjpVVvh9cJaJ m/t_1wp-8a2/_jo7/wzvsihy
+added QmQkib3f9XNX5sj6WEahLUPFpheTcwSRJwUCSvjcv8b9by m/t_1wp-8a2/_jo7
+added Qme987pqNBhZZXy4ckeXiR7zaRQwBabB7fTgHurW2yJfNu m/4r93
+added QmTmc46fhKC8Liuh5soy1VotdnHcqLu3r6HpPGwDZCnqL1 '
+
+add_w_r='QmWpSjVaMts6cXr4g4uQ9AVadunLKxW7Fhyxk3TXo36hEf'
+
+. lib/test-lib.sh
+
+test_add_w() {
+
+  test_expect_success "go-random-files is installed" '
+    type random-files
+  '
+
+  test_expect_success "random-files generates test files" '
+    random-files --seed 7547632 --files 5 --dirs 2 --depth 3 m &&
+    echo "$add_w_m" >expected &&
+    ipfs add -q -r m | tail -n1 >actual &&
+    test_cmp expected actual
+  '
+
+  # test single file
+  test_expect_success "ipfs add -w (single file) succeeds" '
+    ipfs add -w m/4r93 >actual
+  '
+
+  test_expect_success "ipfs add -w (single file) is correct" '
+    echo "$add_w_1" >expected &&
+    test_cmp expected actual
+  '
+
+  # test two files together
+  test_expect_success "ipfs add -w (multiple) succeeds" '
+    ipfs add -w m/4r93 m/4u6ead >actual
+  '
+
+  test_expect_success "ipfs add -w (multiple) is correct" '
+    echo "$add_w_12" >expected  &&
+    test_cmp expected actual
+  '
+
+  test_expect_success "ipfs add -w (multiple) succeeds" '
+    ipfs add -w m/4u6ead m/4r93 >actual
+  '
+
+  test_expect_success "ipfs add -w (multiple) orders" '
+    echo "$add_w_21" >expected  &&
+    test_cmp expected actual
+  '
+
+  # test a directory
+  test_expect_success "ipfs add -w -r (dir) succeeds" '
+    ipfs add -r -w m/t_1wp-8a2/_jo7 >actual
+  '
+
+  test_expect_success "ipfs add -w -r (dir) is correct" '
+    echo "$add_w_d1" >expected &&
+    test_cmp expected actual
+  '
+
+  # test files and directory
+  test_expect_success "ipfs add -w -r <many> succeeds" '
+    ipfs add -w -r m/t_1wp-8a2/h3qpecj0 \
+      m/ha6f0x7su6/gnz66h m/t_1wp-8a2/_jo7 m/4r93 >actual
+  '
+
+  test_expect_success "ipfs add -w -r <many> is correct" '
+    echo "$add_w_d2" >expected &&
+    test_cmp expected actual
+  '
+
+  # test -w -r m/* == -r m
+  test_expect_success "ipfs add -w -r m/* == add -r m  succeeds" '
+    ipfs add -q -w -r m/* | tail -n1 >actual
+  '
+
+  test_expect_success "ipfs add -w -r m/* == add -r m  is correct" '
+    echo "$add_w_m" >expected &&
+    test_cmp expected actual
+  '
+
+  # test repeats together
+  test_expect_success "ipfs add -w (repeats) succeeds" '
+    ipfs add -q -w -r m/t_1wp-8a2/h3qpecj0 m/ha6f0x7su6/gnz66h \
+      m/t_1wp-8a2/_jo7 m/4r93 m/t_1wp-8a2 m/t_1wp-8a2 m/4r93 \
+      m/4r93 m/ha6f0x7su6/_rwujlf3qh_g08 \
+      m/ha6f0x7su6/gnz66h/9cwudvacx | tail -n1 >actual
+  '
+
+  test_expect_success "ipfs add -w (repeats) is correct" '
+    echo "$add_w_r" >expected  &&
+    test_cmp expected actual
+  '
+
+}
+
+test_init_ipfs
+
+test_add_w
+
+test_launch_ipfs_daemon
+
+test_add_w
+
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
a8dae30 (Juan Batiz-Benet, 4 minutes ago)
    add -w: fix to work correctly with dirs.

    this commit changes the behavior of ipfs add -w:

    - it makes it able to work with ipfs add -r <dir>
    - instead of hacking around the add, we simply just add a wrapper
     directory around the whole result of the add. this means that
     ipfs add -w calls will output _two_ lines, but this is actually
     more correct than outputting one line, as two objects were added.
     this _may_ break scripts out there which expect the output to
     look a certain way. we should consider whether the old output is
     more _useful_ (even if less in-line with the model.)

    License: MIT Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

 578fd02 (Juan Batiz-Benet, 7 minutes ago)
    fuse unmount fixes

    unmounting wasn't happening, mostly because of a recent bug in
    goprocess.SetTeardown. This commit bumps up some messages to log.Warnings,
    as users may want to see them, and makes sure to Unmount when a node shuts
    down.

    License: MIT Signed-off-by: Juan Batiz-Benet <juan@benet.ai>

 7a41dcb (Juan Batiz-Benet, 26 minutes ago)
    updated goprocess (SetTeardown fix)

    License: MIT Signed-off-by: Juan Batiz-Benet <juan@benet.ai>