### PR TITLE
remove elliptic.P224 usage

### DIFF
--- a/p2p/crypto/key.go
+++ b/p2p/crypto/key.go
@@ -102,8 +102,6 @@ func GenerateEKeyPair(curveName string) ([]byte, GenSharedKey, error) {
 	var curve elliptic.Curve
 
 	switch curveName {
-	case "P-224":
-		curve = elliptic.P224()
 	case "P-256":
 		curve = elliptic.P256()
 	case "P-384":

--- a/p2p/crypto/secio/al.go
+++ b/p2p/crypto/secio/al.go
@@ -18,7 +18,7 @@ import (
 )
 
 // List of supported ECDH curves
-var SupportedExchanges = "P-256,P-224,P-384,P-521"
+var SupportedExchanges = "P-256,P-384,P-521"
 
 // List of supported Ciphers
 var SupportedCiphers = "AES-256,AES-128,Blowfish"


### PR DESCRIPTION
Fedora/RedHat distros comply with US patent law and remove this curve,
which makes it impossible to run ipfs with distro provided Golang.

I hope the change is OK, but I have not tested it.

I sent more or less the same issue to Ethereum project and it was accepted here: https://github.com/ethereum/go-ethereum/commit/3f07afbbd21a0458830461f06d818aa1f9fa51fe