### PR TITLE
improve nodebuilder code to not depend on NewIPFSNode

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -157,7 +157,7 @@ func addDefaultAssets(out io.Writer, repoRoot string) error {
 		return err
 	}
 
-	nd, err := core.NewIPFSNode(ctx, core.Offline(r))
+	nd, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(ctx)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func initializeIpnsKeyspace(repoRoot string) error {
 		return err
 	}
 
-	nd, err := core.NewIPFSNode(ctx, core.Offline(r))
+	nd, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -204,7 +204,11 @@ func (i *cmdInvocation) constructNodeFunc(ctx context.Context) func() (*core.Ipf
 
 		// ok everything is good. set it on the invocation (for ownership)
 		// and return it.
-		n, err := core.NewIPFSNode(ctx, core.Standard(r, cmdctx.Online))
+		nb := core.NewNodeBuilder().SetRepo(r)
+		if cmdctx.Online {
+			nb.Online()
+		}
+		n, err := nb.Build(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -71,7 +71,8 @@ func run(ipfsPath, watchPath string) error {
 		// TODO handle case: repo doesn't exist or isn't initialized
 		return err
 	}
-	node, err := core.NewIPFSNode(context.Background(), core.Online(r))
+
+	node, err := core.NewNodeBuilder().Online().SetRepo(r).Build(context.Background())
 	if err != nil {
 		return err
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -48,7 +48,8 @@ func TestInitialization(t *testing.T) {
 			C: *c,
 			D: testutil.ThreadSafeCloserMapDatastore(),
 		}
-		n, err := NewIPFSNode(ctx, Standard(r, false))
+
+		n, err := NewNodeBuilder().Offline().SetRepo(r).Build(ctx)
 		if n == nil || err != nil {
 			t.Error("Should have constructed.", i, err)
 		}
@@ -59,7 +60,8 @@ func TestInitialization(t *testing.T) {
 			C: *c,
 			D: testutil.ThreadSafeCloserMapDatastore(),
 		}
-		n, err := NewIPFSNode(ctx, Standard(r, false))
+
+		n, err := NewNodeBuilder().Offline().SetRepo(r).Build(ctx)
 		if n != nil || err == nil {
 			t.Error("Should have failed to construct.", i)
 		}

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -47,7 +47,7 @@ func newNodeWithMockNamesys(t *testing.T, ns mockNamesys) *core.IpfsNode {
 		C: c,
 		D: testutil.ThreadSafeCloserMapDatastore(),
 	}
-	n, err := core.NewIPFSNode(context.Background(), core.Offline(r))
+	n, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreunix/add_test.go
+++ b/core/coreunix/add_test.go
@@ -25,7 +25,8 @@ func TestAddRecursive(t *testing.T) {
 		},
 		D: testutil.ThreadSafeCloserMapDatastore(),
 	}
-	node, err := core.NewIPFSNode(context.Background(), core.Offline(r))
+
+	node, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -44,10 +44,11 @@ func NewMockNode() (*core.IpfsNode, error) {
 		},
 	}
 
-	nd, err := core.Offline(&repo.Mock{
+	r := &repo.Mock{
 		C: c,
 		D: ds2.CloserWrap(syncds.MutexWrap(datastore.NewMapDatastore())),
-	})(ctx)
+	}
+	nd, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -100,10 +101,11 @@ func MockCmdsCtx() (commands.Context, error) {
 		},
 	}
 
-	node, err := core.NewIPFSNode(context.Background(), core.Offline(&repo.Mock{
+	r := &repo.Mock{
 		D: ds2.CloserWrap(syncds.MutexWrap(datastore.NewMapDatastore())),
 		C: conf,
-	}))
+	}
+	node, err := core.NewNodeBuilder().Offline().SetRepo(r).Build(context.Background())
 
 	return commands.Context{
 		Online:     true,

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -93,14 +93,13 @@ func run() error {
 		})
 	}
 
-	node, err := core.NewIPFSNode(
-		ctx,
-		core.OnlineWithOptions(
-			repo,
-			corerouting.SupernodeClient(infos...),
-			core.DefaultHostOption,
-		),
-	)
+	nb := core.NewNodeBuilder()
+	nb.Online()
+	nb.SetRepo(repo)
+	nb.SetRouting(corerouting.SupernodeClient(infos...))
+	nb.SetHost(core.DefaultHostOption)
+
+	node, err := nb.Build(ctx)
 	if err != nil {
 		return err
 	}
@@ -168,10 +167,12 @@ func runFileCattingWorker(ctx context.Context, n *core.IpfsNode) error {
 		return err
 	}
 
-	dummy, err := core.NewIPFSNode(ctx, core.Offline(&repo.Mock{
+	nb := core.NewNodeBuilder().Offline()
+	nb.SetRepo(&repo.Mock{
 		D: ds2.CloserWrap(syncds.MutexWrap(datastore.NewMapDatastore())),
 		C: *conf,
-	}))
+	})
+	dummy, err := nb.Build(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I want to deprecate the function `NewIPFSNode` in favor of the node builder. this is the beginning of that change.

So far, i've left `NewIPFSNode` intact, but i've removed most (not all) callers of it.

I'd like some feedback on the direction i'm taking here before going any farther.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>