### PR TITLE
Config: allow to set maps on null value

### DIFF
--- a/repo/common/common.go
+++ b/repo/common/common.go
@@ -7,12 +7,20 @@ import (
 
 func MapGetKV(v map[string]interface{}, key string) (interface{}, error) {
 	var ok bool
+	var mcursor map[string]interface{}
 	var cursor interface{} = v
+
 	parts := strings.Split(key, ".")
 	for i, part := range parts {
-		cursor, ok = cursor.(map[string]interface{})[part]
+		sofar := strings.Join(parts[:i], ".")
+
+		mcursor, ok = cursor.(map[string]interface{})
 		if !ok {
-			sofar := strings.Join(parts[:i], ".")
+			return nil, fmt.Errorf("%s key is not a map", sofar)
+		}
+
+		cursor, ok = mcursor[part]
+		if !ok {
 			return nil, fmt.Errorf("%s key has no attributes", sofar)
 		}
 	}
@@ -39,7 +47,7 @@ func MapSetKV(v map[string]interface{}, key string, value interface{}) error {
 		}
 
 		cursor, ok = mcursor[part]
-		if !ok { // create map if this is empty
+		if !ok || cursor == nil { // create map if this is empty or is null
 			mcursor[part] = map[string]interface{}{}
 			cursor = mcursor[part]
 		}

--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -57,6 +57,9 @@ test_config_cmd() {
   test_config_cmd_set "--json" "beep3" "true"
   test_config_cmd_set "--json" "beep3" "false"
   test_config_cmd_set "--json" "Discovery" "$CONFIG_SET_JSON_TEST"
+  test_config_cmd_set "--json" "deep-not-defined.prop" "true"
+  test_config_cmd_set "--json" "deep-null" "null"
+  test_config_cmd_set "--json" "deep-null.prop" "true"
 
 }
 


### PR DESCRIPTION
Also, now, if ipfs config foo.bar has value of anything that is not map (0, "0", 0.1),
then ipfs config foo.bar.baz now returns an error instead of a panic

Fixes #1561