### PR TITLE
blockservice.New doesnt need to return an error

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -5,7 +5,6 @@ package blockservice
 
 import (
 	"errors"
-	"fmt"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
@@ -48,10 +47,7 @@ type BlockService struct {
 }
 
 // NewBlockService creates a BlockService with given datastore instance.
-func New(bs blockstore.Blockstore, rem exchange.Interface) (*BlockService, error) {
-	if bs == nil {
-		return nil, fmt.Errorf("BlockService requires valid blockstore")
-	}
+func New(bs blockstore.Blockstore, rem exchange.Interface) *BlockService {
 	if rem == nil {
 		log.Warning("blockservice running in local (offline) mode.")
 	}
@@ -60,7 +56,7 @@ func New(bs blockstore.Blockstore, rem exchange.Interface) (*BlockService, error
 		Blockstore: bs,
 		Exchange:   rem,
 		worker:     worker.NewWorker(rem, wc),
-	}, nil
+	}
 }
 
 // AddBlock adds a particular block to the service, Putting it into the datastore.

--- a/blockservice/test/blocks_test.go
+++ b/blockservice/test/blocks_test.go
@@ -19,11 +19,7 @@ import (
 
 func TestBlocks(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	bs, err := New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Error("failed to construct block service", err)
-		return
-	}
+	bs := New(bstore, offline.Exchange(bstore))
 	defer bs.Close()
 
 	b := blocks.NewBlock([]byte("beep boop"))
@@ -63,7 +59,7 @@ func TestBlocks(t *testing.T) {
 }
 
 func TestGetBlocksSequential(t *testing.T) {
-	var servs = Mocks(t, 4)
+	var servs = Mocks(4)
 	for _, s := range servs {
 		defer s.Close()
 	}

--- a/blockservice/test/mock.go
+++ b/blockservice/test/mock.go
@@ -8,12 +8,8 @@ import (
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
 )
 
-type fataler interface {
-	Fatal(args ...interface{})
-}
-
 // Mocks returns |n| connected mock Blockservices
-func Mocks(t fataler, n int) []*BlockService {
+func Mocks(n int) []*BlockService {
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(0))
 	sg := bitswap.NewTestSessionGenerator(net)
 
@@ -21,11 +17,7 @@ func Mocks(t fataler, n int) []*BlockService {
 
 	var servs []*BlockService
 	for _, i := range instances {
-		bserv, err := New(i.Blockstore(), i.Exchange)
-		if err != nil {
-			t.Fatal(err)
-		}
-		servs = append(servs, bserv)
+		servs = append(servs, New(i.Blockstore(), i.Exchange))
 	}
 	return servs
 }

--- a/core/core.go
+++ b/core/core.go
@@ -148,10 +148,8 @@ func NewIPFSNode(ctx context.Context, option ConfigOption) (*IpfsNode, error) {
 	// to be initialized at this point, and 2) which variables will be
 	// initialized after this point.
 
-	node.Blocks, err = bserv.New(node.Blockstore, node.Exchange)
-	if err != nil {
-		return nil, err
-	}
+	node.Blocks = bserv.New(node.Blockstore, node.Exchange)
+
 	if node.Peerstore == nil {
 		node.Peerstore = peer.NewPeerstore()
 	}

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -25,10 +25,7 @@ import (
 func getDagserv(t *testing.T) merkledag.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
-	blockserv, err := bserv.New(bs, offline.Exchange(bs))
-	if err != nil {
-		t.Fatal(err)
-	}
+	blockserv := bserv.New(bs, offline.Exchange(bs))
 	return merkledag.NewDAGService(blockserv)
 }
 

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -68,10 +68,7 @@ func NewMockNode() (*core.IpfsNode, error) {
 
 	// Bitswap
 	bstore := blockstore.NewBlockstore(nd.Repo.Datastore())
-	bserv, err := blockservice.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		return nil, err
-	}
+	bserv := blockservice.New(bstore, offline.Exchange(bstore))
 
 	nd.DAG = mdag.NewDAGService(bserv)
 

--- a/importer/balanced/balanced_test.go
+++ b/importer/balanced/balanced_test.go
@@ -72,7 +72,7 @@ func testFileConsistency(t *testing.T, bs chunk.SplitterGen, nbytes int) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, bs(read))
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +95,7 @@ func testFileConsistency(t *testing.T, bs chunk.SplitterGen, nbytes int) {
 }
 
 func TestBuilderConsistency(t *testing.T) {
-	dagserv := mdtest.Mock(t)
+	dagserv := mdtest.Mock()
 	nd, should := getTestDag(t, dagserv, 100000, chunk.DefaultBlockSize)
 
 	r, err := uio.NewDagReader(context.Background(), nd, dagserv)
@@ -132,7 +132,7 @@ type dagservAndPinner struct {
 }
 
 func TestIndirectBlocks(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	dag, buf := getTestDag(t, ds, 1024*1024, 512)
 
 	reader, err := uio.NewDagReader(context.Background(), dag, ds)
@@ -152,7 +152,7 @@ func TestIndirectBlocks(t *testing.T) {
 
 func TestSeekingBasic(t *testing.T) {
 	nbytes := int64(10 * 1024)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, should := getTestDag(t, ds, nbytes, 500)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -181,7 +181,7 @@ func TestSeekingBasic(t *testing.T) {
 }
 
 func TestSeekToBegin(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, should := getTestDag(t, ds, 10*1024, 500)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -217,7 +217,7 @@ func TestSeekToBegin(t *testing.T) {
 }
 
 func TestSeekToAlmostBegin(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, should := getTestDag(t, ds, 10*1024, 500)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -254,7 +254,7 @@ func TestSeekToAlmostBegin(t *testing.T) {
 
 func TestSeekEnd(t *testing.T) {
 	nbytes := int64(50 * 1024)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, _ := getTestDag(t, ds, nbytes, 500)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -273,7 +273,7 @@ func TestSeekEnd(t *testing.T) {
 
 func TestSeekEndSingleBlockFile(t *testing.T) {
 	nbytes := int64(100)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, _ := getTestDag(t, ds, nbytes, 5000)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -292,7 +292,7 @@ func TestSeekEndSingleBlockFile(t *testing.T) {
 
 func TestSeekingStress(t *testing.T) {
 	nbytes := int64(1024 * 1024)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, should := getTestDag(t, ds, nbytes, 1000)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)
@@ -330,7 +330,7 @@ func TestSeekingStress(t *testing.T) {
 
 func TestSeekingConsistency(t *testing.T) {
 	nbytes := int64(128 * 1024)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, should := getTestDag(t, ds, nbytes, 500)
 
 	rs, err := uio.NewDagReader(context.Background(), nd, ds)

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getBalancedDag(t testing.TB, size int64, blksize int64) (*dag.Node, dag.DAGService) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildDagFromReader(ds, chunk.NewSizeSplitter(r, blksize), nil)
 	if err != nil {
@@ -25,7 +25,7 @@ func getBalancedDag(t testing.TB, size int64, blksize int64) (*dag.Node, dag.DAG
 }
 
 func getTrickleDag(t testing.TB, size int64, blksize int64) (*dag.Node, dag.DAGService) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildTrickleDagFromReader(ds, chunk.NewSizeSplitter(r, blksize), nil)
 	if err != nil {
@@ -35,7 +35,7 @@ func getTrickleDag(t testing.TB, size int64, blksize int64) (*dag.Node, dag.DAGS
 }
 
 func TestBalancedDag(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	buf := make([]byte, 10000)
 	u.NewTimeSeededRand().Read(buf)
 	r := bytes.NewReader(buf)

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -63,7 +63,7 @@ func testFileConsistency(t *testing.T, bs chunk.SplitterGen, nbytes int) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, bs(read))
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func TestBuilderConsistency(t *testing.T) {
 	buf := new(bytes.Buffer)
 	io.CopyN(buf, u.NewTimeSeededRand(), int64(nbytes))
 	should := dup(buf.Bytes())
-	dagserv := mdtest.Mock(t)
+	dagserv := mdtest.Mock()
 	nd, err := buildTestDag(dagserv, chunk.DefaultSplitter(buf))
 	if err != nil {
 		t.Fatal(err)
@@ -136,7 +136,7 @@ func TestIndirectBlocks(t *testing.T) {
 
 	read := bytes.NewReader(buf)
 
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	dag, err := buildTestDag(ds, splitter(read))
 	if err != nil {
 		t.Fatal(err)
@@ -163,7 +163,7 @@ func TestSeekingBasic(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 512))
 	if err != nil {
 		t.Fatal(err)
@@ -200,7 +200,7 @@ func TestSeekToBegin(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 500))
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +244,7 @@ func TestSeekToAlmostBegin(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 500))
 	if err != nil {
 		t.Fatal(err)
@@ -288,7 +288,7 @@ func TestSeekEnd(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 500))
 	if err != nil {
 		t.Fatal(err)
@@ -314,7 +314,7 @@ func TestSeekEndSingleBlockFile(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 5000))
 	if err != nil {
 		t.Fatal(err)
@@ -340,7 +340,7 @@ func TestSeekingStress(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 1000))
 	if err != nil {
 		t.Fatal(err)
@@ -385,7 +385,7 @@ func TestSeekingConsistency(t *testing.T) {
 	u.NewTimeSeededRand().Read(should)
 
 	read := bytes.NewReader(should)
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 500))
 	if err != nil {
 		t.Fatal(err)
@@ -429,7 +429,7 @@ func TestAppend(t *testing.T) {
 
 	// Reader for half the bytes
 	read := bytes.NewReader(should[:nbytes/2])
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	nd, err := buildTestDag(ds, chunk.NewSizeSplitter(read, 500))
 	if err != nil {
 		t.Fatal(err)
@@ -471,7 +471,7 @@ func TestAppend(t *testing.T) {
 
 // This test appends one byte at a time to an empty file
 func TestMultipleAppends(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 
 	// TODO: fix small size appends and make this number bigger
 	nbytes := int64(1000)
@@ -522,7 +522,7 @@ func TestMultipleAppends(t *testing.T) {
 }
 
 func TestAppendSingleBytesToEmpty(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 
 	data := []byte("AB")
 

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -33,10 +33,7 @@ type dagservAndPinner struct {
 func getDagservAndPinner(t *testing.T) dagservAndPinner {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
-	blockserv, err := bserv.New(bs, offline.Exchange(bs))
-	if err != nil {
-		t.Fatal(err)
-	}
+	blockserv := bserv.New(bs, offline.Exchange(bs))
 	dserv := NewDAGService(blockserv)
 	mpin := pin.NewPinner(db, dserv).GetManual()
 	return dagservAndPinner{
@@ -159,7 +156,7 @@ func TestBatchFetchDupBlock(t *testing.T) {
 
 func runBatchFetchTest(t *testing.T, read io.Reader) {
 	var dagservs []DAGService
-	for _, bsi := range bstest.Mocks(t, 5) {
+	for _, bsi := range bstest.Mocks(5) {
 		dagservs = append(dagservs, NewDAGService(bsi))
 	}
 

--- a/merkledag/test/utils.go
+++ b/merkledag/test/utils.go
@@ -1,8 +1,6 @@
 package mdutils
 
 import (
-	"testing"
-
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
@@ -11,11 +9,8 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
-func Mock(t testing.TB) dag.DAGService {
+func Mock() dag.DAGService {
 	bstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	bserv, err := bsrv.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bsrv.New(bstore, offline.Exchange(bstore))
 	return dag.NewDAGService(bserv)
 }

--- a/merkledag/utils/utils_test.go
+++ b/merkledag/utils/utils_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddLink(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	fishnode := &dag.Node{
 		Data: []byte("fishcakes!"),
 	}
@@ -66,7 +66,7 @@ func assertNodeAtPath(t *testing.T, ds dag.DAGService, root *dag.Node, path stri
 }
 
 func TestInsertNode(t *testing.T) {
-	ds := mdtest.Mock(t)
+	ds := mdtest.Mock()
 	root := new(dag.Node)
 	e := NewDagEditor(ds, root)
 

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -4,15 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	datastore "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
-	sync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
-	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	blockservice "github.com/ipfs/go-ipfs/blockservice"
-	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dagmock "github.com/ipfs/go-ipfs/merkledag/test"
 	path "github.com/ipfs/go-ipfs/path"
 	util "github.com/ipfs/go-ipfs/util"
 )
@@ -27,20 +23,13 @@ func randNode() (*merkledag.Node, key.Key) {
 
 func TestRecurivePathResolution(t *testing.T) {
 	ctx := context.Background()
-	dstore := sync.MutexWrap(datastore.NewMapDatastore())
-	bstore := blockstore.NewBlockstore(dstore)
-	bserv, err := blockservice.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dagService := merkledag.NewDAGService(bserv)
+	dagService := dagmock.Mock()
 
 	a, _ := randNode()
 	b, _ := randNode()
 	c, cKey := randNode()
 
-	err = b.AddNodeLink("grandchild", c)
+	err := b.AddNodeLink("grandchild", c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -29,10 +29,7 @@ func TestPinnerBasic(t *testing.T) {
 
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
-	bserv, err := bs.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bs.New(bstore, offline.Exchange(bstore))
 
 	dserv := mdag.NewDAGService(bserv)
 
@@ -40,7 +37,7 @@ func TestPinnerBasic(t *testing.T) {
 	p := NewPinner(dstore, dserv)
 
 	a, ak := randNode()
-	_, err = dserv.Add(a)
+	_, err := dserv.Add(a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,10 +160,7 @@ func TestDuplicateSemantics(t *testing.T) {
 	ctx := context.Background()
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
-	bserv, err := bs.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bs.New(bstore, offline.Exchange(bstore))
 
 	dserv := mdag.NewDAGService(bserv)
 
@@ -174,7 +168,7 @@ func TestDuplicateSemantics(t *testing.T) {
 	p := NewPinner(dstore, dserv)
 
 	a, _ := randNode()
-	_, err = dserv.Add(a)
+	_, err := dserv.Add(a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,10 +196,7 @@ func TestPinRecursiveFail(t *testing.T) {
 	ctx := context.Background()
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
-	bserv, err := bs.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bs.New(bstore, offline.Exchange(bstore))
 
 	dserv := mdag.NewDAGService(bserv)
 
@@ -213,7 +204,7 @@ func TestPinRecursiveFail(t *testing.T) {
 
 	a, _ := randNode()
 	b, _ := randNode()
-	err = a.AddNodeLinkClean("child", b)
+	err := a.AddNodeLinkClean("child", b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -31,10 +31,7 @@ func getMockDagServ(t testing.TB) (mdag.DAGService, pin.ManualPinner) {
 	dstore := ds.NewMapDatastore()
 	tsds := sync.MutexWrap(dstore)
 	bstore := blockstore.NewBlockstore(tsds)
-	bserv, err := bs.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bs.New(bstore, offline.Exchange(bstore))
 	dserv := mdag.NewDAGService(bserv)
 	return dserv, pin.NewPinner(tsds, dserv).GetManual()
 }
@@ -43,10 +40,7 @@ func getMockDagServAndBstore(t testing.TB) (mdag.DAGService, blockstore.Blocksto
 	dstore := ds.NewMapDatastore()
 	tsds := sync.MutexWrap(dstore)
 	bstore := blockstore.NewBlockstore(tsds)
-	bserv, err := bs.New(bstore, offline.Exchange(bstore))
-	if err != nil {
-		t.Fatal(err)
-	}
+	bserv := bs.New(bstore, offline.Exchange(bstore))
 	dserv := mdag.NewDAGService(bserv)
 	return dserv, bstore, pin.NewPinner(tsds, dserv).GetManual()
 }


### PR DESCRIPTION
I noticed the blockservice constructor only returned an error if the blockstore it was given was nil. thats silly.

Especially since it doesnt catch the following:

```
var bs *MyConcreteBlockstoreType // nil blockstore, concrete type
bserv, err := blockservice.New(bs, exchange)

// err == nil here.
```

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>