### PR TITLE
Add router that does nothing for bitswap_wo_routing test

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -40,6 +40,7 @@ import (
 	dht "github.com/ipfs/go-ipfs/routing/dht"
 	kb "github.com/ipfs/go-ipfs/routing/kbucket"
 	offroute "github.com/ipfs/go-ipfs/routing/offline"
+	nilrouting "github.com/ipfs/go-ipfs/routing/none"
 
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
@@ -613,3 +614,4 @@ type RoutingOption func(context.Context, p2phost.Host, ds.ThreadSafeDatastore) (
 type DiscoveryOption func(p2phost.Host) (discovery.Service, error)
 
 var DHTOption RoutingOption = constructDHTRouting
+var NilRouterOption RoutingOption = nilrouting.ConstructNilRouting

--- a/routing/none/none_client.go
+++ b/routing/none/none_client.go
@@ -1,0 +1,51 @@
+package nilrouting
+
+import (
+	"errors"
+
+	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	key "github.com/ipfs/go-ipfs/blocks/key"
+	p2phost "github.com/ipfs/go-ipfs/p2p/host"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	routing "github.com/ipfs/go-ipfs/routing"
+	u "github.com/ipfs/go-ipfs/util"
+)
+
+var log = u.Logger("mockrouter")
+
+type nilclient struct {
+}
+
+func (c *nilclient) PutValue(_ context.Context, _ key.Key, _ []byte) error {
+	return nil
+}
+
+func (c *nilclient) GetValue(_ context.Context, _ key.Key) ([]byte, error) {
+	return nil, errors.New("Tried GetValue from nil routing.")
+}
+
+func (c *nilclient) FindPeer(_ context.Context, _ peer.ID) (peer.PeerInfo, error) {
+	return peer.PeerInfo{}, nil
+}
+
+func (c *nilclient) FindProvidersAsync(_ context.Context, _ key.Key, _ int) <-chan peer.PeerInfo {
+	out := make(chan peer.PeerInfo)
+	defer close(out)
+	return out
+}
+
+func (c *nilclient) Provide(_ context.Context, _ key.Key) error {
+	return nil
+}
+
+func (c *nilclient) Bootstrap(_ context.Context) error {
+	return nil
+}
+
+func ConstructNilRouting(_ context.Context, _ p2phost.Host, _ ds.ThreadSafeDatastore) (routing.IpfsRouting, error) {
+	return &nilclient{}, nil
+}
+
+//  ensure nilclient satisfies interface
+var _ routing.IpfsRouting = &nilclient{}

--- a/test/integration/bitswap_wo_routing_test.go
+++ b/test/integration/bitswap_wo_routing_test.go
@@ -34,7 +34,7 @@ func TestBitswapWithoutRouting(t *testing.T) {
 
 	var nodes []*core.IpfsNode
 	for _, p := range peers {
-		n, err := core.NewIPFSNode(ctx, core.ConfigOption(MocknetTestRepo(p, mn.Host(p), conf, core.DHTOption)))
+		n, err := core.NewIPFSNode(ctx, core.ConfigOption(MocknetTestRepo(p, mn.Host(p), conf, core.NilRouterOption)))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
@whyrusleeping 
I added a new nilrouting package and routing option that could be useful for future routerless tests.

License: MIT
Signed-off-by: Karthik Bala <karthikbala444@gmail.com>