### PR TITLE
bump development version

### DIFF
--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.3.7"
+const CurrentVersionNumber = "0.3.8-dev"
 
 // Version regulates checking if the most recent version is run
 type Version struct {


### PR DESCRIPTION
` @jbenet | whyrusleeping: we should update the version number after a release, so that _master_ is ahead of the last released version.`

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>