### PR TITLE
use go's built in handling of trailers and dont do custom chunking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ os:
 language: go
 
 go:
-#  - 1.3
-  - 1.4
+    - 1.5.1
 
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ From there:
 
 ### Prerequisite: Install Go
 
-First, you'll need go. If you don't have it: [Download Go 1.4+](https://golang.org/dl/).
+First, you'll need go. If you don't have it: [Download Go 1.5.1+](https://golang.org/dl/).
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -3,11 +3,17 @@ machine:
     TEST_NO_FUSE: 1
     TEST_VERBOSE: 1
     TRAVIS: 1
+  post:
+    - sudo rm -rf /usr/local/go
+    - if [ ! -e go1.5.linux-amd64.tar.gz ]; then curl -o go1.5.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz; fi
+    - sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz
 
 dependencies:
   pre:
     # setup ipv6
     - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 net.ipv6.conf.default.disable_ipv6=0 net.ipv6.conf.all.disable_ipv6=0
+  cache_directories:
+    - ~/go1.5.linux-amd64.tar.gz
 
 test:
   override:

--- a/cmd/ipfs/go_req.go
+++ b/cmd/ipfs/go_req.go
@@ -1,0 +1,3 @@
+// +build !go1.5
+
+`IPFS needs to be built with go version 1.5 or greater`

--- a/test/sharness/t0230-channel-streaming-http-content-type.sh
+++ b/test/sharness/t0230-channel-streaming-http-content-type.sh
@@ -22,11 +22,14 @@ test_ls_cmd() {
 	test_expect_success "Text encoded channel-streaming command output looks good" '
 		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
 		printf "Content-Type: text/plain\r\n" >>expected_output &&
+		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
+		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "\r\n" >>expected_output &&
 		echo QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW >>expected_output &&
-		test_cmp expected_output actual_output
+		cat actual_output | grep -vE Date > cleaned_output &&
+		test_cmp expected_output cleaned_output
 	'
 
 	test_expect_success "JSON encoded channel-streaming command succeeds" '
@@ -39,8 +42,10 @@ test_ls_cmd() {
 	test_expect_success "JSON encoded channel-streaming command output looks good" '
 		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
 		printf "Content-Type: application/json\r\n" >>expected_output &&
+		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
+		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "\r\n" >>expected_output &&
 		cat <<-\EOF >>expected_output &&
 			{
@@ -48,8 +53,10 @@ test_ls_cmd() {
 			  "Err": ""
 			}
 		EOF
+		printf "\n" >> expected_output &&
 		perl -pi -e '"'"'chomp if eof'"'"' expected_output &&
-		test_cmp expected_output actual_output
+		cat actual_output | grep -vE Date > cleaned_output &&
+		test_cmp expected_output cleaned_output
 	'
 }
 


### PR DESCRIPTION
It turns out they implemented http trailers in go's std http lib. I am happy.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>