### PR TITLE
implement symlinks in unixfs, first draft

### DIFF
--- a/commands/files/linkfile.go
+++ b/commands/files/linkfile.go
@@ -1,0 +1,50 @@
+package files
+
+import (
+	"io"
+	"os"
+	"strings"
+)
+
+type Symlink struct {
+	name   string
+	path   string
+	Target string
+	stat   os.FileInfo
+
+	reader io.Reader
+}
+
+func NewLinkFile(name, path, target string, stat os.FileInfo) File {
+	return &Symlink{
+		name:   name,
+		path:   path,
+		Target: target,
+		stat:   stat,
+		reader: strings.NewReader(target),
+	}
+}
+
+func (lf *Symlink) IsDirectory() bool {
+	return false
+}
+
+func (lf *Symlink) NextFile() (File, error) {
+	return nil, io.EOF
+}
+
+func (f *Symlink) FileName() string {
+	return f.name
+}
+
+func (f *Symlink) Close() error {
+	return nil
+}
+
+func (f *Symlink) FullPath() string {
+	return f.path
+}
+
+func (f *Symlink) Read(b []byte) (int, error) {
+	return f.reader.Read(b)
+}

--- a/commands/files/multipartfile.go
+++ b/commands/files/multipartfile.go
@@ -12,6 +12,8 @@ const (
 	multipartFormdataType = "multipart/form-data"
 	multipartMixedType    = "multipart/mixed"
 
+	applicationSymlink = "application/symlink"
+
 	contentTypeHeader = "Content-Type"
 )
 
@@ -31,7 +33,7 @@ func NewFileFromPart(part *multipart.Part) (File, error) {
 	}
 
 	contentType := part.Header.Get(contentTypeHeader)
-	if contentType == "symlink" {
+	if contentType == applicationSymlink {
 		out, err := ioutil.ReadAll(part)
 		if err != nil {
 			return nil, err

--- a/commands/files/multipartfile.go
+++ b/commands/files/multipartfile.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -30,6 +31,17 @@ func NewFileFromPart(part *multipart.Part) (File, error) {
 	}
 
 	contentType := part.Header.Get(contentTypeHeader)
+	if contentType == "symlink" {
+		out, err := ioutil.ReadAll(part)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Symlink{
+			Target: string(out),
+			name:   f.FileName(),
+		}, nil
+	}
 
 	var params map[string]string
 	var err error

--- a/commands/http/multifilereader.go
+++ b/commands/http/multifilereader.go
@@ -69,8 +69,7 @@ func (mfr *MultiFileReader) Read(buf []byte) (written int, err error) {
 			if s, ok := file.(*files.Symlink); ok {
 				mfr.currentFile = s
 
-				// TODO(why): this is a hack. pick a real contentType
-				contentType = "symlink"
+				contentType = "application/symlink"
 			} else if file.IsDirectory() {
 				// if file is a directory, create a multifilereader from it
 				// (using 'multipart/mixed')

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -360,11 +360,13 @@ func (params *adder) addFile(file files.File) (*dag.Node, error) {
 	}
 
 	if s, ok := file.(*files.Symlink); ok {
-		dagnode := &dag.Node{
-			Data: ft.SymlinkData(s.Target),
+		sdata, err := ft.SymlinkData(s.Target)
+		if err != nil {
+			return nil, err
 		}
 
-		_, err := params.node.DAG.Add(dagnode)
+		dagnode := &dag.Node{Data: sdata}
+		_, err = params.node.DAG.Add(dagnode)
 		if err != nil {
 			return nil, err
 		}

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -143,7 +143,6 @@ remains to be implemented.
 					return nil // done
 				}
 
-				log.Errorf("FILE: %#v", file)
 				if _, err := fileAdder.addFile(file); err != nil {
 					return err
 				}
@@ -361,9 +360,6 @@ func (params *adder) addFile(file files.File) (*dag.Node, error) {
 	}
 
 	if s, ok := file.(*files.Symlink); ok {
-		log.Error("SYMLINK: ", s)
-		log.Error(s.Target)
-		log.Error(s.FileName())
 		dagnode := &dag.Node{
 			Data: ft.SymlinkData(s.Target),
 		}

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -99,9 +99,6 @@ size is the IPFS link size.
 			}
 
 			switch t {
-			default:
-				res.SetError(fmt.Errorf("unrecognized type: %s", t), cmds.ErrImplementation)
-				return
 			case unixfspb.Data_File:
 				break
 			case unixfspb.Data_Directory:
@@ -131,6 +128,12 @@ size is the IPFS link size.
 					}
 					links[i] = lsLink
 				}
+			case unixfspb.Data_Symlink:
+				res.SetError(fmt.Errorf("cannot list symlinks yet"), cmds.ErrNormal)
+				return
+			default:
+				res.SetError(fmt.Errorf("unrecognized type: %s", t), cmds.ErrImplementation)
+				return
 			}
 		}
 

--- a/test/sharness/t0044-add-symlink.sh
+++ b/test/sharness/t0044-add-symlink.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test add -w"
+
+. lib/test-lib.sh
+
+test_expect_success "creating files succeeds" '
+	mkdir -p files/foo &&
+	mkdir -p files/bar &&
+	echo "some text" > files/foo/baz &&
+	ln -s files/foo/baz files/bar/baz &&
+	ln -s files/does/not/exist files/bad
+'
+
+test_add_symlinks() {
+	test_expect_success "ipfs add files succeeds" '
+		ipfs add -q -r files | tail -n 1 > filehash_out
+	'
+
+	test_expect_success "output looks good" '
+		echo QmWdiHKoeSW8G1u7ATCgpx4yMoUhYaJBQGkyPLkS9goYZ8 > filehash_exp &&
+		test_cmp filehash_out filehash_exp
+	'
+
+	test_expect_success "adding a symlink adds the link itself" '
+		ipfs add -q files/bar/baz > goodlink_out
+	'
+
+	test_expect_success "output looks good" '
+		echo "QmdocmZeF7qwPT9Z8SiVhMSyKA2KKoA2J7jToW6z6WBmxR" > goodlink_exp &&
+		test_cmp goodlink_out goodlink_exp
+	'
+
+	test_expect_success "adding a broken symlink works" '
+		ipfs add -q files/bad > badlink_out
+	'
+
+	test_expect_success "output looks good" '
+		echo "QmWYN8SEXCgNT2PSjB6BnxAx6NJQtazWoBkTRH9GRfPFFQ" > badlink_exp &&
+		test_cmp badlink_out badlink_exp
+	'
+}
+
+test_init_ipfs
+
+test_add_symlinks
+
+test_launch_ipfs_daemon
+
+test_add_symlinks
+
+test_kill_ipfs_daemon
+
+test_done

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -79,6 +79,8 @@ func (w *Writer) WriteNode(nd *mdag.Node, fpath string) error {
 		fallthrough
 	case upb.Data_File:
 		return w.writeFile(nd, pb, fpath)
+	case upb.Data_Symlink:
+		return writeSymlinkHeader(w.TarW, string(pb.GetData()), fpath)
 	default:
 		return ft.ErrUnrecognizedType
 	}
@@ -106,5 +108,14 @@ func writeFileHeader(w *tar.Writer, fpath string, size uint64) error {
 		Mode:     0644,
 		ModTime:  time.Now(),
 		// TODO: set mode, dates, etc. when added to unixFS
+	})
+}
+
+func writeSymlinkHeader(w *tar.Writer, target, fpath string) error {
+	return w.WriteHeader(&tar.Header{
+		Name:     fpath,
+		Linkname: target,
+		Mode:     0777,
+		Typeflag: tar.TypeSymlink,
 	})
 }

--- a/unixfs/format.go
+++ b/unixfs/format.go
@@ -77,7 +77,7 @@ func WrapData(b []byte) []byte {
 	return out
 }
 
-func SymlinkData(path string) []byte {
+func SymlinkData(path string) ([]byte, error) {
 	pbdata := new(pb.Data)
 	typ := pb.Data_Symlink
 	pbdata.Data = []byte(path)
@@ -85,10 +85,10 @@ func SymlinkData(path string) []byte {
 
 	out, err := proto.Marshal(pbdata)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return out
+	return out, nil
 }
 
 func UnwrapData(data []byte) ([]byte, error) {

--- a/unixfs/format.go
+++ b/unixfs/format.go
@@ -77,6 +77,20 @@ func WrapData(b []byte) []byte {
 	return out
 }
 
+func SymlinkData(path string) []byte {
+	pbdata := new(pb.Data)
+	typ := pb.Data_Symlink
+	pbdata.Data = []byte(path)
+	pbdata.Type = &typ
+
+	out, err := proto.Marshal(pbdata)
+	if err != nil {
+		panic(err)
+	}
+
+	return out
+}
+
 func UnwrapData(data []byte) ([]byte, error) {
 	pbdata := new(pb.Data)
 	err := proto.Unmarshal(data, pbdata)

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -17,6 +17,8 @@ import (
 
 var ErrIsDir = errors.New("this dag node is a directory")
 
+var ErrCantReadSymlinks = errors.New("cannot currently read symlinks")
+
 // DagReader provides a way to easily read the data contained in a dag.
 type DagReader struct {
 	serv mdag.DAGService
@@ -79,6 +81,8 @@ func NewDagReader(ctx context.Context, n *mdag.Node, serv mdag.DAGService) (*Dag
 			return nil, err
 		}
 		return NewDagReader(ctx, child, serv)
+	case ftpb.Data_Symlink:
+		return nil, ErrCantReadSymlinks
 	default:
 		return nil, ft.ErrUnrecognizedType
 	}
@@ -130,6 +134,8 @@ func (dr *DagReader) precalcNextBuf(ctx context.Context) error {
 		return nil
 	case ftpb.Data_Metadata:
 		return errors.New("Shouldnt have had metadata object inside file")
+	case ftpb.Data_Symlink:
+		return errors.New("shouldnt have had symlink inside file")
 	default:
 		return ft.ErrUnrecognizedType
 	}

--- a/unixfs/pb/unixfs.pb.go
+++ b/unixfs/pb/unixfs.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 */
 package unixfs_pb
 
-import proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -28,6 +28,7 @@ const (
 	Data_Directory Data_DataType = 1
 	Data_File      Data_DataType = 2
 	Data_Metadata  Data_DataType = 3
+	Data_Symlink   Data_DataType = 4
 )
 
 var Data_DataType_name = map[int32]string{
@@ -35,12 +36,14 @@ var Data_DataType_name = map[int32]string{
 	1: "Directory",
 	2: "File",
 	3: "Metadata",
+	4: "Symlink",
 }
 var Data_DataType_value = map[string]int32{
 	"Raw":       0,
 	"Directory": 1,
 	"File":      2,
 	"Metadata":  3,
+	"Symlink":   4,
 }
 
 func (x Data_DataType) Enum() *Data_DataType {

--- a/unixfs/pb/unixfs.proto
+++ b/unixfs/pb/unixfs.proto
@@ -6,6 +6,7 @@ message Data {
 		Directory = 1;
 		File = 2;
 		Metadata = 3;
+		Symlink = 4;
 	}
 
 	required DataType Type = 1;


### PR DESCRIPTION
Implemented basic symlink support. Most commands dont follow them yet, need to figure out semantics for things like `ipfs cat QmSymlink`. But they are supported in the fuse mounts.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>