### PR TITLE
FUSE fixes

### DIFF
--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -335,14 +335,16 @@ func (fi *File) Flush(ctx context.Context, req *fuse.FlushRequest) error {
 }
 
 func (fi *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
-	cursize, err := fi.fi.Size()
-	if err != nil {
-		return err
-	}
-	if cursize != int64(req.Size) {
-		err := fi.fi.Truncate(int64(req.Size))
+	if req.Valid.Size() {
+		cursize, err := fi.fi.Size()
 		if err != nil {
 			return err
+		}
+		if cursize != int64(req.Size) {
+			err := fi.fi.Truncate(int64(req.Size))
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -109,7 +109,7 @@ func CreateRoot(ipfs *core.IpfsNode, keys []ci.PrivKey, ipfspath, ipnspath strin
 // Attr returns file attributes.
 func (*Root) Attr(ctx context.Context, a *fuse.Attr) error {
 	log.Debug("Root Attr")
-	*a = fuse.Attr{Mode: os.ModeDir | 0111} // -rw+x
+	a.Mode = os.ModeDir | 0111 // -rw+x
 	return nil
 }
 
@@ -219,11 +219,9 @@ type File struct {
 // Attr returns the attributes of a given node.
 func (d *Directory) Attr(ctx context.Context, a *fuse.Attr) error {
 	log.Debug("Directory Attr")
-	*a = fuse.Attr{
-		Mode: os.ModeDir | 0555,
-		Uid:  uint32(os.Getuid()),
-		Gid:  uint32(os.Getgid()),
-	}
+	a.Mode = os.ModeDir | 0555
+	a.Uid = uint32(os.Getuid())
+	a.Gid = uint32(os.Getgid())
 	return nil
 }
 
@@ -235,12 +233,10 @@ func (fi *File) Attr(ctx context.Context, a *fuse.Attr) error {
 		// In this case, the dag node in question may not be unixfs
 		return fmt.Errorf("fuse/ipns: failed to get file.Size(): %s", err)
 	}
-	*a = fuse.Attr{
-		Mode: os.FileMode(0666),
-		Size: uint64(size),
-		Uid:  uint32(os.Getuid()),
-		Gid:  uint32(os.Getgid()),
-	}
+	a.Mode = os.FileMode(0666)
+	a.Size = uint64(size)
+	a.Uid = uint32(os.Getuid())
+	a.Gid = uint32(os.Getgid())
 	return nil
 }
 

--- a/fuse/ipns/link_unix.go
+++ b/fuse/ipns/link_unix.go
@@ -16,9 +16,7 @@ type Link struct {
 
 func (l *Link) Attr(ctx context.Context, a *fuse.Attr) error {
 	log.Debug("Link attr.")
-	*a = fuse.Attr{
-		Mode: os.ModeSymlink | 0555,
-	}
+	a.Mode = os.ModeSymlink | 0555
 	return nil
 }
 

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -36,7 +36,7 @@ func randObj(t *testing.T, nd *core.IpfsNode, size int64) (*dag.Node, []byte) {
 	buf := make([]byte, size)
 	u.NewTimeSeededRand().Read(buf)
 	read := bytes.NewReader(buf)
-	obj, err := importer.BuildTrickleDagFromReader(read, nd.DAG, chunk.DefaultSplitter, nil)
+	obj, err := importer.BuildTrickleDagFromReader(read, nd.DAG, chunk.DefaultSplitter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -45,7 +45,7 @@ type Root struct {
 
 // Attr returns file attributes.
 func (*Root) Attr(ctx context.Context, a *fuse.Attr) error {
-	*a = fuse.Attr{Mode: os.ModeDir | 0111} // -rw+x
+	a.Mode = os.ModeDir | 0111 // -rw+x
 	return nil
 }
 
@@ -96,28 +96,22 @@ func (s *Node) Attr(ctx context.Context, a *fuse.Attr) error {
 	}
 	switch s.cached.GetType() {
 	case ftpb.Data_Directory:
-		*a = fuse.Attr{
-			Mode: os.ModeDir | 0555,
-			Uid:  uint32(os.Getuid()),
-			Gid:  uint32(os.Getgid()),
-		}
+		a.Mode = os.ModeDir | 0555
+		a.Uid = uint32(os.Getuid())
+		a.Gid = uint32(os.Getgid())
 	case ftpb.Data_File:
 		size := s.cached.GetFilesize()
-		*a = fuse.Attr{
-			Mode:   0444,
-			Size:   uint64(size),
-			Blocks: uint64(len(s.Nd.Links)),
-			Uid:    uint32(os.Getuid()),
-			Gid:    uint32(os.Getgid()),
-		}
+		a.Mode = 0444
+		a.Size = uint64(size)
+		a.Blocks = uint64(len(s.Nd.Links))
+		a.Uid = uint32(os.Getuid())
+		a.Gid = uint32(os.Getgid())
 	case ftpb.Data_Raw:
-		*a = fuse.Attr{
-			Mode:   0444,
-			Size:   uint64(len(s.cached.GetData())),
-			Blocks: uint64(len(s.Nd.Links)),
-			Uid:    uint32(os.Getuid()),
-			Gid:    uint32(os.Getgid()),
-		}
+		a.Mode = 0444
+		a.Size = uint64(len(s.cached.GetData()))
+		a.Blocks = uint64(len(s.Nd.Links))
+		a.Uid = uint32(os.Getuid())
+		a.Gid = uint32(os.Getgid())
 
 	default:
 		return fmt.Errorf("Invalid data type - %s", s.cached.GetType())


### PR DESCRIPTION
commit 44757b64f210ea6f5c8efe95cc7ea1377c7a8560
Author: Tommi Virtanen <tv@eagain.net>
Date:   2015-09-01 15:34:12 -0700

    fuse/ipns: Only change file size in Setattr if asked to
    
    This used to cause files e.g. being edited with `vi` to become 0-size.
    
    License: MIT
    Signed-off-by: Tommi Virtanen <tv@eagain.net>

commit 4be9bd1093229c8592e9aef1c1aa3a3defe53935
Author: Tommi Virtanen <tv@eagain.net>
Date:   2015-08-31 18:03:59 -0700

    fuse/ipns, fuse/readonly: Let the fuse library set defaults for Attr
    
    Without this, all entries will have nlink==0, which confuses a bunch
    of tools. Most dramatically, systemd-nspawn enters a busy loop in its
    lock utility function.
    
    License: MIT
    Signed-off-by: Tommi Virtanen <tv@eagain.net>

commit c0edb6329889e7adfb07103edf2704059fd5235f
Author: Tommi Virtanen <tv@eagain.net>
Date:   2015-08-31 15:04:28 -0700

    fuse/readonly: Fix importer.BuildTrickleDagFromReader call
    
    Last argument was dropped in ffd4c3f4db4be0c9e36c1645fd1b5a6c8e0d8b01
    
    License: MIT
    Signed-off-by: Tommi Virtanen <tv@eagain.net>
