### PR TITLE
Serialfile: Explicit err on unrecognized file type

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -330,3 +330,17 @@ disk_usage() {
     esac
         $DU "$1" | awk "{print \$1}"
 }
+
+# output a file's permission in human readable format
+generic_stat() {
+    # normalize stat across systems
+    case $(uname -s) in
+        Linux)
+            _STAT="stat -c %A"
+            ;;
+        FreeBSD | Darwin | DragonFly)
+            _STAT="stat -f %Sp"
+            ;;
+    esac
+    $_STAT "$1"
+}

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -8,6 +8,10 @@ test_description="Test add and cat commands"
 
 . lib/test-lib.sh
 
+client_err() {
+    printf "$@\n\nUse 'ipfs add --help' for information about this command\n"
+}
+
 test_launch_ipfs_daemon_and_mount
 
 test_expect_success "'ipfs add --help' succeeds" '
@@ -260,6 +264,21 @@ test_expect_success FUSE,EXPENSIVE "cat ipfs/bigfile succeeds" '
 
 test_expect_success FUSE,EXPENSIVE "cat ipfs/bigfile looks good" '
 	test_cmp sha1_expected sha1_actual
+'
+
+test_expect_success "useful error message when adding a named pipe" '
+	mkfifo named-pipe &&
+	test_expect_code 1 ipfs add named-pipe 2>actual &&
+    client_err "Error: Unrecognized file type for named-pipe: $(generic_stat named-pipe)" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "useful error message when recursively adding a named pipe" '
+	mkdir named-pipe-dir &&
+	mkfifo named-pipe-dir/named-pipe &&
+	test_expect_code 1 ipfs add -r named-pipe-dir 2>actual &&
+    printf "Error: Post http://127.0.0.1:$PORT_API/api/v0/add?encoding=json&progress=true&r=true&stream-channels=true: Unrecognized file type for named-pipe-dir/named-pipe: $(generic_stat named-pipe-dir/named-pipe)\n" >expected &&
+	test_cmp expected actual
 '
 
 test_kill_ipfs_daemon

--- a/test/sharness/t0041-add-cat-offline.sh
+++ b/test/sharness/t0041-add-cat-offline.sh
@@ -8,6 +8,10 @@ test_description="Test add and cat commands"
 
 . lib/test-lib.sh
 
+client_err() {
+    printf "$@\n\nUse 'ipfs add --help' for information about this command\n"
+}
+
 test_init_ipfs
 
 test_expect_success "ipfs add file succeeds" '
@@ -51,6 +55,21 @@ test_expect_success "ipfs add --only-hash succeeds" '
 
 test_expect_success "ipfs cat file fails" '
 	test_must_fail ipfs cat $(cat oh_hash)
+'
+
+test_expect_success "useful error message when adding a named pipe" '
+	mkfifo named-pipe &&
+	test_expect_code 1 ipfs add named-pipe 2>actual &&
+    client_err "Error: Unrecognized file type for named-pipe: $(generic_stat named-pipe)" >expected &&
+	test_cmp expected actual
+'
+
+test_expect_success "useful error message when recursively adding a named pipe" '
+	mkdir named-pipe-dir &&
+	mkfifo named-pipe-dir/named-pipe &&
+	test_expect_code 1 ipfs add -r named-pipe-dir 2>actual &&
+    printf "Error: Unrecognized file type for named-pipe-dir/named-pipe: $(generic_stat named-pipe-dir/named-pipe)\n" >expected &&
+	test_cmp expected actual
 '
 
 test_done


### PR DESCRIPTION
"Fixes" #1409 (if the fix is to err when input is a namedpipe)

This PR changes the behavior so that ipfs add on daemon returns err for all cases instead of hangs.
~ a more lightweight version of #1413 except that it doesn't have fileinfo mime types.