### PR TITLE
import sub-lib of iptb so go doesnt whine about importing a binary

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -288,7 +288,7 @@
 		},
 		{
 			"ImportPath": "github.com/whyrusleeping/iptb",
-			"Rev": "3970c95a864f1a40037f796ff596607ce8ae43be"
+			"Rev": "1fd1df917894dbcda078907f8d92f9d0b004f634"
 		},
 		{
 			"ImportPath": "github.com/whyrusleeping/multiaddr-filter",

--- a/Godeps/_workspace/src/github.com/whyrusleeping/iptb/README.md
+++ b/Godeps/_workspace/src/github.com/whyrusleeping/iptb/README.md
@@ -12,6 +12,8 @@ easy!
 		- -n=[number of nodes]
 		- -f : force overwriting of existing nodes
 		- -bootstrap : select bootstrapping style for cluster choices: star, none
+		- -mdns=[true||false] : defaults to false
+		- -p=[start port] : port to start allocations from
 - start 
 	- starts up all testbed nodes
 	- Options:

--- a/Godeps/_workspace/src/github.com/whyrusleeping/iptb/lib/todo.go
+++ b/Godeps/_workspace/src/github.com/whyrusleeping/iptb/lib/todo.go
@@ -1,0 +1,3 @@
+package iptb
+
+// TODO: move code here to be used as a lib

--- a/Godeps/_workspace/src/github.com/whyrusleeping/iptb/main.go
+++ b/Godeps/_workspace/src/github.com/whyrusleeping/iptb/main.go
@@ -12,13 +12,15 @@ import (
 	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
-	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
-	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
 	serial "github.com/ipfs/go-ipfs/repo/fsrepo/serialize"
+
+	manet "github.com/jbenet/go-multiaddr-net"
+	ma "github.com/jbenet/go-multiaddr-net/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 )
 
 // GetNumNodes returns the number of testbed nodes configured in the testbed directory
@@ -70,6 +72,7 @@ type initCfg struct {
 	Force     bool
 	Bootstrap string
 	PortStart int
+	Mdns      bool
 }
 
 func (c *initCfg) swarmAddrForPeer(i int) string {
@@ -144,6 +147,7 @@ func starBootstrap(icfg *initCfg) error {
 	bcfg.Addresses.Swarm = []string{icfg.swarmAddrForPeer(0)}
 	bcfg.Addresses.API = icfg.apiAddrForPeer(0)
 	bcfg.Addresses.Gateway = ""
+	bcfg.Discovery.MDNS.Enabled = icfg.Mdns
 	err = serial.WriteConfigFile(cfgpath, bcfg)
 	if err != nil {
 		return err
@@ -156,8 +160,11 @@ func starBootstrap(icfg *initCfg) error {
 			return err
 		}
 
-		cfg.Bootstrap = []string{fmt.Sprintf("%s/ipfs/%s", bcfg.Addresses.Swarm[0], bcfg.Identity.PeerID)}
+		ba := fmt.Sprintf("%s/ipfs/%s", bcfg.Addresses.Swarm[0], bcfg.Identity.PeerID)
+		ba = strings.Replace(ba, "0.0.0.0", "127.0.0.1", -1)
+		cfg.Bootstrap = []string{ba}
 		cfg.Addresses.Gateway = ""
+		cfg.Discovery.MDNS.Enabled = icfg.Mdns
 		cfg.Addresses.Swarm = []string{
 			icfg.swarmAddrForPeer(i),
 		}
@@ -182,6 +189,7 @@ func clearBootstrapping(icfg *initCfg) error {
 		cfg.Addresses.Gateway = ""
 		cfg.Addresses.Swarm = []string{icfg.swarmAddrForPeer(i)}
 		cfg.Addresses.API = icfg.apiAddrForPeer(i)
+		cfg.Discovery.MDNS.Enabled = icfg.Mdns
 		err = serial.WriteConfigFile(cfgpath, cfg)
 		if err != nil {
 			return err
@@ -440,6 +448,7 @@ func main() {
 	flag.IntVar(&cfg.Count, "n", 0, "number of ipfs nodes to initialize")
 	flag.IntVar(&cfg.PortStart, "p", 4002, "port to start allocations from")
 	flag.BoolVar(&cfg.Force, "f", false, "force initialization (overwrite existing configs)")
+	flag.BoolVar(&cfg.Mdns, "mdns", false, "turn on mdns for nodes")
 	flag.StringVar(&cfg.Bootstrap, "bootstrap", "star", "select bootstrapping style for cluster")
 
 	wait := flag.Bool("wait", false, "wait for nodes to come fully online before exiting")

--- a/util/sadhack/godep.go
+++ b/util/sadhack/godep.go
@@ -5,7 +5,7 @@ package util
 import _ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/dustin/go-humanize"
 
 // similar to the above, only used in the tests makefile
-import _ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/whyrusleeping/iptb"
+import _ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/whyrusleeping/iptb/lib"
 
 import _ "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/chriscool/go-sleep"
 


### PR DESCRIPTION
This is one way (probably the easiest way) we can fix the godeps issue in go1.5

It feels kinda hacky. So i'm not sure if this is the *right* way, but it works

If this is the way we want to do it, @chriscool will need to do something similar for `go-sleep`

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>