### PR TITLE
fix import path of generated proto files

### DIFF
--- a/unixfs/pb/unixfs.pb.go
+++ b/unixfs/pb/unixfs.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 */
 package unixfs_pb
 
-import proto "github.com/gogo/protobuf/proto"
+import proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
build failure to do incorrect import path.

@rht can I get a :+1: to merge asap? (pretty sure jbenet is out for a while)

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>