### PR TITLE
allow channel marshaler to return errors from cmds.Response

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -96,19 +96,25 @@ func (s *BlockService) GetBlock(ctx context.Context, k key.Key) (*blocks.Block, 
 	block, err := s.Blockstore.Get(k)
 	if err == nil {
 		return block, nil
+	}
+
+	if err == blockstore.ErrNotFound && s.Exchange != nil {
 		// TODO be careful checking ErrNotFound. If the underlying
 		// implementation changes, this will break.
-	} else if err == blockstore.ErrNotFound && s.Exchange != nil {
 		log.Debug("Blockservice: Searching bitswap.")
 		blk, err := s.Exchange.GetBlock(ctx, k)
 		if err != nil {
 			return nil, err
 		}
 		return blk, nil
-	} else {
-		log.Debug("Blockservice GetBlock: Not found.")
+	}
+
+	log.Debug("Blockservice GetBlock: Not found.")
+	if err == blockstore.ErrNotFound {
 		return nil, ErrNotFound
 	}
+
+	return nil, err
 }
 
 // GetBlocks gets a list of blocks asynchronously and returns through

--- a/commands/channelmarshaler.go
+++ b/commands/channelmarshaler.go
@@ -5,6 +5,7 @@ import "io"
 type ChannelMarshaler struct {
 	Channel   <-chan interface{}
 	Marshaler func(interface{}) (io.Reader, error)
+	Res       Response
 
 	reader io.Reader
 }
@@ -13,6 +14,10 @@ func (cr *ChannelMarshaler) Read(p []byte) (int, error) {
 	if cr.reader == nil {
 		val, more := <-cr.Channel
 		if !more {
+			//check error in response
+			if cr.Res.Error() != nil {
+				return 0, cr.Res.Error()
+			}
 			return 0, io.EOF
 		}
 

--- a/commands/response.go
+++ b/commands/response.go
@@ -57,6 +57,7 @@ var marshallers = map[EncodingType]Marshaler{
 			return &ChannelMarshaler{
 				Channel:   ch,
 				Marshaler: marshalJson,
+				Res:       res,
 			}, nil
 		}
 

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -131,6 +131,7 @@ var queryDhtCmd = &cmds.Command{
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},
@@ -249,6 +250,7 @@ FindProviders will return a list of peers who are able to provide the value requ
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},
@@ -354,6 +356,7 @@ var findPeerDhtCmd = &cmds.Command{
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},
@@ -461,6 +464,7 @@ GetValue will return the value stored in the dht at the given key.
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},
@@ -571,6 +575,7 @@ PutValue will store the given key value pair in the dht.
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -71,6 +71,7 @@ trip latency information.
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -141,6 +141,7 @@ Note: list all refs recursively with -r.
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -90,6 +90,7 @@ order to reclaim hard disk space.
 			return &cmds.ChannelMarshaler{
 				Channel:   outChan,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -167,6 +167,7 @@ var statBwCmd = &cmds.Command{
 			return &cmds.ChannelMarshaler{
 				Channel:   outCh,
 				Marshaler: marshal,
+				Res:       res,
 			}, nil
 		},
 	},


### PR DESCRIPTION
This doesnt fix the add issue, but it does allow us to actually see the error for it. 

Previously, the goroutine in add would fail, and call `res.SetError`, but nothing would ever check that. 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>