### PR TITLE
first pass at a tar importer

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -108,6 +108,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"resolve":   ResolveCmd,
 	"stats":     StatsCmd,
 	"swarm":     SwarmCmd,
+	"tar":       TarCmd,
 	"tour":      tourCmd,
 	"file":      unixfs.UnixFSCmd,
 	"update":    UpdateCmd,

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"io"
+	"strings"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	core "github.com/ipfs/go-ipfs/core"
+	path "github.com/ipfs/go-ipfs/path"
+	tar "github.com/ipfs/go-ipfs/tar"
+)
+
+var TarCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "utility functions for tar files in ipfs",
+	},
+
+	Subcommands: map[string]*cmds.Command{
+		"add": tarAddCmd,
+		"cat": tarCatCmd,
+	},
+}
+
+var tarAddCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "import a tar file into ipfs",
+		ShortDescription: `
+'ipfs tar add' will parse a tar file and create a merkledag structure to represent it.
+`,
+	},
+
+	Arguments: []cmds.Argument{
+		cmds.FileArg("file", true, false, "tar file to add").EnableStdin(),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		nd, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		fi, err := req.Files().NextFile()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		node, err := tar.ImportTar(fi, nd.DAG)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		k, err := node.Key()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		fi.FileName()
+		res.SetOutput(&AddedObject{
+			Name: fi.FileName(),
+			Hash: k.B58String(),
+		})
+	},
+	Type: AddedObject{},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			o := res.Output().(*AddedObject)
+			return strings.NewReader(o.Hash), nil
+		},
+	},
+}
+
+var tarCatCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "export a tar file from ipfs",
+		ShortDescription: `
+'ipfs tar cat' will export a tar file from a previously imported one in ipfs
+`,
+	},
+
+	Arguments: []cmds.Argument{
+		cmds.StringArg("path", true, false, "ipfs path of archive to export").EnableStdin(),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		nd, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		p, err := path.ParsePath(req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		root, err := core.Resolve(req.Context(), nd, p)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		r, err := tar.ExportTar(req.Context(), root, nd.DAG)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		res.SetOutput(r)
+	},
+}

--- a/test/sharness/t0210-tar.sh
+++ b/test/sharness/t0210-tar.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test tar commands"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_expect_success "create some random files" '
+	mkdir foo &&
+	random 10000 > foo/a &&
+	random 12345 > foo/b &&
+	mkdir foo/bar &&
+	random 5432 > foo/bar/baz &&
+	ln -s ../a foo/bar/link &&
+	echo "exit" > foo/script &&
+	chmod +x foo/script
+'
+
+test_expect_success "tar those random files up" '
+	tar cf files.tar foo/
+'
+
+test_expect_success "'ipfs tar add' succeeds" '
+	TAR_HASH=$(ipfs tar add files.tar)
+'
+
+test_expect_success "'ipfs tar cat' succeeds" '
+	mkdir output &&
+	ipfs tar cat $TAR_HASH > output/out.tar
+'
+
+test_expect_success "can extract tar" '
+	tar xf output/out.tar -C output/
+'
+
+test_expect_success "files look right" '
+	diff foo/a output/foo/a &&
+	diff foo/b output/foo/b &&
+	diff foo/bar/baz output/foo/bar/baz &&
+	[ -L output/foo/bar/link ] &&
+	[ -x foo/script ]
+'
+
+test_done


### PR DESCRIPTION
Allows the importing of tar files into ipfs, provides greater dedupe than simple using 'ipfs add' on the tar file. Also adds a command to export a tar back out from the added hash

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>