### PR TITLE
timeout on shutdown after 10s

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -557,6 +557,11 @@ func (i *cmdInvocation) SetupInterruptHandler(ctx context.Context) (io.Closer, c
 				defer ih.wg.Done()
 				cancelFunc()
 			}()
+			go func() {
+				time.Sleep(10 * time.Second)
+				fmt.Println("Shutdown timed out after 10s, terminating...")
+				os.Exit(-1)
+			}()
 
 		default:
 			fmt.Println("Received another interrupt before graceful shutdown, terminating...")


### PR DESCRIPTION
partially solves #1384

Note/Question: `cancelFunc` is not synchronous. Are you sure this shouldn't wait on
`ctx.Done()` before calling `ih.wg.Done()`? Otherwise, is there any reason for it to be in a goroutine?