### PR TITLE
Build ipfs in container rather than use gobuilder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,26 @@ FROM alpine:3.2
 MAINTAINER Brian Tiger Chow <btc@perfmode.com>
 
 ENV IPFS_PATH /data/ipfs
-ENV VERSION master
+ENV GOPATH /gobuild
+ENV GOPKG github.com/ipfs/go-ipfs
 
 EXPOSE 4001 5001 8080
 # 4001 = Swarm, 5001 = API, 8080 = HTTP transport
 
 VOLUME /data/ipfs
 
-ADD bin/container_daemon /usr/local/bin/start_ipfs
-ADD bin/container_shacheck /usr/local/bin/shacheck
+ADD . $GOPATH/src/$GOPKG
 
 RUN adduser -D -h /data -u 1000 ipfs \
  && mkdir -p /data/ipfs && chown ipfs:ipfs /data/ipfs \
- && apk add --update bash curl wget ca-certificates zip \
- && wget https://gobuilder.me/get/github.com/ipfs/go-ipfs/cmd/ipfs/ipfs_${VERSION}_linux-386.zip \
- && /bin/bash /usr/local/bin/shacheck ${VERSION} ipfs_${VERSION}_linux-386.zip \
- && unzip ipfs_${VERSION}_linux-386.zip \
- && rm ipfs_${VERSION}_linux-386.zip \
- && mv ipfs/ipfs /usr/local/bin/ipfs \
+ && apk add --update go ca-certificates bash \
+ && cd $GOPATH/src/$GOPKG/cmd/ipfs \
+ && go get -v ./... \
+ && go install -v \
+ && mv $GOPATH/bin/ipfs /usr/local/bin/ipfs \
+ && cp ../../bin/container_daemon /usr/local/bin/start_ipfs \
  && chmod 755 /usr/local/bin/start_ipfs \
- && apk del wget zip curl
+ && apk del go && rm -rf /var/cache/apk/* $GOPATH
 
 USER ipfs
 

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -18,4 +18,4 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
-ipfs daemon
+exec ipfs daemon


### PR DESCRIPTION
The old container probably downloaded new versions before they were built by gobuilder, which meant the container was probably behind by a commit all the time. To remedy this, we build go-ipfs inside the container. This has the advantage of being able to easily build the container from uncommitted changes.