### PR TITLE
Added dockerhub trigger

### DIFF
--- a/cmd/ipfs/.gobuilder.yml
+++ b/cmd/ipfs/.gobuilder.yml
@@ -8,3 +8,7 @@ artifacts:
   README.md: dist/README.md
   LICENSE: dist/LICENSE
   install.sh: dist/install.sh
+notify:
+  - type: dockerhub
+    target: U2FsdGVkX18fMPhIZ3k1QDCwnB49ln6DdyvIH2tDDHxTZi3Q3DQ7AKWllo9KngxwteX2dBFQ2P+jLEBh12PEEqOkN2SePNbMhMtmk/c4siHVAqo5wnf8Utgqob0jB40sobmqNN9X3Y/W2yb72LuGJg==
+    filter: success


### PR DESCRIPTION
As discussed in #1685 this trigger will fire after the ipfs cmd has been built and trigger a DockerHub build for the `jbenet/go-ipfs` repo on DockerHub.

Encrypted target was created by using this command:

```bash
# echo -n 'https://registry.hub.docker.com/[...]/' | gobuilder-cli --repo=github.com/ipfs/go-ipfs encrypt
Go ahead and type your secret ...
U2FsdGVkX18fMPhIZ3k1QDCwnB49ln6DdyvIH2tDDHxTZi3Q3DQ7AKWllo9KngxwteX2dBFQ2P+jLEBh12PEEqOkN2SePNbMhMtmk/c4siHVAqo5wnf8Utgqob0jB40sobmqNN9X3Y/W2yb72LuGJg==
```

closes #1685