### PR TITLE
extract logging

### DIFF
--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -12,10 +12,10 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("blockstore")
+var log = logging.Logger("blockstore")
 
 // BlockPrefix namespaces blockstore datastores
 var BlockPrefix = ds.NewKey("blocks")

--- a/blocks/set/set.go
+++ b/blocks/set/set.go
@@ -4,10 +4,10 @@ package set
 import (
 	"github.com/ipfs/go-ipfs/blocks/bloom"
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	"github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("blockset")
+var log = logging.Logger("blockset")
 
 // BlockSet represents a mutable set of keyed blocks
 type BlockSet interface {

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -12,7 +12,7 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	worker "github.com/ipfs/go-ipfs/blockservice/worker"
 	exchange "github.com/ipfs/go-ipfs/exchange"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var wc = worker.Config{
@@ -32,7 +32,7 @@ var wc = worker.Config{
 	WorkerBufferSize: 0,
 }
 
-var log = u.Logger("blockservice")
+var log = logging.Logger("blockservice")
 var ErrNotFound = errors.New("blockservice: key not found")
 
 // BlockService is a hybrid block datastore. It stores data in a local

--- a/blockservice/worker/worker.go
+++ b/blockservice/worker/worker.go
@@ -12,10 +12,11 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	exchange "github.com/ipfs/go-ipfs/exchange"
-	util "github.com/ipfs/go-ipfs/util"
+
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("blockservice")
+var log = logging.Logger("blockservice")
 
 var DefaultConfig = Config{
 	NumWorkers:       1,

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -27,12 +27,12 @@ import (
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 // log is the command logger
-var log = eventlog.Logger("cmd/ipfs")
+var log = logging.Logger("cmd/ipfs")
 
 var (
 	errUnexpectedApiOutput = errors.New("api returned unexpected output")
@@ -62,7 +62,7 @@ type cmdInvocation struct {
 func main() {
 	rand.Seed(time.Now().UnixNano())
 	runtime.GOMAXPROCS(3) // FIXME rm arbitrary choice for n
-	ctx := eventlog.ContextWithLoggable(context.Background(), eventlog.Uuid("session"))
+	ctx := logging.ContextWithLoggable(context.Background(), logging.Uuid("session"))
 	var err error
 	var invoc cmdInvocation
 	defer invoc.close()
@@ -175,7 +175,7 @@ func (i *cmdInvocation) Run(ctx context.Context) (output io.Reader, err error) {
 	}
 	if debug || u.GetenvBool("DEBUG") || os.Getenv("IPFS_LOGGING") == "debug" {
 		u.Debug = true
-		u.SetDebugLogging()
+		logging.SetDebugLogging()
 	}
 
 	res, err := callCommand(ctx, i.req, Root, i.cmd)

--- a/cmd/seccat/seccat.go
+++ b/cmd/seccat/seccat.go
@@ -21,7 +21,7 @@ import (
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	secio "github.com/ipfs/go-ipfs/p2p/crypto/secio"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var verbose = false
@@ -93,7 +93,7 @@ func main() {
 	args := parseArgs()
 	verbose = args.verbose
 	if args.debug {
-		u.SetDebugLogging()
+		logging.SetDebugLogging()
 	}
 
 	go func() {

--- a/cmd/seccat/util.go
+++ b/cmd/seccat/util.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"os"
 
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("seccat")
+var log = logging.Logger("seccat")
 
 func exit(format string, vals ...interface{}) {
 	if format != "" {

--- a/commands/command.go
+++ b/commands/command.go
@@ -15,10 +15,10 @@ import (
 	"reflect"
 	"strings"
 
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("command")
+var log = logging.Logger("command")
 
 // Function is the type of function that Commands use.
 // It reads from the Request, and writes results to the Response.

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -16,10 +16,10 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("commands/http")
+var log = logging.Logger("commands/http")
 
 // the internal handler for the API
 type internalHandler struct {

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -5,8 +5,7 @@ import (
 	"io"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 // Golang os.Args overrides * and replaces the character argument with
@@ -54,7 +53,7 @@ output of a running daemon.
 			subsystem = "*"
 		}
 
-		if err := u.SetLogLevel(subsystem, level); err != nil {
+		if err := logging.SetLogLevel(subsystem, level); err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
@@ -79,7 +78,7 @@ var logTailCmd = &cmds.Command{
 
 	Run: func(req cmds.Request, res cmds.Response) {
 		r, w := io.Pipe()
-		eventlog.WriterGroup.AddWriter(w)
+		logging.WriterGroup.AddWriter(w)
 		go func() {
 			<-req.Context().Done()
 			w.Close()

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -6,10 +6,10 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	unixfs "github.com/ipfs/go-ipfs/core/commands/unixfs"
-	evlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = evlog.Logger("core/commands")
+var log = logging.Logger("core/commands")
 
 type TestOutput struct {
 	Foo string

--- a/core/core.go
+++ b/core/core.go
@@ -33,7 +33,7 @@ import (
 	addrutil "github.com/ipfs/go-ipfs/p2p/net/swarm/addr"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	ping "github.com/ipfs/go-ipfs/p2p/protocol/ping"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	routing "github.com/ipfs/go-ipfs/routing"
 	dht "github.com/ipfs/go-ipfs/routing/dht"
@@ -62,7 +62,7 @@ const kSizeBlockstoreWriteCache = 100
 const kReprovideFrequency = time.Hour * 12
 const discoveryConnTimeout = time.Second * 30
 
-var log = eventlog.Logger("core")
+var log = logging.Logger("core")
 
 type mode int
 

--- a/core/corehttp/corehttp.go
+++ b/core/corehttp/corehttp.go
@@ -14,10 +14,10 @@ import (
 	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	core "github.com/ipfs/go-ipfs/core"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("core/server")
+var log = logging.Logger("core/server")
 
 // ServeOption registers any HTTP handlers it provides on the given mux.
 // It returns the mux to expose to future options, which may be a new mux if it

--- a/core/corehttp/logs.go
+++ b/core/corehttp/logs.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	core "github.com/ipfs/go-ipfs/core"
-	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 type writeErrNotifier struct {
@@ -41,7 +41,7 @@ func LogOption() ServeOption {
 		mux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
 			wnf, errs := newWriteErrNotifier(w)
-			eventlog.WriterGroup.AddWriter(wnf)
+			logging.WriterGroup.AddWriter(wnf)
 			log.Event(n.Context(), "log API client connected")
 			<-errs
 		})

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -5,10 +5,10 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/core"
 
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("corerepo")
+var log = logging.Logger("corerepo")
 
 type KeyRemoved struct {
 	Key key.Key

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -14,11 +14,11 @@ import (
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/pin"
-	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 )
 
-var log = eventlog.Logger("coreunix")
+var log = logging.Logger("coreunix")
 
 // Add builds a merkledag from the a reader, pinning all objects to the local
 // datastore. Returns a key representing the root node.

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -20,10 +20,10 @@ import (
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
-	util "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("diagnostics")
+var log = logging.Logger("diagnostics")
 
 // ProtocolDiag is the diagnostics protocol.ID
 var ProtocolDiag protocol.ID = "/ipfs/diagnostics"

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -22,10 +22,10 @@ import (
 	wantlist "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	"github.com/ipfs/go-ipfs/thirdparty/delay"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("bitswap")
+var log = logging.Logger("bitswap")
 
 const (
 	// maxProvidersPerRequest specifies the maximum number of providers desired
@@ -151,7 +151,7 @@ func (bs *Bitswap) GetBlock(parent context.Context, k key.Key) (*blocks.Block, e
 
 	ctx, cancelFunc := context.WithCancel(parent)
 
-	ctx = eventlog.ContextWithLoggable(ctx, eventlog.Uuid("GetBlockRequest"))
+	ctx = logging.ContextWithLoggable(ctx, logging.Uuid("GetBlockRequest"))
 	log.Event(ctx, "Bitswap.GetBlockRequest.Start", &k)
 	defer log.Event(ctx, "Bitswap.GetBlockRequest.End", &k)
 

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -10,7 +10,7 @@ import (
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	wl "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 // TODO consider taking responsibility for other types of requests. For
@@ -43,7 +43,7 @@ import (
 // whatever it sees fit to produce desired outcomes (get wanted keys
 // quickly, maintain good relationships with peers, etc).
 
-var log = eventlog.Logger("engine")
+var log = logging.Logger("engine")
 
 const (
 	// outboxChanBuffer must be 0 to prevent stale messages from being sent

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -9,10 +9,10 @@ import (
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("bitswap_network")
+var log = logging.Logger("bitswap_network")
 
 // NewFromIpfsHost returns a BitSwapNetwork supported by underlying IPFS host
 func NewFromIpfsHost(host host.Host, r routing.IpfsRouting) BitSwapNetwork {

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -9,7 +9,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var TaskWorkerCount = 8
@@ -45,7 +45,7 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 }
 
 func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
-	idmap := eventlog.LoggableMap{"ID": id}
+	idmap := logging.LoggableMap{"ID": id}
 	defer log.Info("bitswap task worker shutting down...")
 	for {
 		log.Event(ctx, "Bitswap.TaskWorker.Loop", idmap)
@@ -56,7 +56,7 @@ func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
 				if !ok {
 					continue
 				}
-				log.Event(ctx, "Bitswap.TaskWorker.Work", eventlog.LoggableMap{
+				log.Event(ctx, "Bitswap.TaskWorker.Work", logging.LoggableMap{
 					"ID":     id,
 					"Target": envelope.Peer.Pretty(),
 					"Block":  envelope.Block.Multihash.B58String(),
@@ -77,7 +77,7 @@ func (bs *Bitswap) provideWorker(px process.Process) {
 	limiter := ratelimit.NewRateLimiter(px, provideWorkerMax)
 
 	limitedGoProvide := func(k key.Key, wid int) {
-		ev := eventlog.LoggableMap{"ID": wid}
+		ev := logging.LoggableMap{"ID": wid}
 		limiter.LimitedGo(func(px process.Process) {
 
 			ctx := procctx.OnClosingContext(px) // derive ctx from px
@@ -96,7 +96,7 @@ func (bs *Bitswap) provideWorker(px process.Process) {
 	// _ratelimited_ number of workers to handle each key.
 	limiter.Go(func(px process.Process) {
 		for wid := 2; ; wid++ {
-			ev := eventlog.LoggableMap{"ID": 1}
+			ev := logging.LoggableMap{"ID": 1}
 			log.Event(procctx.OnClosingContext(px), "Bitswap.ProvideWorker.Loop", ev)
 
 			select {
@@ -158,7 +158,7 @@ func (bs *Bitswap) providerConnector(parent context.Context) {
 				log.Warning("Received batch request for zero blocks")
 				continue
 			}
-			log.Event(parent, "Bitswap.ProviderConnector.Work", eventlog.LoggableMap{"Keys": keys})
+			log.Event(parent, "Bitswap.ProviderConnector.Work", logging.LoggableMap{"Keys": keys})
 
 			// NB: Optimization. Assumes that providers of key[0] are likely to
 			// be able to provide for all keys. This currently holds true in most

--- a/exchange/reprovide/reprovide.go
+++ b/exchange/reprovide/reprovide.go
@@ -8,10 +8,10 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	blocks "github.com/ipfs/go-ipfs/blocks/blockstore"
 	routing "github.com/ipfs/go-ipfs/routing"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("reprovider")
+var log = logging.Logger("reprovider")
 
 type Reprovider struct {
 	// The routing system to provide values through

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -13,7 +13,7 @@ import (
 	fuse "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse"
 	fs "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse/fs"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	core "github.com/ipfs/go-ipfs/core"
@@ -23,7 +23,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 )
 
-var log = eventlog.Logger("fuse/ipns")
+var log = logging.Logger("fuse/ipns")
 
 // FileSystem is the readwrite IPNS Fuse Filesystem.
 type FileSystem struct {

--- a/fuse/mount/mount.go
+++ b/fuse/mount/mount.go
@@ -10,10 +10,10 @@ import (
 
 	goprocess "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("mount")
+var log = logging.Logger("mount")
 
 var MountTimeout = time.Second * 5
 

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -16,13 +16,13 @@ import (
 	core "github.com/ipfs/go-ipfs/core"
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
 	lgbl "github.com/ipfs/go-ipfs/util/eventlog/loggables"
 )
 
-var log = eventlog.Logger("fuse/ipfs")
+var log = logging.Logger("fuse/ipfs")
 
 // FileSystem is the readonly Ipfs Fuse Filesystem.
 type FileSystem struct {

--- a/importer/chunk/splitting.go
+++ b/importer/chunk/splitting.go
@@ -4,10 +4,10 @@ package chunk
 import (
 	"io"
 
-	"github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("chunk")
+var log = logging.Logger("chunk")
 
 var DefaultBlockSize int64 = 1024 * 256
 

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -13,10 +13,10 @@ import (
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/pin"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("importer")
+var log = logging.Logger("importer")
 
 // Builds a DAG from the given file, writing created blocks to disk as they are
 // created

--- a/ipnsfs/system.go
+++ b/ipnsfs/system.go
@@ -25,10 +25,10 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("ipnsfs")
+var log = logging.Logger("ipnsfs")
 
 var ErrIsDirectory = errors.New("error: is a directory")
 
@@ -236,7 +236,7 @@ func (kr *KeyRoot) Publish(ctx context.Context) error {
 
 	kp := path.FromKey(k)
 
-	ev := &eventlog.Metadata{"name": kr.name, "key": kp}
+	ev := &logging.Metadata{"name": kr.name, "key": kp}
 	defer log.EventBegin(ctx, "ipnsfsPublishing", ev).Done()
 	log.Info("ipnsfs publishing %s -> %s", kr.name, kp)
 

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -9,10 +9,10 @@ import (
 	blocks "github.com/ipfs/go-ipfs/blocks"
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("merkledag")
+var log = logging.Logger("merkledag")
 var ErrNotFound = fmt.Errorf("merkledag: not found")
 
 // DAGService is an IPFS Merkle DAG service.

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -11,10 +11,10 @@ import (
 	pb "github.com/ipfs/go-ipfs/namesys/pb"
 	path "github.com/ipfs/go-ipfs/path"
 	routing "github.com/ipfs/go-ipfs/routing"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("namesys")
+var log = logging.Logger("namesys")
 
 // routingResolver implements NSResolver for the main IPFS SFS-like naming
 type routingResolver struct {

--- a/p2p/crypto/key.go
+++ b/p2p/crypto/key.go
@@ -23,9 +23,10 @@ import (
 
 	pb "github.com/ipfs/go-ipfs/p2p/crypto/pb"
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("crypto")
+var log = logging.Logger("crypto")
 
 var ErrBadKeyType = errors.New("invalid or unsupported key type")
 

--- a/p2p/crypto/secio/protocol.go
+++ b/p2p/crypto/secio/protocol.go
@@ -14,11 +14,11 @@ import (
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	pb "github.com/ipfs/go-ipfs/p2p/crypto/secio/pb"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("secio")
+var log = logging.Logger("secio")
 
 // ErrUnsupportedKeyType is returned when a private key cast/type switch fails.
 var ErrUnsupportedKeyType = errors.New("unsupported key type")

--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/ipfs/go-ipfs/p2p/host"
 	"github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("mdns")
+var log = logging.Logger("mdns")
 
 const ServiceTag = "discovery.ipfs.io"
 

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -8,7 +8,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	metrics "github.com/ipfs/go-ipfs/metrics"
 	mstream "github.com/ipfs/go-ipfs/metrics/stream"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
@@ -17,7 +17,7 @@ import (
 	relay "github.com/ipfs/go-ipfs/p2p/protocol/relay"
 )
 
-var log = eventlog.Logger("p2p/host/basic")
+var log = logging.Logger("p2p/host/basic")
 
 // Option is a type used to pass in options to the host.
 type Option int

--- a/p2p/host/host.go
+++ b/p2p/host/host.go
@@ -7,10 +7,10 @@ import (
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("p2p/host")
+var log = logging.Logger("p2p/host")
 
 // Host is an object participating in a p2p network, which
 // implements protocols or provides services. It handles

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -6,7 +6,7 @@ import (
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	lgbl "github.com/ipfs/go-ipfs/util/eventlog/loggables"
 
 	metrics "github.com/ipfs/go-ipfs/metrics"
@@ -17,7 +17,7 @@ import (
 	routing "github.com/ipfs/go-ipfs/routing"
 )
 
-var log = eventlog.Logger("p2p/host/routed")
+var log = logging.Logger("p2p/host/routed")
 
 // AddressTTL is the expiry time for our addresses.
 // We expire them quickly.

--- a/p2p/nat/nat.go
+++ b/p2p/nat/nat.go
@@ -14,8 +14,8 @@ import (
 	nat "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/fd/go-nat"
 	goprocess "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	periodic "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess/periodic"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	notifier "github.com/ipfs/go-ipfs/thirdparty/notifier"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var (
@@ -23,7 +23,7 @@ var (
 	ErrNoMapping = errors.New("mapping not established")
 )
 
-var log = eventlog.Logger("nat")
+var log = logging.Logger("nat")
 
 // MappingDuration is a default port mapping duration.
 // Port mappings are renewed every (MappingDuration / 3)

--- a/p2p/net/conn/conn.go
+++ b/p2p/net/conn/conn.go
@@ -13,12 +13,12 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	ic "github.com/ipfs/go-ipfs/p2p/crypto"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	u "github.com/ipfs/go-ipfs/util"
 	lgbl "github.com/ipfs/go-ipfs/util/eventlog/loggables"
 )
 
-var log = eventlog.Logger("conn")
+var log = logging.Logger("conn")
 
 // ReleaseBuffer puts the given byte array back into the buffer pool,
 // first verifying that it is the correct size

--- a/p2p/net/mock/mock.go
+++ b/p2p/net/mock/mock.go
@@ -1,12 +1,12 @@
 package mocknet
 
 import (
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = eventlog.Logger("mocknet")
+var log = logging.Logger("mocknet")
 
 // WithNPeers constructs a Mocknet with N peers.
 func WithNPeers(ctx context.Context, n int) (Mocknet, error) {

--- a/p2p/net/swarm/addr/addr.go
+++ b/p2p/net/swarm/addr/addr.go
@@ -3,14 +3,14 @@ package addrutil
 import (
 	"fmt"
 
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = eventlog.Logger("p2p/net/swarm/addr")
+var log = logging.Logger("p2p/net/swarm/addr")
 
 // SupportedTransportStrings is the list of supported transports for the swarm.
 // These are strings of encapsulated multiaddr protocols. E.g.:
@@ -176,12 +176,12 @@ func ResolveUnspecifiedAddresses(unspecAddrs, ifaceAddrs []ma.Multiaddr) ([]ma.M
 		return nil, fmt.Errorf("failed to specify addrs: %s", unspecAddrs)
 	}
 
-	log.Event(context.TODO(), "interfaceListenAddresses", func() eventlog.Loggable {
+	log.Event(context.TODO(), "interfaceListenAddresses", func() logging.Loggable {
 		var addrs []string
 		for _, addr := range outputAddrs {
 			addrs = append(addrs, addr.String())
 		}
-		return eventlog.Metadata{"addresses": addrs}
+		return logging.Metadata{"addresses": addrs}
 	}())
 
 	log.Debug("ResolveUnspecifiedAddresses:", unspecAddrs, ifaceAddrs, outputAddrs)

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -12,7 +12,7 @@ import (
 	filter "github.com/ipfs/go-ipfs/p2p/net/filter"
 	addrutil "github.com/ipfs/go-ipfs/p2p/net/swarm/addr"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	ps "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
@@ -25,7 +25,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = eventlog.Logger("swarm2")
+var log = logging.Logger("swarm2")
 
 var PSTransport pst.Transport
 

--- a/p2p/peer/peer.go
+++ b/p2p/peer/peer.go
@@ -13,9 +13,10 @@ import (
 
 	ic "github.com/ipfs/go-ipfs/p2p/crypto"
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("peer")
+var log = logging.Logger("peer")
 
 // ID represents the identity of a peer.
 type ID string

--- a/p2p/peer/queue/sync.go
+++ b/p2p/peer/queue/sync.go
@@ -3,10 +3,10 @@ package queue
 import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("peerqueue")
+var log = logging.Logger("peerqueue")
 
 // ChanQueue makes any PeerQueue synchronizable through channels.
 type ChanQueue struct {

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -16,11 +16,11 @@ import (
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
 	pb "github.com/ipfs/go-ipfs/p2p/protocol/identify/pb"
 	config "github.com/ipfs/go-ipfs/repo/config"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	lgbl "github.com/ipfs/go-ipfs/util/eventlog/loggables"
 )
 
-var log = eventlog.Logger("net/identify")
+var log = logging.Logger("net/identify")
 
 // ID is the protocol.ID of the Identify Service.
 const ID protocol.ID = "/ipfs/identify"

--- a/p2p/protocol/mux.go
+++ b/p2p/protocol/mux.go
@@ -7,11 +7,11 @@ import (
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	lgbl "github.com/ipfs/go-ipfs/util/eventlog/loggables"
 )
 
-var log = eventlog.Logger("net/mux")
+var log = logging.Logger("net/mux")
 
 type streamHandlerMap map[ID]inet.StreamHandler
 

--- a/p2p/protocol/ping/ping.go
+++ b/p2p/protocol/ping/ping.go
@@ -11,11 +11,11 @@ import (
 	host "github.com/ipfs/go-ipfs/p2p/host"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-var log = eventlog.Logger("ping")
+var log = logging.Logger("ping")
 
 const PingSize = 32
 

--- a/p2p/protocol/relay/relay.go
+++ b/p2p/protocol/relay/relay.go
@@ -10,10 +10,10 @@ import (
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("p2p/protocol/relay")
+var log = logging.Logger("p2p/protocol/relay")
 
 // ID is the protocol.ID of the Relay Service.
 const ID protocol.ID = "/ipfs/relay"

--- a/p2p/protocol/relay/relay_test.go
+++ b/p2p/protocol/relay/relay_test.go
@@ -8,12 +8,12 @@ import (
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
 	relay "github.com/ipfs/go-ipfs/p2p/protocol/relay"
 	testutil "github.com/ipfs/go-ipfs/p2p/test/util"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = eventlog.Logger("relay_test")
+var log = logging.Logger("relay_test")
 
 func TestRelaySimple(t *testing.T) {
 

--- a/p2p/test/backpressure/backpressure_test.go
+++ b/p2p/test/backpressure/backpressure_test.go
@@ -11,13 +11,13 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
 	testutil "github.com/ipfs/go-ipfs/p2p/test/util"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-var log = eventlog.Logger("backpressure")
+var log = logging.Logger("backpressure")
 
 // TestBackpressureStreamHandler tests whether mux handler
 // ratelimiting works. Meaning, since the handler is sequential

--- a/p2p/test/reconnects/reconnect_test.go
+++ b/p2p/test/reconnects/reconnect_test.go
@@ -12,7 +12,7 @@ import (
 	swarm "github.com/ipfs/go-ipfs/p2p/net/swarm"
 	protocol "github.com/ipfs/go-ipfs/p2p/protocol"
 	testutil "github.com/ipfs/go-ipfs/p2p/test/util"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	u "github.com/ipfs/go-ipfs/util"
 
 	ps "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
@@ -24,7 +24,7 @@ func init() {
 	ps.GarbageCollectTimeout = 10 * time.Millisecond
 }
 
-var log = eventlog.Logger("reconnect")
+var log = logging.Logger("reconnect")
 
 func EchoStreamHandler(stream inet.Stream) {
 	c := stream.Conn()

--- a/p2p/test/util/key.go
+++ b/p2p/test/util/key.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	u "github.com/ipfs/go-ipfs/util"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 
@@ -15,7 +15,7 @@ import (
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 )
 
-var log = eventlog.Logger("boguskey")
+var log = logging.Logger("boguskey")
 
 // TestBogusPrivateKey is a key used for testing (to avoid expensive keygen)
 type TestBogusPrivateKey []byte

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
     {
       "name": "dir-index-html",
       "hash": "QmdDfkqDWheE4gsCXNrhixwTwSHnZMPT2cGLcNbiBNcMyU"
+    },
+    {
+      "name": "go-log",
+      "hash": "QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8",
+      "linkname": "go-log-v1.0.0"
     }
   ]
 }

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -11,10 +11,10 @@ import (
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("path")
+var log = logging.Logger("path")
 
 // Paths after a protocol must contain at least one component
 var ErrNoComponents = errors.New(

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -14,10 +14,10 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/blocks/set"
 	mdag "github.com/ipfs/go-ipfs/merkledag"
-	"github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("pin")
+var log = logging.Logger("pin")
 var recursePinDatastoreKey = ds.NewKey("/local/pins/recursive/keys")
 var directPinDatastoreKey = ds.NewKey("/local/pins/direct/keys")
 var indirectPinDatastoreKey = ds.NewKey("/local/pins/indirect/keys")

--- a/repo/config/config.go
+++ b/repo/config/config.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("config")
+var log = logging.Logger("config")
 
 // Config is used to load IPFS config files.
 type Config struct {

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -23,10 +23,10 @@ import (
 	mfsr "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
 	serialize "github.com/ipfs/go-ipfs/repo/fsrepo/serialize"
 	dir "github.com/ipfs/go-ipfs/thirdparty/dir"
-	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
 	util "github.com/ipfs/go-ipfs/util"
 	ds2 "github.com/ipfs/go-ipfs/util/datastore2"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 // version number that we are currently expecting to see
@@ -406,9 +406,9 @@ func (r *FSRepo) openDatastore() error {
 }
 
 func configureEventLoggerAtRepoPath(c *config.Config, repoPath string) {
-	eventlog.Configure(eventlog.LevelInfo)
-	eventlog.Configure(eventlog.LdJSONFormatter)
-	eventlog.Configure(eventlog.Output(eventlog.WriterGroup))
+	logging.Configure(logging.LevelInfo)
+	logging.Configure(logging.LdJSONFormatter)
+	logging.Configure(logging.Output(logging.WriterGroup))
 }
 
 // Close closes the FSRepo, releasing held resources.
@@ -436,7 +436,7 @@ func (r *FSRepo) Close() error {
 	//
 	// TODO It isn't part of the current contract, but callers may like for us
 	// to disable logging once the component is closed.
-	// eventlog.Configure(eventlog.Output(os.Stderr))
+	// logging.Configure(logging.Output(os.Stderr))
 
 	r.closed = true
 	if err := r.lockfile.Close(); err != nil {

--- a/repo/fsrepo/serialize/serialize.go
+++ b/repo/fsrepo/serialize/serialize.go
@@ -11,9 +11,10 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/facebookgo/atomicfile"
 	"github.com/ipfs/go-ipfs/repo/config"
 	"github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = util.Logger("fsrepo")
+var log = logging.Logger("fsrepo")
 
 // ReadConfigFile reads the config from `filename` into `cfg`.
 func ReadConfigFile(filename string, cfg interface{}) error {

--- a/routing/dht/dht.go
+++ b/routing/dht/dht.go
@@ -18,8 +18,8 @@ import (
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	kb "github.com/ipfs/go-ipfs/routing/kbucket"
 	record "github.com/ipfs/go-ipfs/routing/record"
-	"github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
@@ -28,7 +28,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = eventlog.Logger("dht")
+var log = logging.Logger("dht")
 
 var ProtocolDHT protocol.ID = "/ipfs/dht"
 
@@ -98,7 +98,7 @@ func (dht *IpfsDHT) LocalPeer() peer.ID {
 }
 
 // log returns the dht's logger
-func (dht *IpfsDHT) log() eventlog.EventLogger {
+func (dht *IpfsDHT) log() logging.EventLogger {
 	return log // TODO rm
 }
 

--- a/routing/dht/pb/message.go
+++ b/routing/dht/pb/message.go
@@ -6,10 +6,10 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	inet "github.com/ipfs/go-ipfs/p2p/net"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("dht.pb")
+var log = logging.Logger("dht.pb")
 
 type PeerRoutingInfo struct {
 	peer.PeerInfo

--- a/routing/dht/query.go
+++ b/routing/dht/query.go
@@ -8,10 +8,10 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	queue "github.com/ipfs/go-ipfs/p2p/peer/queue"
 	"github.com/ipfs/go-ipfs/routing"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	u "github.com/ipfs/go-ipfs/util"
 	pset "github.com/ipfs/go-ipfs/util/peerset"
 	todoctr "github.com/ipfs/go-ipfs/util/todocounter"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	process "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	ctxproc "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess/context"
@@ -77,7 +77,7 @@ type dhtQueryRunner struct {
 	errs   u.MultiErr      // result errors. maybe should be a map[peer.ID]error
 
 	rateLimit chan struct{} // processing semaphore
-	log       eventlog.EventLogger
+	log       logging.EventLogger
 
 	proc process.Process
 	sync.RWMutex

--- a/routing/kbucket/table.go
+++ b/routing/kbucket/table.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("table")
+var log = logging.Logger("table")
 
 // RoutingTable defines the routing table.
 type RoutingTable struct {

--- a/routing/mock/centralized_client.go
+++ b/routing/mock/centralized_client.go
@@ -10,11 +10,11 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
-	u "github.com/ipfs/go-ipfs/util"
 	"github.com/ipfs/go-ipfs/util/testutil"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("mockrouter")
+var log = logging.Logger("mockrouter")
 
 type client struct {
 	datastore ds.Datastore

--- a/routing/none/none_client.go
+++ b/routing/none/none_client.go
@@ -9,10 +9,10 @@ import (
 	p2phost "github.com/ipfs/go-ipfs/p2p/host"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	routing "github.com/ipfs/go-ipfs/routing"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("mockrouter")
+var log = logging.Logger("mockrouter")
 
 type nilclient struct {
 }

--- a/routing/offline/offline.go
+++ b/routing/offline/offline.go
@@ -13,10 +13,10 @@ import (
 	routing "github.com/ipfs/go-ipfs/routing"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	record "github.com/ipfs/go-ipfs/routing/record"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("offlinerouting")
+var log = logging.Logger("offlinerouting")
 
 var ErrOffline = errors.New("routing system in offline mode")
 

--- a/routing/record/record.go
+++ b/routing/record/record.go
@@ -9,11 +9,11 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var _ = dag.FetchGraph
-var log = eventlog.Logger("routing/record")
+var log = logging.Logger("routing/record")
 
 // MakePutRecord creates and signs a dht record for the given key/value pair
 func MakePutRecord(sk ci.PrivKey, key key.Key, value []byte, sign bool) (*pb.Record, error) {

--- a/routing/supernode/client.go
+++ b/routing/supernode/client.go
@@ -14,10 +14,10 @@ import (
 	routing "github.com/ipfs/go-ipfs/routing"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	proxy "github.com/ipfs/go-ipfs/routing/supernode/proxy"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("supernode")
+var log = logging.Logger("supernode")
 
 type Client struct {
 	peerhost  host.Host
@@ -37,7 +37,7 @@ func NewClient(px proxy.Proxy, h host.Host, ps peer.Peerstore, local peer.ID) (*
 }
 
 func (c *Client) FindProvidersAsync(ctx context.Context, k key.Key, max int) <-chan peer.PeerInfo {
-	ctx = eventlog.ContextWithLoggable(ctx, eventlog.Uuid("findProviders"))
+	ctx = logging.ContextWithLoggable(ctx, logging.Uuid("findProviders"))
 	defer log.EventBegin(ctx, "findProviders", &k).Done()
 	ch := make(chan peer.PeerInfo)
 	go func() {

--- a/routing/supernode/proxy/standard.go
+++ b/routing/supernode/proxy/standard.go
@@ -12,12 +12,12 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 	dhtpb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	kbucket "github.com/ipfs/go-ipfs/routing/kbucket"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 const ProtocolSNR = "/ipfs/supernoderouting"
 
-var log = eventlog.Logger("supernode/proxy")
+var log = logging.Logger("supernode/proxy")
 
 type Proxy interface {
 	Bootstrap(context.Context) error
@@ -127,7 +127,7 @@ func (px *standard) SendRequest(ctx context.Context, m *dhtpb.Message) (*dhtpb.M
 }
 
 func (px *standard) sendRequest(ctx context.Context, m *dhtpb.Message, remote peer.ID) (*dhtpb.Message, error) {
-	e := log.EventBegin(ctx, "sendRoutingRequest", px.Host.ID(), remote, eventlog.Pair("request", m))
+	e := log.EventBegin(ctx, "sendRoutingRequest", px.Host.ID(), remote, logging.Pair("request", m))
 	defer e.Done()
 	if err := px.Host.Connect(ctx, peer.PeerInfo{ID: remote}); err != nil {
 		e.SetError(err)
@@ -157,8 +157,8 @@ func (px *standard) sendRequest(ctx context.Context, m *dhtpb.Message, remote pe
 		e.SetError(err)
 		return nil, err
 	}
-	e.Append(eventlog.Pair("response", response))
-	e.Append(eventlog.Pair("uuid", eventlog.Uuid("foo")))
+	e.Append(logging.Pair("response", response))
+	e.Append(logging.Pair("uuid", logging.Uuid("foo")))
 	return response, nil
 }
 

--- a/tar/format.go
+++ b/tar/format.go
@@ -13,12 +13,12 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutil "github.com/ipfs/go-ipfs/merkledag/utils"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-var log = u.Logger("tarfmt")
+var log = logging.Logger("tarfmt")
 
 var blockSize = 512
 var zeroBlock = make([]byte, blockSize)

--- a/test/integration/addcat_test.go
+++ b/test/integration/addcat_test.go
@@ -18,12 +18,12 @@ import (
 	mock "github.com/ipfs/go-ipfs/core/mock"
 	mocknet "github.com/ipfs/go-ipfs/p2p/net/mock"
 	"github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 	"github.com/ipfs/go-ipfs/thirdparty/unit"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 )
 
-var log = eventlog.Logger("epictest")
+var log = logging.Logger("epictest")
 
 const kSeed = 1
 

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -28,12 +28,12 @@ import (
 	"github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
 	unit "github.com/ipfs/go-ipfs/thirdparty/unit"
 	ds2 "github.com/ipfs/go-ipfs/util/datastore2"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var elog = eventlog.Logger("gc-client")
+var elog = logging.Logger("gc-client")
 
 var (
 	cat             = flag.Bool("cat", false, "else add")
@@ -193,7 +193,7 @@ func runFileCattingWorker(ctx context.Context, n *core.IpfsNode) error {
 			if err != nil {
 				log.Fatal(err)
 			}
-			e := elog.EventBegin(ctx, "cat", eventlog.LoggableF(func() map[string]interface{} {
+			e := elog.EventBegin(ctx, "cat", logging.LoggableF(func() map[string]interface{} {
 				return map[string]interface{}{
 					"key":       k,
 					"localPeer": n.Identity,

--- a/tour/tour.go
+++ b/tour/tour.go
@@ -4,10 +4,10 @@ import (
 	"strconv"
 	"strings"
 
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = u.Logger("tour")
+var log = logging.Logger("tour")
 
 // ID is a string identifier for topics
 type ID string

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -19,7 +19,7 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
 var ErrSeekFail = errors.New("failed to seek properly")
@@ -29,7 +29,7 @@ var ErrUnrecognizedWhence = errors.New("unrecognized whence")
 // 2MB
 var writebufferSize = 1 << 21
 
-var log = u.Logger("dagio")
+var log = logging.Logger("dagio")
 
 // DagModifier is the only struct licensed and able to correctly
 // perform surgery on a DAG 'file'

--- a/updates/updates.go
+++ b/updates/updates.go
@@ -8,7 +8,7 @@ import (
 
 	config "github.com/ipfs/go-ipfs/repo/config"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
-	u "github.com/ipfs/go-ipfs/util"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	semver "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
 	update "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/go-update"
@@ -79,7 +79,7 @@ AAb7RaEDNJOa7qvUFecB
 
 )
 
-var log = u.Logger("updates")
+var log = logging.Logger("updates")
 
 var currentVersion *semver.Version
 

--- a/util/eventlog/loggables/loggables.go
+++ b/util/eventlog/loggables/loggables.go
@@ -11,22 +11,22 @@ import (
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 
-	log "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 )
 
 // NetConn returns an eventlog.Metadata with the conn addresses
-func NetConn(c net.Conn) log.Loggable {
-	return log.Metadata{
+func NetConn(c net.Conn) logging.Loggable {
+	return logging.Metadata{
 		"localAddr":  c.LocalAddr(),
 		"remoteAddr": c.RemoteAddr(),
 	}
 }
 
 // Error returns an eventlog.Metadata with an error
-func Error(e error) log.Loggable {
-	return log.Metadata{
+func Error(e error) logging.Loggable {
+	return logging.Metadata{
 		"error": e.Error(),
 	}
 }

--- a/util/ipfsaddr/ipfsaddr.go
+++ b/util/ipfsaddr/ipfsaddr.go
@@ -7,10 +7,10 @@ import (
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
-	eventlog "github.com/ipfs/go-ipfs/thirdparty/eventlog"
+	logging "github.com/ipfs/go-ipfs/vendor/go-log-v1.0.0"
 )
 
-var log = eventlog.Logger("ipfsaddr")
+var log = logging.Logger("ipfsaddr")
 
 // ErrInvalidAddr signals an address is not a valid ipfs address.
 var ErrInvalidAddr = errors.New("invalid ipfs address")

--- a/util/util.go
+++ b/util/util.go
@@ -35,9 +35,6 @@ var ErrSearchIncomplete = errors.New("Error: Search Incomplete.")
 // ErrNotFound is returned when a search fails to find anything
 var ErrNotFound = ds.ErrNotFound
 
-// ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
-var ErrNoSuchLogger = errors.New("Error: No such logger")
-
 // TildeExpansion expands a filename, which may begin with a tilde.
 func TildeExpansion(filename string) (string, error) {
 	return homedir.Expand(filename)

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/context.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/context.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"errors"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/context_test.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/context_test.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"testing"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/entry.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/entry.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"time"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/example_test.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/example_test.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/log.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/log.go
@@ -1,11 +1,10 @@
-package eventlog
+package log
 
 import (
 	"fmt"
 	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	"github.com/ipfs/go-ipfs/util" // TODO remove IPFS dependency
 )
 
 // StandardLogger provides API compatibility with standard printf loggers
@@ -53,7 +52,16 @@ func Logger(system string) EventLogger {
 
 	// TODO if we would like to adjust log levels at run-time. Store this event
 	// logger in a map (just like the util.Logger impl)
-	return &eventLogger{system: system, StandardLogger: util.Logger(system)}
+	if len(system) == 0 {
+		log.Warnf("Missing name parameter")
+		system = "undefined"
+	}
+	if _, ok := loggers[system]; !ok {
+		loggers[system] = log.WithField("module", system)
+	}
+	logger := loggers[system]
+
+	return &eventLogger{system: system, StandardLogger: logger}
 }
 
 // eventLogger implements the EventLogger and wraps a go-logging Logger

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/loggable.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/loggable.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 // Loggable describes objects that can be marshalled into Metadata for logging
 type Loggable interface {

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/metadata.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/metadata.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"encoding/json"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/metadata_test.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/metadata_test.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import "testing"
 

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/oldlog.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/oldlog.go
@@ -1,6 +1,7 @@
-package util
+package log
 
 import (
+	"errors"
 	"os"
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -27,6 +28,9 @@ const (
 	envLoggingFmt = "IPFS_LOGGING_FMT"
 )
 
+// ErrNoSuchLogger is returned when the util pkg is asked for a non existant logger
+var ErrNoSuchLogger = errors.New("Error: No such logger")
+
 // loggers is the set of loggers in the system
 var loggers = map[string]*logrus.Entry{}
 
@@ -52,10 +56,6 @@ func SetupLogging() {
 		}
 	}
 
-	if Debug := GetenvBool("IPFS_DEBUG"); Debug {
-		lvl = logrus.DebugLevel
-	}
-
 	SetAllLoggers(lvl)
 }
 
@@ -70,18 +70,6 @@ func SetAllLoggers(lvl logrus.Level) {
 	for _, logger := range loggers {
 		logger.Level = lvl
 	}
-}
-
-// Logger retrieves a particular logger
-func Logger(name string) *logrus.Entry {
-	if len(name) == 0 {
-		log.Warnf("Missing name parameter")
-		name = "undefined"
-	}
-	if _, ok := loggers[name]; !ok {
-		loggers[name] = log.WithField("module", name)
-	}
-	return loggers[name]
 }
 
 // SetLogLevel changes the log level of a specific subsystem

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/option.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/option.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"io"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/package.json
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "go-log",
+  "version": "1.0.0",
+  "language": "go"
+}

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/polite_json_formatter.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/polite_json_formatter.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"encoding/json"

--- a/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/writer.go
+++ b/vendor/QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log/writer.go
@@ -1,4 +1,4 @@
-package eventlog
+package log
 
 import (
 	"io"

--- a/vendor/go-log-v1.0.0
+++ b/vendor/go-log-v1.0.0
@@ -1,0 +1,1 @@
+QmXJkcEXB6C9h6Ytb6rrUTFU56Ro62zxgrbxTT3dgjQGA8/go-log


### PR DESCRIPTION
Pulls logging out into `ipfs/go-log` and also consolidates all logging to our 'eventlog' library, on top of logrus.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>