### PR TITLE
Use exec to start IPFS daemon

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -18,4 +18,4 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
-ipfs daemon
+exec ipfs daemon


### PR DESCRIPTION
This incorporates feedback from @RX14 in #1685 and might fix #1537 as the ipfs daemon would get the stop signal from the docker daemon... Maybe that way it stops in a cleaner manner...