### PR TITLE
Fix gzip compression level not being set.

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -188,5 +188,5 @@ func getCompressOptions(req cmds.Request) (int, error) {
 	case cmprs && cmplvlFound && (cmplvl < 1 || cmplvl > 9):
 		return gzip.NoCompression, ErrInvalidCompressionLevel
 	}
-	return gzip.NoCompression, nil
+	return cmplvl, nil
 }


### PR DESCRIPTION
If "compression-level" is set, the compression is set to gzip.NoCompression.