### PR TITLE
Fix build on Windows.

### DIFF
--- a/fuse/mount/fuse.go
+++ b/fuse/mount/fuse.go
@@ -1,4 +1,5 @@
 // +build !nofuse
+// +build !windows
 
 package mount
 


### PR DESCRIPTION
Do not attempt to build fuse on Windows. This allows building ipfs without "nofuse" flag.

Error without this PR:
```
c:\GoPath\src\github.com\ipfs\go-ipfs\cmd\ipfs>go build
# github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse
c:\gopath\src\github.com\ipfs\go-ipfs\Godeps\_workspace\src\bazil.org\fuse\error_std.go:27: undefined: errNoXattr
c:\gopath\src\github.com\ipfs\go-ipfs\Godeps\_workspace\src\bazil.org\fuse\fuse.go:1092: undefined: attr
c:\gopath\src\github.com\ipfs\go-ipfs\Godeps\_workspace\src\bazil.org\fuse\fuse_kernel.go:152: undefined: syscall.O_ACCMODE
c:\gopath\src\github.com\ipfs\go-ipfs\Godeps\_workspace\src\bazil.org\fuse\fuse_kernel.go:378: undefined: attr
```

License: MIT
Signed-off-by: Klaus Post <klauspost@gmail.com>