### PR TITLE
remove hard-coded json content-type for channel streaming http output

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -224,13 +224,8 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 		_, isChan = res.Output().(<-chan interface{})
 	}
 
-	streamChans, _, _ := req.Option("stream-channels").Bool()
 	if isChan {
 		h.Set(channelHeader, "1")
-		if streamChans {
-			// streaming output from a channel will always be json objects
-			mime = applicationJson
-		}
 	}
 
 	if mime != "" {


### PR DESCRIPTION
Fixes #1721

The code showed that there was a stale assumption that streaming output from a channel would always be JSON.

This PR removes that code, allowing the Content-Type to appropriately be set like other, non-channel-streaming commands.

new output:
```bash
$ mkdir testdir
$ echo "hello test" > testdir/test.txt
$ ipfs add -r testdir
added QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW testdir/test.txt
added QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym testdir
$ curl -i "http://localhost:5001/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=text"
HTTP/1.1 200 OK
Content-Type: text/plain
Transfer-Encoding: chunked
X-Chunked-Output: 1

QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW
$ curl -i "http://localhost:5001/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=json"
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
X-Chunked-Output: 1

{
  "Ref": "QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW",
  "Err": ""
}
```