### PR TITLE
remove hard-coded json content-type for streaming http output

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -224,13 +224,8 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 		_, isChan = res.Output().(<-chan interface{})
 	}
 
-	streamChans, _, _ := req.Option("stream-channels").Bool()
 	if isChan {
 		h.Set(channelHeader, "1")
-		if streamChans {
-			// streaming output from a channel will always be json objects
-			mime = applicationJson
-		}
 	}
 
 	if mime != "" {

--- a/test/sharness/t0230-channel-streaming-http-content-type.sh
+++ b/test/sharness/t0230-channel-streaming-http-content-type.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Cayman Nava
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test Content-Type for channel-streaming commands"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_ls_cmd() {
+
+	test_expect_success "Text encoded channel-streaming command succeeds" '
+		mkdir -p testdir &&
+		echo "hello test" >testdir/test.txt &&
+		ipfs add -r testdir &&
+        curl -i "http://localhost:$PORT_API/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=text" >actual_output
+	'
+
+	test_expect_success "Text encoded channel-streaming command output looks good" '
+		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
+		printf "Content-Type: text/plain\r\n" >>expected_output &&
+		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
+		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
+		printf "\r\n" >>expected_output &&
+		echo QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW >>expected_output &&
+		test_cmp expected_output actual_output
+	'
+
+	test_expect_success "JSON encoded channel-streaming command succeeds" '
+		mkdir -p testdir &&
+		echo "hello test" >testdir/test.txt &&
+		ipfs add -r testdir &&
+        curl -i "http://localhost:$PORT_API/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=json" >actual_output
+	'
+
+	test_expect_success "JSON encoded channel-streaming command output looks good" '
+		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
+		printf "Content-Type: application/json\r\n" >>expected_output &&
+		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
+		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
+		printf "\r\n" >>expected_output &&
+		cat <<-\EOF >>expected_output &&
+			{
+			  "Ref": "QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW",
+			  "Err": ""
+			}
+		EOF
+		perl -pi -e '"'"'chomp if eof'"'"' expected_output &&
+		test_cmp expected_output actual_output
+	'
+}
+
+# should work online (only)
+test_launch_ipfs_daemon
+test_ls_cmd
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
Fixes #1721

There was a stale assumption that streaming output from a channel would
always be json.
This commit removes that code, allowing Content-Type to appropriately be
set like other, non-channel-streaming commands.

New output:
```bash
$ mkdir testdir
$ echo "hello test" > testdir/test.txt
$ ipfs add -r testdir
added QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW testdir/test.txt
added QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym testdir
$ curl -i "http://localhost:5001/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=text"
HTTP/1.1 200 OK
Content-Type: text/plain
Transfer-Encoding: chunked
X-Chunked-Output: 1

QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW
$ curl -i "http://localhost:5001/api/v0/refs?arg=QmTcJAn3JP8ZMAKS6WS75q8sbTyojWKbxcUHgLYGWur4Ym&stream-channels=true&encoding=json"
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
X-Chunked-Output: 1

{
  "Ref": "QmRmPLc1FsPAn8F8F9DQDEYADNX5ER2sgqiokEvqnYknVW",
  "Err": ""
}
```

License: MIT
Signed-off-by: Cayman Nava <caymannava@gmail.com>