### PR TITLE
Override baseurl using abs link

### DIFF
--- a/bin/gencmdref
+++ b/bin/gencmdref
@@ -18,7 +18,7 @@ def main():
   print 'generated on', datetime.datetime.now()
   print ''
   for line in lines:
-    print '- [%s](#%s)' % (line, line.replace(' ', '-'))
+    print '- [%s](docs/commands/#%s)' % (line, line.replace(' ', '-'))
   print ''
 
   for line in lines:


### PR DESCRIPTION
This is to fix the relative link anchors being overridden by a `base` tag in docs/commands on the website. Specifically, this is for https://github.com/ipfs/website/pull/55, https://github.com/ipfs/website/pull/58, and https://github.com/ipfs/website/issues/35. 

This can only be merged if this script is not used anywhere else in the entire IPFS ecosystem. Anyone know if it is? 