### PR TITLE
add a ipfs repo ls command

### DIFF
--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -8,6 +8,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	u "github.com/ipfs/go-ipfs/util"
+	"github.com/ipfs/go-ipfs/unixfs"
 )
 
 var RepoCmd = &cmds.Command{
@@ -20,6 +21,7 @@ var RepoCmd = &cmds.Command{
 
 	Subcommands: map[string]*cmds.Command{
 		"gc": repoGcCmd,
+		"ls": repoLsCmd,
 	},
 }
 
@@ -84,6 +86,85 @@ order to reclaim hard disk space.
 				} else {
 					buf = bytes.NewBufferString(fmt.Sprintf("removed %s\n", obj.Key))
 				}
+				return buf, nil
+			}
+
+			return &cmds.ChannelMarshaler{
+				Channel:   outChan,
+				Marshaler: marshal,
+				Res:       res,
+			}, nil
+		},
+	},
+}
+
+type RepoLsOutput struct {
+	Hash string
+	Size uint64
+	Type string
+}
+
+var repoLsCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Totally need a documentation",
+		ShortDescription: `
+		I might agree on that
+		`,
+	},
+
+	Run: func(req cmds.Request, res cmds.Response) {
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		outChan := make(chan interface{})
+		res.SetOutput((<-chan interface{})(outChan))
+
+		go func() {
+			defer close(outChan)
+			for _, k := range n.Pinning.RecursiveKeys() {
+				node, err := n.DAG.Get(req.Context(), k)
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				unixFSNode, err := unixfs.FromBytes(node.Data);
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				outChan <- &RepoLsOutput{
+					Hash: k.Pretty(),
+					Size: unixFSNode.GetFilesize(),
+					Type: unixFSNode.GetType().String(),
+				}
+			}
+		}()
+	},
+
+	Type: RepoLsOutput{},
+
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			outChan, ok := res.Output().(<-chan interface{})
+			if !ok {
+				return nil, u.ErrCast()
+			}
+
+			marshal := func(v interface{}) (io.Reader, error) {
+				obj, ok := v.(*RepoLsOutput)
+				if !ok {
+					return nil, u.ErrCast()
+				}
+
+				buf := new(bytes.Buffer)
+
+				fmt.Fprintf(buf, "%s\t%s     \t%v\n", obj.Hash, obj.Type, obj.Size)
+
 				return buf, nil
 			}
 


### PR DESCRIPTION
I made this mostly to get my hand dirty with golang, to get a better grasp of what's going on in go-ipfs internal, and because I somewhat needed it.

It adds a `ipfs repo ls` command that list the top hash (hash, type, size) available locally
Currently use the recursive pin to find the top hash, so it doesn't list everything. Is there something already there to find the root hash available locally ?

License: MIT
Signed-off-by: Michael Muré <batolettre@gmail.com>