### PR TITLE
Fix #1661 IPFS crashes on windows after first run

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -668,5 +668,6 @@ func apiClientForAddr(addr ma.Multiaddr) (cmdsHttp.Client, error) {
 }
 
 func isConnRefused(err error) bool {
-	return strings.Contains(err.Error(), "connection refused")
+	return  strings.Contains(err.Error(), "connection refused") ||
+	        strings.Contains(err.Error(), "target machine actively refused it")
 }


### PR DESCRIPTION
The first run does not try to connect to API, as an address is not
yet saved in configuration. The second run did not recognize
corrently a refused connection.