### PR TITLE
allow bitswap stat to return total number of bytes wasted

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -156,6 +156,7 @@ var bitswapStatCmd = &cmds.Command{
 			fmt.Fprintf(buf, "\tprovides buffer: %d / %d\n", out.ProvideBufLen, bitswap.HasBlockBufferSize)
 			fmt.Fprintf(buf, "\tblocks received: %d\n", out.BlocksReceived)
 			fmt.Fprintf(buf, "\tdup blocks received: %d\n", out.DupBlksReceived)
+			fmt.Fprintf(buf, "\tdup data received: %d\n", out.DupDataReceived)
 			fmt.Fprintf(buf, "\twantlist [%d keys]\n", len(out.Wantlist))
 			for _, k := range out.Wantlist {
 				fmt.Fprintf(buf, "\t\t%s\n", k.B58String())

--- a/exchange/bitswap/stat.go
+++ b/exchange/bitswap/stat.go
@@ -11,6 +11,7 @@ type Stat struct {
 	Peers           []string
 	BlocksReceived  int
 	DupBlksReceived int
+	DupDataReceived uint64
 }
 
 func (bs *Bitswap) Stat() (*Stat, error) {
@@ -20,6 +21,7 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	bs.counterLk.Lock()
 	st.BlocksReceived = bs.blocksRecvd
 	st.DupBlksReceived = bs.dupBlocksRecvd
+	st.DupDataReceived = bs.dupDataRecvd
 	bs.counterLk.Unlock()
 
 	for _, p := range bs.engine.Peers() {


### PR DESCRIPTION
@ion1 This adds the counter for the total number of bytes received due to duplicate blocks. Is there anything else you think we need here?

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>