### PR TITLE
added docker file permission instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ ipfs files that will persist when you restart the container.
 
     export ipfs_staging=</absolute/path/to/somewhere/>
     export ipfs_data=</absolute/path/to/somewhere_else/>
+    
+Make these folders accesible from docker:
+
+    sudo chmod -R 777 /absolute/path/to/somewhere/
+    sudo chmod -R 777 /absolute/path/to/somewhere_else/
 
 Start a container running ipfs and expose ports 4001, 5001 and 8080:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ ipfs files that will persist when you restart the container.
     export ipfs_staging=</absolute/path/to/somewhere/>
     export ipfs_data=</absolute/path/to/somewhere_else/>
     
-Make these folders accesible from docker:
+Make sure docker can access these folders:
 
     sudo chmod -R 777 /absolute/path/to/somewhere/
     sudo chmod -R 777 /absolute/path/to/somewhere_else/


### PR DESCRIPTION
I added the instructions to make the ipfs_data and ipfs_staging globally readable, which prevents permission errors. 

It may be better to limit permissions in some way, to prevent potential security risks.

License: MIT
Signed-off-by: sroerick <sweeney@roerick.me>