### PR TITLE
ipfs-test-lib: add shellquote()

### DIFF
--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -22,3 +22,15 @@ test_sort_cmp() {
 	sort "$2" >"$2_sorted" &&
 	test_cmp "$1_sorted" "$2_sorted"
 }
+
+# Quote arguments for sh eval
+shellquote() {
+	_space=''
+	for _arg
+	do
+		printf '%s' "$_space"
+		printf '%s' "$_arg" | sed -e "s/'/'\\\\''/g; s/^/'/; s/\$/'/;"
+		_space=' '
+	done
+	printf '\n'
+}


### PR DESCRIPTION
This function can be usefull in many places.

See for example:

https://github.com/ipfs/go-ipfs/pull/1742

Git has `git rev-parse --sq-quote` that does the same thing.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>