### PR TITLE
Add a new line in the output of ipfs log level

### DIFF
--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -58,7 +58,7 @@ output of a running daemon.
 			return
 		}
 
-		s := fmt.Sprintf("Changed log level of '%s' to '%s'", subsystem, level)
+		s := fmt.Sprintf("Changed log level of '%s' to '%s'\n", subsystem, level)
 		log.Info(s)
 		res.SetOutput(&MessageOutput{s})
 	},


### PR DESCRIPTION
So the command line prompt stay where it should. What happend before was this:

```
~ $ ipfs log level all panic
Changed log level of '*' to 'panic' ~ $
̀``