### PR TITLE
Add context to coreunix.Cat argument

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -67,7 +67,7 @@ func cat(ctx context.Context, node *core.IpfsNode, paths []string) ([]io.Reader,
 	readers := make([]io.Reader, 0, len(paths))
 	length := uint64(0)
 	for _, fpath := range paths {
-		read, err := coreunix.Cat(node, fpath)
+		read, err := coreunix.Cat(ctx, node, fpath)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -1,16 +1,17 @@
 package coreunix
 
 import (
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	core "github.com/ipfs/go-ipfs/core"
 	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 )
 
-func Cat(n *core.IpfsNode, pstr string) (*uio.DagReader, error) {
+func Cat(ctx context.Context, n *core.IpfsNode, pstr string) (*uio.DagReader, error) {
 	p := path.FromString(pstr)
-	dagNode, err := n.Resolver.ResolvePath(n.Context(), p)
+	dagNode, err := n.Resolver.ResolvePath(ctx, p)
 	if err != nil {
 		return nil, err
 	}
-	return uio.NewDagReader(n.Context(), dagNode, n.DAG)
+	return uio.NewDagReader(ctx, dagNode, n.DAG)
 }

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -168,7 +168,7 @@ func TestIpfsStressRead(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				read, err := coreunix.Cat(nd, item)
+				read, err := coreunix.Cat(nd.Context(), nd, item)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/integration/addcat_test.go
+++ b/test/integration/addcat_test.go
@@ -138,7 +138,7 @@ func DirectAddCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, added)
+	readerCatted, err := coreunix.Cat(ctx, catter, added)
 	if err != nil {
 		return err
 	}

--- a/test/integration/bench_cat_test.go
+++ b/test/integration/bench_cat_test.go
@@ -84,7 +84,7 @@ func benchCat(b *testing.B, data []byte, conf testutil.LatencyConfig) error {
 	}
 
 	b.StartTimer()
-	readerCatted, err := coreunix.Cat(catter, added)
+	readerCatted, err := coreunix.Cat(ctx, catter, added)
 	if err != nil {
 		return err
 	}

--- a/test/integration/grandcentral_test.go
+++ b/test/integration/grandcentral_test.go
@@ -62,7 +62,7 @@ func RunSupernodeBootstrappedAddCat(data []byte, conf testutil.LatencyConfig) er
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, keyAdded)
+	readerCatted, err := coreunix.Cat(ctx, catter, keyAdded)
 	if err != nil {
 		return err
 	}

--- a/test/integration/three_legged_cat_test.go
+++ b/test/integration/three_legged_cat_test.go
@@ -117,7 +117,7 @@ func RunThreeLeggedCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, added)
+	readerCatted, err := coreunix.Cat(ctx, catter, added)
 	if err != nil {
 		return err
 	}

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -199,7 +199,7 @@ func runFileCattingWorker(ctx context.Context, n *core.IpfsNode) error {
 					"localPeer": n.Identity,
 				}
 			}))
-			if r, err := coreunix.Cat(n, k); err != nil {
+			if r, err := coreunix.Cat(ctx, n, k); err != nil {
 				e.Done()
 				log.Printf("failed to cat file. seed: %d #%d key: %s err: %s", *seed, i, k, err)
 			} else {


### PR DESCRIPTION
In the tests, `node.Context()` are always derived from `ctx` used in this PR.
However, in core/commands, it is not the case for daemon context and `req.Context()`.