### PR TITLE
daemon: instrument the gateway and api HTTP handlers

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -338,6 +338,7 @@ func serveHTTPApi(req cmds.Request) (error, <-chan error) {
 		},
 	})
 	var opts = []corehttp.ServeOption{
+		corehttp.PrometheusCollectorOption("api"),
 		corehttp.CommandsOption(*req.InvocContext()),
 		corehttp.WebUIOption,
 		apiGw.ServeOption(),
@@ -416,6 +417,7 @@ func serveHTTPGateway(req cmds.Request) (error, <-chan error) {
 	}
 
 	var opts = []corehttp.ServeOption{
+		corehttp.PrometheusCollectorOption("gateway"),
 		corehttp.CommandsROOption(*req.InvocContext()),
 		corehttp.VersionOption(),
 		corehttp.IPNSHostnameOption(),

--- a/core/corehttp/prometheus.go
+++ b/core/corehttp/prometheus.go
@@ -11,7 +11,15 @@ import (
 
 func PrometheusOption(path string) ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
-		mux.Handle(path, prom.Handler())
+		mux.Handle(path, prom.UninstrumentedHandler())
 		return mux, nil
+	}
+}
+
+func PrometheusCollectorOption(handlerName string) ServeOption {
+	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+		childMux := http.NewServeMux()
+		mux.HandleFunc("/", prom.InstrumentHandler(handlerName, childMux))
+		return childMux, nil
 	}
 }


### PR DESCRIPTION
So that we can graph them using Prometheus. See #1763 and #1422.

This gets us the following metrics:

```
# HELP http_requests_total Total number of HTTP requests made.
# TYPE http_requests_total counter
http_requests_total{code="200",handler="api",method="get"} 54
http_requests_total{code="200",handler="gateway",method="get"} 60
http_requests_total{code="304",handler="gateway",method="get"} 30
# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
# TYPE http_request_duration_microseconds summary
http_request_duration_microseconds{handler="api",quantile="0.5"} 593.504
http_request_duration_microseconds{handler="api",quantile="0.9"} 852.337
http_request_duration_microseconds{handler="api",quantile="0.99"} 1054.733
http_request_duration_microseconds_sum{handler="api"} 35359.53
http_request_duration_microseconds_count{handler="api"} 54
http_request_duration_microseconds{handler="gateway",quantile="0.5"} 21147.23
http_request_duration_microseconds{handler="gateway",quantile="0.9"} 337680.504
http_request_duration_microseconds{handler="gateway",quantile="0.99"} 2.236680159e+06
http_request_duration_microseconds_sum{handler="gateway"} 2.1692309521000005e+07
http_request_duration_microseconds_count{handler="gateway"} 90
# HELP http_request_size_bytes The HTTP request sizes in bytes.
# TYPE http_request_size_bytes summary
http_request_size_bytes{handler="api",quantile="0.5"} 80
http_request_size_bytes{handler="api",quantile="0.9"} 80
http_request_size_bytes{handler="api",quantile="0.99"} 80
http_request_size_bytes_sum{handler="api"} 4320
http_request_size_bytes_count{handler="api"} 54
http_request_size_bytes{handler="gateway",quantile="0.5"} 587
http_request_size_bytes{handler="gateway",quantile="0.9"} 617
http_request_size_bytes{handler="gateway",quantile="0.99"} 645
http_request_size_bytes_sum{handler="gateway"} 52789
http_request_size_bytes_count{handler="gateway"} 90
```