### PR TITLE
ipfs version 0.3.8 changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # go-ipfs changelog
 
+### 0.3.8 - 2015-10-09
+
+This patch update includes changes to make ipns more consistent and reliable,
+symlink support in unixfs, mild performance improvements, new tooling features,
+a plethora of bugfixes, and greatly improved tests.
+
+NOTICE: Version 0.3.8 also requires golang version 1.5.1 or higher.
+
+* Bugfixes
+  * refactor ipns to be more consistent and reliable (@whyrusleeping)
+  * fix 'ipfs refs' json output (@whyrusleeping)
+  * fix setting null config maps (@rht)
+  * fix output of dht commands (@whyrusleeping)
+  * fix NAT spam dialing (@whyrusleeping)
+  * fix random panics on 32 bit systems (@whyrusleeping)
+  * limit total number of network fd's (@whyrusleeping)
+  * fix http api content type (@WeMeetAgain)
+  * fix writing of api file for port zero daemons (@whyrusleeping)
+  * windows connection refused fixes (@mjanczyk)
+  * use go1.5's built in trailers, no more failures (@whyrusleeping)
+  * fix random bitswap hangs (@whyrusleeping)
+  * rate limit fd usage (@whyrusleeping)
+  * fix panic in bitswap ratelimiting (@whyrusleeping)
+
+* Tool Changes
+  * --empty-repo option for init (@prusnak)
+  * implement symlinks (@whyrusleeping)
+  * improve cmds lib files processing (@rht)
+  * properly return errors through commands (@whyrusleeping)
+  * bitswap unwant command (@whyrusleeping)
+  * tar add/cat commands (@whyrusleeping)
+  * fix gzip compression in get (@klauspost)
+  * bitswap stat logs wasted bytes (@whyrusleeping)
+  * resolve command now uses core.Resolve (@rht)
+  * add `--local` flag to 'name resolve' (@whyrusleeping)
+
+* General Codebase
+  * improvements to dag editor (@whyrusleeping)
+  * swarm IPv6 in default config (Baptiste Jonglez)
+  * improve dir listing css (@rht)
+  * removed elliptic.P224 usage (@prusnak)
+  * improve bitswap providing speed (@jbenet)
+  * print panics that occur in cmds lib (@whyrusleeping)
+  * ipfs api check test fixes (@rht)
+  * update peerstream and datastore (@whyrusleeping)
+  * cleaned up tar-reader code (@jbenet)
+  * write context into coreunix.Cat (@rht)
+  * move assets to separate repo (@rht)
+  * fix proc/ctx wiring in bitswap (@jbenet)
+  * rabin fingerprinting chunker (@whyrusleeping)
+  * better notification on daemon ready (@rht)
+  * coreunix cat cleanup (@rht)
+  * extract logging into go-log (@whyrusleeping)
+  * blockservice.New no longer errors (@whyrusleeping)
+  * refactor ipfs get (@rht)
+  * readonly api on gateway (@rht)
+  * cleanup context usage all over (@rht)
+  * add xml decoding to 'object put' (@ForrestWeston)
+  * replace nodebuilder with NewNode method (@whyrusleeping)
+  * add metrics to http handlers (@lgierth)
+  * rm blockservice workers (@whyrusleeping)
+  * decompose maybeGzWriter (@rht)
+  * makefile sets git commit sha on build (@CaioAlonso)
+
+* Documentation
+  * add contribute file (@RichardLitt)
+  * add go devel guide to contribute.md (@whyrusleeping)
+
+* Testing
+  * fix mock notifs test (@whyrusleeping)
+  * test utf8 with object cmd (@chriscool)
+  * make mocknet conn close idempotent (@jbenet)
+  * fix fuse tests (@pnelson)
+  * improve sharness test quoting (@chriscool)
+  * sharness tests for chunker and add-cat (@rht)
+  * generalize peerid check in sharness (@chriscool)
+  * test_cmp argument cleanup (@chriscool)
+
 ### 0.3.7 - 2015-08-02
 
 This patch update fixes a problem we introduced in 0.3.6 and did not

--- a/docs/implement-api-bindings.md
+++ b/docs/implement-api-bindings.md
@@ -81,7 +81,7 @@ Despite all the generalization spoken about above, the IPFS API is actually very
 > ipfs --api /ip4/127.0.0.1/tcp/5002 swarm addrs local --enc=json
 POST /api/v0/version?enc=json&stream-channels=true HTTP/1.1
 Host: 127.0.0.1:5002
-User-Agent: /go-ipfs/0.3.8-dev/
+User-Agent: /go-ipfs/0.3.8/
 Content-Length: 0
 Content-Type: application/octet-stream
 Accept-Encoding: gzip
@@ -96,7 +96,7 @@ The only hard part is getting the file streaming right. It is (now) fairly easy 
 > ipfs --api /ip4/127.0.0.1/tcp/5002 add -r ~/demo/basic/test
 POST /api/v0/add?encoding=json&progress=true&r=true&stream-channels=true HTTP/1.1
 Host: 127.0.0.1:5002
-User-Agent: /go-ipfs/0.3.8-dev/
+User-Agent: /go-ipfs/0.3.8/
 Transfer-Encoding: chunked
 Content-Disposition: form-data: name="files"
 Content-Type: multipart/form-data; boundary=2186ef15d8f2c4f100af72d6d345afe36a4d17ef11264ec5b8ec4436447f

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -8,7 +8,8 @@ import (
 )
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.3.8-dev"
+const CurrentVersionNumber = "0.3.8"
+
 // CurrentCommit is the current git commit, this is set as a ldflag in the Makefile
 var CurrentCommit string
 


### PR DESCRIPTION
To be merged after all 0.3.8 changes make it into master. 

After this merges, another commit will need to be made to bump the version to '0.3.9-dev' to ensure that ipfs version reports the correct version.

@jbenet @RichardLitt review on the organization, grammar, syntax and content of the changelog would be great!

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>