### PR TITLE
Fix/bitswap hang

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -196,7 +196,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-peerstream",
-			"Rev": "cfdc29a19c1a209d548670f5c33c5cda2e040143"
+			"Rev": "f90119e97e8be7b2bdd5e598067b0dc44df63381"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-random",

--- a/test/sharness/t0130-multinode.sh
+++ b/test/sharness/t0130-multinode.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test multiple ipfs nodes"
+
+. lib/test-lib.sh
+
+export IPTB_ROOT="`pwd`/.iptb"
+
+ipfsi() {
+	dir="$1"
+	shift
+	IPFS_PATH="$IPTB_ROOT/$dir" ipfs $@
+}
+
+check_has_connection() {
+	node=$1
+	ipfsi $node swarm peers | grep ipfs > /dev/null
+}
+
+startup_cluster() {
+	test_expect_success "start up nodes" '
+		iptb start
+	'
+
+	test_expect_success "connect nodes to eachother" '
+		iptb connect [1-4] 0
+	'
+
+	test_expect_success "nodes are connected" '
+		check_has_connection 0 &&
+		check_has_connection 1 &&
+		check_has_connection 2 &&
+		check_has_connection 3 &&
+		check_has_connection 4
+	'
+}
+
+check_file_fetch() {
+	node=$1
+	fhash=$2
+	fname=$3
+
+	test_expect_success "can fetch file" '
+		ipfsi $node cat $fhash > fetch_out
+	'
+
+	test_expect_success "file looks good" '
+		test_cmp $fname fetch_out
+	'
+}
+
+run_basic_test() {
+	startup_cluster 
+
+	test_expect_success "add a file on node1" '
+		random 1000000 > filea &&
+		FILEA_HASH=$(ipfsi 1 add -q filea)
+	'
+
+	check_file_fetch 4 $FILEA_HASH filea
+	check_file_fetch 3 $FILEA_HASH filea
+	check_file_fetch 2 $FILEA_HASH filea
+	check_file_fetch 1 $FILEA_HASH filea
+	check_file_fetch 0 $FILEA_HASH filea
+
+	test_expect_success "shut down nodes" '
+		iptb stop
+	'
+}
+
+test_expect_success "set up tcp testbed" '
+	iptb init -n 5 -p 0 -f --bootstrap=none
+'
+
+run_basic_test
+
+test_done


### PR DESCRIPTION
Bitswap has had a race condition type bug in it for a very long time now, and it manifests rarely. We've always just assumed it was a fluke, but i discovered a repro, and a fix!!

When dialing we dial a bunch of addresses at once, if we get two connections to a peer, one of them gets closed, but not before sending a disconnect notification. Bitswap receives this notification and assumes we are no longer connected to that peer, and closes the worker assigned to that peer, even though we have an active connection to them. 