### PR TITLE
Sharness coverage script

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -67,6 +67,11 @@ test_race: verify_gofmt
 	cd 3nodetest && make GOFLAGS=-race
 	cd dependencies && make GOFLAGS=-race
 
+coverage: coverage_sharness
+
+coverage_sharness:
+	./sharness_test_coverage_helper.sh
+
 IPFS-BUILD-OPTIONS: FORCE
 	@bin/checkflags '$@' '$(GOFLAGS)' '*** new Go flags ***'
 

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -48,53 +48,46 @@ CMD_RAW="$TMPDIR/ipfs_cmd_raw.txt"
 git grep -n -E '\Wipfs\W' -- sharness/t*-*.sh >"$CMD_RAW" ||
 die "Could not grep ipfs in the sharness tests"
 
-log "Remove test_expect_{success,failure} lines"
-CMD_EXPECT="$TMPDIR/ipfs_cmd_expect.txt"
-egrep -v 'test_expect_.*ipfs' "$CMD_RAW" >"$CMD_EXPECT" ||
-die "Could not remove test_expect_{success,failure} lines"
+grep_out() {
+    pattern="$1"
+    src="$TMPDIR/ipfs_cmd_${2}.txt"
+    dst="$TMPDIR/ipfs_cmd_${3}.txt"
+    desc="$4"
 
-log "Remove comments"
-CMD_COMMENT="$TMPDIR/ipfs_cmd_comment.txt"
-egrep -v '^[^:]+:[^:]+:\s*#' "$CMD_EXPECT" >"$CMD_COMMENT" ||
-die "Could not remove comments"
+    log "Remove $desc"
+    egrep -v "$pattern" "$src" >"$dst" || die "Could not remove $desc"
+}
 
-log "Remove test_description lines"
-CMD_DESC="$TMPDIR/ipfs_cmd_description.txt"
-egrep -v 'test_description=' "$CMD_COMMENT" >"$CMD_DESC" ||
-die "Could not remove test_description lines"
+grep_out 'test_expect_.*ipfs' raw expect "test_expect_{success,failure} lines"
+grep_out '^[^:]+:[^:]+:\s*#' expect comment "comments"
+grep_out 'test_description=' comment desc "test_description lines"
+grep_out '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' desc grep "grep lines"
+grep_out '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' grep echo "echo lines"
 
-log "Remove grep lines"
-CMD_GREP="$TMPDIR/ipfs_cmd_grep.txt"
-egrep -v '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' "$CMD_DESC" >"$CMD_GREP" ||
-die "Could not remove grep lines"
+grep_in() {
+    pattern="$1"
+    src="$TMPDIR/ipfs_cmd_${2}.txt"
+    dst="$TMPDIR/ipfs_cmd_${3}.txt"
+    desc="$4"
 
-log "Remove echo lines"
-CMD_ECHO="$TMPDIR/ipfs_cmd_echo.txt"
-egrep -v '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' "$CMD_GREP" >"$CMD_ECHO" ||
-die "Could not remove echo lines"
+    log "Keep $desc"
+    egrep "$pattern" "$src" >"$dst"
+}
 
+grep_in '\Wipfs\W.*/ipfs/' echo slash_in1 "ipfs.*/ipfs/"
+grep_in '/ipfs/.*\Wipfs\W' echo slash_in2 "/ipfs/.*ipfs"
 
+grep_out '/ipfs/' echo slash "/ipfs/"
 
-log "Keep ipfs.*/ipfs/"
-CMD_SLASH_OK="$TMPDIR/ipfs_cmd_slash_ok.txt"
-egrep '\Wipfs\W.*/ipfs/' "$CMD_ECHO" >"$CMD_SLASH_OK"
+grep_in '\Wipfs\W.*\.ipfs' slash dot_in1 "ipfs.*\.ipfs"
+grep_in '\.ipfs.*\Wipfs\W' slash dot_in2 "\.ipfs.*ipfs"
 
-log "Keep ipfs.*\.ipfs and \.ipfs.*ipfs"
-CMD_DOT_OK="$TMPDIR/ipfs_cmd_dot_ok.txt"
-egrep -e '\Wipfs\W.*\.ipfs' -e '\.ipfs.*\Wipfs\W' "$CMD_ECHO" >"$CMD_DOT_OK"
-
-log "Remove /ipfs/"
-CMD_SLASH="$TMPDIR/ipfs_cmd_slash.txt"
-egrep -v '/ipfs/' "$CMD_ECHO" >"$CMD_SLASH" ||
-die "Could not remove /ipfs/"
-
-log "Remove .ipfs"
-CMD_DOT="$TMPDIR/ipfs_cmd_dot.txt"
-egrep -v '\.ipfs' "$CMD_SLASH" >"$CMD_DOT" ||
-die "Could not remove .ipfs"
-
+grep_out '\.ipfs' slash dot ".ipfs"
 
 log "Print result"
-cat "$CMD_DOT" "$CMD_SLASH_OK" "$CMD_DOT_OK" | sort
+for f in dot slash_in1 slash_in2 dot_in1 dot_in2
+do
+    cat "$TMPDIR/ipfs_cmd_${f}.txt"
+done | sort | uniq
 
 # Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -111,28 +111,29 @@ log "Match the test line commands with the commands they use"
 GLOBAL_REV="$TMPDIR/global_results_reversed.txt"
 reverse "$CMD_CMDS" | while read -r ipfs cmd sub1 sub2
 do
-    if test -n "$sub2"
+    if test -n "$cmd"
     then
-	CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}_${sub1}_${sub2}.txt"
-	egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1(\W.*)*\W$sub2" "$CMD_RES" >"$CMD_OUT"
-	reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
-	echo "$ipfs $cmd $sub1 $sub2" >>"$GLOBAL_REV"
-    else
+	CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}"
+	PATTERN="$ipfs(\W.*)*\W$cmd"
+	NAME="$ipfs $cmd"
+
 	if test -n "$sub1"
 	then
-	    CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}_${sub1}.txt"
-	    egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1" "$CMD_RES" >"$CMD_OUT"
-	    reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
-	    echo "$ipfs $cmd $sub1" >>"$GLOBAL_REV"
-	else
-	    if test -n "$cmd"
+	    CMD_OUT="${CMD_OUT}_${sub1}"
+	    PATTERN="$PATTERN(\W.*)*\W$sub1"
+	    NAME="$NAME $sub1"
+
+	    if test -n "$sub2"
 	    then
-		CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}.txt"
-		egrep "$ipfs(\W.*)*\W$cmd" "$CMD_RES" >"$CMD_OUT"
-		reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
-		echo "$ipfs $cmd" >>"$GLOBAL_REV"
+		CMD_OUT="${CMD_OUT}_${sub2}"
+		PATTERN="$PATTERN(\W.*)*\W$sub2"
+		NAME="$NAME $sub2"
 	    fi
 	fi
+
+	egrep "$PATTERN" "$CMD_RES" >"$CMD_OUT"
+	reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
+	echo "$NAME" >>"$GLOBAL_REV"
     fi
 done
 

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -55,7 +55,7 @@ die "Could not remove test_expect_{success,failure} lines"
 
 log "Remove comments"
 CMD_COMMENT="$TMPDIR/ipfs_cmd_comment.txt"
-egrep -v '^\s*#' "$CMD_EXPECT" >"$CMD_COMMENT" ||
+egrep -v '^[^:]+:[^:]+:\s*#' "$CMD_EXPECT" >"$CMD_COMMENT" ||
 die "Could not remove comments"
 
 log "Remove test_description lines"
@@ -65,23 +65,33 @@ die "Could not remove test_description lines"
 
 log "Remove echos lines"
 CMD_ECHO="$TMPDIR/ipfs_cmd_echo.txt"
-egrep -v '\Wecho\s[^|]*ipfs' "$CMD_DESC" >"$CMD_ECHO" ||
+egrep -v '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' "$CMD_DESC" >"$CMD_ECHO" ||
 die "Could not remove echo lines"
 
 
 
 log "Keep ipfs.*/ipfs/"
-CMD_IPFS_OK="$TMPDIR/ipfs_cmd_ipfs_ok.txt"
-egrep '\Wipfs\W.*/ipfs/' "$CMD_ECHO" >"$CMD_IPFS_OK" ||
-die "Could not keep 'ipfs.*/ipfs/'"
+CMD_SLASH_OK="$TMPDIR/ipfs_cmd_slash_ok.txt"
+egrep '\Wipfs\W.*/ipfs/' "$CMD_ECHO" >"$CMD_SLASH_OK"
+# die "Could not keep ipfs.*/ipfs/"
+
+log "Keep ipfs.*\.ipfs and \.ipfs.*ipfs"
+CMD_DOT_OK="$TMPDIR/ipfs_cmd_dot_ok.txt"
+egrep -e '\Wipfs\W.*\.ipfs' -e '\.ipfs.*\Wipfs\W' "$CMD_ECHO" >"$CMD_DOT_OK"
+# die "Could not keep ipfs.*\.ipfs and \.ipfs.*ipfs"
 
 log "Remove /ipfs/"
-CMD_SLASH="$TMPDIR/ipfs_cmd_slash_ipfs.txt"
+CMD_SLASH="$TMPDIR/ipfs_cmd_slash.txt"
 egrep -v '/ipfs/' "$CMD_ECHO" >"$CMD_SLASH" ||
 die "Could not remove /ipfs/"
 
+log "Remove .ipfs"
+CMD_DOT="$TMPDIR/ipfs_cmd_dot.txt"
+egrep -v '\.ipfs' "$CMD_SLASH" >"$CMD_DOT" ||
+die "Could not remove .ipfs"
+
 
 log "Print result"
-cat "$CMD_SLASH" "$CMD_IPFS_OK" | sort
+cat "$CMD_DOT" "$CMD_SLASH_OK" "$CMD_DOT_OK" | sort
 
 # Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+USAGE="$0 [-h] [-v]"
+
+usage() {
+    echo "$USAGE"
+    echo "	Print sharness test coverage"
+    echo "	Options:"
+    echo "		-h|--help: print this usage message and exit"
+    echo "		-v|--verbose: print logs of what happens"
+    exit 0
+}
+
+log() {
+    test -z "$VERBOSE" || echo "->" "$@"
+}
+
+die() {
+    printf >&2 "fatal: %s\n" "$@"
+    exit 1
+}
+
+# get user options
+while [ "$#" -gt "0" ]; do
+    # get options
+    arg="$1"
+    shift
+
+    case "$arg" in
+	-h|--help)
+	    usage ;;
+	-v|--verbose)
+	    VERBOSE=1 ;;
+	-*)
+	    die "unrecognised option: '$arg'\n$USAGE" ;;
+	*)
+	    die "too many arguments\n$USAGE" ;;
+    esac
+done
+
+log "Create temporary directory"
+DATE=$(date +"%Y-%m-%dT%H:%M:%SZ")
+TMPDIR=$(mktemp -d "/tmp/coverage_helper.$DATE.XXXXXX") ||
+die "could not 'mktemp -d /tmp/coverage_helper.$DATE.XXXXXX'"
+
+log "Grep the sharness tests"
+CMDRAW="$TMPDIR/ipfs_cmd_raw.txt"
+git grep -E '\Wipfs\W' -- sharness/t*-*.sh >"$CMDRAW" ||
+die "Could not grep ipfs in the sharness tests"
+
+log "Remove test_expect_{success,failure} lines"
+CMDPROC1="$TMPDIR/ipfs_cmd_proc1.txt"
+egrep -v 'test_expect_.*ipfs' "$CMDRAW" >"$CMDPROC1" ||
+die "Could not remove test_expect_{success,failure} lines"
+
+log "Remove comments"
+CMDPROC2="$TMPDIR/ipfs_cmd_proc2.txt"
+egrep -v '^\s*#' "$CMDPROC1" >"$CMDPROC2" ||
+die "Could not remove comments"
+
+
+log "Print result"
+cat "$CMDPROC2"
+
+# Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -63,9 +63,14 @@ CMD_DESC="$TMPDIR/ipfs_cmd_description.txt"
 egrep -v 'test_description=' "$CMD_COMMENT" >"$CMD_DESC" ||
 die "Could not remove test_description lines"
 
-log "Remove echos lines"
+log "Remove grep lines"
+CMD_GREP="$TMPDIR/ipfs_cmd_grep.txt"
+egrep -v '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' "$CMD_DESC" >"$CMD_GREP" ||
+die "Could not remove grep lines"
+
+log "Remove echo lines"
 CMD_ECHO="$TMPDIR/ipfs_cmd_echo.txt"
-egrep -v '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' "$CMD_DESC" >"$CMD_ECHO" ||
+egrep -v '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' "$CMD_GREP" >"$CMD_ECHO" ||
 die "Could not remove echo lines"
 
 
@@ -73,12 +78,10 @@ die "Could not remove echo lines"
 log "Keep ipfs.*/ipfs/"
 CMD_SLASH_OK="$TMPDIR/ipfs_cmd_slash_ok.txt"
 egrep '\Wipfs\W.*/ipfs/' "$CMD_ECHO" >"$CMD_SLASH_OK"
-# die "Could not keep ipfs.*/ipfs/"
 
 log "Keep ipfs.*\.ipfs and \.ipfs.*ipfs"
 CMD_DOT_OK="$TMPDIR/ipfs_cmd_dot_ok.txt"
 egrep -e '\Wipfs\W.*\.ipfs' -e '\.ipfs.*\Wipfs\W' "$CMD_ECHO" >"$CMD_DOT_OK"
-# die "Could not keep ipfs.*\.ipfs and \.ipfs.*ipfs"
 
 log "Remove /ipfs/"
 CMD_SLASH="$TMPDIR/ipfs_cmd_slash.txt"

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -43,7 +43,7 @@ DATE=$(date +"%Y-%m-%dT%H:%M:%SZ")
 TMPDIR=$(mktemp -d "/tmp/coverage_helper.$DATE.XXXXXX") ||
 die "could not 'mktemp -d /tmp/coverage_helper.$DATE.XXXXXX'"
 
-log "Grep the sharness tests"
+log "Grep the sharness tests for ipfs commands"
 CMD_RAW="$TMPDIR/ipfs_cmd_raw.txt"
 git grep -n -E '\Wipfs\W' -- sharness/t*-*.sh >"$CMD_RAW" ||
 die "Could not grep ipfs in the sharness tests"
@@ -85,9 +85,15 @@ grep_in '\.ipfs.*\Wipfs\W' slash dot_in2 "\.ipfs.*ipfs"
 grep_out '\.ipfs' slash dot ".ipfs"
 
 log "Print result"
+CMD_RES="$TMPDIR/ipfs_cmd_result.txt"
 for f in dot slash_in1 slash_in2 dot_in1 dot_in2
 do
-    cat "$TMPDIR/ipfs_cmd_${f}.txt"
-done | sort | uniq
+    fname="$TMPDIR/ipfs_cmd_${f}.txt"
+    cat "$fname" || die "Could not cat '$fname'"
+done | sort | uniq >"$CMD_RES" || die "Could not write '$CMD_RES'"
+
+log "Get all the ipfs commands from 'ipfs commands'"
+CMD_CMDS="$TMPDIR/commands.txt"
+ipfs commands >"$CMD_CMDS" || die "'ipfs commands' failed"
 
 # Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -106,23 +106,36 @@ reverse() {
     fi
 }
 
-log "Math the test line commands with the commands they use"
+log "Match the test line commands with the commands they use"
+GLOBAL_REV="$TMPDIR/global_results_reversed.txt"
 reverse "$CMD_CMDS" | while read -r ipfs cmd sub1 sub2
 do
     if test -n "$sub2"
     then
-	egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1(\W.*)*\W$sub2" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}_${sub1}_${sub2}.txt"
+	CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}_${sub1}_${sub2}.txt"
+	egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1(\W.*)*\W$sub2" "$CMD_RES" >"$CMD_OUT"
+	reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
+	echo "$ipfs $cmd $sub1 $sub2" >>"$GLOBAL_REV"
     else
 	if test -n "$sub1"
 	then
-	    egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}_${sub1}.txt"
+	    CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}_${sub1}.txt"
+	    egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1" "$CMD_RES" >"$CMD_OUT"
+	    reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
+	    echo "$ipfs $cmd $sub1" >>"$GLOBAL_REV"
 	else
 	    if test -n "$cmd"
 	    then
-		egrep "$ipfs(\W.*)*\W$cmd" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}.txt"
+		CMD_OUT="$TMPDIR/res_${ipfs}_${cmd}.txt"
+		egrep "$ipfs(\W.*)*\W$cmd" "$CMD_RES" >"$CMD_OUT"
+		reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
+		echo "$ipfs $cmd" >>"$GLOBAL_REV"
 	    fi
 	fi
     fi
 done
+
+log "Print results"
+reverse "$GLOBAL_REV"
 
 # Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -63,7 +63,9 @@ grep_out '^[^:]+:[^:]+:\s*#' expect comment "comments"
 grep_out 'test_description=' comment desc "test_description lines"
 grep_out '^[^:]+:[^:]+:\s*\w+="[^"]*"\s*(\&\&)?\s*$' desc def "variable definition lines"
 grep_out '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' def grep "grep lines"
-grep_out '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' grep echo "echo lines"
+grep_out '^[^:]+:[^:]+:\s*cat\W[^|]*\Wipfs' grep cat "cat lines"
+grep_out '^[^:]+:[^:]+:\s*rmdir\W[^|]*\Wipfs' cat rmdir "rmdir lines"
+grep_out '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' cat echo "echo lines"
 
 grep_in() {
     pattern="$1"
@@ -131,11 +133,18 @@ do
 	    fi
 	fi
 
-	egrep "$PATTERN" "$CMD_RES" >"$CMD_OUT"
-	reverse "$CMD_OUT" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
+	egrep "$PATTERN" "$CMD_RES" >"$CMD_OUT.txt"
+	reverse "$CMD_OUT.txt" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
 	echo "$NAME" >>"$GLOBAL_REV"
     fi
 done
+
+# The following will allow us to check that
+# we are properly excuding enough stuff using:
+# diff -u ipfs_cmd_result.txt cmd_found.txt
+log "Get all the line commands that matched"
+CMD_FOUND="$TMPDIR/cmd_found.txt"
+cat $TMPDIR/res_*.txt | sort -n | uniq >"$CMD_FOUND"
 
 log "Print results"
 reverse "$GLOBAL_REV"

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -96,4 +96,33 @@ log "Get all the ipfs commands from 'ipfs commands'"
 CMD_CMDS="$TMPDIR/commands.txt"
 ipfs commands >"$CMD_CMDS" || die "'ipfs commands' failed"
 
+# Portable function to reverse lines in a file
+reverse() {
+    if type tac >/dev/null
+    then
+	tac "$@"
+    else
+	tail -r "$@"
+    fi
+}
+
+log "Math the test line commands with the commands they use"
+reverse "$CMD_CMDS" | while read -r ipfs cmd sub1 sub2
+do
+    if test -n "$sub2"
+    then
+	egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1(\W.*)*\W$sub2" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}_${sub1}_${sub2}.txt"
+    else
+	if test -n "$sub1"
+	then
+	    egrep "$ipfs(\W.*)*\W$cmd(\W.*)*\W$sub1" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}_${sub1}.txt"
+	else
+	    if test -n "$cmd"
+	    then
+		egrep "$ipfs(\W.*)*\W$cmd" "$CMD_RES" >"$TMPDIR/res_${ipfs}_${cmd}.txt"
+	    fi
+	fi
+    fi
+done
+
 # Remove temp directory...

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -148,7 +148,6 @@ process_command() {
 
 	egrep "$PATTERN" "$CMD_RES" >"$CMD_OUT.txt"
 	reverse "$CMD_OUT.txt" | sed -e 's/^sharness\///' | cut -d- -f1 | uniq -c >>"$GLOBAL_REV"
-	echo "$NAME" >>"$GLOBAL_REV"
     fi
 }
 
@@ -159,10 +158,14 @@ do
 
     log "Processing $LONG_CMD"
     process_command $LONG_CMD
+    LONG_NAME="$NAME"
 
     log "Processing $SHORT_CMD"
     process_command $SHORT_CMD
+    SHORT_NAME="$NAME"
 
+    test -n "$SHORT_CMD" && echo "$SHORT_NAME" >>"$GLOBAL_REV"
+    test "$LONG_CMD" != "ipfs" && echo "$LONG_NAME" >>"$GLOBAL_REV"
     echo >>"$GLOBAL_REV"
 done
 

--- a/test/sharness_test_coverage_helper.sh
+++ b/test/sharness_test_coverage_helper.sh
@@ -61,7 +61,8 @@ grep_out() {
 grep_out 'test_expect_.*ipfs' raw expect "test_expect_{success,failure} lines"
 grep_out '^[^:]+:[^:]+:\s*#' expect comment "comments"
 grep_out 'test_description=' comment desc "test_description lines"
-grep_out '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' desc grep "grep lines"
+grep_out '^[^:]+:[^:]+:\s*\w+="[^"]*"\s*(\&\&)?\s*$' desc def "variable definition lines"
+grep_out '^[^:]+:[^:]+:\s*e?grep\W[^|]*\Wipfs' def grep "grep lines"
 grep_out '^[^:]+:[^:]+:\s*echo\W[^|]*\Wipfs' grep echo "echo lines"
 
 grep_in() {


### PR DESCRIPTION
This is a first version of a script that automatically shows Sharness test coverage.
Currently it outputs something like:

```
ipfs file ls
      6 t0200
ipfs get
      1 t0050
      3 t0051
      7 t0090
ipfs id
      2 t0062
      3 t0100
      2 t0140
      2 t0160
ipfs init
      4 t0020
      2 t0060
ipfs log
ipfs log level
ipfs log tail
ipfs ls
      2 t0045
      1 t0051
      6 t0080
     12 t0081
      6 t0200
```

This tells us that `ipfs file ls` appears 6 times in t0200, while `ipfs log` appears nowhere.