### PR TITLE
t0060: don't fail if no nc

### DIFF
--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -98,7 +98,9 @@ test_expect_success "ipfs help output looks good" '
 
 # check transport is encrypted
 
-test_expect_success "transport should be encrypted" '
+type nc >/dev/null && test_set_prereq NC
+
+test_expect_success NC "transport should be encrypted" '
   nc -w 5 localhost 4001 >swarmnc &&
   grep -q "AES-256,AES-128" swarmnc &&
   test_must_fail grep -q "/ipfs/identify" swarmnc ||


### PR DESCRIPTION
This fixes issue #1821 (t0060-daemon fails if nc is not installed).

As now nc is used only in one test, it is ok to not run the test if it is not installed. 