### PR TITLE
Adds the option to see the current git commit with `ipfs version --commit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ else
 go_test=go test
 endif
 
+commit = `git rev-parse --short HEAD`
+ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(commit)"
 
 all:
 	# no-op. try:
@@ -24,7 +26,7 @@ install:
 	cd cmd/ipfs && go install
 
 build:
-	cd cmd/ipfs && go build -i
+	cd cmd/ipfs && go build -i -ldflags=$(ldflags)
 
 nofuse:
 	cd cmd/ipfs && go install -tags nofuse

--- a/cmd/ipfs/Makefile
+++ b/cmd/ipfs/Makefile
@@ -1,7 +1,9 @@
 all: install
+commit = `git rev-parse --short HEAD`
+ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(commit)"
 
 build:
-	go build
+	go build -ldflags=$(ldflags)
 
 install: build
 	go install

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -11,6 +11,7 @@ import (
 
 type VersionOutput struct {
 	Version string
+	Commit string
 }
 
 var VersionCmd = &cmds.Command{
@@ -21,24 +22,36 @@ var VersionCmd = &cmds.Command{
 
 	Options: []cmds.Option{
 		cmds.BoolOption("number", "n", "Only show the version number"),
+		cmds.BoolOption("commit", "Show the commit hash"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		res.SetOutput(&VersionOutput{
 			Version: config.CurrentVersionNumber,
+			Commit: config.CurrentCommit,
 		})
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*VersionOutput)
 
+			commit, found, err := res.Request().Option("commit").Bool()
+			commitTxt := ""
+			if err != nil {
+				return nil, err
+			}
+			if found && commit {
+				commitTxt = "-" + v.Commit
+			}
+
 			number, found, err := res.Request().Option("number").Bool()
 			if err != nil {
 				return nil, err
 			}
 			if found && number {
-				return strings.NewReader(fmt.Sprintln(v.Version)), nil
+				return strings.NewReader(fmt.Sprintln(v.Version + commitTxt)), nil
 			}
-			return strings.NewReader(fmt.Sprintf("ipfs version %s\n", v.Version)), nil
+
+			return strings.NewReader(fmt.Sprintf("ipfs version %s%s\n", v.Version, commitTxt)), nil
 		},
 	},
 	Type: VersionOutput{},

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -9,6 +9,8 @@ import (
 
 // CurrentVersionNumber is the current application's version literal
 const CurrentVersionNumber = "0.3.8-dev"
+// CurrentCommit is the current git commit, this is set as a ldflag in the Makefile
+var CurrentCommit string
 
 // Version regulates checking if the most recent version is run
 type Version struct {


### PR DESCRIPTION
It sets the variable ```config.CurrentCommit``` in the Makefile with the short SHA1 hash of the current commit.

It also adds the ```--commit``` option to ```ipfs version``` so that:
```
$ ipfs version
ipfs version 0.3.8-dev

$ ipfs version --commit
ipfs version 0.3.8-dev-4de5eaa

$ ipfs version --number
0.3.8-dev

$ ipfs version --number --commit
0.3.8-dev-4de5eaa
```