### PR TITLE
remove version requirement file so gobuilder can build still

### DIFF
--- a/cmd/ipfs/go_req.go
+++ b/cmd/ipfs/go_req.go
@@ -1,3 +1,0 @@
-// +build !go1.5
-
-`IPFS needs to be built with go version 1.5 or greater`


### PR DESCRIPTION
removing this temporarily so we can merge 0.3.8 and still get gobuilder builds

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>