### PR TITLE
Fix cli flag orders (long, short)

### DIFF
--- a/commands/option.go
+++ b/commands/option.go
@@ -163,8 +163,8 @@ const (
 )
 
 // options that are used by this package
-var OptionEncodingType = StringOption(EncShort, EncLong, "The encoding type the output should be encoded with (json, xml, or text)")
-var OptionRecursivePath = BoolOption(RecShort, RecLong, "Add directory paths recursively")
+var OptionEncodingType = StringOption(EncLong, EncShort, "The encoding type the output should be encoded with (json, xml, or text)")
+var OptionRecursivePath = BoolOption(RecLong, RecShort, "Add directory paths recursively")
 var OptionStreamChannels = BoolOption(ChanOpt, "Stream channel output")
 var OptionTimeout = StringOption(TimeoutOpt, "set a global timeout on the command")
 

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -53,7 +53,7 @@ ipfs id supports the format option for output with the following keys:
 		cmds.StringArg("peerid", false, false, "peer.ID of node to look up").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("f", "format", "optional output format"),
+		cmds.StringOption("format", "f", "optional output format"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -44,7 +44,7 @@ it contains, with the following format:
 		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to list links from").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("headers", "", "Print table headers (Hash, Name, Size)"),
+		cmds.BoolOption("headers", "v", "Print table headers (Hash, Name, Size)"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()


### PR DESCRIPTION
cc: @chriscool 

- [x] There is `ipfs ls --headers / ipfs ls --` as well.