### PR TITLE
ipns_test: fix namesys.NewNameSystem() call

### DIFF
--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -113,7 +113,7 @@ func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *fstest.M
 		}
 
 		node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.PrivateKey)
-		node.Namesys = namesys.NewNameSystem(node.Routing)
+		node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore())
 
 		ipnsfs, err := nsfs.NewFilesystem(context.Background(), node.DAG, node.Namesys, node.Pinning, node.PrivateKey)
 		if err != nil {


### PR DESCRIPTION
There is the following error otherwise:

```
$ go test github.com/ipfs/go-ipfs/fuse/ipns
../../fuse/ipns/ipns_test.go:116: not enough arguments in call to namesys.NewNameSystem
FAIL    github.com/ipfs/go-ipfs/fuse/ipns [build failed]
```

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>