### PR TITLE
Split long short options

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -106,14 +106,14 @@ future version, along with this notice. Please move to setting the HTTP Headers.
 	},
 
 	Options: []cmds.Option{
-		cmds.BoolOption(initOptionKwd, "Initialize IPFS with default settings if not already initialized"),
-		cmds.StringOption(routingOptionKwd, "Overrides the routing option (dht, supernode)"),
-		cmds.BoolOption(mountKwd, "Mounts IPFS to the filesystem"),
-		cmds.BoolOption(writableKwd, "Enable writing objects (with POST, PUT and DELETE)"),
-		cmds.StringOption(ipfsMountKwd, "Path to the mountpoint for IPFS (if using --mount)"),
-		cmds.StringOption(ipnsMountKwd, "Path to the mountpoint for IPNS (if using --mount)"),
-		cmds.BoolOption(unrestrictedApiAccessKwd, "Allow API access to unlisted hashes"),
-		cmds.BoolOption(unencryptTransportKwd, "Disable transport encryption (for debugging protocols)"),
+		cmds.BoolOption(initOptionKwd, 0, "Initialize IPFS with default settings if not already initialized"),
+		cmds.StringOption(routingOptionKwd, 0, "Overrides the routing option (dht, supernode)"),
+		cmds.BoolOption(mountKwd, 0, "Mounts IPFS to the filesystem"),
+		cmds.BoolOption(writableKwd, 0, "Enable writing objects (with POST, PUT and DELETE)"),
+		cmds.StringOption(ipfsMountKwd, 0, "Path to the mountpoint for IPFS (if using --mount)"),
+		cmds.StringOption(ipnsMountKwd, 0, "Path to the mountpoint for IPNS (if using --mount)"),
+		cmds.BoolOption(unrestrictedApiAccessKwd, 0, "Allow API access to unlisted hashes"),
+		cmds.BoolOption(unencryptTransportKwd, 0, "Disable transport encryption (for debugging protocols)"),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),

--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -25,9 +25,9 @@ var initCmd = &cmds.Command{
 	},
 
 	Options: []cmds.Option{
-		cmds.IntOption("bits", "b", fmt.Sprintf("Number of bits to use in the generated RSA private key (defaults to %d)", nBitsForKeypairDefault)),
-		cmds.BoolOption("force", "f", "Overwrite existing config (if it exists)"),
-		cmds.BoolOption("empty-repo", "e", "Don't add and pin help files to the local storage"),
+		cmds.IntOption("bits", 'b', fmt.Sprintf("Number of bits to use in the generated RSA private key (defaults to %d)", nBitsForKeypairDefault)),
+		cmds.BoolOption("force", 'f', "Overwrite existing config (if it exists)"),
+		cmds.BoolOption("empty-repo", 'e', "Don't add and pin help files to the local storage"),
 
 		// TODO need to decide whether to expose the override as a file or a
 		// directory. That is: should we allow the user to also specify the

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -248,11 +248,23 @@ func optionText(cmd ...*cmds.Command) []string {
 				lines = append(lines, "")
 			}
 
-			names := sortByLength(opt.Names())
-			if len(names) >= j+1 {
-				lines[i] += optionFlag(names[j])
+			len_names := 0
+			long := opt.LongName()
+			short := opt.ShortName()
+			if long != "" {
+				len_names = len_names + 1
 			}
-			if len(names) > j+1 {
+			if short != 0 {
+				len_names = len_names + 1
+			}
+			if len_names >= j+1 {
+				if j == 0 {
+					lines[i] += optionFlag(long)
+				} else if j == 1 {
+					lines[i] += optionFlag(string(short))
+				}
+			}
+			if len_names > j+1 {
 				lines[i] += ", "
 				done = false
 			}

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -33,7 +33,7 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 
 	// if -r is provided, and it is associated with the package builtin
 	// recursive path option, allow recursive file paths
-	recursiveOpt := req.Option(cmds.RecShort)
+	recursiveOpt := req.Option(string(cmds.RecShort))
 	recursive := false
 	if recursiveOpt != nil && recursiveOpt.Definition() == cmds.OptionRecursivePath {
 		recursive, _, err = recursiveOpt.Bool()

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -68,8 +68,8 @@ func TestOptionParsing(t *testing.T) {
 	subCmd := &commands.Command{}
 	cmd := &commands.Command{
 		Options: []commands.Option{
-			commands.StringOption("string", "s", "a string"),
-			commands.BoolOption("bool", "b", "a bool"),
+			commands.StringOption("string", 's', "a string"),
+			commands.BoolOption("bool", 'b', "a bool"),
 		},
 		Subcommands: map[string]*commands.Command{
 			"test": subCmd,

--- a/commands/command.go
+++ b/commands/command.go
@@ -171,6 +171,15 @@ func (c *Command) Get(path []string) (*Command, error) {
 	return cmds[len(cmds)-1], nil
 }
 
+func AddOption(optionsMap map[string]Option, name string, opt Option) error {
+	if _, found := optionsMap[name]; found {
+		return fmt.Errorf("Option name '%s' used multiple times", name)
+	}
+
+	optionsMap[name] = opt
+	return nil
+}
+
 // GetOptions gets the options in the given path of commands
 func (c *Command) GetOptions(path []string) (map[string]Option, error) {
 	options := make([]Option, 0, len(c.Options))
@@ -187,12 +196,17 @@ func (c *Command) GetOptions(path []string) (map[string]Option, error) {
 
 	optionsMap := make(map[string]Option)
 	for _, opt := range options {
-		for _, name := range opt.Names() {
-			if _, found := optionsMap[name]; found {
-				return nil, fmt.Errorf("Option name '%s' used multiple times", name)
+		if opt.LongName() != "" {
+			err := AddOption(optionsMap, opt.LongName(), opt)
+			if err != nil {
+				return nil, err
 			}
-
-			optionsMap[name] = opt
+		}
+		if opt.ShortName() != 0 {
+			err = AddOption(optionsMap, string(opt.ShortName()), opt)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -55,7 +55,7 @@ func TestOptionValidation(t *testing.T) {
 	}
 
 	req, _ = NewRequest(nil, nil, nil, nil, nil, opts)
-	req.SetOption(EncShort, "json")
+	req.SetOption(string(EncShort), "json")
 	res = cmd.Call(req)
 	if res.Error() != nil {
 		t.Error("Should have passed")

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -9,8 +9,8 @@ func noop(req Request, res Response) {
 func TestOptionValidation(t *testing.T) {
 	cmd := Command{
 		Options: []Option{
-			IntOption("b", "beep", "enables beeper"),
-			StringOption("B", "boop", "password for booper"),
+			IntOption("beep", 'b', "enables beeper"),
+			StringOption("boop", 'B', "password for booper"),
 		},
 		Run: noop,
 	}

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -93,14 +93,14 @@ func TestOptionValidation(t *testing.T) {
 func TestRegistration(t *testing.T) {
 	cmdA := &Command{
 		Options: []Option{
-			IntOption("beep", "number of beeps"),
+			IntOption("beep", 0, "number of beeps"),
 		},
 		Run: noop,
 	}
 
 	cmdB := &Command{
 		Options: []Option{
-			IntOption("beep", "number of beeps"),
+			IntOption("beep", 0, "number of beeps"),
 		},
 		Run: noop,
 		Subcommands: map[string]*Command{
@@ -110,7 +110,7 @@ func TestRegistration(t *testing.T) {
 
 	cmdC := &Command{
 		Options: []Option{
-			StringOption("encoding", "data encoding type"),
+			StringOption("encoding", 0, "data encoding type"),
 		},
 		Run: noop,
 	}

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -57,13 +57,13 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 	}
 
 	// save user-provided encoding
-	previousUserProvidedEncoding, found, err := req.Option(cmds.EncShort).String()
+	previousUserProvidedEncoding, found, err := req.Option(string(cmds.EncShort)).String()
 	if err != nil {
 		return nil, err
 	}
 
 	// override with json to send to server
-	req.SetOption(cmds.EncShort, cmds.JSON)
+	req.SetOption(string(cmds.EncShort), cmds.JSON)
 
 	// stream channel output
 	req.SetOption(cmds.ChanOpt, "true")
@@ -138,7 +138,7 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 				// reset to user provided encoding after sending request
 				// NB: if user has provided an encoding but it is the empty string,
 				// still leave it as JSON.
-				req.SetOption(cmds.EncShort, previousUserProvidedEncoding)
+				req.SetOption(string(cmds.EncShort), previousUserProvidedEncoding)
 			}
 			return res, nil
 		}

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -168,7 +168,7 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func guessMimeType(res cmds.Response) (string, error) {
 	// Try to guess mimeType from the encoding option
-	enc, found, err := res.Request().Option(cmds.EncShort).String()
+	enc, found, err := res.Request().Option(string(cmds.EncShort)).String()
 	if err != nil {
 		return "", err
 	}

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -136,10 +136,10 @@ func parseOptions(r *http.Request) (map[string]interface{}, []string) {
 	}
 
 	// default to setting encoding to JSON
-	_, short := opts[cmds.EncShort]
+	_, short := opts[string(cmds.EncShort)]
 	_, long := opts[cmds.EncLong]
 	if !short && !long {
-		opts[cmds.EncShort] = cmds.JSON
+		opts[string(cmds.EncShort)] = cmds.JSON
 	}
 
 	return opts, args

--- a/commands/option.go
+++ b/commands/option.go
@@ -18,19 +18,25 @@ const (
 
 // Option is used to specify a field that will be provided by a consumer
 type Option interface {
-	Names() []string     // a list of unique names matched with user-provided flags
+	LongName() string    // long option name
+	ShortName() rune     // short option name
 	Type() reflect.Kind  // value must be this type
 	Description() string // a short string that describes this option
 }
 
 type option struct {
-	names       []string
+	longName    string
+	shortName   rune
 	kind        reflect.Kind
 	description string
 }
 
-func (o *option) Names() []string {
-	return o.names
+func (o *option) LongName() string {
+	return o.longName
+}
+
+func (o *option) ShortName() rune {
+	return o.shortName
 }
 
 func (o *option) Type() reflect.Kind {
@@ -42,17 +48,11 @@ func (o *option) Description() string {
 }
 
 // constructor helper functions
-func NewOption(kind reflect.Kind, names ...string) Option {
-	if len(names) < 2 {
-		// FIXME(btc) don't panic (fix_before_merge)
-		panic("Options require at least two string values (name and description)")
-	}
-
-	desc := names[len(names)-1]
-	names = names[:len(names)-1]
+func NewOption(kind reflect.Kind, longName string, shortName rune, desc string) Option {
 
 	return &option{
-		names:       names,
+		longName:    longName,
+		shortName:   shortName,
 		kind:        kind,
 		description: desc,
 	}
@@ -64,20 +64,20 @@ func NewOption(kind reflect.Kind, names ...string) Option {
 // For all func {Type}Option(...string) functions, the last variadic argument
 // is treated as the description field.
 
-func BoolOption(names ...string) Option {
-	return NewOption(Bool, names...)
+func BoolOption(longName string, shortName rune, desc string) Option {
+	return NewOption(Bool, longName, shortName, desc)
 }
-func IntOption(names ...string) Option {
-	return NewOption(Int, names...)
+func IntOption(longName string, shortName rune, desc string) Option {
+	return NewOption(Int, longName, shortName, desc)
 }
-func UintOption(names ...string) Option {
-	return NewOption(Uint, names...)
+func UintOption(longName string, shortName rune, desc string) Option {
+	return NewOption(Uint, longName, shortName, desc)
 }
-func FloatOption(names ...string) Option {
-	return NewOption(Float, names...)
+func FloatOption(longName string, shortName rune, desc string) Option {
+	return NewOption(Float, longName, shortName, desc)
 }
-func StringOption(names ...string) Option {
-	return NewOption(String, names...)
+func StringOption(longName string, shortName rune, desc string) Option {
+	return NewOption(String, longName, shortName, desc)
 }
 
 type OptionValue struct {

--- a/commands/option.go
+++ b/commands/option.go
@@ -154,9 +154,9 @@ func (ov OptionValue) String() (value string, found bool, err error) {
 
 // Flag names
 const (
-	EncShort   = "enc"
+	EncShort   = 'E'
 	EncLong    = "encoding"
-	RecShort   = "r"
+	RecShort   = 'r'
 	RecLong    = "recursive"
 	ChanOpt    = "stream-channels"
 	TimeoutOpt = "timeout"
@@ -165,8 +165,8 @@ const (
 // options that are used by this package
 var OptionEncodingType = StringOption(EncLong, EncShort, "The encoding type the output should be encoded with (json, xml, or text)")
 var OptionRecursivePath = BoolOption(RecLong, RecShort, "Add directory paths recursively")
-var OptionStreamChannels = BoolOption(ChanOpt, "Stream channel output")
-var OptionTimeout = StringOption(TimeoutOpt, "set a global timeout on the command")
+var OptionStreamChannels = BoolOption(ChanOpt, 0, "Stream channel output")
+var OptionTimeout = StringOption(TimeoutOpt, 0, "set a global timeout on the command")
 
 // global options, added to every command
 var globalOptions = []Option{

--- a/commands/request.go
+++ b/commands/request.go
@@ -110,11 +110,16 @@ func (r *request) Option(name string) *OptionValue {
 	}
 
 	// try all the possible names, break if we find a value
-	for _, n := range option.Names() {
-		val, found := r.options[n]
-		if found {
-			return &OptionValue{val, found, option}
-		}
+	n := option.LongName()
+	val, found := r.options[n]
+	if found {
+		return &OptionValue{val, found, option}
+	}
+
+	n = string(option.ShortName())
+	val, found = r.options[n]
+	if found {
+		return &OptionValue{val, found, option}
 	}
 
 	// MAYBE_TODO: use default value instead of nil
@@ -149,12 +154,18 @@ func (r *request) SetOption(name string, val interface{}) {
 	}
 
 	// try all the possible names, if we already have a value then set over it
-	for _, n := range option.Names() {
-		_, found := r.options[n]
-		if found {
-			r.options[n] = val
-			return
-		}
+	n := option.LongName()
+	_, found = r.options[n]
+	if found {
+		r.options[n] = val
+		return
+	}
+
+	n = string(option.ShortName())
+	_, found = r.options[n]
+	if found {
+		r.options[n] = val
+		return
 	}
 
 	r.options[name] = val
@@ -291,11 +302,15 @@ func (r *request) ConvertOptions() error {
 			r.options[k] = v
 		}
 
-		for _, name := range opt.Names() {
-			if _, ok := r.options[name]; name != k && ok {
-				return fmt.Errorf("Duplicate command options were provided ('%s' and '%s')",
-					k, name)
-			}
+		name := opt.LongName()
+		if _, ok := r.options[name]; name != k && ok {
+			return fmt.Errorf("Duplicate command options were provided ('%s' and '%s')",
+				k, name)
+		}
+		name = string(opt.ShortName())
+		if _, ok := r.options[name]; name != k && ok {
+			return fmt.Errorf("Duplicate command options were provided ('%s' and '%s')",
+				k, name)
 		}
 	}
 

--- a/commands/response.go
+++ b/commands/response.go
@@ -162,7 +162,7 @@ func (r *response) Marshal() (io.Reader, error) {
 		return bytes.NewReader([]byte{}), nil
 	}
 
-	enc, found, err := r.req.Option(EncShort).String()
+	enc, found, err := r.req.Option(string(EncShort)).String()
 	if err != nil {
 		return nil, err
 	}

--- a/commands/response_test.go
+++ b/commands/response_test.go
@@ -26,7 +26,7 @@ func TestMarshalling(t *testing.T) {
 		t.Error("Should have failed (no encoding type specified in request)")
 	}
 
-	req.SetOption(EncShort, JSON)
+	req.SetOption(string(EncShort), JSON)
 
 	reader, err := res.Marshal()
 	if err != nil {

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -63,13 +63,13 @@ remains to be implemented.
 	},
 	Options: []cmds.Option{
 		cmds.OptionRecursivePath, // a builtin option that allows recursive paths (-r, --recursive)
-		cmds.BoolOption(quietOptionName, "q", "Write minimal output"),
-		cmds.BoolOption(progressOptionName, "p", "Stream progress data"),
-		cmds.BoolOption(trickleOptionName, "t", "Use trickle-dag format for dag generation"),
-		cmds.BoolOption(onlyHashOptionName, "n", "Only chunk and hash - do not write to disk"),
-		cmds.BoolOption(wrapOptionName, "w", "Wrap files with a directory object"),
-		cmds.BoolOption(hiddenOptionName, "H", "Include files that are hidden"),
-		cmds.StringOption(chunkerOptionName, "s", "chunking algorithm to use"),
+		cmds.BoolOption(quietOptionName, 'q', "Write minimal output"),
+		cmds.BoolOption(progressOptionName, 'p', "Stream progress data"),
+		cmds.BoolOption(trickleOptionName, 't', "Use trickle-dag format for dag generation"),
+		cmds.BoolOption(onlyHashOptionName, 'n', "Only chunk and hash - do not write to disk"),
+		cmds.BoolOption(wrapOptionName, 'w', "Wrap files with a directory object"),
+		cmds.BoolOption(hiddenOptionName, 'H', "Include files that are hidden"),
+		cmds.StringOption(chunkerOptionName, 's', "chunking algorithm to use"),
 	},
 	PreRun: func(req cmds.Request) error {
 		if quiet, _, _ := req.Option(quietOptionName).Bool(); quiet {

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -71,7 +71,7 @@ var showWantlistCmd = &cmds.Command{
 Print out all blocks currently on the bitswap wantlist for the local peer`,
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("peer", "p", "specify which peer to show wantlist for (default self)"),
+		cmds.StringOption("peer", 'p', "specify which peer to show wantlist for (default self)"),
 	},
 	Type: KeyList{},
 	Run: func(req cmds.Request, res cmds.Response) {

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -56,7 +56,7 @@ in the bootstrap list).
 	},
 
 	Options: []cmds.Option{
-		cmds.BoolOption("default", "add default bootstrap nodes"),
+		cmds.BoolOption("default", 0, "add default bootstrap nodes"),
 	},
 
 	Run: func(req cmds.Request, res cmds.Response) {
@@ -137,7 +137,7 @@ var bootstrapRemoveCmd = &cmds.Command{
 		cmds.StringArg("peer", false, true, peerOptionDesc).EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("all", "Remove all bootstrap peers."),
+		cmds.BoolOption("all", 0, "Remove all bootstrap peers."),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		input, err := config.ParseBootstrapPeers(req.Arguments())

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -36,7 +36,7 @@ func CommandsCmd(root *cmds.Command) *cmds.Command {
 			ShortDescription: `Lists all available commands (and subcommands) and exits.`,
 		},
 		Options: []cmds.Option{
-			cmds.BoolOption(flagsOptionName, "f", "Show command flags"),
+			cmds.BoolOption(flagsOptionName, 'f', "Show command flags"),
 		},
 		Run: func(req cmds.Request, res cmds.Response) {
 			showOptions, _, _ := req.Option(flagsOptionName).Bool()
@@ -83,21 +83,20 @@ func cmdPathStrings(cmd *Command) []string {
 		cmds = append(cmds, newPrefix)
 		if prefix != "" && cmd.ShowOptions {
 			for _, option := range cmd.Options {
-				names := option.Names()
 				var cmdOpts []string
-				for _, flag := range names {
-					if len(flag) == 1 {
-						flag = "-" + flag
-					} else {
-						flag = "--" + flag
-					}
-					cmdOpts = append(cmdOpts, newPrefix+" "+flag)
+				long := option.LongName()
+				if long != "" {
+					cmdOpts = append(cmdOpts, newPrefix + " --" + long)
+				}
+				short := option.ShortName()
+				if short != 0 {
+					cmdOpts = append(cmdOpts, newPrefix + " -" + string(short))
 				}
 				cmds = append(cmds, strings.Join(cmdOpts, " / "))
 			}
 		}
 		for _, sub := range cmd.Subcommands {
-			recurse(newPrefix+" ", &sub)
+			recurse(newPrefix + " ", &sub)
 		}
 	}
 

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -58,8 +58,8 @@ Set the value of the 'datastore.path' key:
 		cmds.StringArg("value", false, false, "The value to set the config entry to"),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("bool", "Set a boolean value"),
-		cmds.BoolOption("json", "Parse stringified JSON"),
+		cmds.BoolOption("bool", 0, "Set a boolean value"),
+		cmds.BoolOption("json", 0, "Parse stringified JSON"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		args := req.Arguments()

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -43,7 +43,7 @@ var queryDhtCmd = &cmds.Command{
 		cmds.StringArg("peerID", true, true, "The peerID to run the query against"),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write extra information"),
+		cmds.BoolOption("verbose", 'v', "Write extra information"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -151,7 +151,7 @@ FindProviders will return a list of peers who are able to provide the value requ
 		cmds.StringArg("key", true, true, "The key to find providers for"),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write extra information"),
+		cmds.BoolOption("verbose", 'v', "Write extra information"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -376,7 +376,7 @@ GetValue will return the value stored in the dht at the given key.
 		cmds.StringArg("key", true, true, "The key to find a value for"),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write extra information"),
+		cmds.BoolOption("verbose", 'v', "Write extra information"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -495,7 +495,7 @@ PutValue will store the given key value pair in the dht.
 		cmds.StringArg("value", true, false, "The value to store").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write extra information"),
+		cmds.BoolOption("verbose", 'v', "Write extra information"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()

--- a/core/commands/diag.go
+++ b/core/commands/diag.go
@@ -86,7 +86,7 @@ that consume the dot format to generate graphs of the network.
 	},
 
 	Options: []cmds.Option{
-		cmds.StringOption("vis", "output vis. one of: "+strings.Join(visFmts, ", ")),
+		cmds.StringOption("vis", 0, "output vis. one of: "+strings.Join(visFmts, ", ")),
 	},
 
 	Run: func(req cmds.Request, res cmds.Response) {

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -50,7 +50,7 @@ The resolver will give:
 		cmds.StringArg("domain-name", true, false, "The domain-name name to resolve.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Resolve until the result is not a DNS link"),
+		cmds.BoolOption("recursive", 'r', "Resolve until the result is not a DNS link"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -40,10 +40,10 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		cmds.StringArg("ipfs-path", true, false, "The path to the IPFS object(s) to be outputted").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("output", "o", "The path where output should be stored"),
-		cmds.BoolOption("archive", "a", "Output a TAR archive"),
-		cmds.BoolOption("compress", "C", "Compress the output with GZIP compression"),
-		cmds.IntOption("compression-level", "l", "The level of compression (1-9)"),
+		cmds.StringOption("output", 'o', "The path where output should be stored"),
+		cmds.BoolOption("archive", 'a', "Output a TAR archive"),
+		cmds.BoolOption("compress", 'C', "Compress the output with GZIP compression"),
+		cmds.IntOption("compression-level", 'l', "The level of compression (1-9)"),
 	},
 	PreRun: func(req cmds.Request) error {
 		_, err := getCompressOptions(req)

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -53,7 +53,7 @@ ipfs id supports the format option for output with the following keys:
 		cmds.StringArg("peerid", false, false, "peer.ID of node to look up").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("format", "f", "optional output format"),
+		cmds.StringOption("format", 'f', "optional output format"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()

--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -44,7 +44,7 @@ Resolve the value of another name:
 		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Resolve until the result is not an IPNS name"),
+		cmds.BoolOption("recursive", 'r', "Resolve until the result is not an IPNS name"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -44,7 +44,7 @@ it contains, with the following format:
 		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to list links from").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("headers", "v", "Print table headers (Hash, Name, Size)"),
+		cmds.BoolOption("headers", 'v', "Print table headers (Hash, Name, Size)"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -93,8 +93,8 @@ baz
 `,
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("ipfs-path", "f", "The path where IPFS should be mounted"),
-		cmds.StringOption("ipns-path", "n", "The path where IPNS should be mounted"),
+		cmds.StringOption("ipfs-path", 'f', "The path where IPFS should be mounted"),
+		cmds.StringOption("ipns-path", 'n', "The path where IPNS should be mounted"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		cfg, err := req.InvocContext().GetConfig()

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -332,7 +332,7 @@ and then run
 		cmds.FileArg("data", true, false, "Data to be stored as a DAG object").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("inputenc", "Encoding type of input data, either \"protobuf\" or \"json\""),
+		cmds.StringOption("inputenc", 0, "Encoding type of input data, either \"protobuf\" or \"json\""),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -468,7 +468,7 @@ The data inside the node can be modified as well:
 `,
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("create", "p", "create intermediate directories on add-link"),
+		cmds.BoolOption("create", 'p', "create intermediate directories on add-link"),
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("root", true, false, "the hash of the node to modify"),

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -40,7 +40,7 @@ on disk.
 		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be pinned").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Recursively pin the object linked to by the specified object(s)"),
+		cmds.BoolOption("recursive", 'r', "Recursively pin the object linked to by the specified object(s)"),
 	},
 	Type: PinOutput{},
 	Run: func(req cmds.Request, res cmds.Response) {
@@ -105,7 +105,7 @@ collected if needed. (By default, recursively. Use -r=false for direct pins)
 		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be unpinned").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Recursively unpin the object linked to by the specified object(s)"),
+		cmds.BoolOption("recursive", 'r', "Recursively unpin the object linked to by the specified object(s)"),
 	},
 	Type: PinOutput{},
 	Run: func(req cmds.Request, res cmds.Response) {
@@ -173,9 +173,9 @@ Example:
 	},
 
 	Options: []cmds.Option{
-		cmds.StringOption("type", "t", "The type of pinned keys to list. Can be \"direct\", \"indirect\", \"recursive\", or \"all\". Defaults to \"recursive\""),
-		cmds.BoolOption("count", "n", "Show refcount when listing indirect pins"),
-		cmds.BoolOption("quiet", "q", "Write just hashes of objects"),
+		cmds.StringOption("type", 't', "The type of pinned keys to list. Can be \"direct\", \"indirect\", \"recursive\", or \"all\". Defaults to \"recursive\""),
+		cmds.BoolOption("count", 'n', "Show refcount when listing indirect pins"),
+		cmds.BoolOption("quiet", 'q', "Write just hashes of objects"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -41,7 +41,7 @@ trip latency information.
 		cmds.StringArg("peer ID", true, true, "ID of peer to be pinged").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.IntOption("count", "n", "number of ping messages to send"),
+		cmds.IntOption("count", 'n', "number of ping messages to send"),
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -50,8 +50,8 @@ Publish an <ipfs-path> to another public key (not implemented):
 		cmds.StringArg("ipfs-path", true, false, "IPFS path of the obejct to be published").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("resolve", "resolve given path before publishing (default=true)"),
-		cmds.StringOption("lifetime", "t", "time duration that the record will be valid for (default: 24hrs)"),
+		cmds.BoolOption("resolve", 0, "resolve given path before publishing (default=true)"),
+		cmds.StringOption("lifetime", 't', "time duration that the record will be valid for (default: 24hrs)"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		log.Debug("Begin Publish")

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -50,10 +50,10 @@ Note: list all refs recursively with -r.
 		cmds.StringArg("ipfs-path", true, true, "Path to the object(s) to list refs from").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("format", "Emit edges with given format. tokens: <src> <dst> <linkname>"),
-		cmds.BoolOption("edges", "e", "Emit edge format: `<from> -> <to>`"),
-		cmds.BoolOption("unique", "u", "Omit duplicate refs from output"),
-		cmds.BoolOption("recursive", "r", "Recursively list links of child nodes"),
+		cmds.StringOption("format", 0, "Emit edges with given format. tokens: <src> <dst> <linkname>"),
+		cmds.BoolOption("edges", 'e', "Emit edge format: `<from> -> <to>`"),
+		cmds.BoolOption("unique", 'u', "Omit duplicate refs from output"),
+		cmds.BoolOption("recursive", 'r', "Recursively list links of child nodes"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		ctx := req.Context()

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -34,7 +34,7 @@ order to reclaim hard disk space.
 	},
 
 	Options: []cmds.Option{
-		cmds.BoolOption("quiet", "q", "Write minimal output"),
+		cmds.BoolOption("quiet", 'q', "Write minimal output"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -58,7 +58,7 @@ Resolve the value of an IPFS DAG path:
 		cmds.StringArg("name", true, false, "The name to resolve.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Resolve until the result is an IPFS name"),
+		cmds.BoolOption("recursive", 'r', "Resolve until the result is an IPFS name"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -72,12 +72,12 @@ Use 'ipfs <command> --help' to learn more about each command.
 `,
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("config", "c", "Path to the configuration file to use"),
-		cmds.BoolOption("debug", "D", "Operate in debug mode"),
-		cmds.BoolOption("help", "Show the full command help text"),
-		cmds.BoolOption("h", "Show a short version of the command help text"),
-		cmds.BoolOption("local", "L", "Run the command locally, instead of using the daemon"),
-		cmds.StringOption(ApiOption, "Overrides the routing option (dht, supernode)"),
+		cmds.StringOption("config", 'c', "Path to the configuration file to use"),
+		cmds.BoolOption("debug", 'D', "Operate in debug mode"),
+		cmds.BoolOption("help", 0, "Show the full command help text"),
+		cmds.BoolOption("", 'h', "Show a short version of the command help text"),
+		cmds.BoolOption("local", 'L', "Run the command locally, instead of using the daemon"),
+		cmds.StringOption(ApiOption, 0, "Overrides the routing option (dht, supernode)"),
 	},
 }
 

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -33,10 +33,10 @@ var statBwCmd = &cmds.Command{
 		ShortDescription: ``,
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("peer", "p", "specify a peer to print bandwidth for"),
-		cmds.StringOption("proto", "t", "specify a protocol to print bandwidth for"),
-		cmds.BoolOption("poll", "print bandwidth at an interval"),
-		cmds.StringOption("interval", "i", "time interval to wait between updating output"),
+		cmds.StringOption("peer", 'p', "specify a peer to print bandwidth for"),
+		cmds.StringOption("proto", 't', "specify a protocol to print bandwidth for"),
+		cmds.BoolOption("poll", 0, "print bandwidth at an interval"),
+		cmds.StringOption("interval", 'i', "time interval to wait between updating output"),
 	},
 
 	Run: func(req cmds.Request, res cmds.Response) {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -159,7 +159,7 @@ ipfs swarm addrs local lists all local addresses the node is listening on.
 `,
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("id", "Show peer ID in addresses"),
+		cmds.BoolOption("id", 0, "Show peer ID in addresses"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -21,8 +21,8 @@ var VersionCmd = &cmds.Command{
 	},
 
 	Options: []cmds.Option{
-		cmds.BoolOption("number", "n", "Only show the version number"),
-		cmds.BoolOption("commit", "Show the commit hash"),
+		cmds.BoolOption("number", 'n', "Only show the version number"),
+		cmds.BoolOption("commit", 0, "Show the commit hash"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		res.SetOutput(&VersionOutput{

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -94,8 +94,8 @@ test_object_cmd() {
 		test_cmp expected_putBroken actual_putBroken &&
 		test_cmp expected_putBrokenErr actual_putBrokenErr
 	'
-	test_expect_success "'ipfs object get --enc=xml' succeeds" '
-		ipfs object get --enc=xml $HASH >utf8_xml
+	test_expect_success "'ipfs object get -E=xml' succeeds" '
+		ipfs object get -E=xml $HASH >utf8_xml
 	'
 
 	test_expect_success "'ipfs object put --inputenc=xml' succeeds" '
@@ -155,8 +155,8 @@ test_object_cmd() {
 		test_cmp expected actual
 	'
 
-	test_expect_success "'ipfs object get --enc=json' succeeds" '
-		ipfs object get --enc=json $HASH >utf8_json
+	test_expect_success "'ipfs object get -E=json' succeeds" '
+		ipfs object get -E=json $HASH >utf8_json
 	'
 
 	test_expect_success "'ipfs object put --inputenc=json' succeeds" '


### PR DESCRIPTION
This changes the option struct like this:

```
type option struct {
-       names       []string
+       longName    string
+       shortName   rune
        kind        reflect.Kind
        description string
 }
```

and make all the related changes.

This split was suggested in PR #1852 (Make `ipfs commands --flags` option).

A significant change is that the encoding global option has no more both the `--enc` and `--encoding` long names. Instead it has the `-E` short name and the `--encoding` long name.
If we really want the `--enc` long name too, we could perhaps do something like:

```
diff --git a/commands/option.go b/commands/option.go
index 3bb411a..e4a7b08 100644
--- a/commands/option.go
+++ b/commands/option.go
@@ -156,6 +156,7 @@ func (ov OptionValue) String() (value string, found bool, err error) {
 const (
        EncShort   = 'E'
        EncLong    = "encoding"
+       Enc2Long   = "enc"
        RecShort   = 'r'
        RecLong    = "recursive"
        ChanOpt    = "stream-channels"
@@ -164,6 +165,7 @@ const (
 
 // options that are used by this package
 var OptionEncodingType = StringOption(EncLong, EncShort, "The encoding type the output should be encoded with (json, xml, or text)")
+var OptionEncodingType2 = StringOption(Enc2Long, 0, "A synonym for " + EncLong)
 var OptionRecursivePath = BoolOption(RecLong, RecShort, "Add directory paths recursively")
 var OptionStreamChannels = BoolOption(ChanOpt, 0, "Stream channel output")
 var OptionTimeout = StringOption(TimeoutOpt, 0, "set a global timeout on the command")
@@ -171,6 +173,7 @@ var OptionTimeout = StringOption(TimeoutOpt, 0, "set a global timeout on the com
 // global options, added to every command
 var globalOptions = []Option{
        OptionEncodingType,
+       OptionEncodingType2,
        OptionStreamChannels,
        OptionTimeout,
 }
```

cc @whyrusleeping 