### PR TITLE
purposely fail builds pre1.5

### DIFF
--- a/.gobuilder.yml
+++ b/.gobuilder.yml
@@ -1,3 +1,4 @@
 ---
 triggers:
   - github.com/ipfs/go-ipfs/cmd/ipfs
+no_go_fmt: true

--- a/cmd/ipfs/goreq.go
+++ b/cmd/ipfs/goreq.go
@@ -1,0 +1,3 @@
+// +build !go1.5		
+
+`IPFS needs to be built with go version 1.5 or greater`


### PR DESCRIPTION
ensures we dont accidentaly run into #1880 by building with go1.4

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>