### PR TITLE
bitswap: clean log printf and humanize dup data count

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/dustin/go-humanize"
+
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	bitswap "github.com/ipfs/go-ipfs/exchange/bitswap"
@@ -156,7 +158,7 @@ var bitswapStatCmd = &cmds.Command{
 			fmt.Fprintf(buf, "\tprovides buffer: %d / %d\n", out.ProvideBufLen, bitswap.HasBlockBufferSize)
 			fmt.Fprintf(buf, "\tblocks received: %d\n", out.BlocksReceived)
 			fmt.Fprintf(buf, "\tdup blocks received: %d\n", out.DupBlksReceived)
-			fmt.Fprintf(buf, "\tdup data received: %d\n", out.DupDataReceived)
+			fmt.Fprintf(buf, "\tdup data received: %s\n", humanize.Bytes(out.DupDataReceived))
 			fmt.Fprintf(buf, "\twantlist [%d keys]\n", len(out.Wantlist))
 			for _, k := range out.Wantlist {
 				fmt.Fprintf(buf, "\t\t%s\n", k.B58String())

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -308,7 +308,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 	var keys []key.Key
 	for _, block := range iblocks {
 		if _, found := bs.wm.wl.Contains(block.Key()); !found {
-			log.Info("received un-asked-for block: %s", block)
+			log.Infof("received un-asked-for %s from %s", block, p)
 			continue
 		}
 		keys = append(keys, block.Key())


### PR DESCRIPTION
I was quite confused the first time I saw an "dup data received" in `ipfs bitswap stat` that was bigger than several megabytes.

Also fixed the formatting of the `received un-asked-for block` logging statement.

License: MIT
Signed-off-by: Henry <cryptix@riseup.net>