### PR TITLE
Version bump 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # go-ipfs changelog
 
+### 0.3.9 - 2015-10-30
+
+This patch update includes a good number of bugfixes, notably, it fixes
+builds on windows, and puts newlines between streaming json objects for a
+proper nsjon format.
+
+* Features
+  * Writable gateway enabled again (@cryptix)
+
+* Bugfixes
+  * fix windows builds (@whyrusleeping)
+  * content type on command responses default to text (@whyrusleeping)
+  * add check to makefile to ensure windows builds dont fail silently (@whyrusleeping)
+  * put newlines between streaming json output objects (@whyrusleeping)
+  * fix streaming output to flush per write (@whyrusleeping)
+  * purposely fail builds pre go1.5 (@whyrusleeping)
+  * fix ipfs id <self> (@whyrusleeping)
+  * fix a few race conditions in mocknet (@whyrusleeping)
+  * fix makefile failing when not in a git repo (@whyrusleeping)
+  * fix cli flag orders (long, short) (@rht)
+  * fix races in http cors (@miolini)
+  * small webui update (some bugfixes) (@jbenet)
+
+* Tool Changes
+  * make swarm connect return an error when it fails (@whyrusleeping)
+  * Add short flag for `ipfs ls --headers` (v for verbose) (@rht)
+
+* General Codebase
+  * bitswap: clean log printf and humanize dup data count (@cryptix)
+  * config: update pluto's peerID (@lgierth)
+  * config: update bootstrap list hostname (@lgierth)
+
+* Documentation
+  * Pared down contribute to link to new go guidelines (@richardlitt)
+
+* Testing
+  * t0010: add tests for 'ipfs commands --flags' (@chriscool)
+  * ipns_test: fix namesys.NewNameSystem() call (@chriscool)
+  * t0060: fail if no nc (@chriscool)
+
 ### 0.3.8 - 2015-10-09
 
 This patch update includes changes to make ipns more consistent and reliable,

--- a/misc/release-checklist.md
+++ b/misc/release-checklist.md
@@ -1,0 +1,19 @@
+# ipfs release checklist
+
+- [ ] version changed in repo/config/version.go
+- [ ] changelog.md updated
+- [ ] commit tagged
+- [ ] tests
+  - [ ] go-ipfs tests
+  - [ ] sharness tests
+  - [ ] webui works
+  - [ ] js-ipfs-api tests
+- [ ] builds
+  - [ ] windows
+  - [ ] linux
+    - [ ] amd64
+	- [ ] arm
+  - [ ] osx
+
+## post release
+- [ ] bump repo/config/version.go to $NEXT-dev

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.3.9"
+const CurrentVersionNumber = "0.3.10-dev"
 
 // CurrentCommit is the current git commit, this is set as a ldflag in the Makefile
 var CurrentCommit string

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.3.9-dev"
+const CurrentVersionNumber = "0.3.9"
 
 // CurrentCommit is the current git commit, this is set as a ldflag in the Makefile
 var CurrentCommit string


### PR DESCRIPTION
you all know the drill.

One minor difference from previous releases, i'm adding a second commit here to bump the dev version to 0.3.10-dev. The *first* commit in this PR is the one that needs to be tagged as 0.3.9