### PR TITLE
Allow `ipfs cat` on ipns path

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -31,6 +31,13 @@ it contains.
 			return
 		}
 
+		if !node.OnlineMode() {
+			if err := node.SetupOfflineRouting(); err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+		}
+
 		readers, length, err := cat(req.Context(), node, req.Arguments())
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -8,8 +8,7 @@ import (
 )
 
 func Cat(ctx context.Context, n *core.IpfsNode, pstr string) (*uio.DagReader, error) {
-	p := path.FromString(pstr)
-	dagNode, err := n.Resolver.ResolvePath(ctx, p)
+	dagNode, err := core.Resolve(ctx, n, path.Path(pstr))
 	if err != nil {
 		return nil, err
 	}

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -54,6 +54,12 @@ test_expect_success "resolve output looks good" '
 	test_cmp expected4 output
 '
 
+test_expect_success "ipfs cat on published content succeeds" '
+    ipfs cat "/ipfs/$HASH_WELCOME_DOCS/help" >expected &&
+    ipfs cat "/ipns/$PEERID" >actual &&
+    test_cmp expected actual
+'
+
 # publish with an explicit node ID
 
 test_expect_failure "'ipfs name publish <local-id> <hash>' succeeds" '


### PR DESCRIPTION
Partially address #1898.
Why should an ipns key be stored in blockstore instead of the ipfs hash it resolves to?
There is already caching in #1887.