### PR TITLE
Gateway: Add Cache-Control/max-age and ETag to IPNS requests

### DIFF
--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -104,6 +104,10 @@ Publish an <ipfs-path> to another public key (not implemented):
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
+			if d < 0 {
+				res.SetError(fmt.Errorf("ttl can not be negative"), cmds.ErrNormal)
+				return
+			}
 
 			ctx = context.WithValue(ctx, "ipns-publish-ttl", d)
 		}

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -17,21 +17,32 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 	testutil "github.com/ipfs/go-ipfs/util/testutil"
 )
 
 type mockNamesys map[string]path.Path
 
 func (m mockNamesys) Resolve(ctx context.Context, name string) (value path.Path, err error) {
-	return m.ResolveN(ctx, name, namesys.DefaultDepthLimit)
+	p, _, err := m.ResolveWithTTL(ctx, name)
+	return p, err
 }
 
 func (m mockNamesys) ResolveN(ctx context.Context, name string, depth int) (value path.Path, err error) {
+	p, _, err := m.ResolveNWithTTL(ctx, name, depth)
+	return p, err
+}
+
+func (m mockNamesys) ResolveWithTTL(ctx context.Context, name string) (value path.Path, ttl infd.Duration, err error) {
+	return m.ResolveNWithTTL(ctx, name, namesys.DefaultDepthLimit)
+}
+
+func (m mockNamesys) ResolveNWithTTL(ctx context.Context, name string, depth int) (value path.Path, ttl infd.Duration, err error) {
 	p, ok := m[name]
 	if !ok {
-		return "", namesys.ErrResolveFailed
+		return "", infd.FiniteDuration(0), namesys.ErrResolveFailed
 	}
-	return p, nil
+	return p, infd.FiniteDuration(0), nil
 }
 
 func (m mockNamesys) Publish(ctx context.Context, name ci.PrivKey, value path.Path) error {

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -8,6 +8,7 @@ import (
 
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 )
 
 // ErrNoNamesys is an explicit error for when an IPFS node doesn't
@@ -20,38 +21,50 @@ var ErrNoNamesys = errors.New(
 // entries and returning the final merkledag node.  Effectively
 // enables /ipns/, /dns/, etc. in commands.
 func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, error) {
+	node, _, err := ResolveWithTTL(ctx, n, p)
+	return node, err
+}
+
+// ResolveWithTTL is like Resolve but also returns a time-to-live value which
+// indicates the maximum amount of time the result (whether a success or an
+// error) may be cached.
+func ResolveWithTTL(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, infd.Duration, error) {
+	ttl := infd.InfiniteDuration()
+
 	if strings.HasPrefix(p.String(), "/ipns/") {
 		// resolve ipns paths
 
 		// TODO(cryptix): we sould be able to query the local cache for the path
 		if n.Namesys == nil {
-			return nil, ErrNoNamesys
+			return nil, infd.FiniteDuration(0), ErrNoNamesys
 		}
 
 		seg := p.Segments()
 
 		if len(seg) < 2 || seg[1] == "" { // just "/<protocol/>" without further segments
-			return nil, path.ErrNoComponents
+			return nil, infd.InfiniteDuration(), path.ErrNoComponents
 		}
 
 		extensions := seg[2:]
 		resolvable, err := path.FromSegments("/", seg[0], seg[1])
 		if err != nil {
-			return nil, err
+			return nil, infd.InfiniteDuration(), err
 		}
 
-		respath, err := n.Namesys.Resolve(ctx, resolvable.String())
+		resPath, resTTL, err := n.Namesys.ResolveWithTTL(ctx, resolvable.String())
+		ttl = resTTL
 		if err != nil {
-			return nil, err
+			return nil, ttl, err
 		}
 
-		segments := append(respath.Segments(), extensions...)
+		segments := append(resPath.Segments(), extensions...)
 		p, err = path.FromSegments("/", segments...)
 		if err != nil {
-			return nil, err
+			return nil, ttl, err
 		}
 	}
 
 	// ok, we have an ipfs path now (or what we'll treat as one)
-	return n.Resolver.ResolvePath(ctx, p)
+	node, err := n.Resolver.ResolvePath(ctx, p)
+	return node, ttl, err
 }

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -3,6 +3,8 @@ package namesys
 import (
 	"fmt"
 	"testing"
+
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 )
 
 type mockDNS struct {
@@ -93,20 +95,21 @@ func newMockDNS() *mockDNS {
 func TestDNSResolution(t *testing.T) {
 	mock := newMockDNS()
 	r := &DNSResolver{lookupTXT: mock.lookupTXT}
-	testResolution(t, r, "multihash.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "ipfs.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "dns1.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "dns1.example.com", 1, "/ipns/ipfs.example.com", ErrResolveRecursion)
-	testResolution(t, r, "dns2.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "dns2.example.com", 1, "/ipns/dns1.example.com", ErrResolveRecursion)
-	testResolution(t, r, "dns2.example.com", 2, "/ipns/ipfs.example.com", ErrResolveRecursion)
-	testResolution(t, r, "multi.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
-	testResolution(t, r, "multi.example.com", 1, "/ipns/dns1.example.com", ErrResolveRecursion)
-	testResolution(t, r, "multi.example.com", 2, "/ipns/ipfs.example.com", ErrResolveRecursion)
-	testResolution(t, r, "equals.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/=equals", nil)
-	testResolution(t, r, "loop1.example.com", 1, "/ipns/loop2.example.com", ErrResolveRecursion)
-	testResolution(t, r, "loop1.example.com", 2, "/ipns/loop1.example.com", ErrResolveRecursion)
-	testResolution(t, r, "loop1.example.com", 3, "/ipns/loop2.example.com", ErrResolveRecursion)
-	testResolution(t, r, "loop1.example.com", DefaultDepthLimit, "/ipns/loop1.example.com", ErrResolveRecursion)
-	testResolution(t, r, "bad.example.com", DefaultDepthLimit, "", ErrResolveFailed)
+	ttl := infd.FiniteDuration(UnknownTTL)
+	testResolution(t, r, "multihash.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", ttl, nil)
+	testResolution(t, r, "ipfs.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", ttl, nil)
+	testResolution(t, r, "dns1.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", ttl, nil)
+	testResolution(t, r, "dns1.example.com", 1, "/ipns/ipfs.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "dns2.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", ttl, nil)
+	testResolution(t, r, "dns2.example.com", 1, "/ipns/dns1.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "dns2.example.com", 2, "/ipns/ipfs.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "multi.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", ttl, nil)
+	testResolution(t, r, "multi.example.com", 1, "/ipns/dns1.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "multi.example.com", 2, "/ipns/ipfs.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "equals.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/=equals", ttl, nil)
+	testResolution(t, r, "loop1.example.com", 1, "/ipns/loop2.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", 2, "/ipns/loop1.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", 3, "/ipns/loop2.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "loop1.example.com", DefaultDepthLimit, "/ipns/loop1.example.com", ttl, ErrResolveRecursion)
+	testResolution(t, r, "bad.example.com", DefaultDepthLimit, "", ttl, ErrResolveFailed)
 }

--- a/namesys/interface.go
+++ b/namesys/interface.go
@@ -36,6 +36,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	path "github.com/ipfs/go-ipfs/path"
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 )
 
 const (
@@ -47,6 +48,10 @@ const (
 	// trust resolution to eventually complete and can't put an upper
 	// limit on how many steps it will take.
 	UnlimitedDepth = 0
+
+	// UnknownTTL is the time-to-live value to be reported for mutable
+	// paths when accurate information is not available.
+	UnknownTTL = time.Minute
 )
 
 // ErrResolveFailed signals an error when attempting to resolve.
@@ -98,6 +103,16 @@ type Resolver interface {
 	// Most users should use Resolve, since the default limit works well
 	// in most real-world situations.
 	ResolveN(ctx context.Context, name string, depth int) (value path.Path, err error)
+
+	// ResolveWithTTL is like Resolve but also returns a time-to-live value
+	// which indicates the maximum amount of time the result (whether a
+	// success or an error) may be cached.
+	ResolveWithTTL(ctx context.Context, name string) (value path.Path, ttl infd.Duration, err error)
+
+	// ResolveNWithTTL is like ResolveN but also returns a time-to-live
+	// value which indicates the maximum amount of time the result (whether
+	// a success or an error) may be cached.
+	ResolveNWithTTL(ctx context.Context, name string, depth int) (value path.Path, ttl infd.Duration, err error)
 }
 
 // Publisher is an object capable of publishing particular names.

--- a/namesys/namesys_test.go
+++ b/namesys/namesys_test.go
@@ -3,18 +3,25 @@ package namesys
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	path "github.com/ipfs/go-ipfs/path"
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 )
 
 type mockResolver struct {
-	entries map[string]string
+	entries map[string]mockEntry
 }
 
-func testResolution(t *testing.T, resolver Resolver, name string, depth int, expected string, expError error) {
-	p, err := resolver.ResolveN(context.Background(), name, depth)
+type mockEntry struct {
+	path string
+	ttl  infd.Duration
+}
+
+func testResolution(t *testing.T, resolver Resolver, name string, depth int, expected string, expTTL infd.Duration, expError error) {
+	p, ttl, err := resolver.ResolveNWithTTL(context.Background(), name, depth)
 	if err != expError {
 		t.Fatal(fmt.Errorf(
 			"Expected %s with a depth of %d to have a '%s' error, but got '%s'",
@@ -25,26 +32,33 @@ func testResolution(t *testing.T, resolver Resolver, name string, depth int, exp
 			"%s with depth %d resolved to %s != %s",
 			name, depth, p.String(), expected))
 	}
+	if !infd.Equal(ttl, expTTL) {
+		t.Fatal(fmt.Errorf(
+			"%s with depth %d had TTL %v != %v",
+			name, depth, ttl, expTTL))
+	}
 }
 
-func (r *mockResolver) resolveOnce(ctx context.Context, name string) (path.Path, error) {
-	return path.ParsePath(r.entries[name])
+func (r *mockResolver) resolveOnce(ctx context.Context, name string) (path.Path, infd.Duration, error) {
+	entry := r.entries[name]
+	p, err := path.ParsePath(entry.path)
+	return p, entry.ttl, err
 }
 
 func mockResolverOne() *mockResolver {
 	return &mockResolver{
-		entries: map[string]string{
-			"QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy": "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj",
-			"QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n": "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy",
-			"QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD": "/ipns/ipfs.io",
+		entries: map[string]mockEntry{
+			"QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy": mockEntry{"/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.InfiniteDuration()},
+			"QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n": mockEntry{"/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", infd.FiniteDuration(10 * time.Minute)},
+			"QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD": mockEntry{"/ipns/ipfs.io", infd.FiniteDuration(5 * time.Minute)},
 		},
 	}
 }
 
 func mockResolverTwo() *mockResolver {
 	return &mockResolver{
-		entries: map[string]string{
-			"ipfs.io": "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n",
+		entries: map[string]mockEntry{
+			"ipfs.io": mockEntry{"/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", infd.FiniteDuration(1 * time.Minute)},
 		},
 	}
 }
@@ -57,15 +71,15 @@ func TestNamesysResolution(t *testing.T) {
 		},
 	}
 
-	testResolution(t, r, "Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
-	testResolution(t, r, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
-	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
-	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", 1, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
-	testResolution(t, r, "/ipns/ipfs.io", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
-	testResolution(t, r, "/ipns/ipfs.io", 1, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", ErrResolveRecursion)
-	testResolution(t, r, "/ipns/ipfs.io", 2, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
-	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", nil)
-	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 1, "/ipns/ipfs.io", ErrResolveRecursion)
-	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 2, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", ErrResolveRecursion)
-	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 3, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", ErrResolveRecursion)
+	testResolution(t, r, "Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.InfiniteDuration(), nil)
+	testResolution(t, r, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.InfiniteDuration(), nil)
+	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.FiniteDuration(10*time.Minute), nil)
+	testResolution(t, r, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", 1, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", infd.FiniteDuration(10*time.Minute), ErrResolveRecursion)
+	testResolution(t, r, "/ipns/ipfs.io", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.FiniteDuration(1*time.Minute), nil)
+	testResolution(t, r, "/ipns/ipfs.io", 1, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", infd.FiniteDuration(1*time.Minute), ErrResolveRecursion)
+	testResolution(t, r, "/ipns/ipfs.io", 2, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", infd.FiniteDuration(1*time.Minute), ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", DefaultDepthLimit, "/ipfs/Qmcqtw8FfrVSBaRmbWwHxt3AuySBhJLcvmFYi3Lbc4xnwj", infd.FiniteDuration(1*time.Minute), nil)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 1, "/ipns/ipfs.io", infd.FiniteDuration(5*time.Minute), ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 2, "/ipns/QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n", infd.FiniteDuration(1*time.Minute), ErrResolveRecursion)
+	testResolution(t, r, "/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", 3, "/ipns/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy", infd.FiniteDuration(1*time.Minute), ErrResolveRecursion)
 }

--- a/namesys/proquint.go
+++ b/namesys/proquint.go
@@ -6,25 +6,38 @@ import (
 	proquint "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/bren2010/proquint"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	path "github.com/ipfs/go-ipfs/path"
+	infd "github.com/ipfs/go-ipfs/util/infduration"
 )
 
 type ProquintResolver struct{}
 
 // Resolve implements Resolver.
 func (r *ProquintResolver) Resolve(ctx context.Context, name string) (path.Path, error) {
-	return r.ResolveN(ctx, name, DefaultDepthLimit)
+	p, _, err := r.ResolveWithTTL(ctx, name)
+	return p, err
 }
 
 // ResolveN implements Resolver.
 func (r *ProquintResolver) ResolveN(ctx context.Context, name string, depth int) (path.Path, error) {
+	p, _, err := r.ResolveNWithTTL(ctx, name, depth)
+	return p, err
+}
+
+// ResolveWithTTL implements Resolver.
+func (r *ProquintResolver) ResolveWithTTL(ctx context.Context, name string) (path.Path, infd.Duration, error) {
+	return r.ResolveNWithTTL(ctx, name, DefaultDepthLimit)
+}
+
+// ResolveNWithTTL implements Resolver.
+func (r *ProquintResolver) ResolveNWithTTL(ctx context.Context, name string, depth int) (path.Path, infd.Duration, error) {
 	return resolve(ctx, r, name, depth, "/ipns/")
 }
 
 // resolveOnce implements resolver. Decodes the proquint string.
-func (r *ProquintResolver) resolveOnce(ctx context.Context, name string) (path.Path, error) {
+func (r *ProquintResolver) resolveOnce(ctx context.Context, name string) (path.Path, infd.Duration, error) {
 	ok, err := proquint.IsProquint(name)
 	if err != nil || !ok {
-		return "", errors.New("not a valid proquint string")
+		return "", infd.InfiniteDuration(), errors.New("not a valid proquint string")
 	}
-	return path.FromString(string(proquint.Decode(name))), nil
+	return path.FromString(string(proquint.Decode(name))), infd.InfiniteDuration(), nil
 }

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -131,7 +131,15 @@ func checkCtxTTL(ctx context.Context) (time.Duration, bool) {
 	}
 
 	d, ok := v.(time.Duration)
-	return d, ok
+	if !ok {
+		return 0, false
+	}
+
+	if d < 0 {
+		return 0, false
+	}
+
+	return d, true
 }
 
 func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqnum uint64, eol time.Time, r routing.IpfsRouting, id peer.ID) error {

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -10,12 +10,14 @@ test_description="Test ipfs repo operations"
 
 test_init_ipfs
 
+for TTL_PARAMS in "" "--ttl=0s" "--ttl=1h"; do
+
 # test publishing a hash
 
-test_expect_success "'ipfs name publish' succeeds" '
+test_expect_success "'ipfs name publish${TTL_PARAMS:+ $TTL_PARAMS}' succeeds" '
 	PEERID=`ipfs id --format="<id>"` &&
 	test_check_peerid "${PEERID}" &&
-	ipfs name publish "/ipfs/$HASH_WELCOME_DOCS" >publish_out
+	ipfs name publish $TTL_PARAMS "/ipfs/$HASH_WELCOME_DOCS" >publish_out
 '
 
 test_expect_success "publish output looks good" '
@@ -34,10 +36,10 @@ test_expect_success "resolve output looks good" '
 
 # now test with a path
 
-test_expect_success "'ipfs name publish' succeeds" '
+test_expect_success "'ipfs name publish${TTL_PARAMS:+ $TTL_PARAMS}' succeeds" '
 	PEERID=`ipfs id --format="<id>"` &&
 	test_check_peerid "${PEERID}" &&
-	ipfs name publish "/ipfs/$HASH_WELCOME_DOCS/help" >publish_out
+	ipfs name publish $TTL_PARAMS "/ipfs/$HASH_WELCOME_DOCS/help" >publish_out
 '
 
 test_expect_success "publish a path looks good" '
@@ -62,16 +64,18 @@ test_expect_success "ipfs cat on published content succeeds" '
 
 # publish with an explicit node ID
 
-test_expect_failure "'ipfs name publish <local-id> <hash>' succeeds" '
+test_expect_failure "'ipfs name publish${TTL_PARAMS:+ $TTL_PARAMS} <local-id> <hash>' succeeds" '
 	PEERID=`ipfs id --format="<id>"` &&
 	test_check_peerid "${PEERID}" &&
-	echo ipfs name publish "${PEERID}" "/ipfs/$HASH_WELCOME_DOCS" &&
-	ipfs name publish "${PEERID}" "/ipfs/$HASH_WELCOME_DOCS" >actual_node_id_publish
+	echo ipfs name publish $TTL_PARAMS "${PEERID}" "/ipfs/$HASH_WELCOME_DOCS" &&
+	ipfs name publish $TTL_PARAMS "${PEERID}" "/ipfs/$HASH_WELCOME_DOCS" >actual_node_id_publish
 '
 
 test_expect_failure "publish with our explicit node ID looks good" '
 	echo "Published to ${PEERID}: /ipfs/$HASH_WELCOME_DOCS" >expected_node_id_publish &&
 	test_cmp expected_node_id_publish actual_node_id_publish
 '
+
+done
 
 test_done

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -78,4 +78,8 @@ test_expect_failure "publish with our explicit node ID looks good" '
 
 done
 
+test_expect_success "'ipfs name publish --ttl=-1s' fails (negative TTL)" '
+	test_must_fail ipfs name publish --ttl=-1s "/ipfs/$HASH_WELCOME_DOCS"
+'
+
 test_done

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -22,59 +22,180 @@ apiport=$PORT_API
 # define a function to test a gateway, and do so for each port.
 # for now we check 5001 here as 5002 will be checked in gateway-writable.
 
-test_expect_success "GET IPFS path succeeds" '
-  echo "Hello Worlds!" >expected &&
-  HASH=$(ipfs add -q expected) &&
-  curl -sfo actual "http://127.0.0.1:$port/ipfs/$HASH"
-'
+# Overwrites: actual.headers, actual.
+test_run_curl() {
+  rm -f actual.headers actual
+  curl -s -D actual.headers -o actual "$@"
+}
 
-test_expect_success "GET IPFS path output looks good" '
-  test_cmp expected actual &&
-  rm actual
-'
+test_actual_headers_http_status() {
+  test_should_contain '^HTTP/1.1 '"$1"'.$' actual.headers
+}
 
-test_expect_success "GET IPFS path on API forbidden" '
-  test_curl_resp_http_code "http://127.0.0.1:$apiport/ipfs/$HASH" "HTTP/1.1 403 Forbidden"
-'
+test_get_max_age() {
+  perl -nwe 's/^Cache-Control:.* max-age=([0-9]+).*\r$/$1/i && print' "$1"
+}
 
-test_expect_success "GET IPFS directory path succeeds" '
-  mkdir dir &&
-  echo "12345" >dir/test &&
-  ipfs add -r -q dir >actual &&
+test_get_header() {
+  perl -nwe 'BEGIN { $header = shift(@ARGV); } s/^\Q$header\E: (.*)\r$/$1/i && print' "$1" "$2"
+}
+
+test_item_curl() {
+  _item="$1"
+  _url="$2"
+  _http_status="$3"
+
+  # Just use test_expect_success once #1941 is fixed.
+  case "$_url" in
+    */ipns/*) TEST_COMMAND=test_expect_success_1941 ;;
+    *)        TEST_COMMAND=test_expect_success ;;
+  esac
+
+  "$TEST_COMMAND" "$_item: responds with $_http_status" '
+    test_run_curl "$_url" &&
+    test_actual_headers_http_status "$_http_status"
+  '
+}
+
+test_item_output() {
+  _item="$1"
+  _expected_output_file="$2"
+
+  "$TEST_COMMAND" "$_item: output looks good" '
+    test_cmp "$_expected_output_file" actual
+  '
+}
+
+test_item_no_max_age() {
+  _item="$1"
+
+  "$TEST_COMMAND" "$_item: has no Cache-Control max-age" '
+    test_get_max_age actual.headers >actual.max-age
+    test_must_be_empty actual.max-age || test_fsh cat actual.headers
+  '
+}
+
+test_item_max_age() {
+  _item="$1"
+  _max_age="$2"
+
+  "$TEST_COMMAND" "$_item: has Cache-Control max-age=$_max_age" '
+    test_get_max_age actual.headers >actual.max-age
+    printf "%s\n" "$_max_age" >expected.max-age
+    test_cmp expected.max-age actual.max-age || test_fsh cat actual.headers
+  '
+}
+
+IMMUTABLE_TTL=$((10*365*24*60*60))
+UNKNOWN_TTL=60
+
+# DATA1, HASH1: a file
+# DATA2, HASH2: a directory
+# PEERID: the node ID
+test_expect_success "Generating test environment" '
+  DATA1=data1 &&
+  echo "Hello Worlds!" >"$DATA1" &&
+  HASH1=$(ipfs add -q "$DATA1") &&
+  DATA2=data2 &&
+  mkdir "$DATA2" &&
+  echo "12345" >"$DATA2/test" &&
+  mkdir "$DATA2/has-index-html" &&
+  echo "index" >"$DATA2/has-index-html/index.html" &&
+  ipfs add -r -q "$DATA2" >actual &&
   HASH2=$(tail -n 1 actual) &&
-  curl -sf "http://127.0.0.1:$port/ipfs/$HASH2"
-'
-
-test_expect_success "GET IPFS directory file succeeds" '
-  curl -sfo actual "http://127.0.0.1:$port/ipfs/$HASH2/test"
-'
-
-test_expect_success "GET IPFS directory file output looks good" '
-  test_cmp dir/test actual
-'
-
-test_expect_success "GET IPFS non existent file returns code expected (404)" '
-  test_curl_resp_http_code "http://127.0.0.1:$port/ipfs/$HASH2/pleaseDontAddMe" "HTTP/1.1 404 Not Found"
-'
-
-test_expect_failure "GET IPNS path succeeds" '
-  ipfs name publish "$HASH" &&
   PEERID=$(ipfs config Identity.PeerID) &&
-  test_check_peerid "$PEERID" &&
-  curl -sfo actual "http://127.0.0.1:$port/ipns/$PEERID"
+  test_check_peerid "$PEERID"
 '
 
-test_expect_failure "GET IPNS path output looks good" '
-  test_cmp expected actual
+ITEM="GET IPFS path"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH1" "200 OK"
+test_item_output  "$ITEM" "$DATA1"
+test_item_max_age "$ITEM" "$IMMUTABLE_TTL"
+
+ITEM="GET IPFS path on API"
+test_item_curl       "$ITEM" "http://127.0.0.1:$apiport/ipfs/$HASH1" "403 Forbidden"
+test_item_no_max_age "$ITEM"
+
+ITEM="GET IPFS directory path"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH2" "200 OK"
+test_item_max_age "$ITEM" "$IMMUTABLE_TTL"
+test_expect_success "$ITEM: output looks good" '
+  test_should_contain "Index of /ipfs/$HASH2" actual
 '
 
-test_expect_success "GET invalid IPFS path errors" '
-  test_must_fail curl -sf "http://127.0.0.1:$port/ipfs/12345"
+ITEM="GET IPFS directory file"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH2/test" "200 OK"
+test_item_output  "$ITEM" "$DATA2/test"
+test_item_max_age "$ITEM" "$IMMUTABLE_TTL"
+
+ITEM="GET IPFS directory path with index.html"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH2/has-index-html" "302 Found"
+test_item_max_age "$ITEM" "$IMMUTABLE_TTL"
+test_expect_success "$ITEM: redirects to path/" '
+  test_get_header Location actual.headers >actual.location &&
+  printf "%s\n" "/ipfs/$HASH2/has-index-html/" >expected.location &&
+  test_cmp expected.location actual.location || test_fsh cat actual.headers
 '
 
-test_expect_success "GET invalid path errors" '
-  test_must_fail curl -sf "http://127.0.0.1:$port/12345"
+ITEM="GET IPFS directory path/ with index.html"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH2/has-index-html/" "200 OK"
+test_item_output  "$ITEM" "$DATA2/has-index-html/index.html"
+test_item_max_age "$ITEM" "$IMMUTABLE_TTL"
+
+ITEM="GET IPFS non-existent file"
+test_item_curl       "$ITEM" "http://127.0.0.1:$port/ipfs/$HASH2/pleaseDontAddMe" "404 Not Found"
+test_item_no_max_age "$ITEM"
+
+TTL=10
+
+ITEM="GET IPNS path"
+test_expect_success_1941 "$ITEM: IPNS publish with TTL $TTL succeeds" '
+  ipfs name publish --ttl="${TTL}s" "$HASH1"
 '
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipns/$PEERID" "200 OK"
+test_item_output  "$ITEM" "$DATA1"
+test_item_max_age "$ITEM" "$TTL"
+
+test_timer_start EXPIRY_TIMER "${TTL}s" # The cache entry has expired when this finishes.
+
+ITEM="GET IPNS path again before cache expiry"
+# Publish a new version now, the previous version should still be cached.  The
+# next item will resolve this version.
+test_expect_success_1941 "$ITEM: IPNS publish with default TTL succeeds" '
+  ipfs name publish "$HASH2"
+'
+go-sleep 1s # Ensure the following max-age is strictly less than TTL.
+test_item_curl   "$ITEM" "http://127.0.0.1:$port/ipns/$PEERID" "200 OK"
+test_item_output "$ITEM" "$DATA1"
+test_expect_success_1941 "$ITEM: has Cache-Control max-age between 0 and $TTL" '
+  max_age="$(test_get_max_age actual.headers)" &&
+  test "$max_age" -gt 0 &&
+  test "$max_age" -lt "$TTL" ||
+  test_fsh cat actual.headers
+'
+
+# Make sure the expiry timer is still running, otherwise the result might be
+# wrong.  If this fails, we will need to increase TTL above to give enough time
+# for the tests.
+test_expect_success "$ITEM: tests did not take too long" '
+  test_timer_is_running "$EXPIRY_TIMER"
+'
+test_expect_success "$ITEM: previous version is no longer cached" '
+  test_timer_wait "$EXPIRY_TIMER"
+'
+
+ITEM="GET IPNS path again after cache expiry"
+test_item_curl    "$ITEM" "http://127.0.0.1:$port/ipns/$PEERID/test" "200 OK"
+test_item_output  "$ITEM" "$DATA2/test"
+test_item_max_age "$ITEM" "$UNKNOWN_TTL"
+
+ITEM="GET invalid IPFS path"
+test_item_curl       "$ITEM" "http://127.0.0.1:$port/ipfs/12345" "400 Bad Request"
+test_item_no_max_age "$ITEM"
+
+ITEM="GET invalid root path"
+test_item_curl       "$ITEM" "http://127.0.0.1:$port/12345" "404 Not Found"
+test_item_no_max_age "$ITEM"
 
 test_expect_success "GET /webui returns code expected" '
   test_curl_resp_http_code "http://127.0.0.1:$apiport/webui" "HTTP/1.1 302 Found" "HTTP/1.1 301 Moved Permanently"
@@ -103,7 +224,7 @@ test_expect_success "get IPFS directory file through readonly API succeeds" '
 '
 
 test_expect_success "get IPFS directory file through readonly API output looks good" '
-  test_cmp dir/test actual
+  test_cmp "$DATA2/test" actual
 '
 
 test_expect_success "refs IPFS directory file through readonly API succeeds" '

--- a/test/sharness/t0160-resolve.sh
+++ b/test/sharness/t0160-resolve.sh
@@ -14,104 +14,129 @@ test_expect_success "resolve: prepare files" '
 	c_hash=$(ipfs add -q -r a/b/c | tail -n1)
 '
 
-test_resolve_setup_name() {
-	ref=$1
+test_name_publish() {
+	ref="$1"; shift
+	publish_args="$(shellquote "$@")"
 
-	test_expect_success "resolve: prepare name" '
+	test_expect_success_1941 "resolve: name publish $ref${1:+ ($publish_args)}" '
 		id_hash=$(ipfs id -f="<id>") &&
-		ipfs name publish "$ref" &&
-		printf "$ref" >expected_nameval &&
-		ipfs name resolve >actual_nameval &&
-		test_cmp expected_nameval actual_nameval
+		ipfs name publish '"$publish_args"' "$ref"
 	'
 }
 
-test_resolve_setup_name_fail() {
-	ref=$1
+test_name_resolve() {
+	ref="$1"
 
-	test_expect_failure "resolve: prepare name" '
-		id_hash=$(ipfs id -f="<id>") &&
-		ipfs name publish "$ref" &&
-		printf "$ref" >expected_nameval &&
+	test_expect_success_1941 "resolve: name resolve $ref" '
+		printf "%s" "$ref" >expected_nameval &&
 		ipfs name resolve >actual_nameval &&
 		test_cmp expected_nameval actual_nameval
 	'
 }
 
 test_resolve() {
-	src=$1
-	dst=$2
+	src="$1"
+	dst="$2"
 
-	test_expect_success "resolve succeeds: $src" '
+	# Just use test_expect_success once #1941 is fixed.
+	case "$src" in
+	  /ipns/*) test_cmd=test_expect_success_1941 ;;
+	  *)       test_cmd=test_expect_success ;;
+	esac
+
+	"$test_cmd" "resolve succeeds: $src" '
 		ipfs resolve -r "$src" >actual
 	'
 
-	test_expect_success "resolved correctly: $src -> $dst" '
-		printf "$dst" >expected &&
+	"$test_cmd" "resolved correctly: $src -> $dst" '
+		printf "%s" "$dst" >expected &&
 		test_cmp expected actual
 	'
 }
 
-test_resolve_cmd() {
-
+# Any parameters are passed to ipfs name publish.
+test_common() {
 	test_resolve "/ipfs/$a_hash" "/ipfs/$a_hash"
 	test_resolve "/ipfs/$a_hash/b" "/ipfs/$b_hash"
 	test_resolve "/ipfs/$a_hash/b/c" "/ipfs/$c_hash"
 	test_resolve "/ipfs/$b_hash/c" "/ipfs/$c_hash"
 
-	test_resolve_setup_name "/ipfs/$a_hash"
+	test_name_publish "/ipfs/$a_hash" "$@"
+	test_name_resolve "/ipfs/$a_hash"
 	test_resolve "/ipns/$id_hash" "/ipfs/$a_hash"
 	test_resolve "/ipns/$id_hash/b" "/ipfs/$b_hash"
 	test_resolve "/ipns/$id_hash/b/c" "/ipfs/$c_hash"
 
-	test_resolve_setup_name "/ipfs/$b_hash"
+	test_name_publish "/ipfs/$b_hash" "$@"
+	test_name_resolve "/ipfs/$b_hash"
 	test_resolve "/ipns/$id_hash" "/ipfs/$b_hash"
 	test_resolve "/ipns/$id_hash/c" "/ipfs/$c_hash"
 
-	test_resolve_setup_name "/ipfs/$c_hash"
+	test_name_publish "/ipfs/$c_hash" "$@"
+	test_name_resolve "/ipfs/$c_hash"
 	test_resolve "/ipns/$id_hash" "/ipfs/$c_hash"
 }
 
-#todo remove this once the online resolve is fixed
-test_resolve_fail() {
-	src=$1
-	dst=$2
-
-	test_expect_failure "resolve succeeds: $src" '
-		ipfs resolve "$src" >actual
-	'
-
-	test_expect_failure "resolved correctly: $src -> $dst" '
-		printf "$dst" >expected &&
-		test_cmp expected actual
-	'
-}
-
-test_resolve_cmd_fail() {
-	test_resolve "/ipfs/$a_hash" "/ipfs/$a_hash"
-	test_resolve "/ipfs/$a_hash/b" "/ipfs/$b_hash"
-	test_resolve "/ipfs/$a_hash/b/c" "/ipfs/$c_hash"
-	test_resolve "/ipfs/$b_hash/c" "/ipfs/$c_hash"
-
-	test_resolve_setup_name_fail "/ipfs/$a_hash"
-	test_resolve_fail "/ipns/$id_hash" "/ipfs/$a_hash"
-	test_resolve_fail "/ipns/$id_hash/b" "/ipfs/$b_hash"
-	test_resolve_fail "/ipns/$id_hash/b/c" "/ipfs/$c_hash"
-
-	test_resolve_setup_name_fail "/ipfs/$b_hash"
-	test_resolve_fail "/ipns/$id_hash" "/ipfs/$b_hash"
-	test_resolve_fail "/ipns/$id_hash/c" "/ipfs/$c_hash"
-
-	test_resolve_setup_name_fail "/ipfs/$c_hash"
-	test_resolve_fail "/ipns/$id_hash" "/ipfs/$c_hash"
-}
-
 # should work offline
-test_resolve_cmd
+test_common --ttl=0s
+
+# should work offline with non-zero TTL; cache should not be in effect.
+test_common # Default TTL
+test_common --ttl=1h
 
 # should work online
 test_launch_ipfs_daemon
-test_resolve_cmd_fail
+test_common --ttl=0s
+
+# The following tests test the caching by publishing a new name and expecting
+# the previous resolve result to stay cached.  The first test_(name_)resolve
+# after a test_name_publish will generate the cache entry and any subsequent
+# test_resolve invocations will use that cache entry until the expiry timer
+# finishes (test_timer_wait).
+
+TTL=10
+
+test_name_publish "/ipfs/$a_hash" --ttl="${TTL}s"
+test_name_resolve "/ipfs/$a_hash"
+
+# The cache entry has expired when this finishes.
+test_timer_start EXPIRY_TIMER "${TTL}s"
+# Publish a new version now, the previous version should still be cached.
+test_name_publish "/ipfs/$b_hash" --ttl="${TTL}s"
+
+test_resolve "/ipns/$id_hash" "/ipfs/$a_hash"
+test_resolve "/ipns/$id_hash/b" "/ipfs/$b_hash"
+test_resolve "/ipns/$id_hash/b/c" "/ipfs/$c_hash"
+
+# Make sure the expiry timer is still running, otherwise the result might be
+# wrong.  If this fails, we will need to increase TTL above to give enough time
+# for the tests.
+test_expect_success "tests did not take too long" '
+	test_timer_is_running "$EXPIRY_TIMER"
+'
+test_expect_success "previous version is no longer cached" '
+	test_timer_wait "$EXPIRY_TIMER"
+'
+
+test_name_resolve "/ipfs/$b_hash"
+
+test_timer_start EXPIRY_TIMER "${TTL}s"
+# Publish a new version now, the previous version should still be cached.
+test_name_publish "/ipfs/$c_hash" # Default TTL for the final one.
+
+test_resolve "/ipns/$id_hash" "/ipfs/$b_hash"
+test_resolve "/ipns/$id_hash/c" "/ipfs/$c_hash"
+
+test_expect_success "tests did not take too long" '
+	test_timer_is_running "$EXPIRY_TIMER"
+'
+test_expect_success "previous version is no longer cached" '
+	test_timer_wait "$EXPIRY_TIMER"
+'
+
+test_name_resolve "/ipfs/$c_hash"
+test_resolve "/ipns/$id_hash" "/ipfs/$c_hash"
+
 test_kill_ipfs_daemon
 
 test_done

--- a/util/infduration/infduration.go
+++ b/util/infduration/infduration.go
@@ -1,0 +1,84 @@
+package infduration
+
+import (
+	"fmt"
+	"time"
+)
+
+// Duration represents a possibly (positive) infinite time.Duration.
+type Duration struct {
+	// A positive infinite duration is internally represented as a nil
+	// pointer, but this implementation detail is not to be exposed.
+	tduration *time.Duration
+}
+
+// InfiniteDuration constructs a positive infinite Duration.
+func InfiniteDuration() Duration {
+	return Duration{tduration: nil}
+}
+
+// FiniteDuration constructs a finite Duration given a time.Duration.
+func FiniteDuration(d time.Duration) Duration {
+	return Duration{tduration: &d}
+}
+
+func (dur Duration) String() string {
+	if dur.tduration != nil {
+		return fmt.Sprintf("FiniteDuration(%v)", *dur.tduration)
+	}
+	return "InfiniteDuration()"
+}
+
+// IsInfinite indicates whether a given Duration is infinite.
+func IsInfinite(dur Duration) bool {
+	return dur.tduration == nil
+}
+
+// GetFiniteDuration returns the time.Duration held by an Duration if it is
+// finite, falling back to the parameter otherwise.
+func GetFiniteDuration(dur Duration, infinity time.Duration) (tdur time.Duration) {
+	if dur.tduration != nil {
+		return *dur.tduration
+	}
+	return infinity
+}
+
+// Equal returns true if both Durations are infinite or both are finite and
+// equal.
+func Equal(durA, durB Duration) bool {
+	if durA.tduration == nil && durB.tduration == nil {
+		return true
+	}
+	if durA.tduration == nil || durB.tduration == nil {
+		return false
+	}
+	return *durA.tduration == *durB.tduration
+}
+
+// Min returns the lesser Duration.
+func Min(idufA, idufB Duration) Duration {
+	if IsInfinite(idufB) {
+		return idufA
+	}
+	if IsInfinite(idufA) {
+		return idufB
+	}
+	if GetFiniteDuration(idufA, 0) <= GetFiniteDuration(idufB, 0) {
+		return idufA
+	}
+	return idufB
+}
+
+// Max returns the greater Duration.
+func Max(idufA, idufB Duration) Duration {
+	if IsInfinite(idufA) {
+		return idufA
+	}
+	if IsInfinite(idufB) {
+		return idufB
+	}
+	if GetFiniteDuration(idufA, 0) >= GetFiniteDuration(idufB, 0) {
+		return idufA
+	}
+	return idufB
+}

--- a/util/infduration/infduration_test.go
+++ b/util/infduration/infduration_test.go
@@ -1,0 +1,96 @@
+package infduration
+
+import (
+	"testing"
+	"time"
+)
+
+var durations = [...]time.Duration{
+	-10000 * time.Hour,
+	-1,
+	0,
+	1,
+	10 * time.Second,
+	10000 * time.Hour,
+}
+
+func TestInfinite(t *testing.T) {
+	dur := InfiniteDuration()
+	if b := IsInfinite(dur); !b {
+		t.Errorf("IsInfinite(%v): got %v, expected %v", dur, b, true)
+	}
+	if got := GetFiniteDuration(dur, 42); got != 42 {
+		t.Errorf("GetFiniteDuration(%v, 42): got %v, expected %v", dur, got, 42)
+	}
+}
+
+func TestFinite(t *testing.T) {
+	for _, tdur := range durations {
+		dur := FiniteDuration(tdur)
+		if b := IsInfinite(dur); b {
+			t.Errorf("IsInfinite(%v): got %v, expected %v", dur, b, false)
+		}
+		if got := GetFiniteDuration(dur, 42); got != tdur {
+			t.Errorf("GetFiniteDuration(%v, 42): got %v, expected %v", dur, got, tdur)
+		}
+	}
+}
+
+func TestEqualMinMax(t *testing.T) {
+	inf := InfiniteDuration()
+
+	if b := Equal(inf, inf); !b {
+		t.Errorf("Equal(%v, %v): got %v, expected %v", inf, inf, b, true)
+	}
+	if got := Min(inf, inf); !Equal(got, inf) {
+		t.Errorf("Min(%v, %v): got %v, expected %v", inf, inf, got, inf)
+	}
+	if got := Max(inf, inf); !Equal(got, inf) {
+		t.Errorf("Max(%v, %v): got %v, expected %v", inf, inf, got, inf)
+	}
+
+	for _, tdur := range durations {
+		dur := FiniteDuration(tdur)
+		if b := Equal(dur, inf); b {
+			t.Errorf("Equal(%v, %v): got %v, expected %v", dur, inf, b, false)
+		}
+		if b := Equal(inf, dur); b {
+			t.Errorf("Equal(%v, %v): got %v, expected %v", inf, dur, b, false)
+		}
+		if got := Min(dur, inf); !Equal(got, dur) {
+			t.Errorf("Min(%v, %v): got %v, expected %v", dur, inf, got, dur)
+		}
+		if got := Min(inf, dur); !Equal(got, dur) {
+			t.Errorf("Min(%v, %v): got %v, expected %v", inf, dur, got, dur)
+		}
+		if got := Max(dur, inf); !Equal(got, inf) {
+			t.Errorf("Max(%v, %v): got %v, expected %v", dur, inf, got, inf)
+		}
+		if got := Max(inf, dur); !Equal(got, inf) {
+			t.Errorf("Max(%v, %v): got %v, expected %v", inf, dur, got, inf)
+		}
+	}
+
+	for _, tdurA := range durations {
+		durA := FiniteDuration(tdurA)
+		for _, tdurB := range durations {
+			durB := FiniteDuration(tdurB)
+
+			durMin, durMax := durA, durB
+			if tdurB < tdurA {
+				durMin, durMax = durB, durA
+			}
+			eq := tdurA == tdurB
+
+			if b := Equal(durA, durB); b != eq {
+				t.Errorf("Equal(%v, %v): got %v, expected %v", durA, durB, b, eq)
+			}
+			if got := Min(durA, durB); !Equal(got, durMin) {
+				t.Errorf("Min(%v, %v): got %v, expected %v", durA, durB, got, durMin)
+			}
+			if got := Max(durA, durB); !Equal(got, durMax) {
+				t.Errorf("Max(%v, %v): got %v, expected %v", durA, durB, got, durMax)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Based on https://github.com/ipfs/go-ipfs/pull/1887 “cache ipns entries to speed things up a little”.

Addresses https://github.com/ipfs/go-ipfs/issues/1818.

This is my first time learning Go, I hope I’m doing things somewhat correctly.
