### PR TITLE
Wire offline routing for ipns in core.Resolve

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -31,13 +31,6 @@ it contains.
 			return
 		}
 
-		if !node.OnlineMode() {
-			if err := node.SetupOfflineRouting(); err != nil {
-				res.SetError(err, cmds.ErrNormal)
-				return
-			}
-		}
-
 		readers, length, err := cat(req.Context(), node, req.Arguments())
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)


### PR DESCRIPTION
With this commit, ipfs get, ls, refs, tar, object can resolve ipns
entries from local cache when offline.