### PR TITLE
improves memory usage of add

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -440,7 +440,7 @@ func (params *adder) addDir(file files.File) (*dag.Node, error) {
 		if node != nil {
 			_, name := path.Split(file.FileName())
 
-			err = tree.AddNodeLink(name, node)
+			err = tree.AddNodeLinkClean(name, node)
 			if err != nil {
 				return nil, err
 			}

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -599,14 +599,17 @@ func rmLinkCaller(req cmds.Request, root *dag.Node) (key.Key, error) {
 
 	path := req.Arguments()[2]
 
-	e := dagutils.NewDagEditor(nd.DAG, root)
+	e := dagutils.NewDagEditor(root, nd.DAG)
 
 	err = e.RmLink(req.Context(), path)
 	if err != nil {
 		return "", err
 	}
 
-	nnode := e.GetNode()
+	nnode, err := e.Finalize(nd.DAG)
+	if err != nil {
+		return "", err
+	}
 
 	return nnode.Key()
 }
@@ -636,7 +639,7 @@ func addLinkCaller(req cmds.Request, root *dag.Node) (key.Key, error) {
 		}
 	}
 
-	e := dagutils.NewDagEditor(nd.DAG, root)
+	e := dagutils.NewDagEditor(root, nd.DAG)
 
 	childnd, err := nd.DAG.Get(req.Context(), childk)
 	if err != nil {
@@ -648,7 +651,10 @@ func addLinkCaller(req cmds.Request, root *dag.Node) (key.Key, error) {
 		return "", err
 	}
 
-	nnode := e.GetNode()
+	nnode, err := e.Finalize(nd.DAG)
+	if err != nil {
+		return "", err
+	}
 
 	return nnode.Key()
 }

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -321,14 +321,20 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		e := dagutils.NewDagEditor(i.node.DAG, rnode)
+		e := dagutils.NewDagEditor(rnode, i.node.DAG)
 		err = e.InsertNodeAtPath(ctx, newPath, newnode, uio.NewEmptyDirectory)
 		if err != nil {
 			webError(w, "putHandler: InsertNodeAtPath failed", err, http.StatusInternalServerError)
 			return
 		}
 
-		newkey, err = e.GetNode().Key()
+		nnode, err := e.Finalize(i.node.DAG)
+		if err != nil {
+			webError(w, "putHandler: could not get node", err, http.StatusInternalServerError)
+			return
+		}
+
+		newkey, err = nnode.Key()
 		if err != nil {
 			webError(w, "putHandler: could not get key of edited node", err, http.StatusInternalServerError)
 			return

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -21,6 +21,7 @@ type DAGService interface {
 	AddRecursive(*Node) error
 	Get(context.Context, key.Key) (*Node, error)
 	Remove(*Node) error
+	RemoveRecursive(*Node) error
 
 	// GetDAG returns, in order, all the single leve child
 	// nodes of the passed in node.
@@ -107,13 +108,22 @@ func (n *dagService) Get(ctx context.Context, k key.Key) (*Node, error) {
 	return Decoded(b.Data)
 }
 
-// Remove deletes the given node and all of its children from the BlockService
-func (n *dagService) Remove(nd *Node) error {
+// RemoveRecursive deletes the given node and all of its children from the BlockService
+func (n *dagService) RemoveRecursive(nd *Node) error {
 	for _, l := range nd.Links {
 		if l.Node != nil {
-			n.Remove(l.Node)
+			n.RemoveRecursive(l.Node)
 		}
 	}
+	k, err := nd.Key()
+	if err != nil {
+		return err
+	}
+	return n.Blocks.DeleteBlock(k)
+}
+
+// Remove deletes the given node from the BlockService
+func (n *dagService) Remove(nd *Node) error {
 	k, err := nd.Key()
 	if err != nil {
 		return err

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -9,6 +9,8 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 )
 
+var ErrLinkNotFound = fmt.Errorf("no link by that name")
+
 // Node represents a node in the IPFS Merkle DAG.
 // nodes have opaque data and a set of navigable links.
 type Node struct {
@@ -160,7 +162,7 @@ func (n *Node) GetNodeLink(name string) (*Link, error) {
 			}, nil
 		}
 	}
-	return nil, ErrNotFound
+	return nil, ErrLinkNotFound
 }
 
 func (n *Node) GetLinkedNode(ctx context.Context, ds DAGService, name string) (*Node, error) {

--- a/merkledag/utils/diff.go
+++ b/merkledag/utils/diff.go
@@ -37,7 +37,7 @@ func (c *Change) String() string {
 }
 
 func ApplyChange(ctx context.Context, ds dag.DAGService, nd *dag.Node, cs []*Change) (*dag.Node, error) {
-	e := NewDagEditor(ds, nd)
+	e := NewDagEditor(nd, ds)
 	for _, c := range cs {
 		switch c.Type {
 		case Add:
@@ -71,7 +71,8 @@ func ApplyChange(ctx context.Context, ds dag.DAGService, nd *dag.Node, cs []*Cha
 			}
 		}
 	}
-	return e.GetNode(), nil
+
+	return e.Finalize(ds)
 }
 
 func Diff(ctx context.Context, ds dag.DAGService, a, b *dag.Node) []*Change {

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -4,20 +4,41 @@ import (
 	"errors"
 	"strings"
 
+	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	syncds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
+	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	bserv "github.com/ipfs/go-ipfs/blockservice"
+	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
 type Editor struct {
 	root *dag.Node
-	ds   dag.DAGService
+
+	// tmp is a temporary in memory (for now) dagstore for all of the
+	// intermediary nodes to be stored in
+	tmp dag.DAGService
+
+	// src is the dagstore with *all* of the data on it, it is used to pull
+	// nodes from for modification (nil is a valid value)
+	src dag.DAGService
 }
 
-func NewDagEditor(ds dag.DAGService, root *dag.Node) *Editor {
+func NewMemoryDagService() dag.DAGService {
+	// build mem-datastore for editor's intermediary nodes
+	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
+	bsrv := bserv.New(bs, offline.Exchange(bs))
+	return dag.NewDAGService(bsrv)
+}
+
+// root is the node to be modified, source is the dagstore to pull nodes from (optional)
+func NewDagEditor(root *dag.Node, source dag.DAGService) *Editor {
 	return &Editor{
 		root: root,
-		ds:   ds,
+		tmp:  NewMemoryDagService(),
+		src:  source,
 	}
 }
 
@@ -26,7 +47,7 @@ func (e *Editor) GetNode() *dag.Node {
 }
 
 func (e *Editor) GetDagService() dag.DAGService {
-	return e.ds
+	return e.tmp
 }
 
 func addLink(ctx context.Context, ds dag.DAGService, root *dag.Node, childname string, childnd *dag.Node) (*dag.Node, error) {
@@ -58,7 +79,7 @@ func addLink(ctx context.Context, ds dag.DAGService, root *dag.Node, childname s
 
 func (e *Editor) InsertNodeAtPath(ctx context.Context, path string, toinsert *dag.Node, create func() *dag.Node) error {
 	splpath := strings.Split(path, "/")
-	nd, err := insertNodeAtPath(ctx, e.ds, e.root, splpath, toinsert, create)
+	nd, err := e.insertNodeAtPath(ctx, e.root, splpath, toinsert, create)
 	if err != nil {
 		return err
 	}
@@ -66,27 +87,32 @@ func (e *Editor) InsertNodeAtPath(ctx context.Context, path string, toinsert *da
 	return nil
 }
 
-func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, path []string, toinsert *dag.Node, create func() *dag.Node) (*dag.Node, error) {
+func (e *Editor) insertNodeAtPath(ctx context.Context, root *dag.Node, path []string, toinsert *dag.Node, create func() *dag.Node) (*dag.Node, error) {
 	if len(path) == 1 {
-		return addLink(ctx, ds, root, path[0], toinsert)
+		return addLink(ctx, e.tmp, root, path[0], toinsert)
 	}
 
-	nd, err := root.GetLinkedNode(ctx, ds, path[0])
+	nd, err := root.GetLinkedNode(ctx, e.tmp, path[0])
 	if err != nil {
 		// if 'create' is true, we create directories on the way down as needed
-		if err == dag.ErrNotFound && create != nil {
+		if err == dag.ErrLinkNotFound && create != nil {
 			nd = create()
-		} else {
+			err = nil // no longer an error case
+		} else if err == dag.ErrNotFound {
+			nd, err = root.GetLinkedNode(ctx, e.src, path[0])
+		}
+
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	ndprime, err := insertNodeAtPath(ctx, ds, nd, path[1:], toinsert, create)
+	ndprime, err := e.insertNodeAtPath(ctx, nd, path[1:], toinsert, create)
 	if err != nil {
 		return nil, err
 	}
 
-	_ = ds.Remove(root)
+	_ = e.tmp.Remove(root)
 
 	_ = root.RemoveNodeLink(path[0])
 	err = root.AddNodeLinkClean(path[0], ndprime)
@@ -94,7 +120,7 @@ func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, pa
 		return nil, err
 	}
 
-	_, err = ds.Add(root)
+	_, err = e.tmp.Add(root)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +130,7 @@ func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, pa
 
 func (e *Editor) RmLink(ctx context.Context, path string) error {
 	splpath := strings.Split(path, "/")
-	nd, err := rmLink(ctx, e.ds, e.root, splpath)
+	nd, err := e.rmLink(ctx, e.root, splpath)
 	if err != nil {
 		return err
 	}
@@ -112,7 +138,7 @@ func (e *Editor) RmLink(ctx context.Context, path string) error {
 	return nil
 }
 
-func rmLink(ctx context.Context, ds dag.DAGService, root *dag.Node, path []string) (*dag.Node, error) {
+func (e *Editor) rmLink(ctx context.Context, root *dag.Node, path []string) (*dag.Node, error) {
 	if len(path) == 1 {
 		// base case, remove node in question
 		err := root.RemoveNodeLink(path[0])
@@ -120,7 +146,7 @@ func rmLink(ctx context.Context, ds dag.DAGService, root *dag.Node, path []strin
 			return nil, err
 		}
 
-		_, err = ds.Add(root)
+		_, err = e.tmp.Add(root)
 		if err != nil {
 			return nil, err
 		}
@@ -128,12 +154,16 @@ func rmLink(ctx context.Context, ds dag.DAGService, root *dag.Node, path []strin
 		return root, nil
 	}
 
-	nd, err := root.GetLinkedNode(ctx, ds, path[0])
+	nd, err := root.GetLinkedNode(ctx, e.tmp, path[0])
+	if err == dag.ErrNotFound {
+		nd, err = root.GetLinkedNode(ctx, e.src, path[0])
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
-	nnode, err := rmLink(ctx, ds, nd, path[1:])
+	nnode, err := e.rmLink(ctx, nd, path[1:])
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +174,7 @@ func rmLink(ctx context.Context, ds dag.DAGService, root *dag.Node, path []strin
 		return nil, err
 	}
 
-	_, err = ds.Add(root)
+	_, err = e.tmp.Add(root)
 	if err != nil {
 		return nil, err
 	}
@@ -152,8 +182,10 @@ func rmLink(ctx context.Context, ds dag.DAGService, root *dag.Node, path []strin
 	return root, nil
 }
 
-func (e *Editor) WriteOutputTo(ds dag.DAGService) error {
-	return copyDag(e.GetNode(), e.ds, ds)
+func (e *Editor) Finalize(ds dag.DAGService) (*dag.Node, error) {
+	nd := e.GetNode()
+	err := copyDag(nd, e.tmp, ds)
+	return nd, err
 }
 
 func copyDag(nd *dag.Node, from, to dag.DAGService) error {

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -40,6 +40,9 @@ func addLink(ctx context.Context, ds dag.DAGService, root *dag.Node, childname s
 		return nil, err
 	}
 
+	// remove previous root
+	_ = ds.Remove(root)
+
 	// ensure no link with that name already exists
 	_ = root.RemoveNodeLink(childname) // ignore error, only option is ErrNotFound
 
@@ -82,6 +85,8 @@ func insertNodeAtPath(ctx context.Context, ds dag.DAGService, root *dag.Node, pa
 	if err != nil {
 		return nil, err
 	}
+
+	_ = ds.Remove(root)
 
 	_ = root.RemoveNodeLink(path[0])
 	err = root.AddNodeLinkClean(path[0], ndprime)

--- a/merkledag/utils/utils_test.go
+++ b/merkledag/utils/utils_test.go
@@ -66,13 +66,12 @@ func assertNodeAtPath(t *testing.T, ds dag.DAGService, root *dag.Node, path stri
 }
 
 func TestInsertNode(t *testing.T) {
-	ds := mdtest.Mock()
 	root := new(dag.Node)
-	e := NewDagEditor(ds, root)
+	e := NewDagEditor(root, nil)
 
 	testInsert(t, e, "a", "anodefortesting", false, "")
 	testInsert(t, e, "a/b", "data", false, "")
-	testInsert(t, e, "a/b/c/d/e", "blah", false, "merkledag: not found")
+	testInsert(t, e, "a/b/c/d/e", "blah", false, "no link by that name")
 	testInsert(t, e, "a/b/c/d/e", "foo", true, "")
 	testInsert(t, e, "a/b/c/d/f", "baz", true, "")
 	testInsert(t, e, "a/b/c/d/f", "bar", true, "")
@@ -92,7 +91,7 @@ func TestInsertNode(t *testing.T) {
 
 func testInsert(t *testing.T, e *Editor, path, data string, create bool, experr string) {
 	child := &dag.Node{Data: []byte(data)}
-	ck, err := e.ds.Add(child)
+	ck, err := e.tmp.Add(child)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,8 +116,8 @@ func testInsert(t *testing.T, e *Editor, path, data string, create bool, experr 
 	}
 
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal(err, path, data, create, experr)
 	}
 
-	assertNodeAtPath(t, e.ds, e.root, path, ck)
+	assertNodeAtPath(t, e.tmp, e.root, path, ck)
 }


### PR DESCRIPTION
Most of the memory leak in add was because the dag editor is given an in memory dagservice, and it adds *all* of the intermediate nodes to it. This makes it remove an intermediary node if its about to be changed and readded.

Memory pressure is reduced a good amount, but its not 'good' yet. The other changes I want to make need to be made on top dev0.4.0

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>