### PR TITLE
repo: remove Log config

### DIFF
--- a/repo/config/config.go
+++ b/repo/config/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	SupernodeRouting SupernodeClientConfig // local node's routing servers (if SupernodeRouting enabled)
 	API              API                   // local node's API settings
 	Swarm            SwarmConfig
-	Log              Log
 }
 
 const (

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -53,10 +53,6 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			Enabled:  true,
 			Interval: 10,
 		}},
-		Log: Log{
-			MaxSizeMB:  250,
-			MaxBackups: 1,
-		},
 
 		// setup the node mount points.
 		Mounts: Mounts{

--- a/repo/config/log.go
+++ b/repo/config/log.go
@@ -1,7 +1,0 @@
-package config
-
-type Log struct {
-	MaxSizeMB  int
-	MaxBackups int
-	MaxAgeDays int
-}

--- a/repo/config/logs.go
+++ b/repo/config/logs.go
@@ -1,1 +1,0 @@
-package config


### PR DESCRIPTION
We stopped logging to files in a676b5a8ac2848a57318283f4b2b52d7d8686323
and this config section was missed.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>