### PR TITLE
initial support for commands to use external binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ dependencies as well.
 * Shell command completion is available in `misc/completion/ipfs-completion.bash`. Read [docs/command-completion.md](docs/command-completion.md) to learn how to install it.
 * See the [init examples](https://github.com/ipfs/examples/tree/master/examples/init) for how to connect IPFS to systemd or whatever init system your distro uses.
 
+### Updating
+ipfs has an updating tool that can be accessed through `ipfs update`. The tool is
+not installed alongside ipfs in order to keep that logic indepedent of the main
+codebase. To install ipfs update, either [download it here](https://gobuilder.me/github.com/ipfs/ipfs-update)
+or install it from source with `go get -u github.com/ipfs/ipfs-update`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ dependencies as well.
 
 ### Updating
 ipfs has an updating tool that can be accessed through `ipfs update`. The tool is
-not installed alongside ipfs in order to keep that logic indepedent of the main
+not installed alongside ipfs in order to keep that logic independent of the main
 codebase. To install ipfs update, either [download it here](https://gobuilder.me/github.com/ipfs/ipfs-update)
 or install it from source with `go get -u github.com/ipfs/ipfs-update`.
 

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -204,6 +204,13 @@ func parseOpts(args []string, root *cmds.Command) (
 				if err != nil {
 					return
 				}
+
+				// If we've come across an external binary call, pass all the remaining
+				// arguments on to it
+				if cmd.External {
+					stringVals = append(stringVals, args[i+1:]...)
+					return
+				}
 			} else {
 				stringVals = append(stringVals, arg)
 			}

--- a/commands/command.go
+++ b/commands/command.go
@@ -9,9 +9,12 @@ output to the user, including text, JSON, and XML marshallers.
 package commands
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"reflect"
 	"strings"
 
@@ -58,6 +61,10 @@ type Command struct {
 	PostRun    Function
 	Marshalers map[EncodingType]Marshaler
 	Helptext   HelpText
+
+	// External denotes that a command is actually an external binary.
+	// fewer checks and validations will be performed on such commands.
+	External bool
 
 	// Type describes the type of the output of the Command's Run Function.
 	// In precise terms, the value of Type is an instance of the return type of
@@ -261,4 +268,68 @@ func checkArgValue(v string, found bool, def Argument) error {
 
 func ClientError(msg string) error {
 	return &Error{Code: ErrClient, Message: msg}
+}
+
+func ExternalBinary() *Command {
+	return &Command{
+		Arguments: []Argument{
+			StringArg("args", false, true, "arguments for subcommand"),
+		},
+		External: true,
+		Run: func(req Request, res Response) {
+			binname := strings.Join(append([]string{"ipfs"}, req.Path()...), "-")
+			_, err := exec.LookPath(binname)
+			if err != nil {
+				// special case for '--help' on uninstalled binaries.
+				if req.Arguments()[0] == "--help" {
+					buf := new(bytes.Buffer)
+					fmt.Fprintf(buf, "%s is an 'external' command.\n", binname)
+					fmt.Fprintf(buf, "it does not currently appear to be installated.\n")
+					fmt.Fprintf(buf, "please refer to the ipfs documentation for instructions\n")
+					res.SetOutput(buf)
+					return
+				}
+
+				res.SetError(fmt.Errorf("%s not installed."), ErrNormal)
+				return
+			}
+
+			r, w := io.Pipe()
+
+			cmd := exec.Command(binname, req.Arguments()...)
+
+			// TODO: make commands lib be able to pass stdin through daemon
+			//cmd.Stdin = req.Stdin()
+			cmd.Stdin = io.LimitReader(nil, 0)
+			cmd.Stdout = w
+			cmd.Stderr = w
+
+			// setup env of child program
+			env := os.Environ()
+
+			nd, err := req.InvocContext().GetNode()
+			if err == nil {
+				env = append(env, fmt.Sprintf("IPFS_ONLINE=%t", nd.OnlineMode()))
+			}
+
+			cmd.Env = env
+
+			err = cmd.Start()
+			if err != nil {
+				res.SetError(fmt.Errorf("failed to start subcommand: %s", err), ErrNormal)
+				return
+			}
+
+			res.SetOutput(r)
+
+			go func() {
+				err = cmd.Wait()
+				if err != nil {
+					res.SetError(err, ErrNormal)
+				}
+
+				w.Close()
+			}()
+		},
+	}
 }

--- a/commands/command.go
+++ b/commands/command.go
@@ -284,7 +284,7 @@ func ExternalBinary() *Command {
 				if req.Arguments()[0] == "--help" {
 					buf := new(bytes.Buffer)
 					fmt.Fprintf(buf, "%s is an 'external' command.\n", binname)
-					fmt.Fprintf(buf, "it does not currently appear to be installated.\n")
+					fmt.Fprintf(buf, "it does not currently appear to be installed.\n")
 					fmt.Fprintf(buf, "please refer to the ipfs documentation for instructions\n")
 					res.SetOutput(buf)
 					return

--- a/core/commands/external.go
+++ b/core/commands/external.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+)
+
+func ExternalBinary() *cmds.Command {
+	return &cmds.Command{
+		Arguments: []cmds.Argument{
+			cmds.StringArg("args", false, true, "arguments for subcommand"),
+		},
+		External: true,
+		Run: func(req cmds.Request, res cmds.Response) {
+			binname := strings.Join(append([]string{"ipfs"}, req.Path()...), "-")
+			_, err := exec.LookPath(binname)
+			if err != nil {
+				// special case for '--help' on uninstalled binaries.
+				for _, arg := range req.Arguments() {
+					if arg == "--help" || arg == "-h" {
+						buf := new(bytes.Buffer)
+						fmt.Fprintf(buf, "%s is an 'external' command.\n", binname)
+						fmt.Fprintf(buf, "it does not currently appear to be installed.\n")
+						fmt.Fprintf(buf, "please refer to the ipfs documentation for instructions\n")
+						res.SetOutput(buf)
+						return
+					}
+				}
+
+				res.SetError(fmt.Errorf("%s not installed."), cmds.ErrNormal)
+				return
+			}
+
+			r, w := io.Pipe()
+
+			cmd := exec.Command(binname, req.Arguments()...)
+
+			// TODO: make commands lib be able to pass stdin through daemon
+			//cmd.Stdin = req.Stdin()
+			cmd.Stdin = io.LimitReader(nil, 0)
+			cmd.Stdout = w
+			cmd.Stderr = w
+
+			// setup env of child program
+			env := os.Environ()
+
+			nd, err := req.InvocContext().GetNode()
+			if err == nil {
+				env = append(env, fmt.Sprintf("IPFS_ONLINE=%t", nd.OnlineMode()))
+			}
+
+			cmd.Env = env
+
+			err = cmd.Start()
+			if err != nil {
+				res.SetError(fmt.Errorf("failed to start subcommand: %s", err), cmds.ErrNormal)
+				return
+			}
+
+			res.SetOutput(r)
+
+			go func() {
+				err = cmd.Wait()
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+				}
+
+				w.Close()
+			}()
+		},
+	}
+}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -111,7 +111,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"tar":       TarCmd,
 	"tour":      tourCmd,
 	"file":      unixfs.UnixFSCmd,
-	"update":    UpdateCmd,
+	"update":    cmds.ExternalBinary(),
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -111,7 +111,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"tar":       TarCmd,
 	"tour":      tourCmd,
 	"file":      unixfs.UnixFSCmd,
-	"update":    cmds.ExternalBinary(),
+	"update":    ExternalBinary(),
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,
 }


### PR DESCRIPTION
Allows us to have `ipfs-update` as a separate binary be called as `ipfs update`

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>