### PR TITLE
if bucket doesnt have enough peers, grab more elsewhere

### DIFF
--- a/routing/kbucket/sorting.go
+++ b/routing/kbucket/sorting.go
@@ -32,10 +32,6 @@ func copyPeersFromList(target ID, peerArr peerSorterArr, peerList *list.List) pe
 			distance: xor(target, pID),
 		}
 		peerArr = append(peerArr, &pd)
-		if e == nil {
-			log.Debug("list element was nil")
-			return peerArr
-		}
 	}
 	return peerArr
 }

--- a/routing/kbucket/table.go
+++ b/routing/kbucket/table.go
@@ -155,9 +155,10 @@ func (rt *RoutingTable) NearestPeers(id ID, count int) []peer.ID {
 	bucket = rt.Buckets[cpl]
 
 	var peerArr peerSorterArr
-	if bucket.Len() == 0 {
-		// In the case of an unusual split, one bucket may be empty.
-		// if this happens, search both surrounding buckets for nearest peer
+	peerArr = copyPeersFromList(id, peerArr, bucket.list)
+	if len(peerArr) < count {
+		// In the case of an unusual split, one bucket may be short or empty.
+		// if this happens, search both surrounding buckets for nearby peers
 		if cpl > 0 {
 			plist := rt.Buckets[cpl-1].list
 			peerArr = copyPeersFromList(id, peerArr, plist)
@@ -167,8 +168,6 @@ func (rt *RoutingTable) NearestPeers(id ID, count int) []peer.ID {
 			plist := rt.Buckets[cpl+1].list
 			peerArr = copyPeersFromList(id, peerArr, plist)
 		}
-	} else {
-		peerArr = copyPeersFromList(id, peerArr, bucket.list)
 	}
 
 	// Sort by distance to local peer


### PR DESCRIPTION
If the bucket chosen by the common prefix length doesnt have as many peers as we are requesting, grab some from the buckets on either side, This should help dht queries complete faster as they are more likely to query a larger number of peers.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>