### PR TITLE
gateway: add path prefix for directory listings

### DIFF
--- a/core/corehttp/ipns_hostname.go
+++ b/core/corehttp/ipns_hostname.go
@@ -24,7 +24,7 @@ func IPNSHostnameOption() ServeOption {
 			if len(host) > 0 && isd.IsDomain(host) {
 				name := "/ipns/" + host
 				if _, err := n.Namesys.Resolve(ctx, name); err == nil {
-					r.Header["X-IPNS-Original-Path"] = []string{r.URL.Path}
+					r.Header["X-Ipns-Original-Path"] = []string{r.URL.Path}
 					r.URL.Path = name + r.URL.Path
 				}
 			}


### PR DESCRIPTION
The other option would be a config option to rule them all. This one here, lets the reverse proxy signal the path prefix, which allows having the same gateway accessible at multiple paths.

Fixes #1955 