### PR TITLE
Remove chunker channel

### DIFF
--- a/importer/balanced/balanced_test.go
+++ b/importer/balanced/balanced_test.go
@@ -22,15 +22,12 @@ import (
 // TODO: extract these tests and more as a generic layout test suite
 
 func buildTestDag(ds dag.DAGService, spl chunk.Splitter) (*dag.Node, error) {
-	// Start the splitter
-	blkch, errs := chunk.Chan(spl)
-
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
 	}
 
-	return BalancedLayout(dbp.New(blkch, errs))
+	return BalancedLayout(dbp.New(spl))
 }
 
 func getTestDag(t *testing.T, ds dag.DAGService, size int64, blksize int64) (*dag.Node, []byte) {

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -52,7 +52,6 @@ func (db *DagBuilderHelper) prepareNext() {
 func (db *DagBuilderHelper) Done() bool {
 	// ensure we have an accurate perspective on data
 	// as `done` this may be called before `next`.
-	//db.prepareNext() // idempotent
 	db.prepareNext() // idempotent
 	return db.nextData == nil
 }

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
@@ -8,8 +9,7 @@ import (
 // efficiently create unixfs dag trees
 type DagBuilderHelper struct {
 	dserv    dag.DAGService
-	in       <-chan []byte
-	errs     <-chan error
+	spl      chunk.Splitter
 	recvdErr error
 	nextData []byte // the next item to return.
 	maxlinks int
@@ -24,45 +24,35 @@ type DagBuilderParams struct {
 	Dagserv dag.DAGService
 }
 
-// Generate a new DagBuilderHelper from the given params, using 'in' as a
-// data source
-func (dbp *DagBuilderParams) New(in <-chan []byte, errs <-chan error) *DagBuilderHelper {
+// Generate a new DagBuilderHelper from the given params, which data source comes
+// from chunks object
+func (dbp *DagBuilderParams) New(spl chunk.Splitter) *DagBuilderHelper {
 	return &DagBuilderHelper{
 		dserv:    dbp.Dagserv,
-		in:       in,
-		errs:     errs,
+		spl:      spl,
 		maxlinks: dbp.Maxlinks,
 		batch:    dbp.Dagserv.Batch(),
 	}
 }
 
-// prepareNext consumes the next item from the channel and puts it
+// prepareNext consumes the next item from the splitter and puts it
 // in the nextData field. it is idempotent-- if nextData is full
 // it will do nothing.
-//
-// i realized that building the dag becomes _a lot_ easier if we can
-// "peek" the "are done yet?" (i.e. not consume it from the channel)
 func (db *DagBuilderHelper) prepareNext() {
-	if db.in == nil {
-		// if our input is nil, there is "nothing to do". we're done.
-		// as if there was no data at all. (a sort of zero-value)
-		return
-	}
-
-	// if we already have data waiting to be consumed, we're ready.
+	// if we already have data waiting to be consumed, we're ready
 	if db.nextData != nil {
 		return
 	}
 
-	// if it's closed, nextData will be correctly set to nil, signaling
-	// that we're done consuming from the channel.
-	db.nextData = <-db.in
+	// TODO: handle err (which wasn't handled either when the splitter was channeled)
+	db.nextData, _ = db.spl.NextBytes()
 }
 
 // Done returns whether or not we're done consuming the incoming data.
 func (db *DagBuilderHelper) Done() bool {
 	// ensure we have an accurate perspective on data
 	// as `done` this may be called before `next`.
+	//db.prepareNext() // idempotent
 	db.prepareNext() // idempotent
 	return db.nextData == nil
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -39,25 +39,19 @@ func BuildDagFromFile(fpath string, ds dag.DAGService) (*dag.Node, error) {
 }
 
 func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (*dag.Node, error) {
-	// Start the splitter
-	blkch, errch := chunk.Chan(spl)
-
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
 	}
 
-	return bal.BalancedLayout(dbp.New(blkch, errch))
+	return bal.BalancedLayout(dbp.New(spl))
 }
 
 func BuildTrickleDagFromReader(ds dag.DAGService, spl chunk.Splitter) (*dag.Node, error) {
-	// Start the splitter
-	blkch, errch := chunk.Chan(spl)
-
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
 	}
 
-	return trickle.TrickleLayout(dbp.New(blkch, errch))
+	return trickle.TrickleLayout(dbp.New(spl))
 }


### PR DESCRIPTION
PR to keep track and measure the time and memory perf of `ipfs add` with channel iterator replaced with chunker object. Perhaps have to wait until go2.x when channel iterator becomes about as fast as counter object.

- [x] fix tests
- [ ] fixes #1969

Ran perf test on lots of 1MB files, `ipfs add` is about O(rsync) (faster than `git add`?)

Edit: this plot below is misleading (the add operation is run under a goroutine, and without outputDagnode checking, the client exits long before the (ephemeral) daemon has finished the process), updated plot is in my last comment.
![We say that people condemn a man to death and then we say the Law condemns him to death. "Although the Jury can pardon (acquit?) him, the Law can't." (This *may* mean the Law can't take bribes, etc) The idea of something super-strict, something stricter than any judge can be, super-rigidity. The point being, you are inclined to ask: "Do we have a picture of something more rigorous?" Hardly. But we are inclined to express ourselves in the form of a superlative.](https://cloud.githubusercontent.com/assets/395821/11177377/b8e630ea-8c77-11e5-9ef1-33cdddfb3ea4.png)
