### PR TITLE
send record fixes to peers who send outdated records

### DIFF
--- a/routing/dht/dht.go
+++ b/routing/dht/dht.go
@@ -150,6 +150,8 @@ func (dht *IpfsDHT) putProvider(ctx context.Context, p peer.ID, skey string) err
 	return nil
 }
 
+var errInvalidRecord = errors.New("received invalid record")
+
 // getValueOrPeers queries a particular peer p for the value for
 // key. It returns either the value or a list of closer peers.
 // NOTE: it will update the dht's peerstore with any new addresses
@@ -173,11 +175,11 @@ func (dht *IpfsDHT) getValueOrPeers(ctx context.Context, p peer.ID,
 		err = dht.verifyRecordOnline(ctx, record)
 		if err != nil {
 			log.Info("Received invalid record! (discarded)")
-			// still return a non-nil record to signify that we received
-			// a bad record from this peer
+			// return a sentinal to signify an invalid record was received
+			err = errInvalidRecord
 			record = new(pb.Record)
 		}
-		return record, peers, nil
+		return record, peers, err
 	}
 
 	if len(peers) > 0 {

--- a/routing/dht/dht.go
+++ b/routing/dht/dht.go
@@ -173,7 +173,9 @@ func (dht *IpfsDHT) getValueOrPeers(ctx context.Context, p peer.ID,
 		err = dht.verifyRecordOnline(ctx, record)
 		if err != nil {
 			log.Info("Received invalid record! (discarded)")
-			return nil, nil, err
+			// still return a non-nil record to signify that we received
+			// a bad record from this peer
+			record = new(pb.Record)
 		}
 		return record, peers, nil
 	}

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -171,21 +171,26 @@ func (dht *IpfsDHT) GetValues(ctx context.Context, key key.Key, nvals int) ([]ro
 		})
 
 		rec, peers, err := dht.getValueOrPeers(ctx, p, key)
-		if err != nil {
-			if err == routing.ErrNotFound {
-				// in this case, they responded with nothing,
-				// still send a notification
-				notif.PublishQueryEvent(parent, &notif.QueryEvent{
-					Type: notif.PeerResponse,
-					ID:   p,
-				})
-			}
+		switch err {
+		case routing.ErrNotFound:
+			// in this case, they responded with nothing,
+			// still send a notification so listeners can know the
+			// request has completed 'successfully'
+			notif.PublishQueryEvent(parent, &notif.QueryEvent{
+				Type: notif.PeerResponse,
+				ID:   p,
+			})
 			return nil, err
+		default:
+			return nil, err
+
+		case nil, errInvalidRecord:
+			// in either of these cases, we want to keep going
 		}
 
 		res := &dhtQueryResult{closerPeers: peers}
 
-		if rec.GetValue() != nil {
+		if rec.GetValue() != nil || err == errInvalidRecord {
 			rv := routing.RecvdVal{
 				Val:  rec.GetValue(),
 				From: p,


### PR DESCRIPTION
Peers who send records with expired validity are currently not sent a 'fixup' record after a peer does a get operation. This makes invalid records just return a blank record so that the later fixup logic can send them a better record.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>