### PR TITLE
Add correct access control headers to the default api config

### DIFF
--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -81,6 +81,14 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		Gateway: Gateway{
 			RootRedirect: "",
 			Writable:     false,
+			HTTPHeaders: map[string][]string{
+				"Access-Control-Allow-Headers": []string{
+					"X-Stream-Output, X-Chunked-Output",
+				},
+				"Access-Control-Expose-Headers": []string{
+					"X-Stream-Output, X-Chunked-Output",
+				},
+			},
 		},
 	}
 

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -44,6 +44,16 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			API:     "/ip4/127.0.0.1/tcp/5001",
 			Gateway: "/ip4/127.0.0.1/tcp/8080",
 		},
+		API: API{
+			HTTPHeaders: map[string][]string{
+				"Access-Control-Allow-Headers": []string{
+					"X-Stream-Output, X-Chunked-Output",
+				},
+				"Access-Control-Expose-Headers": []string{
+					"X-Stream-Output, X-Chunked-Output",
+				},
+			},
+		},
 
 		Bootstrap:        BootstrapPeerStrings(bootstrapPeers),
 		SupernodeRouting: *snr,

--- a/test/sharness/t0230-channel-streaming-http-content-type.sh
+++ b/test/sharness/t0230-channel-streaming-http-content-type.sh
@@ -21,6 +21,8 @@ test_ls_cmd() {
 
 	test_expect_success "Text encoded channel-streaming command output looks good" '
 		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
+		printf "Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
+		printf "Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
 		printf "Content-Type: text/plain\r\n" >>expected_output &&
 		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
@@ -41,6 +43,8 @@ test_ls_cmd() {
 
 	test_expect_success "JSON encoded channel-streaming command output looks good" '
 		printf "HTTP/1.1 200 OK\r\n" >expected_output &&
+		printf "Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
+		printf "Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
 		printf "Content-Type: application/json\r\n" >>expected_output &&
 		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&


### PR DESCRIPTION
Nedded to fix https://github.com/ipfs/js-ipfs-api/issues/76 and for https://github.com/ipfs/js-ipfs-api/issues/128 for details why this is needed see: https://github.com/ipfs/js-ipfs-api/issues/76#issuecomment-158216527


--- 

Probably lots wrong with this, so please excuse any obvious mistakes
