### PR TITLE
--help: Add a note on using IPFS_PATH to the footer of the helptext.

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -69,6 +69,11 @@ TOOL COMMANDS
     commands      List all available commands
 
 Use 'ipfs <command> --help' to learn more about each command.
+
+ipfs uses a repository in the local file system. By default, the repo is located
+at ~/.ipfs. To change the repo location, set the $IPFS_PATH environment variable:
+
+    export IPFS_PATH=/path/to/ipfsrepo
 `,
 	},
 	Options: []cmds.Option{


### PR DESCRIPTION
I couldn't find this piece of information in the official docs, just scattered over a few issues on GitHub.