### PR TITLE
Remove hardcoded "/"

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -184,7 +184,7 @@ func parseOpts(args []string, root *cmds.Command) (
 					}
 				}
 				var end bool
-				end, err = parseFlag(arg[0:1], rest, mustUse)
+				end, err = parseFlag(arg[:1], rest, mustUse)
 				if err != nil {
 					return
 				}

--- a/commands/command.go
+++ b/commands/command.go
@@ -152,7 +152,7 @@ func (c *Command) Resolve(pth []string) ([]*Command, error) {
 		cmd = cmd.Subcommand(name)
 
 		if cmd == nil {
-			pathS := path.Join(pth[0:i])
+			pathS := path.Join(pth[:i])
 			return nil, fmt.Errorf("Undefined command: '%s'", pathS)
 		}
 

--- a/commands/command.go
+++ b/commands/command.go
@@ -13,8 +13,8 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"strings"
 
+	"github.com/ipfs/go-ipfs/path"
 	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
 )
 
@@ -143,16 +143,16 @@ func (c *Command) Call(req Request) Response {
 }
 
 // Resolve gets the subcommands at the given path
-func (c *Command) Resolve(path []string) ([]*Command, error) {
-	cmds := make([]*Command, len(path)+1)
+func (c *Command) Resolve(pth []string) ([]*Command, error) {
+	cmds := make([]*Command, len(pth)+1)
 	cmds[0] = c
 
 	cmd := c
-	for i, name := range path {
+	for i, name := range pth {
 		cmd = cmd.Subcommand(name)
 
 		if cmd == nil {
-			pathS := strings.Join(path[0:i], "/")
+			pathS := path.Join(pth[0:i])
 			return nil, fmt.Errorf("Undefined command: '%s'", pathS)
 		}
 

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
+	path "github.com/ipfs/go-ipfs/path"
 	config "github.com/ipfs/go-ipfs/repo/config"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
@@ -85,8 +86,8 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 		reader = strings.NewReader("")
 	}
 
-	path := strings.Join(req.Path(), "/")
-	url := fmt.Sprintf(ApiUrlFormat, c.serverAddress, ApiPath, path, query)
+	pth := path.Join(req.Path())
+	url := fmt.Sprintf(ApiUrlFormat, c.serverAddress, ApiPath, pth, query)
 
 	httpReq, err := http.NewRequest("POST", url, reader)
 	if err != nil {

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -9,6 +9,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	files "github.com/ipfs/go-ipfs/commands/files"
+	path "github.com/ipfs/go-ipfs/path"
 )
 
 // Parse parses the data in a http.Request and returns a command Request object
@@ -16,24 +17,24 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 	if !strings.HasPrefix(r.URL.Path, ApiPath) {
 		return nil, errors.New("Unexpected path prefix")
 	}
-	path := strings.Split(strings.TrimPrefix(r.URL.Path, ApiPath+"/"), "/")
+	pth := path.SplitList(strings.TrimPrefix(r.URL.Path, ApiPath+"/"))
 
 	stringArgs := make([]string, 0)
 
-	cmd, err := root.Get(path[:len(path)-1])
+	cmd, err := root.Get(pth[:len(pth)-1])
 	if err != nil {
 		// 404 if there is no command at that path
 		return nil, ErrNotFound
 
-	} else if sub := cmd.Subcommand(path[len(path)-1]); sub == nil {
-		if len(path) <= 1 {
+	} else if sub := cmd.Subcommand(pth[len(pth)-1]); sub == nil {
+		if len(pth) <= 1 {
 			return nil, ErrNotFound
 		}
 
 		// if the last string in the path isn't a subcommand, use it as an argument
 		// e.g. /objects/Qabc12345 (we are passing "Qabc12345" to the "objects" command)
-		stringArgs = append(stringArgs, path[len(path)-1])
-		path = path[:len(path)-1]
+		stringArgs = append(stringArgs, pth[len(pth)-1])
+		pth = pth[:len(pth)-1]
 
 	} else {
 		cmd = sub
@@ -86,7 +87,7 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		}
 	}
 
-	optDefs, err := root.GetOptions(path)
+	optDefs, err := root.GetOptions(pth)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,7 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
 	}
 
-	req, err := cmds.NewRequest(path, opts, args, f, cmd, optDefs)
+	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs)
 	if err != nil {
 		return nil, err
 	}

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -12,6 +12,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	notif "github.com/ipfs/go-ipfs/notifications"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	path "github.com/ipfs/go-ipfs/path"
 	ipdht "github.com/ipfs/go-ipfs/routing/dht"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -605,7 +606,7 @@ func escapeDhtKey(s string) (key.Key, error) {
 		return key.B58KeyDecode(s), nil
 	case 3:
 		k := key.B58KeyDecode(parts[2])
-		return key.Key(strings.Join(append(parts[:2], string(k)), "/")), nil
+		return key.Key(path.Join(append(parts[:2], k.String()))), nil
 	default:
 		return "", errors.New("invalid key")
 	}

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
@@ -600,7 +599,7 @@ PutValue will store the given key value pair in the dht.
 }
 
 func escapeDhtKey(s string) (key.Key, error) {
-	parts := strings.Split(s, "/")
+	parts := path.SplitList(s)
 	switch len(parts) {
 	case 1:
 		return key.B58KeyDecode(s), nil

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -245,8 +245,7 @@ Examples:
 			res.SetOutput(&FilesLsOutput{listing})
 			return
 		case *mfs.File:
-			parts := strings.Split(path, "/")
-			name := parts[len(parts)-1]
+			_, name := gopath.Split(path)
 			out := &FilesLsOutput{[]mfs.NodeListing{mfs.NodeListing{Name: name, Type: 1}}}
 			res.SetOutput(out)
 			return

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -213,7 +213,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			var backLink string = urlPath
 
 			// don't go further up than /ipfs/$hash/
-			pathSplit := strings.Split(backLink, "/")
+			pathSplit := path.SplitList(backLink)
 			switch {
 			// keep backlink
 			case len(pathSplit) == 3: // url: /ipfs/$hash

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -236,7 +236,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 				if len(pathSplit) > 5 {
 					// also strip the trailing segment, because it's a backlink
 					backLinkParts := pathSplit[3 : len(pathSplit)-2]
-					backLink += strings.Join(backLinkParts, "/") + "/"
+					backLink += path.Join(backLinkParts) + "/"
 				}
 			}
 
@@ -304,7 +304,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	var newPath string
 	if len(rsegs) > 1 {
-		newPath = strings.Join(rsegs[2:], "/")
+		newPath = path.Join(rsegs[2:])
 	}
 
 	var newkey key.Key
@@ -429,7 +429,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", key.String())
-	http.Redirect(w, r, ipfsPathPrefix+key.String()+"/"+strings.Join(components[:len(components)-1], "/"), http.StatusCreated)
+	http.Redirect(w, r, gopath.Join(ipfsPathPrefix+key.String(), path.Join(components[:len(components)-1])), http.StatusCreated)
 }
 
 func (i *gatewayHandler) addUserHeaders(w http.ResponseWriter) {

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	fuse "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse"
 	fs "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse/fs"
@@ -194,7 +193,7 @@ func (s *Root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 
 	segments := resolved.Segments()
 	if segments[0] == "ipfs" {
-		p := strings.Join(resolved.Segments()[1:], "/")
+		p := path.Join(resolved.Segments()[1:])
 		return &Link{s.IpfsRoot + "/" + p}, nil
 	}
 

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -2,7 +2,6 @@ package dagutils
 
 import (
 	"errors"
-	"strings"
 
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	syncds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
@@ -12,6 +11,7 @@ import (
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	dag "github.com/ipfs/go-ipfs/merkledag"
+	path "github.com/ipfs/go-ipfs/path"
 )
 
 type Editor struct {
@@ -76,8 +76,8 @@ func addLink(ctx context.Context, ds dag.DAGService, root *dag.Node, childname s
 	return root, nil
 }
 
-func (e *Editor) InsertNodeAtPath(ctx context.Context, path string, toinsert *dag.Node, create func() *dag.Node) error {
-	splpath := strings.Split(path, "/")
+func (e *Editor) InsertNodeAtPath(ctx context.Context, pth string, toinsert *dag.Node, create func() *dag.Node) error {
+	splpath := path.SplitList(pth)
 	nd, err := e.insertNodeAtPath(ctx, e.root, splpath, toinsert, create)
 	if err != nil {
 		return err
@@ -130,8 +130,8 @@ func (e *Editor) insertNodeAtPath(ctx context.Context, root *dag.Node, path []st
 	return root, nil
 }
 
-func (e *Editor) RmLink(ctx context.Context, path string) error {
-	splpath := strings.Split(path, "/")
+func (e *Editor) RmLink(ctx context.Context, pth string) error {
+	splpath := path.SplitList(pth)
 	nd, err := e.rmLink(ctx, e.root, splpath)
 	if err != nil {
 		return err

--- a/merkledag/utils/utils_test.go
+++ b/merkledag/utils/utils_test.go
@@ -1,12 +1,12 @@
 package dagutils
 
 import (
-	"strings"
 	"testing"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
+	path "github.com/ipfs/go-ipfs/path"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
@@ -43,8 +43,8 @@ func TestAddLink(t *testing.T) {
 	}
 }
 
-func assertNodeAtPath(t *testing.T, ds dag.DAGService, root *dag.Node, path string, exp key.Key) {
-	parts := strings.Split(path, "/")
+func assertNodeAtPath(t *testing.T, ds dag.DAGService, root *dag.Node, pth string, exp key.Key) {
+	parts := path.SplitList(pth)
 	cur := root
 	for _, e := range parts {
 		nxt, err := cur.GetLinkedNode(context.Background(), ds, e)

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -8,12 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
-	"strings"
 	"testing"
 
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	"github.com/ipfs/go-ipfs/path"
 
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	key "github.com/ipfs/go-ipfs/blocks/key"
@@ -43,8 +43,8 @@ func getRandFile(t *testing.T, ds dag.DAGService, size int64) *dag.Node {
 	return nd
 }
 
-func mkdirP(t *testing.T, root *Directory, path string) *Directory {
-	dirs := strings.Split(path, "/")
+func mkdirP(t *testing.T, root *Directory, pth string) *Directory {
+	dirs := path.SplitList(pth)
 	cur := root
 	for _, d := range dirs {
 		n, err := cur.Mkdir(d)
@@ -69,15 +69,15 @@ func mkdirP(t *testing.T, root *Directory, path string) *Directory {
 	return cur
 }
 
-func assertDirAtPath(root *Directory, path string, children []string) error {
-	fsn, err := DirLookup(root, path)
+func assertDirAtPath(root *Directory, pth string, children []string) error {
+	fsn, err := DirLookup(root, pth)
 	if err != nil {
 		return err
 	}
 
 	dir, ok := fsn.(*Directory)
 	if !ok {
-		return fmt.Errorf("%s was not a directory", path)
+		return fmt.Errorf("%s was not a directory", pth)
 	}
 
 	listing, err := dir.List()
@@ -113,13 +113,13 @@ func compStrArrs(a, b []string) bool {
 	return true
 }
 
-func assertFileAtPath(ds dag.DAGService, root *Directory, exp *dag.Node, path string) error {
-	parts := strings.Split(path, "/")
+func assertFileAtPath(ds dag.DAGService, root *Directory, exp *dag.Node, pth string) error {
+	parts := path.SplitList(pth)
 	cur := root
 	for i, d := range parts[:len(parts)-1] {
 		next, err := cur.Child(d)
 		if err != nil {
-			return fmt.Errorf("looking for %s failed: %s", path, err)
+			return fmt.Errorf("looking for %s failed: %s", pth, err)
 		}
 
 		nextDir, ok := next.(*Directory)
@@ -138,7 +138,7 @@ func assertFileAtPath(ds dag.DAGService, root *Directory, exp *dag.Node, path st
 
 	file, ok := finaln.(*File)
 	if !ok {
-		return fmt.Errorf("%s was not a file!", path)
+		return fmt.Errorf("%s was not a file!", pth)
 	}
 
 	out, err := ioutil.ReadAll(file)

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -101,7 +101,7 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 // Mkdir creates a directory at 'path' under the directory 'd', creating
 // intermediary directories as needed if 'parents' is set to true
 func Mkdir(r *Root, pth string, parents bool) error {
-	parts := strings.Split(pth, "/")
+	parts := path.SplitList(pth)
 	if parts[0] == "" {
 		parts = parts[1:]
 	}
@@ -159,7 +159,7 @@ func Lookup(r *Root, path string) (FSNode, error) {
 // under the directory 'd'
 func DirLookup(d *Directory, pth string) (FSNode, error) {
 	pth = strings.Trim(pth, "/")
-	parts := strings.Split(pth, "/")
+	parts := path.SplitList(pth)
 	if len(parts) == 1 && parts[0] == "" {
 		return d, nil
 	}

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	dag "github.com/ipfs/go-ipfs/merkledag"
+	path "github.com/ipfs/go-ipfs/path"
 )
 
 // Mv moves the file or directory at 'src' to 'dst'
@@ -99,8 +100,8 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 
 // Mkdir creates a directory at 'path' under the directory 'd', creating
 // intermediary directories as needed if 'parents' is set to true
-func Mkdir(r *Root, path string, parents bool) error {
-	parts := strings.Split(path, "/")
+func Mkdir(r *Root, pth string, parents bool) error {
+	parts := strings.Split(pth, "/")
 	if parts[0] == "" {
 		parts = parts[1:]
 	}
@@ -112,7 +113,7 @@ func Mkdir(r *Root, path string, parents bool) error {
 
 	if len(parts) == 0 {
 		// this will only happen on 'mkdir /'
-		return fmt.Errorf("cannot mkdir '%s'", path)
+		return fmt.Errorf("cannot mkdir '%s'", pth)
 	}
 
 	cur := r.GetValue().(*Directory)
@@ -130,7 +131,7 @@ func Mkdir(r *Root, path string, parents bool) error {
 
 		next, ok := fsn.(*Directory)
 		if !ok {
-			return fmt.Errorf("%s was not a directory", strings.Join(parts[:i], "/"))
+			return fmt.Errorf("%s was not a directory", path.Join(parts[:i]))
 		}
 		cur = next
 	}
@@ -156,9 +157,9 @@ func Lookup(r *Root, path string) (FSNode, error) {
 
 // DirLookup will look up a file or directory at the given path
 // under the directory 'd'
-func DirLookup(d *Directory, path string) (FSNode, error) {
-	path = strings.Trim(path, "/")
-	parts := strings.Split(path, "/")
+func DirLookup(d *Directory, pth string) (FSNode, error) {
+	pth = strings.Trim(pth, "/")
+	parts := strings.Split(pth, "/")
 	if len(parts) == 1 && parts[0] == "" {
 		return d, nil
 	}
@@ -168,7 +169,7 @@ func DirLookup(d *Directory, path string) (FSNode, error) {
 	for i, p := range parts {
 		chdir, ok := cur.(*Directory)
 		if !ok {
-			return nil, fmt.Errorf("cannot access %s: Not a directory", strings.Join(parts[:i+1], "/"))
+			return nil, fmt.Errorf("cannot access %s: Not a directory", path.Join(parts[:i+1]))
 		}
 
 		child, err := chdir.Child(p)

--- a/p2p/crypto/key.go
+++ b/p2p/crypto/key.go
@@ -216,11 +216,11 @@ func KeyStretcher(cipherType string, hashType string, secret []byte) (StretchedK
 	var k1 StretchedKeys
 	var k2 StretchedKeys
 
-	k1.IV = r1[0:ivSize]
+	k1.IV = r1[:ivSize]
 	k1.CipherKey = r1[ivSize : ivSize+cipherKeySize]
 	k1.MacKey = r1[ivSize+cipherKeySize:]
 
-	k2.IV = r2[0:ivSize]
+	k2.IV = r2[:ivSize]
 	k2.CipherKey = r2[ivSize : ivSize+cipherKeySize]
 	k2.MacKey = r2[ivSize+cipherKeySize:]
 

--- a/p2p/peer/addr/addrsrcs_test.go
+++ b/p2p/peer/addr/addrsrcs_test.go
@@ -43,7 +43,7 @@ func addrSourcesSame(a, b Source) bool {
 
 func TestAddrCombine(t *testing.T) {
 	addrs := newAddrs(t, 30)
-	a := Slice(addrs[0:10])
+	a := Slice(addrs[:10])
 	b := Slice(addrs[10:20])
 	c := Slice(addrs[20:30])
 	d := CombineSources(a, b, c)
@@ -58,7 +58,7 @@ func TestAddrCombine(t *testing.T) {
 func TestAddrUnique(t *testing.T) {
 
 	addrs := newAddrs(t, 40)
-	a := Slice(addrs[0:20])
+	a := Slice(addrs[:20])
 	b := Slice(addrs[10:30])
 	c := Slice(addrs[20:40])
 	d := CombineSources(a, b, c)

--- a/path/path.go
+++ b/path/path.go
@@ -102,3 +102,7 @@ func (p *Path) IsValid() error {
 	_, err := ParsePath(p.String())
 	return err
 }
+
+func Join(pths []string) string {
+	return strings.Join(pths, "/")
+}

--- a/path/path.go
+++ b/path/path.go
@@ -106,3 +106,7 @@ func (p *Path) IsValid() error {
 func Join(pths []string) string {
 	return strings.Join(pths, "/")
 }
+
+func SplitList(pth string) []string {
+	return strings.Split(pth, "/")
+}

--- a/routing/record/selection.go
+++ b/routing/record/selection.go
@@ -2,9 +2,9 @@ package record
 
 import (
 	"errors"
-	"strings"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
+	path "github.com/ipfs/go-ipfs/path"
 )
 
 // A SelectorFunc selects the best value for the given key from
@@ -18,7 +18,7 @@ func (s Selector) BestRecord(k key.Key, recs [][]byte) (int, error) {
 		return 0, errors.New("no records given!")
 	}
 
-	parts := strings.Split(string(k), "/")
+	parts := path.SplitList(string(k))
 	if len(parts) < 3 {
 		log.Infof("Record key does not have selectorfunc: %s", k)
 		return 0, errors.New("record key does not have selectorfunc")

--- a/routing/record/validation.go
+++ b/routing/record/validation.go
@@ -3,10 +3,10 @@ package record
 import (
 	"bytes"
 	"errors"
-	"strings"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
+	path "github.com/ipfs/go-ipfs/path"
 	pb "github.com/ipfs/go-ipfs/routing/dht/pb"
 	u "github.com/ipfs/go-ipfs/util"
 )
@@ -37,7 +37,7 @@ type ValidChecker struct {
 // It runs needed validators
 func (v Validator) VerifyRecord(r *pb.Record) error {
 	// Now, check validity func
-	parts := strings.Split(r.GetKey(), "/")
+	parts := path.SplitList(r.GetKey())
 	if len(parts) < 3 {
 		log.Infof("Record key does not have validator: %s", key.Key(r.GetKey()))
 		return nil
@@ -54,7 +54,7 @@ func (v Validator) VerifyRecord(r *pb.Record) error {
 
 func (v Validator) IsSigned(k key.Key) (bool, error) {
 	// Now, check validity func
-	parts := strings.Split(string(k), "/")
+	parts := path.SplitList(string(k))
 	if len(parts) < 3 {
 		log.Infof("Record key does not have validator: %s", k)
 		return false, nil

--- a/tar/format.go
+++ b/tar/format.go
@@ -12,6 +12,7 @@ import (
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutil "github.com/ipfs/go-ipfs/merkledag/utils"
+	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
 
@@ -96,12 +97,12 @@ func ImportTar(r io.Reader, ds dag.DAGService) (*dag.Node, error) {
 
 // adds a '-' to the beginning of each path element so we can use 'data' as a
 // special link in the structure without having to worry about
-func escapePath(path string) string {
-	elems := strings.Split(strings.Trim(path, "/"), "/")
+func escapePath(pth string) string {
+	elems := strings.Split(strings.Trim(pth, "/"), "/")
 	for i, e := range elems {
 		elems[i] = "-" + e
 	}
-	return strings.Join(elems, "/")
+	return path.Join(elems)
 }
 
 type tarReader struct {

--- a/tar/format.go
+++ b/tar/format.go
@@ -98,7 +98,7 @@ func ImportTar(r io.Reader, ds dag.DAGService) (*dag.Node, error) {
 // adds a '-' to the beginning of each path element so we can use 'data' as a
 // special link in the structure without having to worry about
 func escapePath(pth string) string {
-	elems := strings.Split(strings.Trim(pth, "/"), "/")
+	elems := path.SplitList(strings.Trim(pth, "/"))
 	for i, e := range elems {
 		elems[i] = "-" + e
 	}

--- a/util/ipfsaddr/ipfsaddr.go
+++ b/util/ipfsaddr/ipfsaddr.go
@@ -2,11 +2,11 @@ package ipfsaddr
 
 import (
 	"errors"
-	"strings"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	path "github.com/ipfs/go-ipfs/path"
 	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
 )
 
@@ -94,7 +94,7 @@ func ParseMultiaddr(m ma.Multiaddr) (a IPFSAddr, err error) {
 	}
 
 	// make sure ipfs id parses as a peer.ID
-	peerIdParts := strings.Split(ipfspart.String(), "/")
+	peerIdParts := path.SplitList(ipfspart.String())
 	peerIdStr := peerIdParts[len(peerIdParts)-1]
 	id, err := peer.IDB58Decode(peerIdStr)
 	if err != nil {

--- a/util/ipfsaddr/ipfsaddr_test.go
+++ b/util/ipfsaddr/ipfsaddr_test.go
@@ -1,11 +1,11 @@
 package ipfsaddr
 
 import (
-	"strings"
 	"testing"
 
 	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	path "github.com/ipfs/go-ipfs/path"
 )
 
 var good = []string{
@@ -87,7 +87,7 @@ func TestIDMatches(t *testing.T) {
 			continue
 		}
 
-		sp := strings.Split(g, "/")
+		sp := path.SplitList(g)
 		sid := sp[len(sp)-1]
 		id, err := peer.IDB58Decode(sid)
 		if err != nil {


### PR DESCRIPTION
Just small fixes.

Another option, it would be faster to just use strings.Join(elms, "/") and put it in path/path.go, since golang's path does path.Clean of every elements.