### PR TITLE
gateway: harden path prefix

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -448,7 +448,7 @@ func serveHTTPGateway(req cmds.Request) (error, <-chan error) {
 		corehttp.CommandsROOption(*req.InvocContext()),
 		corehttp.VersionOption(),
 		corehttp.IPNSHostnameOption(),
-		corehttp.GatewayOption(writable),
+		corehttp.GatewayOption(writable, cfg.Gateway.PathPrefixes),
 	}
 
 	if len(cfg.Gateway.RootRedirect) > 0 {

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -84,7 +84,7 @@ func run(ipfsPath, watchPath string) error {
 	if *http {
 		addr := "/ip4/127.0.0.1/tcp/5001"
 		var opts = []corehttp.ServeOption{
-			corehttp.GatewayOption(true),
+			corehttp.GatewayOption(true, nil),
 			corehttp.WebUIOption,
 			corehttp.CommandsOption(cmdCtx(node, ipfsPath)),
 		}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -17,9 +17,10 @@ type Gateway struct {
 }
 
 type GatewayConfig struct {
-	Headers   map[string][]string
-	BlockList *BlockList
-	Writable  bool
+	Headers      map[string][]string
+	BlockList    *BlockList
+	Writable     bool
+	PathPrefixes []string
 }
 
 func NewGateway(conf GatewayConfig) *Gateway {
@@ -48,10 +49,11 @@ func (g *Gateway) ServeOption() ServeOption {
 	}
 }
 
-func GatewayOption(writable bool) ServeOption {
+func GatewayOption(writable bool, prefixes []string) ServeOption {
 	g := NewGateway(GatewayConfig{
-		Writable:  writable,
-		BlockList: &BlockList{},
+		Writable:     writable,
+		BlockList:    &BlockList{},
+		PathPrefixes: prefixes,
 	})
 	return g.ServeOption()
 }

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -131,8 +131,13 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	// It will be prepended to links in directory listings and the index.html redirect.
 	prefix := ""
 	if prefixHdr := r.Header["X-Ipfs-Gateway-Prefix"]; len(prefixHdr) > 0 {
-		log.Debugf("X-Ipfs-Gateway-Prefix: %s", prefixHdr[0])
-		prefix = prefixHdr[0]
+		prfx := prefixHdr[0]
+		for _, p := range i.config.PathPrefixes {
+			if prfx == p || strings.HasPrefix(prfx, p+"/") {
+				prefix = prfx
+				break
+			}
+		}
 	}
 
 	// IPNSHostnameOption might have constructed an IPNS path using the Host header.

--- a/repo/config/gateway.go
+++ b/repo/config/gateway.go
@@ -5,4 +5,5 @@ type Gateway struct {
 	HTTPHeaders  map[string][]string // HTTP headers to return with the gateway
 	RootRedirect string
 	Writable     bool
+	PathPrefixes []string
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -65,6 +65,7 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		Gateway: Gateway{
 			RootRedirect: "",
 			Writable:     false,
+			PathPrefixes: []string{},
 		},
 	}
 

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -109,7 +109,7 @@ func run() error {
 
 	opts := []corehttp.ServeOption{
 		corehttp.CommandsOption(cmdCtx(node, repoPath)),
-		corehttp.GatewayOption(false),
+		corehttp.GatewayOption(false, nil),
 	}
 
 	if *cat {


### PR DESCRIPTION
See https://github.com/ipfs/go-ipfs/pull/1971#discussion_r45099840 ff.

Only allow paths, so we stay local to this gateway,
and don't get tricked into linking to a different host,
or even redirecting to one.

I can't come up with a concrete attack right off the bat,
but who knows how things are going to change.
Not restricting it would be silly.

**Edit**:

- [ ] make this a configurable set of allowed prefixes instead