### PR TITLE
http client: reuse transport previously created in NewClient

### DIFF
--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -132,6 +132,9 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 			tr.CancelRequest(httpReq)
 			dc = nil // Wait for ec or rc
 		case err := <-ec:
+			if strings.Contains(err.Error(), "request canceled") {
+				err = errors.New("request canceled")
+			}
 			return nil, err
 		case res := <-rc:
 			if found && len(previousUserProvidedEncoding) > 0 {

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -128,7 +128,7 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 		select {
 		case <-dc:
 			log.Debug("Context cancelled, cancelling HTTP request...")
-			tr := http.DefaultTransport.(*http.Transport)
+			tr := c.httpClient.Transport.(*http.Transport)
 			tr.CancelRequest(httpReq)
 			dc = nil // Wait for ec or rc
 		case err := <-ec:


### PR DESCRIPTION
In case https://github.com/ipfs/go-ipfs/pull/1986#issuecomment-158735845 is a bug. Which is more likely, since the err "request cancelled" is supposed to be printed out https://github.com/ipfs/go-ipfs/blob/master/commands/http/client.go#L134.