### PR TITLE
Directly wire ctx into http request

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -360,7 +360,7 @@
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",
-			"Rev": "ff8eb9a34a5cbb9941ffc6f84a19a8014c2646ad"
+			"Rev": "c764672d0ee39ffd83cfcb375804d3181302b62b"
 		},
 		{
 			"ImportPath": "golang.org/x/net/internal/iana",

--- a/Godeps/_workspace/src/golang.org/x/net/context/context_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/context_test.go
@@ -375,7 +375,7 @@ func TestAllocs(t *testing.T) {
 				<-c.Done()
 			},
 			limit:      8,
-			gccgoLimit: 13,
+			gccgoLimit: 15,
 		},
 		{
 			desc: "WithCancel(bg)",
@@ -536,7 +536,7 @@ func testLayers(t *testing.T, seed int64, testTimeout bool) {
 	if testTimeout {
 		select {
 		case <-ctx.Done():
-		case <-time.After(timeout + timeout/10):
+		case <-time.After(timeout + 100*time.Millisecond):
 			errorf("ctx should have timed out")
 		}
 		checkValues("after timeout")

--- a/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/cancelreq.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/cancelreq.go
@@ -1,0 +1,18 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.5
+
+package ctxhttp
+
+import "net/http"
+
+func canceler(client *http.Client, req *http.Request) func() {
+	ch := make(chan struct{})
+	req.Cancel = ch
+
+	return func() {
+		close(ch)
+	}
+}

--- a/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/cancelreq_go14.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/cancelreq_go14.go
@@ -1,0 +1,23 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.5
+
+package ctxhttp
+
+import "net/http"
+
+type requestCanceler interface {
+	CancelRequest(*http.Request)
+}
+
+func canceler(client *http.Client, req *http.Request) func() {
+	rc, ok := client.Transport.(requestCanceler)
+	if !ok {
+		return func() {}
+	}
+	return func() {
+		rc.CancelRequest(req)
+	}
+}

--- a/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/ctxhttp.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/ctxhttp.go
@@ -1,0 +1,79 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ctxhttp provides helper functions for performing context-aware HTTP requests.
+package ctxhttp
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+// Do sends an HTTP request with the provided http.Client and returns an HTTP response.
+// If the client is nil, http.DefaultClient is used.
+// If the context is canceled or times out, ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// Request cancelation changed in Go 1.5, see cancelreq.go and cancelreq_go14.go.
+	cancel := canceler(client, req)
+
+	type responseAndError struct {
+		resp *http.Response
+		err  error
+	}
+	result := make(chan responseAndError, 1)
+
+	go func() {
+		resp, err := client.Do(req)
+		result <- responseAndError{resp, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	case r := <-result:
+		return r.resp, r.err
+	}
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}

--- a/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/ctxhttp_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp/ctxhttp_test.go
@@ -1,0 +1,72 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ctxhttp
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	requestDuration = 100 * time.Millisecond
+	requestBody     = "ok"
+)
+
+func TestNoTimeout(t *testing.T) {
+	ctx := context.Background()
+	resp, err := doRequest(ctx)
+
+	if resp == nil || err != nil {
+		t.Fatalf("error received from client: %v %v", err, resp)
+	}
+}
+func TestCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(requestDuration / 2)
+		cancel()
+	}()
+
+	resp, err := doRequest(ctx)
+
+	if resp != nil || err == nil {
+		t.Fatalf("expected error, didn't get one. resp: %v", resp)
+	}
+	if err != ctx.Err() {
+		t.Fatalf("expected error from context but got: %v", err)
+	}
+}
+
+func TestCancelAfterRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	resp, err := doRequest(ctx)
+
+	// Cancel before reading the body.
+	// Request.Body should still be readable after the context is canceled.
+	cancel()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil || string(b) != requestBody {
+		t.Fatalf("could not read body: %q %v", b, err)
+	}
+}
+
+func doRequest(ctx context.Context) (*http.Response, error) {
+	var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(requestDuration)
+		w.Write([]byte(requestBody))
+	})
+
+	serv := httptest.NewServer(okHandler)
+	defer serv.Close()
+
+	return Get(ctx, nil, serv.URL)
+}

--- a/Godeps/_workspace/src/golang.org/x/net/context/withtimeout_test.go
+++ b/Godeps/_workspace/src/golang.org/x/net/context/withtimeout_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	"golang.org/x/net/context"
 )
 
 func ExampleWithTimeout() {

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -16,7 +16,7 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	ctxhttp "golang.org/x/net/context/ctxhttp"
+	ctxhttp "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context/ctxhttp"
 )
 
 const (
@@ -41,9 +41,7 @@ func NewClient(address string) Client {
 	return &client{
 		serverAddress: address,
 		httpClient: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives: true,
-			},
+			Transport: &http.Transport{},
 		},
 	}
 }

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -16,6 +16,7 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
 )
 
 const (
@@ -30,7 +31,7 @@ type Client interface {
 
 type client struct {
 	serverAddress string
-	httpClient    http.Client
+	httpClient    *http.Client
 }
 
 func NewClient(address string) Client {
@@ -39,7 +40,7 @@ func NewClient(address string) Client {
 	// refused on 'client.Do'
 	return &client{
 		serverAddress: address,
-		httpClient: http.Client{
+		httpClient: &http.Client{
 			Transport: &http.Transport{
 				DisableKeepAlives: true,
 			},
@@ -105,10 +106,9 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 
 	ec := make(chan error, 1)
 	rc := make(chan cmds.Response, 1)
-	dc := req.Context().Done()
 
 	go func() {
-		httpRes, err := c.httpClient.Do(httpReq)
+		httpRes, err := ctxhttp.Do(req.Context(), c.httpClient, httpReq)
 		if err != nil {
 			ec <- err
 			return
@@ -124,24 +124,17 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 		rc <- res
 	}()
 
-	for {
-		select {
-		case <-dc:
-			log.Debug("Context cancelled, cancelling HTTP request...")
-			tr := http.DefaultTransport.(*http.Transport)
-			tr.CancelRequest(httpReq)
-			dc = nil // Wait for ec or rc
-		case err := <-ec:
-			return nil, err
-		case res := <-rc:
-			if found && len(previousUserProvidedEncoding) > 0 {
-				// reset to user provided encoding after sending request
-				// NB: if user has provided an encoding but it is the empty string,
-				// still leave it as JSON.
-				req.SetOption(cmds.EncShort, previousUserProvidedEncoding)
-			}
-			return res, nil
+	select {
+	case err := <-ec:
+		return nil, err
+	case res := <-rc:
+		if found && len(previousUserProvidedEncoding) > 0 {
+			// reset to user provided encoding after sending request
+			// NB: if user has provided an encoding but it is the empty string,
+			// still leave it as JSON.
+			req.SetOption(cmds.EncShort, previousUserProvidedEncoding)
 		}
+		return res, nil
 	}
 }
 


### PR DESCRIPTION
Updated version of #1991.

- [x] put ctxhttp into  Godep. Blocked on `godep update` ("no buildable Go source files in $GOPATH/src/github.com/StackExchange/wmi")