### PR TITLE
gateway: /version tests, add CurrentCommit

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -148,6 +148,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 	},
 	"refs": RefsROCmd,
 	//"resolve": ResolveCmd,
+	"version": VersionCmd,
 }
 
 func init() {

--- a/core/commands/sysdiag.go
+++ b/core/commands/sysdiag.go
@@ -53,7 +53,7 @@ Prints out information about your computer to aid in easier debugging.
 		}
 
 		info["ipfs_version"] = config.CurrentVersionNumber
-		info["ipfs_git_sha"] = config.CurrentCommit
+		info["ipfs_commit"] = config.CurrentCommit
 		res.SetOutput(info)
 	},
 }

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -8,6 +8,7 @@ import (
 
 	core "github.com/ipfs/go-ipfs/core"
 	id "github.com/ipfs/go-ipfs/p2p/protocol/identify"
+	config "github.com/ipfs/go-ipfs/repo/config"
 )
 
 // Gateway should be instantiated using NewGateway
@@ -58,7 +59,8 @@ func GatewayOption(writable bool) ServeOption {
 func VersionOption() ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "Client Version:   %s\n", id.ClientVersion)
+			fmt.Fprintf(w, "Commit: %s\n", config.CurrentCommit)
+			fmt.Fprintf(w, "Client Version: %s\n", id.ClientVersion)
 			fmt.Fprintf(w, "Protocol Version: %s\n", id.IpfsVersion)
 		})
 		return mux, nil

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -401,6 +401,8 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
+	config.CurrentCommit = "theshortcommithash"
+
 	ns := mockNamesys{}
 	ts, _ := newTestServerAndNode(t, ns)
 	t.Logf("test server url: %s", ts.URL)
@@ -420,6 +422,10 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("error reading response: %s", err)
 	}
 	s := string(body)
+
+	if !strings.Contains(s, "Commit: theshortcommithash") {
+		t.Fatalf("response doesn't contain commit:\n%s", s)
+	}
 
 	if !strings.Contains(s, "Client Version: "+id.ClientVersion) {
 		t.Fatalf("response doesn't contain client version:\n%s", s)


### PR DESCRIPTION
I'm not 100% sure this is a good idea, but I though I'd put it up for discussion. Chatted about this briefly with @harlantwood, and think it's useful.

Need to build with `make build` so that `repo/config.CurrentCommit` gets set, otherwise it'll just be an empty string.