### PR TITLE
Expose corenet on the command line

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -340,7 +340,7 @@ func callCommand(ctx context.Context, req cmds.Request, root *cmds.Command, cmd 
 		}
 
 		// Okay!!!!! NOW we can call the command.
-		res = root.Call(req)
+		res = root.Call(req, os.Stdout, os.Stderr)
 
 	}
 
@@ -643,7 +643,7 @@ func doVersionRequest(client cmdsHttp.Client) (*coreCmds.VersionOutput, error) {
 		return nil, err
 	}
 
-	req, err := cmds.NewRequest([]string{"version"}, nil, nil, nil, cmd, optDefs)
+	req, err := cmds.NewRequest([]string{"version"}, nil, nil, nil, cmd, optDefs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -26,7 +26,7 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 		return nil, cmd, path, err
 	}
 
-	req, err := cmds.NewRequest(path, opts, nil, nil, cmd, optDefs)
+	req, err := cmds.NewRequest(path, opts, nil, nil, cmd, optDefs, nil)
 	if err != nil {
 		return nil, cmd, path, err
 	}

--- a/commands/command.go
+++ b/commands/command.go
@@ -58,6 +58,7 @@ type Command struct {
 	PostRun    Function
 	Marshalers map[EncodingType]Marshaler
 	Helptext   HelpText
+	Interact   func(Request, io.ReadWriter) error
 
 	// Type describes the type of the output of the Command's Run Function.
 	// In precise terms, the value of Type is an instance of the return type of
@@ -76,8 +77,8 @@ var ErrNoFormatter = ClientError("This command cannot be formatted to plain text
 var ErrIncorrectType = errors.New("The command returned a value with a different type than expected")
 
 // Call invokes the command for the given Request
-func (c *Command) Call(req Request) Response {
-	res := NewResponse(req)
+func (c *Command) Call(req Request, stdout, stderr io.Writer) Response {
+	res := NewResponse(req, stdout, stderr)
 
 	cmds, err := c.Resolve(req.Path())
 	if err != nil {

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -109,7 +109,7 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
 	}
 
-	req, err := cmds.NewRequest(path, opts, args, f, cmd, optDefs)
+	req, err := cmds.NewRequest(path, opts, args, f, cmd, optDefs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/http/websocketio.go
+++ b/commands/http/websocketio.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"io"
+	"time"
+
+	websocket "github.com/gorilla/websocket"
+)
+
+type WebsocketIO struct {
+	conn *websocket.Conn
+	reader io.Reader
+}
+
+func NewWebsocketIO(conn *websocket.Conn) WebsocketIO {
+	return WebsocketIO{conn, nil}
+}
+
+func (wsio WebsocketIO) Read(buf []byte) (int, error) {
+	for {
+		if wsio.reader == nil {
+			_, reader, err := wsio.conn.NextReader()
+			closeError, ok := err.(*websocket.CloseError)
+			if ok && closeError.Code == 1000 {
+				return 0, io.EOF
+			}
+			if err != nil {
+				return 0, err 
+			}
+			wsio.reader = reader
+		}
+		n, err := wsio.reader.Read(buf)
+		if (err != nil) {
+			wsio.reader = nil
+			if n == 0 && err == io.EOF {
+				continue
+			}
+		}
+		return n, err
+	}
+}
+
+func (wsio WebsocketIO) Write(buf []byte) (int, error) {
+	err := wsio.conn.WriteMessage(websocket.BinaryMessage, buf)
+	if err != nil {
+		return 0, err
+	}
+	return len(buf), nil
+}
+
+func (wsio WebsocketIO) Close() error {
+	_ = wsio.conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		time.Now().Add(2 * time.Second))
+	return wsio.conn.Close()
+}

--- a/commands/request.go
+++ b/commands/request.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	// "os"
 	"reflect"
 	"strconv"
 	"time"
@@ -78,6 +78,7 @@ type Request interface {
 	SetInvocContext(Context)
 	Command() *Command
 	Values() map[string]interface{}
+	SetStdin(io.Reader)
 	Stdin() io.Reader
 
 	ConvertOptions() error
@@ -253,6 +254,10 @@ func (r *request) Values() map[string]interface{} {
 	return r.values
 }
 
+func (r *request) SetStdin(stdin io.Reader) {
+	r.stdin = stdin
+}
+
 func (r *request) Stdin() io.Reader {
 	return r.stdin
 }
@@ -304,12 +309,12 @@ func (r *request) ConvertOptions() error {
 
 // NewEmptyRequest initializes an empty request
 func NewEmptyRequest() (Request, error) {
-	return NewRequest(nil, nil, nil, nil, nil, nil)
+	return NewRequest(nil, nil, nil, nil, nil, nil, nil)
 }
 
 // NewRequest returns a request initialized with given arguments
 // An non-nil error will be returned if the provided option values are invalid
-func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd *Command, optDefs map[string]Option) (Request, error) {
+func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd *Command, optDefs map[string]Option, stdin io.Reader) (Request, error) {
 	if opts == nil {
 		opts = make(OptMap)
 	}
@@ -328,7 +333,7 @@ func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd 
 		ctx:        ctx,
 		optionDefs: optDefs,
 		values:     values,
-		stdin:      os.Stdin,
+		stdin:      stdin,
 	}
 	err := req.ConvertOptions()
 	if err != nil {

--- a/commands/response.go
+++ b/commands/response.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"os"
+	// "os"
 	"strings"
 )
 
@@ -241,10 +241,10 @@ func (r *response) Stderr() io.Writer {
 }
 
 // NewResponse returns a response to match given Request
-func NewResponse(req Request) Response {
+func NewResponse(req Request, stdout, stderr io.Writer) Response {
 	return &response{
 		req:    req,
-		stdout: os.Stdout,
-		stderr: os.Stderr,
+		stdout: stdout,
+		stderr: stderr,
 	}
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -114,6 +114,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"update":    UpdateCmd,
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,
+	"service":   ServiceCmd,
 }
 
 // RootRO is the readonly version of Root

--- a/core/commands/service.go
+++ b/core/commands/service.go
@@ -1,0 +1,197 @@
+package commands
+
+import (
+	// "bytes"
+	"fmt"
+	"io"
+	"os"
+	// "reflect"
+	// "strings"
+	// "time"
+	exec "os/exec"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	corenet "github.com/ipfs/go-ipfs/core/corenet"
+	// core "github.com/ipfs/go-ipfs/core"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	// u "github.com/ipfs/go-ipfs/util"
+
+	// ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+	// context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+var ServiceCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Remote services over IPFS",
+	},
+	Subcommands: map[string]*cmds.Command{
+		"listen": ListenCmd,
+		"dial": DialCmd,
+	},
+}
+
+var ListenCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Listen for connections",
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("Name", true, false, "Name of service to listen on"),
+		cmds.StringArg("Command", false, true, "Command to expose"),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("verbose", "v", "Be verbose"),
+		cmds.BoolOption("server", "s", "Keep serving requests until killed"),
+		cmds.BoolOption("unique", "u", "Disallow other listeners on same name"),
+		cmds.StringOption("proxy", "p", "multiaddr"),
+		cmds.StringOption("auth", "a", "reserved for future authentication or authorization"),
+	},
+	PreRun: func(req cmds.Request) error {
+		if req.Option("server").Found() { return fmt.Errorf("--server not implemented") }
+		if req.Option("unique").Found() { return fmt.Errorf("--unique not implemented") }
+		if req.Option("proxy").Found() { return fmt.Errorf("--proxy not implemented") }
+		if req.Option("auth").Found() { return fmt.Errorf("--auth not implemented") }
+
+		return nil
+	},
+	Interact: interactWithRemote,
+	Run: func(req cmds.Request, res cmds.Response) {
+		// ctx := req.Context()
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		list, err := corenet.Listen(n, "/app/" + req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		conn, err := list.Accept()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		defer conn.Close()
+		if val, _, _ := req.Option("verbose").Bool(); val {
+			fmt.Fprintf(res.Stdout(), "Connection from: %s\n", conn.Conn().RemotePeer())
+		}
+		err = Copy2(conn, req.Stdin(), res.Stdout(), conn)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		} 
+	},
+}
+
+var DialCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Dial a remote service",
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("NodeID", true, false, "IPFS node to connect to"),
+		cmds.StringArg("Name", true, false, "Name of service to connect to"),
+		cmds.StringArg("Command", false, true, "Command to expose"),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("verbose", "v", "Be verbose"),
+		cmds.StringOption("proxy", "p", "multiaddr"),
+		cmds.StringOption("auth", "a", "reserved for future authentication or authorization"),
+	},
+	PreRun: func(req cmds.Request) error {
+		if req.Option("proxy").Found() { return fmt.Errorf("--proxy not implemented") }
+		if req.Option("auth").Found() { return fmt.Errorf("--auth not implemented") }
+
+		return nil
+	},
+	Interact: interactWithRemote,
+	Run: func(req cmds.Request, res cmds.Response) {
+		// ctx := req.Context()
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		target, err := peer.IDB58Decode(req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		
+		conn, err := corenet.Dial(n, target, "/app/" + req.Arguments()[1])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		if val, _, _ := req.Option("verbose").Bool(); val {
+			fmt.Fprintf(res.Stdout(), "Connected to: %s\n", target)
+		}
+		err = Copy2(conn, req.Stdin(), res.Stdout(), conn)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		} 
+	},
+}
+
+
+func Copy2(dst1 io.Writer, src1 io.Reader, dst2 io.Writer, src2 io.Reader) error {
+	done1 := make(chan error)
+	done2 := make(chan error)
+	go func() {
+		_, err := io.Copy(dst1, src1)
+		done1 <- err
+	}()
+	go func() {
+		_, err := io.Copy(dst2, src2)
+		done2 <- err
+	}()
+	ok := 0
+	for {
+		var err error
+		select {
+		case err = <-done1:
+		case err = <-done2:
+		}
+		if err != nil {
+			return err
+		} 
+		ok += 1 
+		if ok == 2 {
+			return nil
+		}
+	}
+}
+
+func interactWithRemote(req cmds.Request, conn io.ReadWriter) error {
+	n := len(req.Command().Arguments) - 1	
+	args := req.Arguments()
+	if len(args) > n {
+		path, err := exec.LookPath(args[n])
+		if err != nil { path = args[n] }
+		cmd := exec.Cmd{
+			Path: path,
+			Args: args[n+1:],
+			Stdin: conn,
+			Stdout: conn,
+			Stderr: conn,
+		}
+		return cmd.Run()
+	} else {
+		return Copy2(conn, os.Stdin, os.Stdout, conn)
+	}
+}


### PR DESCRIPTION
This is an incomplete proof of concept. Is there any interest in adding this kind of feature to ipfs?

```
proteus$ ipfs service listen foo -- bc
```

```
nereid$ ipfs service dial -v QmNEpP... foo
Connected to: <peer.ID NEpP...>
1 + 1
2
```

I like using ipfs to store and share files, but I've been wondering if it could also be used to serve streams and dynamic content.

I saw there was some previous work in a similar direction in #1089. There is also [an example](https://github.com/ipfs/examples/tree/master/examples/api/service) for writing custom ipfs nodes in go.