### PR TITLE
ipfs files ls without -l is faster

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -235,14 +235,33 @@ Examples:
 			return
 		}
 
+		long, _, _ := req.Option("l").Bool()
+
 		switch fsn := fsn.(type) {
 		case *mfs.Directory:
-			listing, err := fsn.List()
-			if err != nil {
-				res.SetError(err, cmds.ErrNormal)
-				return
+			if !long {
+				mdnd, err := fsn.GetNode()
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				var output []mfs.NodeListing
+				for _, lnk := range mdnd.Links {
+					output = append(output, mfs.NodeListing{
+						Name: lnk.Name,
+						Hash: lnk.Hash.B58String(),
+					})
+				}
+				res.SetOutput(&FilesLsOutput{output})
+			} else {
+				listing, err := fsn.List()
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+				res.SetOutput(&FilesLsOutput{listing})
 			}
-			res.SetOutput(&FilesLsOutput{listing})
 			return
 		case *mfs.File:
 			parts := strings.Split(path, "/")


### PR DESCRIPTION
dont check types of child entries if `-l` isnt specified.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>