### PR TITLE
use ServeContent for index.html

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -204,9 +204,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			defer dr.Close()
 
 			// write to request
-			if r.Method != "HEAD" {
-				io.Copy(w, dr)
-			}
+			http.ServeContent(w, r, "index.html", modtime, dr)
 			break
 		}
 


### PR DESCRIPTION
This solves a problem with implicit `index.html` files being served with `Content-Type: text/plain`. For example:

* https://ipfs.io/ipfs/QmSyVmxwqFaiNYzgAFJ7WVMN6V6kApYiSwWVqFUpo5n24V/
* https://ipfs.io/ipfs/QmSyVmxwqFaiNYzgAFJ7WVMN6V6kApYiSwWVqFUpo5n24V/index.html