### PR TITLE
add option to disable flushing files structure on writes

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -68,7 +68,7 @@ var FilesStatCmd = &cmds.Command{
 			return
 		}
 
-		o, err := statNode(fsn)
+		o, err := statNode(node.DAG, fsn)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -90,13 +90,14 @@ var FilesStatCmd = &cmds.Command{
 	Type: Object{},
 }
 
-func statNode(fsn mfs.FSNode) (*Object, error) {
+func statNode(ds dag.DAGService, fsn mfs.FSNode) (*Object, error) {
 	nd, err := fsn.GetNode()
 	if err != nil {
 		return nil, err
 	}
 
-	k, err := nd.Key()
+	// add to dagserv to ensure its available
+	k, err := ds.Add(nd)
 	if err != nil {
 		return nil, err
 	}
@@ -434,10 +435,20 @@ a beginning offset to write to. The entire length of the input will be written.
 If the '--create' option is specified, the file will be created if it does not
 exist. Nonexistant intermediate directories will not be created.
 
+If the '--flush' option is set to false, changes will not be propogated to the
+merkledag root. This can make operations much faster when doing a large number
+of writes to a deeper directory structure. 
+
 Example:
 
     echo "hello world" | ipfs files write --create /myfs/a/b/file
     echo "hello world" | ipfs files write --truncate /myfs/a/b/file
+
+Warning:
+
+    Usage of the '--flush=false' option does not guarantee data durability until
+	the tree has been flushed. This can be accomplished by running 'ipfs files stat'
+	on the file or any of its ancestors.
 `,
 	},
 	Arguments: []cmds.Argument{
@@ -449,6 +460,7 @@ Example:
 		cmds.BoolOption("e", "create", "create the file if it does not exist"),
 		cmds.BoolOption("t", "truncate", "truncate the file before writing"),
 		cmds.IntOption("n", "count", "maximum number of bytes to read"),
+		cmds.BoolOption("f", "flush", "flush file and ancestors after write (default: true)"),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		path, err := checkPath(req.Arguments()[0])
@@ -459,6 +471,10 @@ Example:
 
 		create, _, _ := req.Option("create").Bool()
 		trunc, _, _ := req.Option("truncate").Bool()
+		flush, set, _ := req.Option("flush").Bool()
+		if !set {
+			flush = true
+		}
 
 		nd, err := req.InvocContext().GetNode()
 		if err != nil {
@@ -471,7 +487,12 @@ Example:
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
-		defer fi.Close()
+
+		if flush {
+			defer fi.Close()
+		} else {
+			defer fi.Sync()
+		}
 
 		if trunc {
 			if err := fi.Truncate(0); err != nil {

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -316,13 +316,26 @@ test_files_api() {
 		verify_dir_contents /cats file1 ipfs this
 	'
 
+	test_expect_success "write 'no-flush' succeeds" '
+		echo "testing" | ipfs files write -f -e /cats/walrus
+	'
+
+	test_expect_success "changes bubbled up to root on inspection" '
+		ipfs files stat / | head -n1 > root_hash
+	'
+
+	test_expect_success "root hash looks good" '
+		echo "QmcwKfTMCT7AaeiD92hWjnZn9b6eh9NxnhfSzN5x2vnDpt" > root_hash_exp &&
+		test_cmp root_hash_exp root_hash 
+	'
+
 	# test mv
 	test_expect_success "can mv dir" '
 		ipfs files mv /cats/this/is /cats/
 	'
 
 	test_expect_success "mv worked" '
-		verify_dir_contents /cats file1 ipfs this is &&
+		verify_dir_contents /cats file1 ipfs this is walrus &&
 		verify_dir_contents /cats/this
 	'
 


### PR DESCRIPTION
Currently, `ipfs files write` will always call close once the operation completes, close will flush and rehash the directory structure all the way up to the root.

This adds the option to put off that work, and just run a sync on the file instead of a full 'flush'. The flush is performed the next time close is called on that file, or when sync is called on any of the parent directories of the file (as usual)


A somewhat related aside for ipfs-blob-store:

@diasdavid give this a try, and also try removing the stat call in `writeBuffer` from your code if you can, I'm willing to bet that it improves performance a bit.

Also, if you could run the daemon with the env var `IPFS_PROF` set to true, and send me the resulting ipfs.cpuprof and ipfs.memprof along with your ipfs binary at the time, that would be really helpful.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>