### PR TITLE
t0020: cleanup dir with bad perms

### DIFF
--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -24,6 +24,11 @@ test_expect_success "ipfs init output looks good" '
 	test_cmp init_fail_exp init_fail_out
 '
 
+test_expect_success "cleanup dir with bad perms" '
+	chmod 775 "$IPFS_PATH" &&
+	rmdir "$IPFS_PATH"
+'
+
 # test no repo error message
 # this applies to `ipfs add sth`, `ipfs refs <hash>`
 test_expect_success "ipfs cat fails" '


### PR DESCRIPTION
This is needed on OSX otherwise the trash directory for the
t0020-init.sh test fails to be removed due to a permissions
error.

This fixes issue https://github.com/ipfs/go-ipfs/issues/2026.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>