### PR TITLE
flatten multipart transfers

### DIFF
--- a/commands/files/file_test.go
+++ b/commands/files/file_test.go
@@ -20,36 +20,38 @@ func TestSliceFiles(t *testing.T) {
 	sf := NewSliceFile(name, name, files)
 
 	if !sf.IsDirectory() {
-		t.Error("SliceFile should always be a directory")
+		t.Fatal("SliceFile should always be a directory")
 	}
-	if n, err := sf.Read(buf); n > 0 || err != ErrNotReader {
-		t.Error("Shouldn't be able to call `Read` on a SliceFile")
+
+	if n, err := sf.Read(buf); n > 0 || err != io.EOF {
+		t.Fatal("Shouldn't be able to read data from a SliceFile")
 	}
+
 	if err := sf.Close(); err != ErrNotReader {
-		t.Error("Shouldn't be able to call `Close` on a SliceFile")
+		t.Fatal("Shouldn't be able to call `Close` on a SliceFile")
 	}
 
 	file, err := sf.NextFile()
 	if file == nil || err != nil {
-		t.Error("Expected a file and nil error")
+		t.Fatal("Expected a file and nil error")
 	}
 	read, err := file.Read(buf)
 	if read != 11 || err != nil {
-		t.Error("NextFile got a file in the wrong order")
+		t.Fatal("NextFile got a file in the wrong order")
 	}
 
 	file, err = sf.NextFile()
 	if file == nil || err != nil {
-		t.Error("Expected a file and nil error")
+		t.Fatal("Expected a file and nil error")
 	}
 	file, err = sf.NextFile()
 	if file == nil || err != nil {
-		t.Error("Expected a file and nil error")
+		t.Fatal("Expected a file and nil error")
 	}
 
 	file, err = sf.NextFile()
 	if file != nil || err != io.EOF {
-		t.Error("Expected a nil file and io.EOF")
+		t.Fatal("Expected a nil file and io.EOF")
 	}
 }
 
@@ -59,21 +61,21 @@ func TestReaderFiles(t *testing.T) {
 	buf := make([]byte, len(message))
 
 	if rf.IsDirectory() {
-		t.Error("ReaderFile should never be a directory")
+		t.Fatal("ReaderFile should never be a directory")
 	}
 	file, err := rf.NextFile()
 	if file != nil || err != ErrNotDirectory {
-		t.Error("Expected a nil file and ErrNotDirectory")
+		t.Fatal("Expected a nil file and ErrNotDirectory")
 	}
 
 	if n, err := rf.Read(buf); n == 0 || err != nil {
-		t.Error("Expected to be able to read")
+		t.Fatal("Expected to be able to read")
 	}
 	if err := rf.Close(); err != nil {
-		t.Error("Should be able to close")
+		t.Fatal("Should be able to close")
 	}
 	if n, err := rf.Read(buf); n != 0 || err != io.EOF {
-		t.Error("Expected EOF when reading after close")
+		t.Fatal("Expected EOF when reading after close")
 	}
 }
 
@@ -86,23 +88,9 @@ Some-Header: beep
 
 beep
 --Boundary!
-Content-Type: multipart/mixed; boundary=OtherBoundary
+Content-Type: application/x-directory
 Content-Disposition: file; filename="dir"
 
---OtherBoundary
-Content-Type: text/plain
-Content-Disposition: file; filename="some/file/path"
-
-test
---OtherBoundary
-Content-Type: text/plain
-
-boop
---OtherBoundary
-Content-Type: text/plain
-
-bloop
---OtherBoundary--
 --Boundary!--
 
 `
@@ -114,81 +102,48 @@ bloop
 	// test properties of a file created from the first part
 	part, err := mpReader.NextPart()
 	if part == nil || err != nil {
-		t.Error("Expected non-nil part, nil error")
+		t.Fatal("Expected non-nil part, nil error")
 	}
 	mpf, err := NewFileFromPart(part)
 	if mpf == nil || err != nil {
-		t.Error("Expected non-nil MultipartFile, nil error")
+		t.Fatal("Expected non-nil MultipartFile, nil error")
 	}
 	if mpf.IsDirectory() {
-		t.Error("Expected file to not be a directory")
+		t.Fatal("Expected file to not be a directory")
 	}
 	if mpf.FileName() != "name" {
-		t.Error("Expected filename to be \"name\"")
+		t.Fatal("Expected filename to be \"name\"")
 	}
 	if file, err := mpf.NextFile(); file != nil || err != ErrNotDirectory {
-		t.Error("Expected a nil file and ErrNotDirectory")
+		t.Fatal("Expected a nil file and ErrNotDirectory")
 	}
 	if n, err := mpf.Read(buf); n != 4 || err != nil {
-		t.Error("Expected to be able to read 4 bytes")
+		t.Fatal("Expected to be able to read 4 bytes")
 	}
 	if err := mpf.Close(); err != nil {
-		t.Error("Expected to be able to close file")
+		t.Fatal("Expected to be able to close file")
 	}
 
 	// test properties of file created from second part (directory)
 	part, err = mpReader.NextPart()
 	if part == nil || err != nil {
-		t.Error("Expected non-nil part, nil error")
+		t.Fatal("Expected non-nil part, nil error")
 	}
 	mpf, err = NewFileFromPart(part)
 	if mpf == nil || err != nil {
-		t.Error("Expected non-nil MultipartFile, nil error")
+		t.Fatal("Expected non-nil MultipartFile, nil error")
 	}
 	if !mpf.IsDirectory() {
-		t.Error("Expected file to be a directory")
+		t.Fatal("Expected file to be a directory")
 	}
 	if mpf.FileName() != "dir" {
-		t.Error("Expected filename to be \"dir\"")
+		t.Fatal("Expected filename to be \"dir\"")
 	}
 	if n, err := mpf.Read(buf); n > 0 || err != ErrNotReader {
-		t.Error("Shouldn't be able to call `Read` on a directory")
+		t.Fatal("Shouldn't be able to call `Read` on a directory")
 	}
 	if err := mpf.Close(); err != ErrNotReader {
-		t.Error("Shouldn't be able to call `Close` on a directory")
+		t.Fatal("Shouldn't be able to call `Close` on a directory")
 	}
 
-	// test properties of first child file
-	child, err := mpf.NextFile()
-	if child == nil || err != nil {
-		t.Error("Expected to be able to read a child file")
-	}
-	if child.IsDirectory() {
-		t.Error("Expected file to not be a directory")
-	}
-	if child.FileName() != "some/file/path" {
-		t.Error("Expected filename to be \"some/file/path\"")
-	}
-
-	// test processing files out of order
-	child, err = mpf.NextFile()
-	if child == nil || err != nil {
-		t.Error("Expected to be able to read a child file")
-	}
-	child2, err := mpf.NextFile()
-	if child == nil || err != nil {
-		t.Error("Expected to be able to read a child file")
-	}
-	if n, err := child2.Read(buf); n != 5 || err != nil {
-		t.Error("Expected to be able to read")
-	}
-	if n, err := child.Read(buf); n != 0 || err == nil {
-		t.Error("Expected to not be able to read after advancing NextFile() past this file")
-	}
-
-	// make sure the end is handled properly
-	child, err = mpf.NextFile()
-	if child != nil || err == nil {
-		t.Error("Expected NextFile to return (nil, EOF)")
-	}
 }

--- a/commands/files/serialfile.go
+++ b/commands/files/serialfile.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -18,9 +19,10 @@ type serialFile struct {
 	files   []os.FileInfo
 	stat    os.FileInfo
 	current *File
+	hidden  bool
 }
 
-func NewSerialFile(name, path string, stat os.FileInfo) (File, error) {
+func NewSerialFile(name, path string, hidden bool, stat os.FileInfo) (File, error) {
 	switch mode := stat.Mode(); {
 	case mode.IsRegular():
 		file, err := os.Open(path)
@@ -35,7 +37,7 @@ func NewSerialFile(name, path string, stat os.FileInfo) (File, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &serialFile{name, path, contents, stat, nil}, nil
+		return &serialFile{name, path, contents, stat, nil, hidden}, nil
 	case mode&os.ModeSymlink != 0:
 		target, err := os.Readlink(path)
 		if err != nil {
@@ -68,6 +70,15 @@ func (f *serialFile) NextFile() (File, error) {
 	stat := f.files[0]
 	f.files = f.files[1:]
 
+	for !f.hidden && strings.HasPrefix(stat.Name(), ".") {
+		if len(f.files) == 0 {
+			return nil, io.EOF
+		}
+
+		stat = f.files[0]
+		f.files = f.files[1:]
+	}
+
 	// open the next file
 	fileName := filepath.ToSlash(filepath.Join(f.name, stat.Name()))
 	filePath := filepath.ToSlash(filepath.Join(f.path, stat.Name()))
@@ -75,7 +86,7 @@ func (f *serialFile) NextFile() (File, error) {
 	// recursively call the constructor on the next file
 	// if it's a regular file, we will open it as a ReaderFile
 	// if it's a directory, files in it will be opened serially
-	sf, err := NewSerialFile(fileName, filePath, stat)
+	sf, err := NewSerialFile(fileName, filePath, f.hidden, stat)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +105,7 @@ func (f *serialFile) FullPath() string {
 }
 
 func (f *serialFile) Read(p []byte) (int, error) {
-	return 0, ErrNotReader
+	return 0, io.EOF
 }
 
 func (f *serialFile) Close() error {

--- a/commands/files/serialfile.go
+++ b/commands/files/serialfile.go
@@ -14,12 +14,12 @@ import (
 // No more than one file will be opened at a time (directories will advance
 // to the next file when NextFile() is called).
 type serialFile struct {
-	name    string
-	path    string
-	files   []os.FileInfo
-	stat    os.FileInfo
-	current *File
-	hidden  bool
+	name              string
+	path              string
+	files             []os.FileInfo
+	stat              os.FileInfo
+	current           *File
+	handleHiddenFiles bool
 }
 
 func NewSerialFile(name, path string, hidden bool, stat os.FileInfo) (File, error) {
@@ -70,7 +70,7 @@ func (f *serialFile) NextFile() (File, error) {
 	stat := f.files[0]
 	f.files = f.files[1:]
 
-	for !f.hidden && strings.HasPrefix(stat.Name(), ".") {
+	for !f.handleHiddenFiles && strings.HasPrefix(stat.Name(), ".") {
 		if len(f.files) == 0 {
 			return nil, io.EOF
 		}
@@ -86,7 +86,7 @@ func (f *serialFile) NextFile() (File, error) {
 	// recursively call the constructor on the next file
 	// if it's a regular file, we will open it as a ReaderFile
 	// if it's a directory, files in it will be opened serially
-	sf, err := NewSerialFile(fileName, filePath, f.hidden, stat)
+	sf, err := NewSerialFile(fileName, filePath, f.handleHiddenFiles, stat)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/files/slicefile.go
+++ b/commands/files/slicefile.go
@@ -41,7 +41,7 @@ func (f *SliceFile) FullPath() string {
 }
 
 func (f *SliceFile) Read(p []byte) (int, error) {
-	return 0, ErrNotReader
+	return 0, io.EOF
 }
 
 func (f *SliceFile) Close() error {

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	path "github.com/ipfs/go-ipfs/path"
 	config "github.com/ipfs/go-ipfs/repo/config"
 
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
@@ -86,8 +85,8 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 		reader = strings.NewReader("")
 	}
 
-	pth := path.Join(req.Path())
-	url := fmt.Sprintf(ApiUrlFormat, c.serverAddress, ApiPath, pth, query)
+	path := strings.Join(req.Path(), "/")
+	url := fmt.Sprintf(ApiUrlFormat, c.serverAddress, ApiPath, path, query)
 
 	httpReq, err := http.NewRequest("POST", url, reader)
 	if err != nil {

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -96,7 +96,6 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 	// TODO extract string consts?
 	if fileReader != nil {
 		httpReq.Header.Set(contentTypeHeader, "multipart/form-data; boundary="+fileReader.Boundary())
-		httpReq.Header.Set(contentDispHeader, "form-data: name=\"files\"")
 	} else {
 		httpReq.Header.Set(contentTypeHeader, applicationOctetStream)
 	}

--- a/commands/http/multifilereader.go
+++ b/commands/http/multifilereader.go
@@ -92,12 +92,7 @@ func (mfr *MultiFileReader) Read(buf []byte) (written int, err error) {
 			// write the boundary and headers
 			header := make(textproto.MIMEHeader)
 			filename := url.QueryEscape(file.FileName())
-			if mfr.form {
-				contentDisposition := fmt.Sprintf("form-data; name=\"file\"; filename=\"%s\"", filename)
-				header.Set("Content-Disposition", contentDisposition)
-			} else {
-				header.Set("Content-Disposition", fmt.Sprintf("file; filename=\"%s\"", filename))
-			}
+			header.Set("Content-Disposition", fmt.Sprintf("file; filename=\"%s\"", filename))
 
 			header.Set("Content-Type", contentType)
 

--- a/commands/http/multifilereader_test.go
+++ b/commands/http/multifilereader_test.go
@@ -29,78 +29,86 @@ func TestOutput(t *testing.T) {
 
 	part, err := mpReader.NextPart()
 	if part == nil || err != nil {
-		t.Error("Expected non-nil part, nil error")
+		t.Fatal("Expected non-nil part, nil error")
 	}
 	mpf, err := files.NewFileFromPart(part)
 	if mpf == nil || err != nil {
-		t.Error("Expected non-nil MultipartFile, nil error")
+		t.Fatal("Expected non-nil MultipartFile, nil error")
 	}
 	if mpf.IsDirectory() {
-		t.Error("Expected file to not be a directory")
+		t.Fatal("Expected file to not be a directory")
 	}
 	if mpf.FileName() != "file.txt" {
-		t.Error("Expected filename to be \"file.txt\"")
+		t.Fatal("Expected filename to be \"file.txt\"")
 	}
 	if n, err := mpf.Read(buf); n != len(text) || err != nil {
-		t.Error("Expected to read from file", n, err)
+		t.Fatal("Expected to read from file", n, err)
 	}
 	if string(buf[:len(text)]) != text {
-		t.Error("Data read was different than expected")
+		t.Fatal("Data read was different than expected")
 	}
 
 	part, err = mpReader.NextPart()
 	if part == nil || err != nil {
-		t.Error("Expected non-nil part, nil error")
+		t.Fatal("Expected non-nil part, nil error")
 	}
 	mpf, err = files.NewFileFromPart(part)
 	if mpf == nil || err != nil {
-		t.Error("Expected non-nil MultipartFile, nil error")
+		t.Fatal("Expected non-nil MultipartFile, nil error")
 	}
 	if !mpf.IsDirectory() {
-		t.Error("Expected file to be a directory")
+		t.Fatal("Expected file to be a directory")
 	}
 	if mpf.FileName() != "boop" {
-		t.Error("Expected filename to be \"boop\"")
+		t.Fatal("Expected filename to be \"boop\"")
 	}
 
-	child, err := mpf.NextFile()
+	part, err = mpReader.NextPart()
+	if part == nil || err != nil {
+		t.Fatal("Expected non-nil part, nil error")
+	}
+	child, err := files.NewFileFromPart(part)
 	if child == nil || err != nil {
-		t.Error("Expected to be able to read a child file")
+		t.Fatal("Expected to be able to read a child file")
 	}
 	if child.IsDirectory() {
-		t.Error("Expected file to not be a directory")
+		t.Fatal("Expected file to not be a directory")
 	}
 	if child.FileName() != "boop/a.txt" {
-		t.Error("Expected filename to be \"some/file/path\"")
+		t.Fatal("Expected filename to be \"some/file/path\"")
 	}
 
-	child, err = mpf.NextFile()
+	part, err = mpReader.NextPart()
+	if part == nil || err != nil {
+		t.Fatal("Expected non-nil part, nil error")
+	}
+	child, err = files.NewFileFromPart(part)
 	if child == nil || err != nil {
-		t.Error("Expected to be able to read a child file")
+		t.Fatal("Expected to be able to read a child file")
 	}
 	if child.IsDirectory() {
-		t.Error("Expected file to not be a directory")
+		t.Fatal("Expected file to not be a directory")
 	}
 	if child.FileName() != "boop/b.txt" {
-		t.Error("Expected filename to be \"some/file/path\"")
+		t.Fatal("Expected filename to be \"some/file/path\"")
 	}
 
 	child, err = mpf.NextFile()
 	if child != nil || err != io.EOF {
-		t.Error("Expected to get (nil, io.EOF)")
+		t.Fatal("Expected to get (nil, io.EOF)")
 	}
 
 	part, err = mpReader.NextPart()
 	if part == nil || err != nil {
-		t.Error("Expected non-nil part, nil error")
+		t.Fatal("Expected non-nil part, nil error")
 	}
 	mpf, err = files.NewFileFromPart(part)
 	if mpf == nil || err != nil {
-		t.Error("Expected non-nil MultipartFile, nil error")
+		t.Fatal("Expected non-nil MultipartFile, nil error")
 	}
 
 	part, err = mpReader.NextPart()
 	if part != nil || err != io.EOF {
-		t.Error("Expected to get (nil, io.EOF)")
+		t.Fatal("Expected to get (nil, io.EOF)")
 	}
 }

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/cheggaaa/pb"
 	"github.com/ipfs/go-ipfs/core/coreunix"
@@ -147,26 +146,8 @@ remains to be implemented.
 		fileAdder.Pin = dopin
 		fileAdder.Silent = silent
 
-		// addAllFiles loops over a convenience slice file to
-		// add each file individually. e.g. 'ipfs add a b c'
-		addAllFiles := func(sliceFile files.File) error {
-			for {
-				file, err := sliceFile.NextFile()
-				if err != nil && err != io.EOF {
-					return err
-				}
-				if file == nil {
-					return nil // done
-				}
-
-				if err := fileAdder.AddFile(file); err != nil {
-					return err
-				}
-			}
-		}
-
 		addAllAndPin := func(f files.File) error {
-			if err := addAllFiles(f); err != nil {
+			if err := fileAdder.AddFile(f); err != nil {
 				return err
 			}
 

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -328,6 +328,13 @@ func (adder *Adder) addNode(node *dag.Node, path string) error {
 		path = key.Pretty()
 	}
 
+	dir := gopath.Dir(path)
+	if dir != "." {
+		if err := mfs.Mkdir(adder.mr, dir, true); err != nil {
+			return err
+		}
+	}
+
 	if err := mfs.PutNode(adder.mr, path, node); err != nil {
 		return err
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -255,7 +255,7 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 		return "", err
 	}
 
-	f, err := files.NewSerialFile(root, root, stat)
+	f, err := files.NewSerialFile(root, root, false, stat)
 	if err != nil {
 		return "", err
 	}
@@ -354,7 +354,7 @@ func (adder *Adder) addFile(file files.File) error {
 
 	switch {
 	case files.IsHidden(file) && !adder.Hidden:
-		log.Debugf("%s is hidden, skipping", file.FileName())
+		log.Infof("%s is hidden, skipping", file.FileName())
 		return &hiddenFileError{file.FileName()}
 	case file.IsDirectory():
 		return adder.addDir(file)

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -89,7 +89,7 @@ func (bs *Bitswap) provideWorker(px process.Process) {
 		defer cancel()
 
 		if err := bs.network.Provide(ctx, k); err != nil {
-			log.Error(err)
+			log.Warning(err)
 		}
 	}
 

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -29,7 +29,7 @@ func BuildDagFromFile(fpath string, ds dag.DAGService) (*dag.Node, error) {
 		return nil, fmt.Errorf("`%s` is a directory", fpath)
 	}
 
-	f, err := files.NewSerialFile(fpath, fpath, stat)
+	f, err := files.NewSerialFile(fpath, fpath, false, stat)
 	if err != nil {
 		return nil, err
 	}

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -268,7 +268,9 @@ func (d *Directory) Mkdir(name string) (*Directory, error) {
 		return nil, err
 	}
 
-	return d.childDir(name)
+	dirobj := NewDirectory(d.ctx, name, ndir, d, d.dserv)
+	d.childDirs[name] = dirobj
+	return dirobj, nil
 }
 
 func (d *Directory) Unlink(name string) error {

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -116,7 +116,10 @@ func Mkdir(r *Root, pth string, parents bool) error {
 
 	if len(parts) == 0 {
 		// this will only happen on 'mkdir /'
-		return fmt.Errorf("cannot mkdir '%s'", pth)
+		if parents {
+			return nil
+		}
+		return fmt.Errorf("cannot create directory '/': Already exists")
 	}
 
 	cur := r.GetValue().(*Directory)

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -102,7 +102,7 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 // intermediary directories as needed if 'parents' is set to true
 func Mkdir(r *Root, pth string, parents bool) error {
 	if pth == "" {
-		panic("empty path")
+		return nil
 	}
 	parts := path.SplitList(pth)
 	if parts[0] == "" {


### PR DESCRIPTION
This is based on #2039 so wait until it merges to review this.

But this removes the whole recursive multipart thing.

The multipart 'Next()' bug in #1688 is what i set out to fix, but that was apparently fixed in go version 1.5.2