### PR TITLE
travis-ci: use go 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 language: go
 
 go:
-    - 1.5.1
+    - 1.5.2
 
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive


### PR DESCRIPTION
License: MIT
Signed-off-by: Juan Benet <juan@benet.ai>