### PR TITLE
run external commands client side

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -321,7 +321,7 @@ func callCommand(ctx context.Context, req cmds.Request, root *cmds.Command, cmd 
 		}
 	}
 
-	if client != nil {
+	if client != nil && !cmd.External {
 		log.Debug("Executing command via API")
 		res, err = client.Send(req)
 		if err != nil {

--- a/test/sharness/t0063-external.sh
+++ b/test/sharness/t0063-external.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="test external command functionality"
+
+. lib/test-lib.sh
+
+
+# set here so daemon launches with it
+PATH=`pwd`/bin:$PATH
+
+test_init_ipfs
+
+test_launch_ipfs_daemon
+
+test_expect_success "create fake ipfs-update bin" '
+	mkdir bin &&
+	echo "#!/bin/sh" > bin/ipfs-update &&
+	echo "pwd" >> bin/ipfs-update &&
+	chmod +x bin/ipfs-update
+'
+
+test_expect_success "external command runs from current user directory" '
+	mkdir just_for_test &&
+	(cd just_for_test && ipfs update) > actual
+'
+
+test_expect_success "output looks good" '
+	echo `pwd`/just_for_test > exp &&
+	test_cmp exp actual
+'
+
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
Fixes a slight bug where external commands would be executed in the cwd of the daemon, as opposed to the client.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>