### PR TITLE
add 'get' to the allowed gateway commands

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -137,6 +137,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 	},
 	"cat":      CatCmd,
 	"commands": CommandsDaemonROCmd,
+	"get":      GetCmd,
 	"ls":       LsCmd,
 	"name": &cmds.Command{
 		Subcommands: map[string]*cmds.Command{

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -150,6 +150,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 			"links": objectLinksCmd,
 			"get":   objectGetCmd,
 			"stat":  objectStatCmd,
+			"patch": objectPatchCmd,
 		},
 	},
 	"refs": RefsROCmd,


### PR DESCRIPTION
Allows the use of 'get' on the gateways.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>