### PR TITLE
Have install.sh put the full path to ipfs binary if detected

### DIFF
--- a/misc/launchd/README.md
+++ b/misc/launchd/README.md
@@ -2,4 +2,3 @@
 
 A bare-bones launchd agent file for ipfs. To have launchd automatically run the ipfs daemon for you, run `./misc/launchd/install.sh`
 
-Note that the `ipfs` binary must be on the *system* PATH for this to work. Adding a symlink in /usr/bin works well enough for me.

--- a/misc/launchd/install.sh
+++ b/misc/launchd/install.sh
@@ -6,9 +6,13 @@ dest_dir="$HOME/Library/LaunchAgents"
 IPFS_PATH="${IPFS_PATH:-$HOME/.ipfs}"
 escaped_ipfs_path=$(echo $IPFS_PATH|sed 's/\//\\\//g')
 
+IPFS_BIN=$(which ipfs || echo ipfs)
+escaped_ipfs_bin=$(echo $IPFS_BIN|sed 's/\//\\\//g')
+
 mkdir -p "$dest_dir"
 
-sed 's/{{IPFS_PATH}}/'"$escaped_ipfs_path"'/g' \
+sed -e 's/{{IPFS_PATH}}/'"$escaped_ipfs_path"'/g' \
+  -e 's/{{IPFS_BIN}}/'"$escaped_ipfs_bin"'/g' \
   "$src_dir/$plist" \
   > "$dest_dir/$plist"
 

--- a/misc/launchd/install.sh
+++ b/misc/launchd/install.sh
@@ -23,5 +23,10 @@ if [ $? ]; then
 fi
 
 echo Loading ipfs-daemon
-launchctl load "$dest_dir/$plist"
+if [[ `sw_vers -productVersion` == 10.1* ]]; then
+  sudo chown root "$dest_dir/$plist"
+  sudo launchctl bootstrap system "$dest_dir/$plist"
+else
+  launchctl load "$dest_dir/$plist"
+fi
 launchctl list | grep ipfs-daemon

--- a/misc/launchd/io.ipfs.ipfs-daemon.plist
+++ b/misc/launchd/io.ipfs.ipfs-daemon.plist
@@ -8,7 +8,7 @@
     <string>io.ipfs.ipfs-daemon</string>
     <key>ProgramArguments</key>
     <array>
-      <string>ipfs</string>
+      <string>{{IPFS_BIN}}</string>
       <string>daemon</string>
     </array>
     <key>EnvironmentVariables</key>


### PR DESCRIPTION
For some reason, I had to sudo launchctl load, after doing sudo chmod 600 ~/Library/LaunchAgents/io.ipfs.ipfs-daemon.plist and sudo chown root ~/Library/LaunchAgents/io.ipfs-daemon.plist on el capitan.