### PR TITLE
Change mDNS service string to conform to RFC6763 standard.

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -20,7 +20,7 @@ import (
 
 var log = logging.Logger("mdns")
 
-const ServiceTag = "discovery.ipfs.io"
+const ServiceTag = "_ipfs._tcp"
 
 type Service interface {
 	io.Closer


### PR DESCRIPTION
Changed the serviceTag constant from discovery.ipfs.io to _ipfs._tcp.

Tested this change with:
1) Two separate nodes (an actual machine and a VM) on the same LAN.
2) No internet connection.

 and they were still able to find each other.