### PR TITLE
More robust version checking

### DIFF
--- a/misc/launchd/install.sh
+++ b/misc/launchd/install.sh
@@ -23,7 +23,7 @@ if [ $? ]; then
 fi
 
 echo Loading ipfs-daemon
-if [[ `sw_vers -productVersion` == 10.1* ]]; then
+if (( `sw_vers -productVersion | cut -d'.' -f2` > 9 )); then
   sudo chown root "$dest_dir/$plist"
   sudo launchctl bootstrap system "$dest_dir/$plist"
 else


### PR DESCRIPTION
OK, this checks that the actual value is above 10.9, since this should work on 10.10 as well (though I only tested 10.11).