### PR TITLE
Feat/mfs locking perf

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -586,24 +586,17 @@ Examples:
 			return
 		}
 
-		err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp)
-		if err != nil {
-			res.SetError(err, cmds.ErrNormal)
-			return
-		}
-
 		flush, found, _ := req.Option("flush").Bool()
 		if !found {
 			flush = true
 		}
 
-		if flush {
-			err := n.FilesRoot.Flush()
-			if err != nil {
-				res.SetError(err, cmds.ErrNormal)
-				return
-			}
+		err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp, flush)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
 		}
+
 	},
 }
 

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -659,6 +659,17 @@ remove files or directories
 
 		dashr, _, _ := req.Option("r").Bool()
 
+		var success bool
+		defer func() {
+			if success {
+				err := pdir.Flush()
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+			}
+		}()
+
 		// if '-r' specified, don't check file type (in bad scenarios, the block may not exist)
 		if dashr {
 			err := pdir.Unlink(name)
@@ -667,6 +678,7 @@ remove files or directories
 				return
 			}
 
+			success = true
 			return
 		}
 
@@ -686,6 +698,8 @@ remove files or directories
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
+
+			success = true
 		}
 	},
 }

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -330,7 +330,7 @@ func (adder *Adder) addNode(node *dag.Node, path string) error {
 
 	dir := gopath.Dir(path)
 	if dir != "." {
-		if err := mfs.Mkdir(adder.mr, dir, true); err != nil {
+		if err := mfs.Mkdir(adder.mr, dir, true, false); err != nil {
 			return err
 		}
 	}
@@ -403,7 +403,7 @@ func (adder *Adder) addFile(file files.File) error {
 func (adder *Adder) addDir(dir files.File) error {
 	log.Infof("adding directory: %s", dir.FileName())
 
-	err := mfs.Mkdir(adder.mr, dir.FileName(), true)
+	err := mfs.Mkdir(adder.mr, dir.FileName(), true, false)
 	if err != nil {
 		return err
 	}

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -278,11 +278,6 @@ func (d *Directory) Mkdir(name string) (*Directory, error) {
 		return nil, err
 	}
 
-	err = d.flushUp()
-	if err != nil {
-		return nil, err
-	}
-
 	dirobj := NewDirectory(d.ctx, name, ndir, d, d.dserv)
 	d.childDirs[name] = dirobj
 	return dirobj, nil
@@ -300,12 +295,21 @@ func (d *Directory) Unlink(name string) error {
 		return err
 	}
 
-	return d.flushUp()
-}
-
-func (d *Directory) flushUp() error {
+	_, err = d.dserv.Add(d.node)
+	if err != nil {
+		return err
+	}
 
 	return d.parent.closeChild(d.name, d.node)
+}
+
+func (d *Directory) Flush() error {
+	nd, err := d.flushCurrentNode()
+	if err != nil {
+		return err
+	}
+
+	return d.parent.closeChild(d.name, nd)
 }
 
 // AddChild adds the node 'nd' under this directory giving it the name 'name'

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -258,9 +258,9 @@ func (d *Directory) Mkdir(name string) (*Directory, error) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	_, err := d.childDir(name)
+	child, err := d.childDir(name)
 	if err == nil {
-		return nil, os.ErrExist
+		return child, os.ErrExist
 	}
 	_, err = d.childFile(name)
 	if err == nil {
@@ -395,7 +395,7 @@ func (d *Directory) GetNode() (*dag.Node, error) {
 		return nil, err
 	}
 
-	return d.node, nil
+	return d.node.Copy(), nil
 }
 
 func (d *Directory) Lock() {

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -48,7 +49,7 @@ func NewDirectory(ctx context.Context, name string, node *dag.Node, parent child
 }
 
 // closeChild updates the child by the given name to the dag node 'nd'
-// and changes its own dag node, then propogates the changes upward
+// and changes its own dag node
 func (d *Directory) closeChild(name string, nd *dag.Node) error {
 	mynd, err := d.closeChildUpdate(name, nd)
 	if err != nil {
@@ -300,7 +301,7 @@ func (d *Directory) Unlink(name string) error {
 		return err
 	}
 
-	return d.parent.closeChild(d.name, d.node)
+	return nil
 }
 
 func (d *Directory) Flush() error {
@@ -373,6 +374,16 @@ func (d *Directory) sync() error {
 	}
 
 	return nil
+}
+
+func (d *Directory) Path() string {
+	cur := d
+	var out string
+	for cur != nil {
+		out = path.Join(cur.name, out)
+		cur = cur.parent.(*Directory)
+	}
+	return out
 }
 
 func (d *Directory) GetNode() (*dag.Node, error) {

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -65,6 +65,7 @@ func (fi *File) Close() error {
 	if fi.hasChanges {
 		err := fi.mod.Sync()
 		if err != nil {
+			fi.Unlock()
 			return err
 		}
 
@@ -74,6 +75,7 @@ func (fi *File) Close() error {
 		// it will manage the lock for us
 		return fi.flushUp()
 	}
+	fi.Unlock()
 
 	return nil
 }
@@ -93,12 +95,13 @@ func (fi *File) flushUp() error {
 		return err
 	}
 
-	name := fi.name
-	parent := fi.parent
+	//name := fi.name
+	//parent := fi.parent
 
 	// explicit unlock *only* before closeChild call
 	fi.Unlock()
-	return parent.closeChild(name, nd)
+	return nil
+	//return parent.closeChild(name, nd)
 }
 
 // Sync flushes the changes in the file to disk

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"sort"
 	"testing"
 
+	randbo "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/dustin/randbo"
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore/sync"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
@@ -472,5 +474,148 @@ func TestMfsFile(t *testing.T) {
 	err = fi.Close()
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func randomWalk(d *Directory, n int) (*Directory, error) {
+	for i := 0; i < n; i++ {
+		dirents, err := d.List()
+		if err != nil {
+			return nil, err
+		}
+
+		var childdirs []NodeListing
+		for _, child := range dirents {
+			if child.Type == int(TDir) {
+				childdirs = append(childdirs, child)
+			}
+		}
+		if len(childdirs) == 0 {
+			return d, nil
+		}
+
+		next := childdirs[rand.Intn(len(childdirs))].Name
+
+		nextD, err := d.Child(next)
+		if err != nil {
+			return nil, err
+		}
+
+		d = nextD.(*Directory)
+	}
+	return d, nil
+}
+
+func randomName() string {
+	set := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_"
+	length := rand.Intn(10) + 2
+	var out string
+	for i := 0; i < length; i++ {
+		j := rand.Intn(len(set))
+		out += set[j : j+1]
+	}
+	return out
+}
+
+func actorMakeFile(d *Directory) error {
+	d, err := randomWalk(d, rand.Intn(7))
+	if err != nil {
+		return err
+	}
+
+	name := randomName()
+	f, err := NewFile(name, &dag.Node{Data: ft.FilePBData(nil, 0)}, d, d.dserv)
+	if err != nil {
+		return err
+	}
+
+	r := io.LimitReader(randbo.New(), int64(77*rand.Intn(123)))
+	_, err = io.Copy(f, r)
+	if err != nil {
+		return err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+func actorMkdir(d *Directory) error {
+	d, err := randomWalk(d, rand.Intn(7))
+	if err != nil {
+		return err
+	}
+
+	_, err = d.Mkdir(randomName())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func actorRemoveFile(d *Directory) error {
+	d, err := randomWalk(d, rand.Intn(7))
+	if err != nil {
+		return err
+	}
+
+	ents, err := d.List()
+	if err != nil {
+		return err
+	}
+
+	if len(ents) == 0 {
+		return nil
+	}
+
+	re := ents[rand.Intn(len(ents))]
+
+	return d.Unlink(re.Name)
+}
+
+func testActor(rt *Root, iterations int, errs chan error) {
+	d := rt.GetValue().(*Directory)
+	for i := 0; i < iterations; i++ {
+		switch rand.Intn(4) {
+		case 0:
+			if err := actorMkdir(d); err != nil {
+				errs <- err
+				return
+			}
+		case 1, 2:
+			if err := actorMakeFile(d); err != nil {
+				errs <- err
+				return
+			}
+		case 3:
+			if err := actorRemoveFile(d); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}
+	errs <- nil
+}
+
+func TestMfsStress(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, rt := setupRoot(ctx, t)
+
+	numroutines := 2
+
+	errs := make(chan error)
+	for i := 0; i < numroutines; i++ {
+		go testActor(rt, 50, errs)
+	}
+
+	for i := 0; i < numroutines; i++ {
+		err := <-errs
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -99,8 +99,8 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 }
 
 // Mkdir creates a directory at 'path' under the directory 'd', creating
-// intermediary directories as needed if 'parents' is set to true
-func Mkdir(r *Root, pth string, parents bool, flush bool) error {
+// intermediary directories as needed if 'mkparents' is set to true
+func Mkdir(r *Root, pth string, mkparents bool, flush bool) error {
 	if pth == "" {
 		return nil
 	}
@@ -116,7 +116,7 @@ func Mkdir(r *Root, pth string, parents bool, flush bool) error {
 
 	if len(parts) == 0 {
 		// this will only happen on 'mkdir /'
-		if parents {
+		if mkparents {
 			return nil
 		}
 		return fmt.Errorf("cannot create directory '/': Already exists")
@@ -125,7 +125,7 @@ func Mkdir(r *Root, pth string, parents bool, flush bool) error {
 	cur := r.GetValue().(*Directory)
 	for i, d := range parts[:len(parts)-1] {
 		fsn, err := cur.Child(d)
-		if err == os.ErrNotExist && parents {
+		if err == os.ErrNotExist && mkparents {
 			mkd, err := cur.Mkdir(d)
 			if err != nil {
 				return err
@@ -144,7 +144,7 @@ func Mkdir(r *Root, pth string, parents bool, flush bool) error {
 
 	final, err := cur.Mkdir(parts[len(parts)-1])
 	if err != nil {
-		if !parents || err != os.ErrExist {
+		if !mkparents || err != os.ErrExist || final == nil {
 			return err
 		}
 	}

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -100,7 +100,7 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 
 // Mkdir creates a directory at 'path' under the directory 'd', creating
 // intermediary directories as needed if 'parents' is set to true
-func Mkdir(r *Root, pth string, parents bool) error {
+func Mkdir(r *Root, pth string, parents bool, flush bool) error {
 	if pth == "" {
 		return nil
 	}
@@ -142,9 +142,16 @@ func Mkdir(r *Root, pth string, parents bool) error {
 		cur = next
 	}
 
-	_, err := cur.Mkdir(parts[len(parts)-1])
+	final, err := cur.Mkdir(parts[len(parts)-1])
 	if err != nil {
 		if !parents || err != os.ErrExist {
+			return err
+		}
+	}
+
+	if flush {
+		err := final.Flush()
+		if err != nil {
 			return err
 		}
 	}

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -109,6 +109,23 @@ func (kr *Root) GetValue() FSNode {
 	return kr.val
 }
 
+func (kr *Root) Flush() error {
+	nd, err := kr.GetValue().GetNode()
+	if err != nil {
+		return err
+	}
+
+	k, err := kr.dserv.Add(nd)
+	if err != nil {
+		return err
+	}
+
+	if kr.repub != nil {
+		kr.repub.Update(k)
+	}
+	return nil
+}
+
 // closeChild implements the childCloser interface, and signals to the publisher that
 // there are changes ready to be published
 func (kr *Root) closeChild(name string, nd *dag.Node) error {

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -352,6 +352,31 @@ test_files_api() {
 	test_expect_success "cleanup looks good" '
 		verify_dir_contents /
 	'
+
+	# test flush flags
+	test_expect_success "mkdir --flush works" '
+		ipfs files mkdir --flush --parents /flushed/deep
+	'
+
+	test_expect_success "mkdir --flush works a second time" '
+		ipfs files mkdir --flush --parents /flushed/deep
+	'
+
+	test_expect_success "dir looks right" '
+		verify_dir_contents / flushed
+	'
+
+	test_expect_success "child dir looks right" '
+		verify_dir_contents /flushed deep
+	'
+
+	test_expect_success "cleanup" '
+		ipfs files rm -r /flushed
+	'
+
+	test_expect_success "child dir looks right" '
+		verify_dir_contents /
+	'
 }
 
 # test offline and online


### PR DESCRIPTION
This PR makes a few performance changes and bugfixes to mfs.

First, It avoids holding multiple locks at a time when syncing filesystem changes up to the root, this is both a bugfix (deadlocks were found) and a performance improvement (holding multiple locks gets exponentially more expensive under load).

The second (third commit) change adds the `--flush` flag to the `ipfs files mkdir` command, it defaults to true, but can be set to false with `--flush=false` to avoid syncing the entire directory tree every time mkdir is called.