### PR TITLE
namesys: Make paths with multiple segemnts work. Fixes #2059

### DIFF
--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -61,7 +61,7 @@ func (r *DNSResolver) resolveOnce(ctx context.Context, name string) (path.Path, 
 		p, err := parseEntry(t)
 		if err == nil {
 			if len(segments) > 1 {
-				return path.FromSegments(p.String() + "/", segments[1])
+				return path.FromSegments("", strings.TrimRight(p.String(), "/"), segments[1])
 			}
 			return p, nil
 		}

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -18,6 +18,7 @@ func (m *mockDNS) lookupTXT(name string) (txt []string, err error) {
 }
 
 func TestDnsEntryParsing(t *testing.T) {
+
 	goodEntries := []string{
 		"QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
@@ -86,6 +87,12 @@ func newMockDNS() *mockDNS {
 			"bad.example.com": []string{
 				"dnslink=",
 			},
+			"withsegment.example.com": []string{
+				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment",
+			},
+			"withrecsegment.example.com": []string{
+				"dnslink=/ipns/withsegment.example.com/subsub",
+			},
 		},
 	}
 }
@@ -109,4 +116,6 @@ func TestDNSResolution(t *testing.T) {
 	testResolution(t, r, "loop1.example.com", 3, "/ipns/loop2.example.com", ErrResolveRecursion)
 	testResolution(t, r, "loop1.example.com", DefaultDepthLimit, "/ipns/loop1.example.com", ErrResolveRecursion)
 	testResolution(t, r, "bad.example.com", DefaultDepthLimit, "", ErrResolveFailed)
+	testResolution(t, r, "withsegment.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment", nil)
+	testResolution(t, r, "withrecsegment.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/subsub", nil)
 }

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -26,6 +26,7 @@ func TestDnsEntryParsing(t *testing.T) {
 		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/foo",
 		"dnslink=/ipns/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/bar",
 		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/foo/bar/baz",
+		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/foo/bar/baz/",
 		"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 	}
 
@@ -93,6 +94,12 @@ func newMockDNS() *mockDNS {
 			"withrecsegment.example.com": []string{
 				"dnslink=/ipns/withsegment.example.com/subsub",
 			},
+			"withtrailing.example.com": []string{
+				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/",
+			},
+			"withtrailingrec.example.com": []string{
+				"dnslink=/ipns/withtrailing.example.com/segment/",
+			},
 		},
 	}
 }
@@ -118,4 +125,8 @@ func TestDNSResolution(t *testing.T) {
 	testResolution(t, r, "bad.example.com", DefaultDepthLimit, "", ErrResolveFailed)
 	testResolution(t, r, "withsegment.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment", nil)
 	testResolution(t, r, "withrecsegment.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/subsub", nil)
+	testResolution(t, r, "withsegment.example.com/test1", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/test1", nil)
+	testResolution(t, r, "withrecsegment.example.com/test2", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/subsub/test2", nil)
+	testResolution(t, r, "withrecsegment.example.com/test3/", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/subsub/test3/", nil)
+	testResolution(t, r, "withtrailingrec.example.com", DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/", nil)
 }

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -75,7 +75,7 @@ func (ns *mpns) resolveOnce(ctx context.Context, name string) (path.Path, error)
 		p, err := resolver.resolveOnce(ctx, segments[2])
 		if err == nil {
 			if len(segments) > 3 {
-				return path.FromSegments(p.String() + "/", segments[3])
+				return path.FromSegments("", strings.TrimRight(p.String(), "/"), segments[3])
 			} else {
 				return p, err
 			}

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -64,17 +64,21 @@ func (ns *mpns) resolveOnce(ctx context.Context, name string) (path.Path, error)
 	if !strings.HasPrefix(name, "/ipns/") {
 		name = "/ipns/" + name
 	}
-	segments := strings.SplitN(name, "/", 3)
+	segments := strings.SplitN(name, "/", 4)
 	if len(segments) < 3 || segments[0] != "" {
 		log.Warningf("Invalid name syntax for %s", name)
 		return "", ErrResolveFailed
 	}
 
 	for protocol, resolver := range ns.resolvers {
-		log.Debugf("Attempting to resolve %s with %s", name, protocol)
+		log.Debugf("Attempting to resolve %s with %s", segments[2], protocol)
 		p, err := resolver.resolveOnce(ctx, segments[2])
 		if err == nil {
-			return p, err
+			if len(segments) > 3 {
+				return path.FromSegments(p.String() + "/", segments[3])
+			} else {
+				return p, err
+			}
 		}
 	}
 	log.Warningf("No resolver found for %s", name)

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -123,7 +123,7 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 
 	hash, err := mh.FromB58String(name)
 	if err != nil {
-		log.Warning("RoutingResolve: bad input hash: [%s]\n", name)
+		log.Warningf("RoutingResolve: bad input hash: [%s]\n", name)
 		return "", err
 	}
 	// name should be a multihash. if it isn't, error out here.


### PR DESCRIPTION
Also fixes non-recursive resolve erring instead showing one step.

The patch of `core/commands/resolve.go` could be done better but I don't know how to get access to `ErrResolveRecursion`.

It allows for dnslinks into sub-segments. So ie. hosting multiple blogs on just domains from one pubkey.

Fixes #2059