### PR TITLE
fsrepo: Allow for custom datastore path

### DIFF
--- a/repo/config/datastore.go
+++ b/repo/config/datastore.go
@@ -35,6 +35,10 @@ type S3Datastore struct {
 
 // DataStorePath returns the default data store path given a configuration root
 // (set an empty string to have the default configuration root)
-func DataStorePath(configroot string) (string, error) {
+func DataStorePath(configroot string, datastore string) (string, error) {
+	if len(datastore) != 0 {
+		return Path("", datastore)
+	}
+
 	return Path(configroot, DefaultDataStoreDirectory)
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -10,7 +10,7 @@ import (
 	peer "github.com/ipfs/go-ipfs/p2p/peer"
 )
 
-func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
+func Init(out io.Writer, nBitsForKeypair int, datastore string) (*Config, error) {
 	identity, err := identityConfig(out, nBitsForKeypair)
 	if err != nil {
 		return nil, err
@@ -22,6 +22,11 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 	}
 
 	snr, err := initSNRConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ds, err := datastoreConfig("", datastore)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +63,8 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			ResolveCacheSize: 128,
 		},
 
+		Datastore: *ds,
+
 		// tracking ipfs version used to generate the init folder and adding
 		// update checker default setting.
 		Version: VersionDefaultValue(),
@@ -71,11 +78,16 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 	return conf, nil
 }
 
-func datastoreConfig() (*Datastore, error) {
-	dspath, err := DataStorePath("")
+func datastoreConfig(configroot string, datastore string) (*Datastore, error) {
+	dspath, err := DataStorePath(configroot, datastore)
 	if err != nil {
 		return nil, err
 	}
+
+	if len(datastore) != 0 {
+		dspath = datastore
+	}
+
 	return &Datastore{
 		Path:               dspath,
 		Type:               "leveldb",


### PR DESCRIPTION
Gives the user the option to set a `datastore` flag to change where the leveldb and flatfs database live.

Addresses #2117

I might rewrite this a bit to change the fsrepo checking and such around to better suit this option. This is slightly hacked together due to the way the original code was written. It made it hard to pipe through a few things. Some functions might need to be rewritten. I'm mostly not too keen on the random blank strings and passing nil around when the config doesn't exist yet.