### PR TITLE
Fixed: On windows 'ipfs add -r .' used the full path

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -392,7 +392,11 @@ func appendFile(args []files.File, inputs []string, argDef *cmds.Argument, recur
 		}
 	}
 
-	arg, err := files.NewSerialFile(path.Base(fpath), fpath, stat)
+	basename := path.Base(fpath)
+	if stat.IsDir() {
+		basename = "."
+	}
+	arg, err := files.NewSerialFile(basename, fpath, stat)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Previously 'ipfs add -r .' created an ipfs node with the full
path of the directory as the root node (e.g.
C:\Users\someone\yourdatadirtoshare\ ), from now on, it won't
include the full path of the root directory in the ipfs nodes.