### PR TITLE
Update alpine to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER Brian Tiger Chow <btc@perfmode.com>
 
 ENV IPFS_PATH /data/ipfs


### PR DESCRIPTION
In order to have latest certificates included into the container and to have patches for maybe present security flaws in `alpine:3.2` update to `alpine:3.3` (latest stable version).

```
[23:53] luzifer ~/g/g/s/g/i/go-ipfs (master)> docker run --rm -ti alpine:3.2 apk --update info ca-certificates
fetch http://dl-4.alpinelinux.org/alpine/v3.2/main/x86_64/APKINDEX.tar.gz
ca-certificates-20141019-r2 description:
Common CA certificates PEM files

ca-certificates-20141019-r2 webpage:
http://packages.debian.org/sid/ca-certificates

ca-certificates-20141019-r2 installed size:
802816

[23:53] luzifer ~/g/g/s/g/i/go-ipfs (master)> docker run --rm -ti alpine:3.3 apk --update info ca-certificates
fetch http://dl-4.alpinelinux.org/alpine/v3.3/main/x86_64/APKINDEX.tar.gz
fetch http://dl-4.alpinelinux.org/alpine/v3.3/community/x86_64/APKINDEX.tar.gz
ca-certificates-20150426-r3 description:
Common CA certificates PEM files

ca-certificates-20150426-r3 webpage:
http://packages.debian.org/sid/ca-certificates

ca-certificates-20150426-r3 installed size:
843776
```