### PR TITLE
Lets 'ipfs add' include top-level hidden files

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -359,11 +359,7 @@ func (adder *Adder) addFile(file files.File) error {
 		return err
 	}
 
-	switch {
-	case files.IsHidden(file) && !adder.Hidden:
-		log.Infof("%s is hidden, skipping", file.FileName())
-		return &hiddenFileError{file.FileName()}
-	case file.IsDirectory():
+	if file.IsDirectory() {
 		return adder.addDir(file)
 	}
 
@@ -417,11 +413,13 @@ func (adder *Adder) addDir(dir files.File) error {
 			break
 		}
 
-		err = adder.addFile(file)
-		if _, ok := err.(*hiddenFileError); ok {
-			// hidden file error, skip file
+		// Skip hidden files when adding recursively, unless Hidden is enabled.
+		if files.IsHidden(file) && !adder.Hidden {
+			log.Infof("%s is hidden, skipping", file.FileName())
 			continue
-		} else if err != nil {
+		}
+		err = adder.addFile(file)
+		if err != nil {
 			return err
 		}
 	}

--- a/test/sharness/t0042-add-skip.sh
+++ b/test/sharness/t0042-add-skip.sh
@@ -48,6 +48,17 @@ test_add_skip() {
 		test_cmp expected actual
 	'
 
+	test_expect_success "'ipfs add' includes hidden files given explicitly even without --hidden" '
+    mkdir -p mountdir/dotfiles &&
+    echo "set nocompatible" > mountdir/dotfiles/.vimrc
+		cat >expected <<-\EOF &&
+added QmT4uMRDCN7EMpFeqwvKkboszbqeW1kWVGrBxBuCGqZcQc .vimrc
+		EOF
+		ipfs add mountdir/dotfiles/.vimrc >actual
+    cat actual
+		test_cmp expected actual
+	'
+
 }
 
 # should work offline


### PR DESCRIPTION
Fixes ipfs/go-ipfs/#2145. The --hidden switch (still) only affects recursive adding.

License: MIT
Signed-off-by: Stephen Whitmore <noffle@ipfs.io>