### PR TITLE
Fix test str contains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@
 *.orig
 *~
 
-/test/bin
 .ipfs

--- a/test/bin/.gitignore
+++ b/test/bin/.gitignore
@@ -1,0 +1,11 @@
+# Ignore everything in this directory by default
+/**
+
+# Do not ignore this file itself
+!.gitignore
+
+# Do not ignore the following special scripts
+!checkflags
+!continueyn
+!ipfs-pin-stat
+!verify-go-fmt.sh

--- a/test/bin/ipfs-pin-stat
+++ b/test/bin/ipfs-pin-stat
@@ -19,12 +19,12 @@ if [ "$?" -eq 0 ]; then
 fi
 
 ipfs pin ls --type=recursive | grep "$path" >/dev/null
-[ "$?" -eq 0 ] && echo "$path pinned recursively"
+[ "$?" -eq 0 ] && echo "$path pinned recursive-ly"
 
 ipfs pin ls --type=indirect | grep "$path" >/dev/null
-[ "$?" -eq 0 ] && echo "$path pinned indirectly"
+[ "$?" -eq 0 ] && echo "$path pinned indirect-ly"
 
 ipfs pin ls --type=direct | grep "$path" >/dev/null
-[ "$?" -eq 0 ] && echo "$path pinned directly"
+[ "$?" -eq 0 ] && echo "$path pinned direct-ly"
 
 exit 0

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -321,7 +321,7 @@ test_should_contain() {
 test_str_contains() {
 	find=$1
 	shift
-	echo "$@" | grep "$find" >/dev/null
+	echo "$@" | grep "\b$find\b" >/dev/null
 }
 
 disk_usage() {

--- a/test/sharness/t0081-repo-pinning.sh
+++ b/test/sharness/t0081-repo-pinning.sh
@@ -17,7 +17,7 @@ test_pin_flag() {
 
 	echo "test_pin_flag" $@
 
-	ipfs-pin-stat "$object" | grep "$ptype"
+	ipfs-pin-stat "$object" | egrep "\b$ptype\b"
 	actual=$?
 
 	if [ "$expect" = "true" ]; then


### PR DESCRIPTION
t0081-repo-pinning.sh looks buggy to me without those 2 fixes.
Because when we grep for just "direct", it matches "indirect":

```
> echo "indirect" | grep direct
indirect
> echo "indirect" | egrep "\bdirect\b"
> echo "direct" | egrep "\bdirect\b"
direct
```

Unfortunately with those 2 fixes, now some tests are failing. This either means that we have bugs in go-ipfs that were previously hidden or that the tests that fail are wrong.

cc @whyrusleeping @jbenet 