### PR TITLE
test-lib: improve on previous fix

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -321,7 +321,7 @@ test_should_contain() {
 test_str_contains() {
 	find=$1
 	shift
-	echo "$@" | grep "\b$find\b" >/dev/null
+	echo "$@" | egrep "\b$find\b" >/dev/null
 }
 
 disk_usage() {


### PR DESCRIPTION
With GNU "grep" \b works but it's safer to use "egrep" which is also
POSIX rather than "grep" as not all the "grep"s out there might support \b.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>