### PR TITLE
Remove duplicate Transfer-Encoding header

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -46,7 +46,7 @@ const (
 	channelHeader          = "X-Chunked-Output"
 	uaHeader               = "User-Agent"
 	contentTypeHeader      = "Content-Type"
-	contentLengthHeader    = "Content-Length"
+	contentLengthHeader    = "X-Content-Length"
 	contentDispHeader      = "Content-Disposition"
 	transferEncodingHeader = "Transfer-Encoding"
 	applicationJson        = "application/json"
@@ -255,7 +255,6 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 	}
 
 	h.Set(contentTypeHeader, mime)
-	h.Set(transferEncodingHeader, "chunked")
 
 	// set 'allowed' headers
 	h.Set("Access-Control-Allow-Headers", "X-Stream-Output, X-Chunked-Output")

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -36,6 +36,12 @@ test_expect_success "'ipfs config Identity.PeerID' works" '
   PEERID=$(ipfs config Identity.PeerID)
 '
 
+# see https://github.com/ipfs/go-ipfs/issues/2190
+test_expect_success "test for duplicate Transfer-Encoding Header" '
+    curl -v -i http://localhost:5001/api/v0/version 2> curl_output &&
+    test $(grep -c "Transfer-Encoding" curl_output) -eq 1
+'
+
 test_expect_success "'ipfs swarm addrs local' works" '
   ipfs swarm addrs local >local_addrs
 '

--- a/test/sharness/t0230-channel-streaming-http-content-type.sh
+++ b/test/sharness/t0230-channel-streaming-http-content-type.sh
@@ -25,7 +25,6 @@ test_ls_cmd() {
 		printf "Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
 		printf "Content-Type: text/plain\r\n" >>expected_output &&
 		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
-		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "\r\n" >>expected_output &&
@@ -47,7 +46,6 @@ test_ls_cmd() {
 		printf "Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output\r\n" >>expected_output &&
 		printf "Content-Type: application/json\r\n" >>expected_output &&
 		printf "Trailer: X-Stream-Error\r\n" >>expected_output &&
-		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "X-Chunked-Output: 1\r\n" >>expected_output &&
 		printf "Transfer-Encoding: chunked\r\n" >>expected_output &&
 		printf "\r\n" >>expected_output &&


### PR DESCRIPTION
Address #2190, #1765.

It is a duplicate since chunked Transfer-Encoding header is already set in http responsewriter.