### PR TITLE
trivial: fix `ipfs update` error message

### DIFF
--- a/core/commands/external.go
+++ b/core/commands/external.go
@@ -33,7 +33,7 @@ func ExternalBinary() *cmds.Command {
 					}
 				}
 
-				res.SetError(fmt.Errorf("%s not installed."), cmds.ErrNormal)
+				res.SetError(fmt.Errorf("%s not installed.", binname), cmds.ErrNormal)
 				return
 			}
 


### PR DESCRIPTION
Adds an argument to the formatted error string.

License: MIT
Signed-off-by: Thomas Gardner <tmg@fastmail.com>
