### PR TITLE
bitswap GetBlocks: CancelWant on ctx cancel

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -150,15 +150,12 @@ func (bs *Bitswap) GetBlock(parent context.Context, k key.Key) (*blocks.Block, e
 	// when this context's cancel func is executed. This is difficult to
 	// enforce. May this comment keep you safe.
 
-	ctx, cancelFunc := context.WithCancel(parent)
+	ctx, cancel := context.WithCancel(parent)
 
 	ctx = logging.ContextWithLoggable(ctx, logging.Uuid("GetBlockRequest"))
 	log.Event(ctx, "Bitswap.GetBlockRequest.Start", &k)
 	defer log.Event(ctx, "Bitswap.GetBlockRequest.End", &k)
-
-	defer func() {
-		cancelFunc()
-	}()
+	defer cancel()
 
 	promise, err := bs.GetBlocks(ctx, []key.Key{k})
 	if err != nil {
@@ -209,17 +206,17 @@ func (bs *Bitswap) GetBlocks(ctx context.Context, keys []key.Key) (<-chan *block
 	}
 
 	bs.wm.WantBlocks(keys)
+	go func() {
+		<-ctx.Done()
+		bs.CancelWants(keys)
+	}()
 
 	req := &blockRequest{
 		keys: keys,
 		ctx:  ctx,
 	}
-	select {
-	case bs.findKeys <- req:
-		return promise, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
+	bs.findKeys <- req
+	return promise, nil
 }
 
 // CancelWant removes a given key from the wantlist


### PR DESCRIPTION
(ctx cleanup)
An updated #1995.
Also that #1986 doesn't fix this issue even when closenotify works.

- [ ] test

Though, tested on the local branch:
- `ipfs daemon &`
- `ipfs get $hash`
- in a separate tab, `ipfs bitswap wantlist`, sees hash
- C-c `ipfs get`
- in a separate tab, `ipfs bitswap wantlist`, hash is gone.

The "detached request" comment in https://github.com/ipfs/go-ipfs/pull/1995#issuecomment-160836797 shouldn't be the default (and the feature depends on api key/acl to be implemented). One can always flood a gateway/IpfsNode with nonexistent hashes.
(while I think a bittorent client is more equivalent to an IpfsNode instead of a GET request to one)