### PR TITLE
Reduce the number of process zombies on daemon shutdown

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -145,6 +145,6 @@ func (s *BlockService) DeleteBlock(k key.Key) error {
 }
 
 func (s *BlockService) Close() error {
-	log.Debug("blockservice is shutting down...")
+	defer log.Debug("blockservice is shutting down...")
 	return s.Exchange.Close()
 }

--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -92,6 +92,10 @@ func Bootstrap(n *IpfsNode, cfg BootstrapConfig) (io.Closer, error) {
 	// kick off the node's periodic bootstrapping
 	proc := periodicproc.Tick(cfg.Period, periodic)
 	proc.Go(periodic) // run one right now.
+	go func() {
+		<-proc.Closing()
+		log.Info("bootstrapper is shutting down...")
+	}()
 
 	// kick off Routing.Bootstrap
 	if n.Routing != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -343,7 +343,7 @@ func (n *IpfsNode) teardown() error {
 	}
 
 	if dht, ok := n.Routing.(*dht.IpfsDHT); ok {
-		closers = append(closers, dht.Process())
+		closers = append(closers, dht)
 	}
 
 	if n.Blocks != nil {

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -377,6 +377,7 @@ func (bs *Bitswap) ReceiveError(err error) {
 }
 
 func (bs *Bitswap) Close() error {
+	defer log.Info("bitswap is shutting down...")
 	return bs.process.Close()
 }
 

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -205,6 +205,7 @@ func (pm *WantManager) Disconnected(p peer.ID) {
 
 // TODO: use goprocess here once i trust it
 func (pm *WantManager) Run() {
+	defer log.Infof("bitswap wantmanager shutting down...")
 	tock := time.NewTicker(rebroadcastDelay.Get())
 	defer tock.Stop()
 	for {

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -45,7 +45,7 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 
 func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
 	idmap := logging.LoggableMap{"ID": id}
-	defer log.Info("bitswap task worker shutting down...")
+	defer log.Infof("bitswap task worker %d shutting down...", id)
 	for {
 		log.Event(ctx, "Bitswap.TaskWorker.Loop", idmap)
 		select {
@@ -118,6 +118,7 @@ func (bs *Bitswap) provideWorker(px process.Process) {
 }
 
 func (bs *Bitswap) provideCollector(ctx context.Context) {
+	defer log.Info("bitswap provide collector shutting down...")
 	defer close(bs.provideKeys)
 	var toProvide []key.Key
 	var nextKey key.Key
@@ -181,6 +182,7 @@ func (bs *Bitswap) providerConnector(parent context.Context) {
 }
 
 func (bs *Bitswap) rebroadcastWorker(parent context.Context) {
+	defer log.Info("bitswap rebroadcast worker shutting down...")
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -246,6 +246,7 @@ func (h *BasicHost) Addrs() []ma.Multiaddr {
 
 // Close shuts down the Host's services (network, etc).
 func (h *BasicHost) Close() error {
+	defer log.Info("host is shutting down...")
 	return h.proc.Close()
 }
 

--- a/p2p/host/basic/natmgr.go
+++ b/p2p/host/basic/natmgr.go
@@ -52,6 +52,7 @@ func newNatManager(host *BasicHost) *natManager {
 // Close closes the natManager, closing the underlying nat
 // and unregistering from network events.
 func (nmgr *natManager) Close() error {
+	defer log.Info("natManager is shutting down...")
 	return nmgr.proc.Close()
 }
 

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -116,6 +116,7 @@ func (rh *RoutedHost) NewStream(pid protocol.ID, p peer.ID) (inet.Stream, error)
 }
 func (rh *RoutedHost) Close() error {
 	// no need to close IpfsRouting. we dont own it.
+	defer log.Info("routed host is shutting down...")
 	return rh.host.Close()
 }
 

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -124,6 +124,7 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 }
 
 func (s *Swarm) teardown() error {
+	defer log.Info("swarm is shutting down...")
 	return s.swarm.Close()
 }
 

--- a/routing/dht/dht.go
+++ b/routing/dht/dht.go
@@ -331,5 +331,6 @@ func (dht *IpfsDHT) Process() goprocess.Process {
 
 // Close calls Process Close
 func (dht *IpfsDHT) Close() error {
+	defer log.Info("dht routing is shutting down...")
 	return dht.proc.Close()
 }


### PR DESCRIPTION
And add log for the shutdown of each processes.

There is an issue with the stall of the graceful shutdown.
To reproduce the issue:
- run daemon (with no internet connection) for at least 5 min
- notice it takes 2 C-c's to shutdown

This PR hasn't fully resolved the issue yet, but I have narrowed down the remaining problem to `n.Routing` or `n.PeerHost`.

It would be too long (at least 5min) to put a test on this on travis-ci/circleci.