### PR TITLE
fix #1083: Append a newline to `ipfs id` output.

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -75,7 +75,7 @@ The resolver will give:
 			if !ok {
 				return nil, util.ErrCast()
 			}
-			return strings.NewReader(output.Path.String()), nil
+			return strings.NewReader(output.Path.String() + "\n"), nil
 		},
 	},
 	Type: ResolvedPath{},

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -133,6 +133,7 @@ ipfs id supports the format option for output with the following keys:
 				if err != nil {
 					return nil, err
 				}
+				marshaled = append(marshaled, byte('\n'))
 				return bytes.NewReader(marshaled), nil
 			}
 		},


### PR DESCRIPTION
    The JSON package developers reckon no trailing newline is a feature;
    it allows marshalled JSON to be embedded inside more JSON.[0]

    --
    [0] https://golang.org/pkg/encoding/json/

License: MIT
Signed-off-by: Thomas Gardner <tmg@fastmail.com>