### PR TITLE
Restrict ipfs object patch in ro api

### DIFF
--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -27,7 +27,7 @@ result. This is the merkle-dag version of modifying an object.
 	Arguments: []cmds.Argument{},
 	Subcommands: map[string]*cmds.Command{
 		"append-data": patchAppendDataCmd,
-		"add-link":    patchAddLinkCmd,
+		"add-link":    PatchAddLinkCmd,
 		"rm-link":     patchRmLinkCmd,
 		"set-data":    patchSetDataCmd,
 	},
@@ -229,7 +229,7 @@ removes a link by the given name from root.
 	},
 }
 
-var patchAddLinkCmd = &cmds.Command{
+var PatchAddLinkCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Add a link to a given object.",
 		ShortDescription: `

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -153,7 +153,11 @@ var rootROSubcommands = map[string]*cmds.Command{
 			"links": ocmd.ObjectLinksCmd,
 			"get":   ocmd.ObjectGetCmd,
 			"stat":  ocmd.ObjectStatCmd,
-			"patch": ocmd.ObjectPatchCmd,
+			"patch": &cmds.Command{
+				Subcommands: map[string]*cmds.Command{
+					"add-link": ocmd.PatchAddLinkCmd,
+				},
+			},
 		},
 	},
 	"refs": RefsROCmd,

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -126,7 +126,7 @@ test_expect_success "refs IPFS directory file through readonly API succeeds" '
 '
 
 test_expect_success "test gateway api is sanitized" '
-for cmd in "add" "block/put" "bootstrap" "config" "dht" "diag" "dns" "get" "id" "mount" "name/publish" "object/put" "object/new" "object/patch" "pin" "ping" "refs/local" "repo" "resolve" "stats" "swarm" "tour" "file" "update" "version" "bitswap"; do
+for cmd in "add" "block/put" "bootstrap" "config" "dht" "diag" "dns" "get" "id" "mount" "name/publish" "object/put" "object/new" "object/patch/append-data" "object/patch/rm-link" "object/patch/set-data" "pin" "ping" "refs/local" "repo" "resolve" "stats" "swarm" "tour" "file" "update" "version" "bitswap"; do
     test_curl_resp_http_code "http://127.0.0.1:$port/api/v0/$cmd" "HTTP/1.1 404 Not Found"
   done
 '


### PR DESCRIPTION
`add-link` is local node-specific operation, so it is relatively safer. But I think it should have been removed.

- [ ] remove add-link?