### PR TITLE
add more events for debugging

### DIFF
--- a/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/all_test.go
+++ b/Godeps/_workspace/src/github.com/matttproud/golang_protobuf_extensions/pbutil/all_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/matttproud/golang_protobuf_extensions/pbtest"
-
 	. "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/golang/protobuf/proto"
 	. "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/golang/protobuf/proto/testdata"
+	"gx/ipfs/QmUsh7scAkKe2erRhfGJpvxokArYL46ye2EJvFEp6XSbLr/golang_protobuf_extensions/pbtest"
 )
 
 func TestWriteDelimited(t *testing.T) {

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -86,6 +86,7 @@ func (bs *blockstore) Get(k key.Key) (*blocks.Block, error) {
 		return nil, ValueTypeMismatch
 	}
 
+	log.Event(context.TODO(), "blockstore.Get", &k)
 	return blocks.NewBlockWithHash(bdata, mh.Multihash(k))
 }
 

--- a/blocks/key/key.go
+++ b/blocks/key/key.go
@@ -67,6 +67,14 @@ func (k *Key) Loggable() map[string]interface{} {
 	}
 }
 
+type KeyList []Key
+
+func (kl *KeyList) Loggable() map[string]interface{} {
+	return map[string]interface{}{
+		"keys": *kl,
+	}
+}
+
 // KeyFromDsKey returns a Datastore key
 func KeyFromDsKey(dsk ds.Key) Key {
 	return Key(dsk.String()[1:])

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -28,7 +28,7 @@ var CatCmd = &cmds.Command{
 	PreRun: func(req cmds.Request) error {
 		verbose, _, _ := req.Option("verbose").Bool()
 		if verbose {
-			return PrintDebugLog(req)
+			return PrintDebugLog(req, req.Arguments()[0])
 		}
 		return nil
 	},

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -22,6 +22,16 @@ var CatCmd = &cmds.Command{
 	Arguments: []cmds.Argument{
 		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to be outputted.").EnableStdin(),
 	},
+	Options: []cmds.Option{
+		cmds.BoolOption("v", "verbose", "print verbose debugging information"),
+	},
+	PreRun: func(req cmds.Request) error {
+		verbose, _, _ := req.Option("verbose").Bool()
+		if verbose {
+			return PrintDebugLog(req)
+		}
+		return nil
+	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()
 		if err != nil {

--- a/core/commands/debug.go
+++ b/core/commands/debug.go
@@ -113,7 +113,7 @@ func PrintDebugLog(req cmds.Request) error {
 				}
 			case "path.ResolveLinks":
 				if interested[e["key"].(string)] {
-					nkey := e["nextKey"].(string)
+					nkey := e["linkkey"].(string)
 					interested[nkey] = true
 					write(" * resolve elem %q = %s", e["linkname"], nkey)
 				}

--- a/core/commands/debug.go
+++ b/core/commands/debug.go
@@ -11,9 +11,9 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 
-	"golang.org/x/net/context"
-	ma "gx/ipfs/QmR3JkmZBKYXgNMNsNZawm914455Qof3PEopwuVSeXG7aV/go-multiaddr"
-	manet "gx/ipfs/QmYtzQmUwPFGxjCXctJ8e6GXS8sYfoXy2pdeMbS5SFWqRi/go-multiaddr-net"
+	manet "gx/ipfs/QmYVqhVfbK4BKvbW88Lhm26b3ud14sTBvcm1H7uWUx1Fkp/go-multiaddr-net"
+	"gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
+	ma "gx/ipfs/QmcobAGsCjYt5DXoq9et9L8yR8er7o7Cu3DTvpaq12jYSz/go-multiaddr"
 )
 
 func GetEventStream(req cmds.Request) (<-chan map[string]interface{}, error) {

--- a/core/commands/debug.go
+++ b/core/commands/debug.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	path "github.com/ipfs/go-ipfs/path"
+	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
+
+	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
+)
+
+func GetEventStream(req cmds.Request) (<-chan map[string]interface{}, error) {
+	addr, err := fsrepo.APIAddr(req.InvocContext().ConfigRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	maddr, err := ma.NewMultiaddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	_, host, err := manet.DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Get("http://" + host + "/api/v0/log/tail?stream-channels=true")
+	if err != nil {
+		return nil, err
+	}
+
+	events := make(chan map[string]interface{})
+	go func() {
+		defer resp.Body.Close()
+
+		dec := json.NewDecoder(resp.Body)
+		for {
+			var obj map[string]interface{}
+			err := dec.Decode(&obj)
+			if err != nil {
+				if err != io.EOF {
+					log.Error("end of event stream error: ", err)
+				}
+				return
+			}
+
+			select {
+			case events <- obj:
+			case <-req.Context().Done():
+				return
+			}
+		}
+	}()
+
+	return events, nil
+}
+
+func PrintDebugLog(req cmds.Request) error {
+	events, err := GetEventStream(req)
+	if err != nil {
+		return err
+	}
+
+	write := func(f string, args ...interface{}) {
+		fmt.Fprintf(os.Stderr, f+"\n", args...)
+	}
+
+	p, err := path.ParsePath(req.Arguments()[0])
+	if err != nil {
+		return err
+	}
+
+	target := p.Segments()[1]
+
+	go func() {
+		interested := map[string]bool{
+			target: true,
+		}
+
+		for e := range events {
+			switch e["event"] {
+			case "blockstore.Get":
+				if interested[e["key"].(string)] {
+					write(" * got block locally: %s", e["key"])
+				}
+			case "findProviders":
+				if interested[e["key"].(string)] {
+					write(" * searching for providers for %s", e["key"])
+				}
+			case "receivedBlock":
+				if interested[e["key"].(string)] {
+					write(" * got %s from %s", e["key"], e["peerID"])
+				}
+			case "gotProvider":
+				if interested[e["key"].(string)] {
+					write(" * got provider %s for %s", e["peerID"], e["key"])
+				}
+			case "getDAG":
+				if interested[e["key"].(string)] {
+					keys, ok := e["keys"].([]interface{})
+					if ok {
+						for _, k := range keys {
+							interested[k.(string)] = true
+						}
+					}
+				}
+			case "path.ResolveLinks":
+				if interested[e["key"].(string)] {
+					nkey := e["nextKey"].(string)
+					interested[nkey] = true
+					write(" * resolve elem %q = %s", e["linkname"], nkey)
+				}
+			default:
+				write("UNRECOGNIZED: %s", e["event"])
+			}
+		}
+	}()
+
+	return nil
+}

--- a/core/commands/debug.go
+++ b/core/commands/debug.go
@@ -83,6 +83,7 @@ func PrintDebugLog(req cmds.Request) error {
 		interested := map[string]bool{
 			target: true,
 		}
+		provs := make(map[string]bool)
 
 		for e := range events {
 			switch e["event"] {
@@ -101,6 +102,7 @@ func PrintDebugLog(req cmds.Request) error {
 			case "gotProvider":
 				if interested[e["key"].(string)] {
 					write(" * got provider %s for %s", e["peerID"], e["key"])
+					provs[e["peerID"].(string)] = true
 				}
 			case "getDAG":
 				if interested[e["key"].(string)] {
@@ -111,12 +113,20 @@ func PrintDebugLog(req cmds.Request) error {
 						}
 					}
 				}
+
 			case "path.ResolveLinks":
 				if interested[e["key"].(string)] {
 					nkey := e["linkkey"].(string)
 					interested[nkey] = true
 					write(" * resolve elem %q = %s", e["linkname"], nkey)
 				}
+
+			case "swarmDialDoSetup":
+				p := e["remotePeer"].(string)
+				if provs[p] {
+					write(" * connected to provider %s on %s", p, e["remoteAddr"])
+				}
+
 			default:
 				write("UNRECOGNIZED: %s", e["event"])
 			}

--- a/core/commands/debug.go
+++ b/core/commands/debug.go
@@ -11,8 +11,8 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 
-	ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
-	manet "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
+	ma "gx/ipfs/QmR3JkmZBKYXgNMNsNZawm914455Qof3PEopwuVSeXG7aV/go-multiaddr"
+	manet "gx/ipfs/QmYtzQmUwPFGxjCXctJ8e6GXS8sYfoXy2pdeMbS5SFWqRi/go-multiaddr-net"
 )
 
 func GetEventStream(req cmds.Request) (<-chan map[string]interface{}, error) {
@@ -113,22 +113,21 @@ func PrintDebugLog(req cmds.Request) error {
 						}
 					}
 				}
-
 			case "path.ResolveLinks":
 				if interested[e["key"].(string)] {
 					nkey := e["linkkey"].(string)
 					interested[nkey] = true
 					write(" * resolve elem %q = %s", e["linkname"], nkey)
 				}
-
 			case "swarmDialDoSetup":
 				p := e["remotePeer"].(string)
 				if provs[p] {
-					write(" * connected to provider %s on %s", p, e["remoteAddr"])
-				}
+					addr := e["remoteAddr"].(map[string]interface{})
+					ip := addr["IP"]
+					port := int(addr["Port"].(float64))
 
-			default:
-				write("UNRECOGNIZED: %s", e["event"])
+					write(" * connected to provider %s on %s:%s", p, ip, port)
+				}
 			}
 		}
 	}()

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -44,10 +44,20 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		cmds.BoolOption("archive", "a", "Output a TAR archive. Default: false."),
 		cmds.BoolOption("compress", "C", "Compress the output with GZIP compression. Default: false."),
 		cmds.IntOption("compression-level", "l", "The level of compression (1-9). Default: -1."),
+		cmds.BoolOption("verbose", "v", "enable verbose debug output"),
 	},
 	PreRun: func(req cmds.Request) error {
 		_, err := getCompressOptions(req)
-		return err
+		if err != nil {
+			return err
+		}
+
+		verbose, _, _ := req.Option("verbose").Bool()
+		if verbose {
+			return PrintDebugLog(req, req.Arguments()[0])
+		}
+
+		return nil
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		cmplvl, err := getCompressOptions(req)

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -86,6 +86,7 @@ var logTailCmd = &cmds.Command{
 			<-ctx.Done()
 		}()
 		logging.WriterGroup.AddWriter(w)
+		log.Event(ctx, "log API client connected")
 		res.SetOutput(r)
 	},
 }

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -325,7 +325,9 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			log.Infof("received un-asked-for %s from %s", block, p)
 			continue
 		}
-		keys = append(keys, block.Key())
+		k := block.Key()
+		keys = append(keys, k)
+		log.Event(ctx, "receivedBlock", &k, &p)
 	}
 	bs.wm.CancelWants(keys)
 

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -247,6 +247,9 @@ func (bs *Bitswap) HasBlock(blk *blocks.Block) error {
 	default:
 	}
 
+	k := blk.Key()
+	log.Event(context.TODO(), "HasBlock", &k)
+
 	err := bs.tryPutBlock(blk, 4) // attempt to store block up to four times
 	if err != nil {
 		log.Errorf("Error writing block to datastore: %s", err)

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -123,7 +123,7 @@ func (bsnet *impl) FindProvidersAsync(ctx context.Context, k key.Key, max int) <
 		defer close(out)
 		providers := bsnet.routing.FindProvidersAsync(ctx, k, max)
 		for info := range providers {
-			log.Event(ctx, "gotProvider", &k, &info)
+			log.Event(ctx, "gotProvider", &k, &info.ID)
 			if info.ID == bsnet.host.ID() {
 				continue // ignore self as provider
 			}

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -123,6 +123,7 @@ func (bsnet *impl) FindProvidersAsync(ctx context.Context, k key.Key, max int) <
 		defer close(out)
 		providers := bsnet.routing.FindProvidersAsync(ctx, k, max)
 		for info := range providers {
+			log.Event(ctx, "gotProvider", &k, &info)
 			if info.ID == bsnet.host.ID() {
 				continue // ignore self as provider
 			}

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -158,11 +158,13 @@ func (ds *dagService) GetMany(ctx context.Context, keys []key.Key) <-chan *NodeO
 // It returns a channel of nodes, which the caller can receive
 // all the child nodes of 'root' on, in proper order.
 func GetDAG(ctx context.Context, ds DAGService, root *Node) []NodeGetter {
-	var keys []key.Key
+	var keys key.KeyList
 	for _, lnk := range root.Links {
 		keys = append(keys, key.Key(lnk.Hash))
 	}
 
+	rootk, _ := root.Key()
+	log.Event(ctx, "getDAG", &rootk, &keys)
 	return GetNodes(ctx, ds, keys)
 }
 

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -78,6 +78,13 @@ func (l *Link) GetNode(ctx context.Context, serv DAGService) (*Node, error) {
 	return serv.Get(ctx, key.Key(l.Hash))
 }
 
+func (l *Link) Loggable() map[string]interface{} {
+	return map[string]interface{}{
+		"linkname": l.Name,
+		"linkkey":  l.Hash.B58String(),
+	}
+}
+
 // AddNodeLink adds a link to another node.
 func (n *Node) AddNodeLink(name string, that *Node) error {
 	n.encoded = nil

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -127,16 +127,10 @@ func (s *Resolver) ResolveLinks(ctx context.Context, ndd *merkledag.Node, names 
 		// for each of the links in nd, the current object
 		for _, link := range nd.Links {
 			if link.Name == name {
-				this := key.Key(link.Hash)
-				log.Event(ctx, "path.ResolveLinks", &prev, logging.LoggableF(func() map[string]interface{} {
-					return map[string]interface{}{
-						"linkname": name,
-						"nextKey":  this.B58String(),
-					}
-				}))
+				log.Event(ctx, "path.ResolveLinks", &prev, link)
 
 				prev = next
-				next = this
+				next = key.Key(link.Hash)
 				nlink = link
 				break
 			}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -79,8 +79,13 @@ var (
 type FSRepo struct {
 	// has Close been called already
 	closed bool
+
 	// path is the file-system path
 	path string
+
+	// api address cached here
+	apiaddr string
+
 	// lockfile is the file system lock to prevent others from opening
 	// the same fsrepo path concurrently
 	lockfile io.Closer
@@ -308,6 +313,14 @@ func (r *FSRepo) SetAPIAddr(addr string) error {
 
 	_, err = f.WriteString(addr)
 	return err
+}
+
+func (r *FSRepo) GetAPIAddr() (string, error) {
+	if r.apiaddr == "" {
+		return "", errors.New("api address not set")
+	}
+
+	return r.apiaddr, nil
 }
 
 // openConfig returns an error if the config file is not present.

--- a/repo/mock.go
+++ b/repo/mock.go
@@ -38,3 +38,4 @@ func (m *Mock) GetStorageUsage() (uint64, error) { return 0, nil }
 func (m *Mock) Close() error { return errTODO }
 
 func (m *Mock) SetAPIAddr(addr string) error { return errTODO }
+func (m *Mock) GetAPIAddr() (string, error)  { return "", errTODO }

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -25,6 +25,8 @@ type Repo interface {
 	// SetAPIAddr sets the API address in the repo.
 	SetAPIAddr(addr string) error
 
+	GetAPIAddr() (string, error)
+
 	io.Closer
 }
 

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -317,7 +317,6 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key key.Key, 
 		// Add unique providers from request, up to 'count'
 		for _, prov := range provs {
 			if ps.TryAdd(prov.ID) {
-				log.Event(ctx, "gotProvider", &key, &prov.ID)
 				select {
 				case peerOut <- prov:
 				case <-ctx.Done():

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -395,7 +395,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (peer.PeerInfo, er
 		// see it we got the peer here
 		for _, npi := range clpeerInfos {
 			if npi.ID == id {
-				log.Event(ctx, "findPeerSuccess", &npi)
+				log.Event(ctx, "findPeerSuccess", &npi.ID)
 				return &dhtQueryResult{
 					peer:    npi,
 					success: true,

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -316,9 +316,8 @@ func (dht *IpfsDHT) findProvidersAsyncRoutine(ctx context.Context, key key.Key, 
 
 		// Add unique providers from request, up to 'count'
 		for _, prov := range provs {
-			log.Debugf("got provider: %s", prov)
 			if ps.TryAdd(prov.ID) {
-				log.Debugf("using provider: %s", prov)
+				log.Event(ctx, "gotProvider", &key, &prov.ID)
 				select {
 				case peerOut <- prov:
 				case <-ctx.Done():
@@ -397,6 +396,7 @@ func (dht *IpfsDHT) FindPeer(ctx context.Context, id peer.ID) (peer.PeerInfo, er
 		// see it we got the peer here
 		for _, npi := range clpeerInfos {
 			if npi.ID == id {
+				log.Event(ctx, "findPeerSuccess", &npi)
 				return &dhtQueryResult{
 					peer:    npi,
 					success: true,


### PR DESCRIPTION
This is going to be adding a few different events that i'm using for an `ipfs-dbg` program. The idea is that we will be able to run:

```
$ ipfs-dbg cat QmNyHtPXDY5q8ALSYFh3pPxGwd8eYS2yW2p34KV4VUKFTQ
* Starting request (bitswap)
* Finding providers for QmNyHtPXDY5q8ALSYFh3pPxGwd8eYS2yW2p34KV4VUKFTQ
  * provider: QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
* looking up addresses for QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
  * provider: QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
* looking up addresses for QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
* found address /ip4/104.131.131.82/tcp/4001 for QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
* dialing QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
* dial QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ success!
* requesting block from QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
* got block!
```

(output made up, final results will differ)

License: MIT
Signed-off-by: Jeromy jeromyj@gmail.com
