### PR TITLE
allow promises to fail

### DIFF
--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -176,9 +176,8 @@ func GetNodes(ctx context.Context, ds DAGService, keys []key.Key) []NodeGetter {
 	}
 
 	promises := make([]NodeGetter, len(keys))
-	sendChans := make([]chan<- *Node, len(keys))
 	for i := range keys {
-		promises[i], sendChans[i] = newNodePromise(ctx)
+		promises[i] = newNodePromise(ctx)
 	}
 
 	dedupedKeys := dedupeKeys(keys)
@@ -199,7 +198,9 @@ func GetNodes(ctx context.Context, ds DAGService, keys []key.Key) []NodeGetter {
 				}
 
 				if opt.Err != nil {
-					log.Error("error fetching: ", opt.Err)
+					for _, p := range promises {
+						p.Fail(opt.Err)
+					}
 					return
 				}
 
@@ -214,7 +215,7 @@ func GetNodes(ctx context.Context, ds DAGService, keys []key.Key) []NodeGetter {
 				is := FindLinks(keys, k, 0)
 				for _, i := range is {
 					count++
-					sendChans[i] <- nd
+					promises[i].Send(nd)
 				}
 			case <-ctx.Done():
 				return
@@ -237,18 +238,18 @@ func dedupeKeys(ks []key.Key) []key.Key {
 	return out
 }
 
-func newNodePromise(ctx context.Context) (NodeGetter, chan<- *Node) {
-	ch := make(chan *Node, 1)
+func newNodePromise(ctx context.Context) NodeGetter {
 	return &nodePromise{
-		recv: ch,
+		recv: make(chan *Node, 1),
 		ctx:  ctx,
 		err:  make(chan error, 1),
-	}, ch
+	}
 }
 
 type nodePromise struct {
 	cache *Node
-	recv  <-chan *Node
+	clk   sync.Mutex
+	recv  chan *Node
 	ctx   context.Context
 	err   chan error
 }
@@ -260,20 +261,49 @@ type nodePromise struct {
 type NodeGetter interface {
 	Get(context.Context) (*Node, error)
 	Fail(err error)
+	Send(*Node)
 }
 
 func (np *nodePromise) Fail(err error) {
+	np.clk.Lock()
+	v := np.cache
+	np.clk.Unlock()
+
+	// if promise has a value, don't fail it
+	if v != nil {
+		return
+	}
+
 	np.err <- err
 }
 
-func (np *nodePromise) Get(ctx context.Context) (*Node, error) {
+func (np *nodePromise) Send(nd *Node) {
+	var already bool
+	np.clk.Lock()
 	if np.cache != nil {
-		return np.cache, nil
+		already = true
+	}
+	np.cache = nd
+	np.clk.Unlock()
+
+	if already {
+		panic("sending twice to the same promise is an error!")
+	}
+
+	np.recv <- nd
+}
+
+func (np *nodePromise) Get(ctx context.Context) (*Node, error) {
+	np.clk.Lock()
+	c := np.cache
+	np.clk.Unlock()
+	if c != nil {
+		return c, nil
 	}
 
 	select {
-	case blk := <-np.recv:
-		np.cache = blk
+	case nd := <-np.recv:
+		return nd, nil
 	case <-np.ctx.Done():
 		return nil, np.ctx.Err()
 	case <-ctx.Done():
@@ -281,7 +311,6 @@ func (np *nodePromise) Get(ctx context.Context) (*Node, error) {
 	case err := <-np.err:
 		return nil, err
 	}
-	return np.cache, nil
 }
 
 type Batch struct {

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -113,8 +113,29 @@ test_get_cmd() {
 	'
 }
 
+test_get_fail() {
+	test_expect_success "create an object that has unresolveable links" '
+		cat <<-\EOF >bad_object &&
+{ "Links": [ { "Name": "foo", "Hash": "QmZzaC6ydNXiR65W8VjGA73ET9MZ6VFAqUT1ngYMXcpihn", "Size": 1897 }, { "Name": "bar", "Hash": "Qmd4mG6pDFDmDTn6p3hX1srP8qTbkyXKj5yjpEsiHDX3u8", "Size": 56 }, { "Name": "baz", "Hash": "QmUTjwRnG28dSrFFVTYgbr6LiDLsBmRr2SaUSTGheK2YqG", "Size": 24266 } ], "Data": "\b\u0001" }
+		EOF
+		cat bad_object | ipfs object put > put_out
+	'
+
+	test_expect_success "output looks good" '
+		echo "added QmaGidyrnX8FMbWJoxp8HVwZ1uRKwCyxBJzABnR1S2FVUr" > put_exp &&
+		test_cmp put_exp put_out
+	'
+
+	test_expect_success "ipfs get fails" '
+		test_expect_code 1 ipfs get QmaGidyrnX8FMbWJoxp8HVwZ1uRKwCyxBJzABnR1S2FVUr 
+	'
+}
+
 # should work offline
 test_get_cmd
+
+# only really works offline, will try and search network when online
+test_get_fail
 
 # should work online
 test_launch_ipfs_daemon


### PR DESCRIPTION
This allows the nodepromise thing to fail. In cases such as `ipfs refs -r` run offline when not all blocks are local, ipfs currently hangs. 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>