### PR TITLE
Adds offline key resolution on ipns mount.

### DIFF
--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -87,8 +87,26 @@ func loadRoot(ctx context.Context, rt *keyRoot, ipfs *core.IpfsNode, name string
 
 	node, err := core.Resolve(ctx, ipfs, p)
 	if err != nil {
-		log.Errorf("looking up %s: %s", p, err)
-		return nil, err
+		log.Debugf("failed to look up %s: %s", p, err)
+
+		// Attempt to perform an offline resolve of the path, since the node's key
+		// may not yet exist in in the network.
+		log.Debugf("trying offline lookup")
+		offlineNode, err := core.NewNode(ctx, &core.BuildCfg{
+			Online: false,
+			Repo:   ipfs.Repo,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := offlineNode.SetupOfflineRouting(); err != nil {
+			return nil, err
+		}
+		node, err = core.Resolve(ctx, offlineNode, p)
+		if err != nil {
+			log.Errorf("failed to look up %s: %s", p, err)
+			return nil, err
+		}
 	}
 
 	root, err := mfs.NewRoot(ctx, ipfs.DAG, node, ipnsPubFunc(ipfs, rt.k))


### PR DESCRIPTION
Uses the local repo when an online public key resolution fails on mount.
This is particularly useful in tests or other young nodes where its
public key may not yet exist on the network.

License: MIT
Signed-off-by: Stephen Whitmore <noffle@ipfs.io>