### PR TITLE
Use 'dag' forall namespace import prefixes of merkledag

### DIFF
--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -8,7 +8,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
@@ -61,7 +61,7 @@ it contains, with the following format:
 
 		paths := req.Arguments()
 
-		var dagnodes []*merkledag.Node
+		var dagnodes []*dag.Node
 		for _, fpath := range paths {
 			dagnode, err := core.Resolve(req.Context(), node, path.Path(fpath))
 			if err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -50,7 +50,7 @@ import (
 	mfs "github.com/ipfs/go-ipfs/mfs"
 
 	mount "github.com/ipfs/go-ipfs/fuse/mount"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	ipnsrp "github.com/ipfs/go-ipfs/namesys/republisher"
 	path "github.com/ipfs/go-ipfs/path"
@@ -91,11 +91,11 @@ type IpfsNode struct {
 	PrivateKey ic.PrivKey // the local node's private Key
 
 	// Services
-	Peerstore  peer.Peerstore       // storage for other Peer instances
-	Blockstore bstore.GCBlockstore  // the block store (lower level)
-	Blocks     *bserv.BlockService  // the block service, get/add blocks.
-	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
-	Resolver   *path.Resolver       // the path resolution system
+	Peerstore  peer.Peerstore      // storage for other Peer instances
+	Blockstore bstore.GCBlockstore // the block store (lower level)
+	Blocks     *bserv.BlockService // the block service, get/add blocks.
+	DAG        dag.DAGService      // the merkle dag service, get/add objects.
+	Resolver   *path.Resolver      // the path resolution system
 	Reporter   metrics.Reporter
 	Discovery  discovery.Service
 	FilesRoot  *mfs.Root
@@ -477,7 +477,7 @@ func (n *IpfsNode) loadFilesRoot() error {
 		return n.Repo.Datastore().Put(dsk, []byte(k))
 	}
 
-	var nd *merkledag.Node
+	var nd *dag.Node
 	val, err := n.Repo.Datastore().Get(dsk)
 
 	switch {

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -20,12 +20,12 @@ import (
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/core"
-	"github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 )
 
 func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]key.Key, error) {
-	dagnodes := make([]*merkledag.Node, 0)
+	dagnodes := make([]*dag.Node, 0)
 	for _, fpath := range paths {
 		dagnode, err := core.Resolve(ctx, n, path.Path(fpath))
 		if err != nil {

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -16,17 +16,17 @@ import (
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	importer "github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-func getDagserv(t *testing.T) merkledag.DAGService {
+func getDagserv(t *testing.T) dag.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))
-	return merkledag.NewDAGService(blockserv)
+	return dag.NewDAGService(blockserv)
 }
 
 func TestMetadata(t *testing.T) {

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -7,7 +7,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 )
 
@@ -20,7 +20,7 @@ var ErrNoNamesys = errors.New(
 // entries (e.g. /ipns/<node-key>) and then going through the /ipfs/
 // entries and returning the final merkledag node.  Effectively
 // enables /ipns/, /dns/, etc. in commands.
-func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*merkledag.Node, error) {
+func Resolve(ctx context.Context, n *IpfsNode, p path.Path) (*dag.Node, error) {
 	if strings.HasPrefix(p.String(), "/ipns/") {
 		// resolve ipns paths
 

--- a/fuse/ipns/common.go
+++ b/fuse/ipns/common.go
@@ -4,7 +4,7 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	"github.com/ipfs/go-ipfs/core"
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	nsys "github.com/ipfs/go-ipfs/namesys"
 	ci "github.com/ipfs/go-ipfs/p2p/crypto"
 	path "github.com/ipfs/go-ipfs/path"
@@ -14,7 +14,7 @@ import (
 // InitializeKeyspace sets the ipns record for the given key to
 // point to an empty directory.
 func InitializeKeyspace(n *core.IpfsNode, key ci.PrivKey) error {
-	emptyDir := &mdag.Node{Data: ft.FolderPBData()}
+	emptyDir := &dag.Node{Data: ft.FolderPBData()}
 	nodek, err := n.DAG.Add(emptyDir)
 	if err != nil {
 		return err

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -14,7 +14,7 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	core "github.com/ipfs/go-ipfs/core"
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
@@ -77,7 +77,7 @@ func (*Root) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 // Node is the core object representing a filesystem tree node.
 type Node struct {
 	Ipfs   *core.IpfsNode
-	Nd     *mdag.Node
+	Nd     *dag.Node
 	fd     *uio.DagReader
 	cached *ftpb.Data
 }

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	h "github.com/ipfs/go-ipfs/importer/helpers"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 	pin "github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
@@ -20,7 +20,7 @@ import (
 	u "github.com/ipfs/go-ipfs/util"
 )
 
-func buildTestDag(ds merkledag.DAGService, spl chunk.Splitter) (*merkledag.Node, error) {
+func buildTestDag(ds dag.DAGService, spl chunk.Splitter) (*dag.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
@@ -121,7 +121,7 @@ func arrComp(a, b []byte) error {
 }
 
 type dagservAndPinner struct {
-	ds merkledag.DAGService
+	ds dag.DAGService
 	mp pin.Pinner
 }
 
@@ -523,7 +523,7 @@ func TestAppendSingleBytesToEmpty(t *testing.T) {
 
 	data := []byte("AB")
 
-	nd := new(merkledag.Node)
+	nd := new(dag.Node)
 	nd.Data = ft.FilePBData(nil, 0)
 
 	dbp := &h.DagBuilderParams{
@@ -561,7 +561,7 @@ func TestAppendSingleBytesToEmpty(t *testing.T) {
 	}
 }
 
-func printDag(nd *merkledag.Node, ds merkledag.DAGService, indent int) {
+func printDag(nd *dag.Node, ds dag.DAGService, indent int) {
 	pbd, err := ft.FromBytes(nd.Data)
 	if err != nil {
 		panic(err)

--- a/merkledag/traverse/traverse.go
+++ b/merkledag/traverse/traverse.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
 // Order is an identifier for traversal algorithm orders
@@ -20,17 +20,17 @@ const (
 
 // Options specifies a series of traversal options
 type Options struct {
-	DAG     mdag.DAGService // the dagservice to fetch nodes
-	Order   Order           // what order to traverse in
-	Func    Func            // the function to perform at each step
-	ErrFunc ErrFunc         // see ErrFunc. Optional
+	DAG     dag.DAGService // the dagservice to fetch nodes
+	Order   Order          // what order to traverse in
+	Func    Func           // the function to perform at each step
+	ErrFunc ErrFunc        // see ErrFunc. Optional
 
 	SkipDuplicates bool // whether to skip duplicate nodes
 }
 
 // State is a current traversal state
 type State struct {
-	Node  *mdag.Node
+	Node  *dag.Node
 	Depth int
 }
 
@@ -39,7 +39,7 @@ type traversal struct {
 	seen map[string]struct{}
 }
 
-func (t *traversal) shouldSkip(n *mdag.Node) (bool, error) {
+func (t *traversal) shouldSkip(n *dag.Node) (bool, error) {
 	if t.opts.SkipDuplicates {
 		k, err := n.Key()
 		if err != nil {
@@ -63,9 +63,9 @@ func (t *traversal) callFunc(next State) error {
 // stop processing. if it returns a nil node, just skip it.
 //
 // the error handling is a little complicated.
-func (t *traversal) getNode(link *mdag.Link) (*mdag.Node, error) {
+func (t *traversal) getNode(link *dag.Link) (*dag.Node, error) {
 
-	getNode := func(l *mdag.Link) (*mdag.Node, error) {
+	getNode := func(l *dag.Link) (*dag.Node, error) {
 		next, err := l.GetNode(context.TODO(), t.opts.DAG)
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ type Func func(current State) error
 //
 type ErrFunc func(err error) error
 
-func Traverse(root *mdag.Node, o Options) error {
+func Traverse(root *dag.Node, o Options) error {
 	t := traversal{
 		opts: o,
 		seen: map[string]struct{}{},

--- a/merkledag/traverse/traverse_test.go
+++ b/merkledag/traverse/traverse_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
 func TestDFSPreNoSkip(t *testing.T) {
@@ -314,7 +314,7 @@ func TestBFSSkip(t *testing.T) {
 `))
 }
 
-func testWalkOutputs(t *testing.T, root *mdag.Node, opts Options, expect []byte) {
+func testWalkOutputs(t *testing.T, root *dag.Node, opts Options, expect []byte) {
 	expect = bytes.TrimLeft(expect, "\n")
 
 	buf := new(bytes.Buffer)
@@ -341,8 +341,8 @@ func testWalkOutputs(t *testing.T, root *mdag.Node, opts Options, expect []byte)
 	}
 }
 
-func newFan(t *testing.T) *mdag.Node {
-	a := &mdag.Node{Data: []byte("/a")}
+func newFan(t *testing.T) *dag.Node {
+	a := &dag.Node{Data: []byte("/a")}
 	addChild(t, a, "aa")
 	addChild(t, a, "ab")
 	addChild(t, a, "ac")
@@ -350,8 +350,8 @@ func newFan(t *testing.T) *mdag.Node {
 	return a
 }
 
-func newLinkedList(t *testing.T) *mdag.Node {
-	a := &mdag.Node{Data: []byte("/a")}
+func newLinkedList(t *testing.T) *dag.Node {
+	a := &dag.Node{Data: []byte("/a")}
 	aa := addChild(t, a, "aa")
 	aaa := addChild(t, aa, "aaa")
 	aaaa := addChild(t, aaa, "aaaa")
@@ -359,8 +359,8 @@ func newLinkedList(t *testing.T) *mdag.Node {
 	return a
 }
 
-func newBinaryTree(t *testing.T) *mdag.Node {
-	a := &mdag.Node{Data: []byte("/a")}
+func newBinaryTree(t *testing.T) *dag.Node {
+	a := &dag.Node{Data: []byte("/a")}
 	aa := addChild(t, a, "aa")
 	ab := addChild(t, a, "ab")
 	addChild(t, aa, "aaa")
@@ -370,8 +370,8 @@ func newBinaryTree(t *testing.T) *mdag.Node {
 	return a
 }
 
-func newBinaryDAG(t *testing.T) *mdag.Node {
-	a := &mdag.Node{Data: []byte("/a")}
+func newBinaryDAG(t *testing.T) *dag.Node {
+	a := &dag.Node{Data: []byte("/a")}
 	aa := addChild(t, a, "aa")
 	aaa := addChild(t, aa, "aaa")
 	aaaa := addChild(t, aaa, "aaaa")
@@ -383,15 +383,15 @@ func newBinaryDAG(t *testing.T) *mdag.Node {
 	return a
 }
 
-func addLink(t *testing.T, a, b *mdag.Node) {
+func addLink(t *testing.T, a, b *dag.Node) {
 	to := string(a.Data) + "2" + string(b.Data)
 	if err := a.AddNodeLink(to, b); err != nil {
 		t.Error(err)
 	}
 }
 
-func addChild(t *testing.T, a *mdag.Node, name string) *mdag.Node {
-	c := &mdag.Node{Data: []byte(string(a.Data) + "/" + name)}
+func addChild(t *testing.T, a *dag.Node, name string) *dag.Node {
+	c := &dag.Node{Data: []byte(string(a.Data) + "/" + name)}
 	addLink(t, a, c)
 	return c
 }

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	logging "github.com/ipfs/go-ipfs/vendor/QmQg1J6vikuXF9oDvm4wpdeAUvvkVEKW1EYDw9HhTMnP2b/go-log"
 )
 
@@ -33,7 +33,7 @@ func (e ErrNoLink) Error() string {
 // Resolver provides path resolution to IPFS
 // It has a pointer to a DAGService, which is uses to resolve nodes.
 type Resolver struct {
-	DAG merkledag.DAGService
+	DAG dag.DAGService
 }
 
 // SplitAbsPath clean up and split fpath. It extracts the first component (which
@@ -64,7 +64,7 @@ func SplitAbsPath(fpath Path) (mh.Multihash, []string, error) {
 
 // ResolvePath fetches the node for given path. It returns the last item
 // returned by ResolvePathComponents.
-func (s *Resolver) ResolvePath(ctx context.Context, fpath Path) (*merkledag.Node, error) {
+func (s *Resolver) ResolvePath(ctx context.Context, fpath Path) (*dag.Node, error) {
 	// validate path
 	if err := fpath.IsValid(); err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func (s *Resolver) ResolvePath(ctx context.Context, fpath Path) (*merkledag.Node
 // ResolvePathComponents fetches the nodes for each segment of the given path.
 // It uses the first path component as a hash (key) of the first node, then
 // resolves all other components walking the links, with ResolveLinks.
-func (s *Resolver) ResolvePathComponents(ctx context.Context, fpath Path) ([]*merkledag.Node, error) {
+func (s *Resolver) ResolvePathComponents(ctx context.Context, fpath Path) ([]*dag.Node, error) {
 	h, parts, err := SplitAbsPath(fpath)
 	if err != nil {
 		return nil, err
@@ -102,9 +102,9 @@ func (s *Resolver) ResolvePathComponents(ctx context.Context, fpath Path) ([]*me
 //
 // ResolveLinks(nd, []string{"foo", "bar", "baz"})
 // would retrieve "baz" in ("bar" in ("foo" in nd.Links).Links).Links
-func (s *Resolver) ResolveLinks(ctx context.Context, ndd *merkledag.Node, names []string) ([]*merkledag.Node, error) {
+func (s *Resolver) ResolveLinks(ctx context.Context, ndd *dag.Node, names []string) ([]*dag.Node, error) {
 
-	result := make([]*merkledag.Node, 0, len(names)+1)
+	result := make([]*dag.Node, 0, len(names)+1)
 	result = append(result, ndd)
 	nd := ndd // dup arg workaround
 
@@ -112,7 +112,7 @@ func (s *Resolver) ResolveLinks(ctx context.Context, ndd *merkledag.Node, names 
 	for _, name := range names {
 
 		var next key.Key
-		var nlink *merkledag.Link
+		var nlink *dag.Link
 		// for each of the links in nd, the current object
 		for _, link := range nd.Links {
 			if link.Name == name {

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -7,14 +7,14 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagmock "github.com/ipfs/go-ipfs/merkledag/test"
 	path "github.com/ipfs/go-ipfs/path"
 	util "github.com/ipfs/go-ipfs/util"
 )
 
-func randNode() (*merkledag.Node, key.Key) {
-	node := new(merkledag.Node)
+func randNode() (*dag.Node, key.Key) {
+	node := new(dag.Node)
 	node.Data = make([]byte, 32)
 	util.NewTimeSeededRand().Read(node.Data)
 	k, _ := node.Key()

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -12,12 +12,12 @@ import (
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	bs "github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/exchange/offline"
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	"github.com/ipfs/go-ipfs/util"
 )
 
-func randNode() (*mdag.Node, key.Key) {
-	nd := new(mdag.Node)
+func randNode() (*dag.Node, key.Key) {
+	nd := new(dag.Node)
 	nd.Data = make([]byte, 32)
 	util.NewTimeSeededRand().Read(nd.Data)
 	k, _ := nd.Key()
@@ -42,7 +42,7 @@ func TestPinnerBasic(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := dag.NewDAGService(bserv)
 
 	// TODO does pinner need to share datastore with blockservice?
 	p := NewPinner(dstore, dserv)
@@ -147,7 +147,7 @@ func TestDuplicateSemantics(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := dag.NewDAGService(bserv)
 
 	// TODO does pinner need to share datastore with blockservice?
 	p := NewPinner(dstore, dserv)
@@ -182,7 +182,7 @@ func TestFlush(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := dag.NewDAGService(bserv)
 	p := NewPinner(dstore, dserv)
 	_, k := randNode()
 
@@ -198,7 +198,7 @@ func TestPinRecursiveFail(t *testing.T) {
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
-	dserv := mdag.NewDAGService(bserv)
+	dserv := dag.NewDAGService(bserv)
 
 	p := NewPinner(dstore, dserv)
 

--- a/pin/set_test.go
+++ b/pin/set_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/exchange/offline"
-	"github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 )
 
 func ignoreKeys(key.Key) {}
@@ -28,7 +28,7 @@ func TestMultisetRoundtrip(t *testing.T) {
 	dstore := dssync.MutexWrap(datastore.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := blockservice.New(bstore, offline.Exchange(bstore))
-	dag := merkledag.NewDAGService(bserv)
+	dag := dag.NewDAGService(bserv)
 
 	fn := func(m map[key.Key]uint16) bool {
 		// Generate a smaller range for refcounts than full uint64, as
@@ -43,7 +43,7 @@ func TestMultisetRoundtrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("storing multiset: %v", err)
 		}
-		root := &merkledag.Node{}
+		root := &dag.Node{}
 		const linkName = "dummylink"
 		if err := root.AddNodeLink(linkName, n); err != nil {
 			t.Fatalf("adding link to root node: %v", err)

--- a/unixfs/archive/archive.go
+++ b/unixfs/archive/archive.go
@@ -8,7 +8,7 @@ import (
 
 	cxt "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	tar "github.com/ipfs/go-ipfs/unixfs/archive/tar"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 )
@@ -30,7 +30,7 @@ func (i *identityWriteCloser) Close() error {
 }
 
 // DagArchive is equivalent to `ipfs getdag $hash | maybe_tar | maybe_gzip`
-func DagArchive(ctx cxt.Context, nd *mdag.Node, name string, dag mdag.DAGService, archive bool, compression int) (io.Reader, error) {
+func DagArchive(ctx cxt.Context, nd *dag.Node, name string, dag dag.DAGService, archive bool, compression int) (io.Reader, error) {
 
 	_, filename := path.Split(name)
 

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -9,7 +9,7 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	cxt "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	upb "github.com/ipfs/go-ipfs/unixfs/pb"
@@ -19,14 +19,14 @@ import (
 // unixfs merkledag nodes as a tar archive format.
 // It wraps any io.Writer.
 type Writer struct {
-	Dag  mdag.DAGService
+	Dag  dag.DAGService
 	TarW *tar.Writer
 
 	ctx cxt.Context
 }
 
 // NewWriter wraps given io.Writer.
-func NewWriter(ctx cxt.Context, dag mdag.DAGService, archive bool, compression int, w io.Writer) (*Writer, error) {
+func NewWriter(ctx cxt.Context, dag dag.DAGService, archive bool, compression int, w io.Writer) (*Writer, error) {
 	return &Writer{
 		Dag:  dag,
 		TarW: tar.NewWriter(w),
@@ -34,7 +34,7 @@ func NewWriter(ctx cxt.Context, dag mdag.DAGService, archive bool, compression i
 	}, nil
 }
 
-func (w *Writer) writeDir(nd *mdag.Node, fpath string) error {
+func (w *Writer) writeDir(nd *dag.Node, fpath string) error {
 	if err := writeDirHeader(w.TarW, fpath); err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (w *Writer) writeDir(nd *mdag.Node, fpath string) error {
 	return nil
 }
 
-func (w *Writer) writeFile(nd *mdag.Node, pb *upb.Data, fpath string) error {
+func (w *Writer) writeFile(nd *dag.Node, pb *upb.Data, fpath string) error {
 	if err := writeFileHeader(w.TarW, fpath, pb.GetFilesize()); err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (w *Writer) writeFile(nd *mdag.Node, pb *upb.Data, fpath string) error {
 	return nil
 }
 
-func (w *Writer) WriteNode(nd *mdag.Node, fpath string) error {
+func (w *Writer) WriteNode(nd *dag.Node, fpath string) error {
 	pb := new(upb.Data)
 	if err := proto.Unmarshal(nd.Data, pb); err != nil {
 		return err

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -10,7 +10,7 @@ import (
 	proto "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/gogo/protobuf/proto"
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
 )
@@ -21,10 +21,10 @@ var ErrCantReadSymlinks = errors.New("cannot currently read symlinks")
 
 // DagReader provides a way to easily read the data contained in a dag.
 type DagReader struct {
-	serv mdag.DAGService
+	serv dag.DAGService
 
 	// the node being read
-	node *mdag.Node
+	node *dag.Node
 
 	// cached protobuf structure from node.Data
 	pbdata *ftpb.Data
@@ -34,7 +34,7 @@ type DagReader struct {
 	buf ReadSeekCloser
 
 	// NodeGetters for each of 'nodes' child links
-	promises []mdag.NodeGetter
+	promises []dag.NodeGetter
 
 	// the index of the child link currently being read from
 	linkPosition int
@@ -58,7 +58,7 @@ type ReadSeekCloser interface {
 
 // NewDagReader creates a new reader object that reads the data represented by the given
 // node, using the passed in DAGService for data retreival
-func NewDagReader(ctx context.Context, n *mdag.Node, serv mdag.DAGService) (*DagReader, error) {
+func NewDagReader(ctx context.Context, n *dag.Node, serv dag.DAGService) (*DagReader, error) {
 	pb := new(ftpb.Data)
 	if err := proto.Unmarshal(n.Data, pb); err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func NewDagReader(ctx context.Context, n *mdag.Node, serv mdag.DAGService) (*Dag
 	}
 }
 
-func NewDataFileReader(ctx context.Context, n *mdag.Node, pb *ftpb.Data, serv mdag.DAGService) *DagReader {
+func NewDataFileReader(ctx context.Context, n *dag.Node, pb *ftpb.Data, serv dag.DAGService) *DagReader {
 	fctx, cancel := context.WithCancel(ctx)
 	promises := serv.GetDAG(fctx, n)
 	return &DagReader{

--- a/unixfs/io/dirbuilder.go
+++ b/unixfs/io/dirbuilder.go
@@ -4,22 +4,22 @@ import (
 	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	format "github.com/ipfs/go-ipfs/unixfs"
 )
 
 type directoryBuilder struct {
-	dserv   mdag.DAGService
-	dirnode *mdag.Node
+	dserv   dag.DAGService
+	dirnode *dag.Node
 }
 
 // NewEmptyDirectory returns an empty merkledag Node with a folder Data chunk
-func NewEmptyDirectory() *mdag.Node {
-	return &mdag.Node{Data: format.FolderPBData()}
+func NewEmptyDirectory() *dag.Node {
+	return &dag.Node{Data: format.FolderPBData()}
 }
 
 // NewDirectory returns a directoryBuilder. It needs a DAGService to add the Children
-func NewDirectory(dserv mdag.DAGService) *directoryBuilder {
+func NewDirectory(dserv dag.DAGService) *directoryBuilder {
 	db := new(directoryBuilder)
 	db.dserv = dserv
 	db.dirnode = NewEmptyDirectory()
@@ -37,6 +37,6 @@ func (d *directoryBuilder) AddChild(ctx context.Context, name string, k key.Key)
 }
 
 // GetNode returns the root of this directoryBuilder
-func (d *directoryBuilder) GetNode() *mdag.Node {
+func (d *directoryBuilder) GetNode() *dag.Node {
 	return d.dirnode
 }

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ipfs/go-ipfs/importer/chunk"
 	h "github.com/ipfs/go-ipfs/importer/helpers"
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
-	mdag "github.com/ipfs/go-ipfs/merkledag"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	u "github.com/ipfs/go-ipfs/util"
@@ -24,24 +24,24 @@ import (
 	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
-func getMockDagServ(t testing.TB) mdag.DAGService {
+func getMockDagServ(t testing.TB) dag.DAGService {
 	dstore := ds.NewMapDatastore()
 	tsds := sync.MutexWrap(dstore)
 	bstore := blockstore.NewBlockstore(tsds)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
-	return mdag.NewDAGService(bserv)
+	return dag.NewDAGService(bserv)
 }
 
-func getMockDagServAndBstore(t testing.TB) (mdag.DAGService, blockstore.GCBlockstore) {
+func getMockDagServAndBstore(t testing.TB) (dag.DAGService, blockstore.GCBlockstore) {
 	dstore := ds.NewMapDatastore()
 	tsds := sync.MutexWrap(dstore)
 	bstore := blockstore.NewBlockstore(tsds)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
-	dserv := mdag.NewDAGService(bserv)
+	dserv := dag.NewDAGService(bserv)
 	return dserv, bstore
 }
 
-func getNode(t testing.TB, dserv mdag.DAGService, size int64) ([]byte, *mdag.Node) {
+func getNode(t testing.TB, dserv dag.DAGService, size int64) ([]byte, *dag.Node) {
 	in := io.LimitReader(u.NewTimeSeededRand(), size)
 	node, err := imp.BuildTrickleDagFromReader(dserv, sizeSplitterGen(500)(in))
 	if err != nil {
@@ -575,7 +575,7 @@ func arrComp(a, b []byte) error {
 	return nil
 }
 
-func printDag(nd *mdag.Node, ds mdag.DAGService, indent int) {
+func printDag(nd *dag.Node, ds dag.DAGService, indent int) {
 	pbd, err := ft.FromBytes(nd.Data)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Based on #1983.

Might cause merge conflict to the gx-libp2p PR.