### PR TITLE
Removed extra space

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -217,7 +217,7 @@ can't be undone.
 func getConfig(r repo.Repo, key string) (*ConfigField, error) {
 	value, err := r.GetConfigKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get config value: %s", err)
+		return nil, fmt.Errorf("Failed to get config value: %q", err)
 	}
 	return &ConfigField{
 		Key:   key,


### PR DESCRIPTION
This was coming up as an extra space. For instance:

```
$ curl -i http://localhost:5001/api/v0/config?arg=kitten
//"Message": "Failed to get config value:  key has no attributes",
```

Removing it here.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>