### PR TITLE
Added an example to `ipfs id`

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -49,6 +49,10 @@ If no peer is specified, prints out information for local peers.
 <pver>: Protocol version.
 <pubkey>: Public key.
 <addrs>: Addresses (newline delimited).
+
+EXAMPLE:
+
+    ipfs id Qmece2RkXhsKe5CRooNisBTh4SK119KrXXGmoK6V3kb8aH -f="<addrs>\n"
 `,
 	},
 	Arguments: []cmds.Argument{


### PR DESCRIPTION
I was super confused how to use the `-f` flag. This helped, but I had to go into
the test files to find it. Added it here.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>