### PR TITLE
fix go1.6rc2 panic where closenotify was called from wrong goroutine

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -138,9 +138,10 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(node.Context())
 	defer cancel()
 	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone := cn.CloseNotify()
 		go func() {
 			select {
-			case <-cn.CloseNotify():
+			case <-clientGone:
 			case <-ctx.Done():
 			}
 			cancel()


### PR DESCRIPTION
This issue is referenced in the comments of  #2108.  Docker had a similar bug mentioned in golang/go#14001