### PR TITLE
wait for peers in wantmanager to all appear

### DIFF
--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -158,6 +158,19 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 
 	t.Log("Give the blocks to the first instance")
 
+	nump := len(instances) - 1
+	// assert we're properly connected
+	for _, inst := range instances {
+		peers := inst.Exchange.wm.ConnectedPeers()
+		for i := 0; i < 10 && len(peers) != nump; i++ {
+			time.Sleep(time.Millisecond * 50)
+			peers = inst.Exchange.wm.ConnectedPeers()
+		}
+		if len(peers) != nump {
+			t.Fatal("not enough peers connected to instance")
+		}
+	}
+
 	var blkeys []key.Key
 	first := instances[0]
 	for _, b := range blocks {


### PR DESCRIPTION
https://travis-ci.org/ipfs/go-ipfs/jobs/107894026

In some of these bitswap tests, the peers werent making it into the wantmanager by the time `HasBlock` was called, meaning some peers missed the announcements. This slowed down most of the tests when it happened (as it caused them to wait for a rebroadcast), but in the test that was testing no rebroadcasts, it caused a timeout and failure. This should fix the issue.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>