### PR TITLE
fix another panic where CloseNotify was called from wrong goroutine

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -114,9 +114,10 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone := cn.CloseNotify()
 		go func() {
 			select {
-			case <-cn.CloseNotify():
+			case <-clientGone:
 			case <-ctx.Done():
 			}
 			cancel()


### PR DESCRIPTION
Same cause/fix as  #2315:

```
Initializing daemon...
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/128.104.184.236/tcp/4001
Swarm listening on /ip4/172.17.42.1/tcp/4001
Swarm listening on /ip6/2607:f388:1082:fff9:a248:1cff:fe90:c73a/tcp/4001
Swarm listening on /ip6/::1/tcp/4001
API server listening on /ip4/127.0.0.1/tcp/5001
Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080
Daemon is ready
panic: net/http: CloseNotify called after ServeHTTP finished

goroutine 180 [running]:
net/http.(*response).CloseNotify(0xc8220684e0, 0x0)
	/home/r/go/src/net/http/server.go:1535 +0x9d
github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus.(*fancyResponseWriterDelegator).CloseNotify(0xc820028318, 0xc821a0)
	/home/r/src/github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/prometheus/client_golang/prometheus/http.go:219 +0x68
github.com/ipfs/go-ipfs/core/corehttp.(*gatewayHandler).getOrHeadHandler.func1(0x7fc09632df50, 0xc820028318, 0x7fc0963b1f10, 0xc822059140, 0xc82214d190)
	/home/r/src/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go:119 +0x39
created by github.com/ipfs/go-ipfs/core/corehttp.(*gatewayHandler).getOrHeadHandler
	/home/r/src/github.com/ipfs/go-ipfs/core/corehttp/gateway_handler.go:123 +0x216
```