### PR TITLE
Prevents 'ipfs name publish' when /ipns is mounted.

### DIFF
--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -74,6 +74,11 @@ Publish an <ipfs-path> to another public key (not implemented):
 			}
 		}
 
+		if n.Mounts.Ipns != nil && n.Mounts.Ipns.IsActive() {
+			res.SetError(errors.New("You cannot manually publish while IPNS is mounted."), cmds.ErrNormal)
+			return
+		}
+
 		pstr := req.Arguments()[0]
 
 		if n.Identity == "" {

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -151,10 +151,7 @@ func TestIpnsLocalLink(t *testing.T) {
 	defer mnt.Close()
 	name := mnt.Dir + "/local"
 
-	_, err := os.Stat(name)
-	if err != nil {
-		t.Fatal(err)
-	}
+	checkExists(t, name)
 
 	linksto, err := os.Readlink(name)
 	if err != nil {

--- a/test/sharness/lib/iptb-lib.sh
+++ b/test/sharness/lib/iptb-lib.sh
@@ -1,4 +1,4 @@
-# iptb test framework 
+# iptb test framework
 #
 # Copyright (c) 2014, 2016 Jeromy Johnson, Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0031-mount-publish.sh
+++ b/test/sharness/t0031-mount-publish.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
-#
-# MIT Licensed; see the LICENSE file in this repository.
-#
 
 test_description="Test mount command in conjunction with publishing"
 
+# imports
 . lib/test-lib.sh
 
 # if in travis CI, dont test mount (no fuse)
@@ -16,56 +14,47 @@ fi
 
 test_init_ipfs
 
-# start iptb
-iptb init -n 2 -f --bootstrap=star --port=$PORT_SWARM
-iptb start --wait
-BADDR="/ip4/127.0.0.1/tcp/$PORT_SWARM/ipfs/"
-ADDR1="${BADDR}$(iptb get id 0)"
-ADDR2="${BADDR}$(iptb get id 1)"
-
-# bootstrap to the iptb peers
-test_expect_success "bootstrap to iptb peers" '
-  ipfs bootstrap add '$ADDR1' &&
-  ipfs bootstrap add '$ADDR2'
-'
-
-# launch the daemon
-test_launch_ipfs_daemon
-
-# wait for peer bootstrapping
-# TODO(noffle): this is very fragile -- how can we wait for this to happen for sure?
-sleep 3
+# start iptb + wait for peering
+NUM_NODES=3
+iptb init -n $NUM_NODES -f --bootstrap=none --port=0
+startup_cluster $NUM_NODES
 
 # pre-mount publish
-HASH=$(echo 'hello warld' | ipfs add -q)
+HASH=$(echo 'hello warld' | ipfsi 0 add -q)
 test_expect_success "can publish before mounting /ipns" '
-  ipfs name publish '$HASH'
+  ipfsi 0 name publish '$HASH'
 '
 
 # mount
-test_mount_ipfs
-
-test_expect_success "cannot publish after mounting /ipns" '
-  echo "Error: You cannot manually publish while IPNS is mounted." >expected &&
-  test_must_fail ipfs name publish '$HASH' 2>actual &&
+IPFS_MOUNT_DIR="$PWD/ipfs"
+IPNS_MOUNT_DIR="$PWD/ipns"
+test_expect_success FUSE "'ipfs mount' succeeds" '
+  ipfsi 0 mount -f "'"$IPFS_MOUNT_DIR"'" -n "'"$IPNS_MOUNT_DIR"'" >actual
+'
+test_expect_success FUSE "'ipfs mount' output looks good" '
+  echo "IPFS mounted at: $PWD/ipfs" >expected &&
+  echo "IPNS mounted at: $PWD/ipns" >>expected &&
   test_cmp expected actual
 '
 
+test_expect_success "cannot publish after mounting /ipns" '
+  echo "Error: You cannot manually publish while IPNS is mounted." >expected &&
+  test_must_fail ipfsi 0 name publish '$HASH' 2>actual &&
+  test_cmp expected actual
+'
 
 test_expect_success "unmount /ipns out-of-band" '
-  fusermount -u ipns
+  fusermount -u "'"$IPNS_MOUNT_DIR"'"
 '
-
-# wait a moment for the daemon to notice and clean up
-# TODO(noffle): this is very fragile -- how can we wait for this to happen for sure?
-sleep 2
 
 test_expect_success "can publish after unmounting /ipns" '
-  ipfs name publish '$HASH'
+  ipfsi 0 name publish '$HASH'
 '
 
-# clean-up
-test_kill_ipfs_daemon
+# clean-up ipfs
+test_expect_success "unmount /ipfs" '
+  fusermount -u "'"$IPFS_MOUNT_DIR"'"
+'
 iptb stop
 
 test_done

--- a/test/sharness/t0031-mount-publish.sh
+++ b/test/sharness/t0031-mount-publish.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test mount command in conjunction with publishing"
+
+. lib/test-lib.sh
+
+# if in travis CI, dont test mount (no fuse)
+if ! test_have_prereq FUSE; then
+	skip_all='skipping mount tests, fuse not available'
+
+	test_done
+fi
+
+test_init_ipfs
+
+# start iptb
+iptb init -n 2 -f --bootstrap=star --port=$PORT_SWARM
+iptb start --wait
+BADDR="/ip4/127.0.0.1/tcp/$PORT_SWARM/ipfs/"
+ADDR1="${BADDR}$(iptb get id 0)"
+ADDR2="${BADDR}$(iptb get id 1)"
+
+# bootstrap to the iptb peers
+test_expect_success "bootstrap to iptb peers" '
+  ipfs bootstrap add '$ADDR1' &&
+  ipfs bootstrap add '$ADDR2'
+'
+
+# launch the daemon
+test_launch_ipfs_daemon
+
+# wait for peer bootstrapping
+# TODO(noffle): this is very fragile -- how can we wait for this to happen for sure?
+sleep 3
+
+# pre-mount publish
+HASH=$(echo 'hello warld' | ipfs add -q)
+test_expect_success "can publish before mounting /ipns" '
+  ipfs name publish '$HASH'
+'
+
+# mount
+test_mount_ipfs
+
+test_expect_success "cannot publish after mounting /ipns" '
+  echo "Error: You cannot manually publish while IPNS is mounted." >expected &&
+  test_must_fail ipfs name publish '$HASH' 2>actual &&
+  test_cmp expected actual
+'
+
+
+test_expect_success "unmount /ipns out-of-band" '
+  fusermount -u ipns
+'
+
+# wait a moment for the daemon to notice and clean up
+# TODO(noffle): this is very fragile -- how can we wait for this to happen for sure?
+sleep 2
+
+test_expect_success "can publish after unmounting /ipns" '
+  ipfs name publish '$HASH'
+'
+
+# clean-up
+test_kill_ipfs_daemon
+iptb stop
+
+test_done

--- a/test/sharness/t0031-mount-publish.sh
+++ b/test/sharness/t0031-mount-publish.sh
@@ -16,8 +16,10 @@ test_init_ipfs
 
 # start iptb + wait for peering
 NUM_NODES=3
-iptb init -n $NUM_NODES -f --bootstrap=none --port=0
-startup_cluster $NUM_NODES
+test_expect_success 'init iptb' '
+  iptb init -n $NUM_NODES -f --bootstrap=none --port=0 &&
+  startup_cluster $NUM_NODES
+'
 
 # pre-mount publish
 HASH=$(echo 'hello warld' | ipfsi 0 add -q)

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -49,15 +49,15 @@ test_ls_cmd() {
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/
 			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1
 			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2
-	
+
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
 			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024
 			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a
-	
+
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139 128
 			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14  a
-	
+
 		EOF
 		test_cmp expected_ls actual_ls
 	'
@@ -74,17 +74,17 @@ test_ls_cmd() {
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/
 			QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1
 			QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2
-	
+
 			QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
 			Hash                                           Size Name
 			QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024
 			QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a
-	
+
 			QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 			Hash                                           Size Name
 			QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128
 			QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a
-	
+
 		EOF
 		test_cmp expected_ls_headers actual_ls_headers
 	'

--- a/test/sharness/t0121-bootstrap-iptb.sh
+++ b/test/sharness/t0121-bootstrap-iptb.sh
@@ -45,7 +45,7 @@ test_expect_success "bring down iptb nodes" '
 	PID4=$(cat "$IPTB_ROOT/4/daemon.pid") &&
 	iptb stop && # TODO: add --wait flag to iptb stop
 	betterwait $PID0
-	betterwait $PID1 
+	betterwait $PID1
 	betterwait $PID2
 	betterwait $PID3
 	betterwait $PID4


### PR DESCRIPTION
Addresses https://github.com/ipfs/go-ipfs/issues/1186.