### PR TITLE
bump kvalue from 10 to 20

### DIFF
--- a/routing/dht/util.go
+++ b/routing/dht/util.go
@@ -8,7 +8,7 @@ import (
 var PoolSize = 6
 
 // K is the maximum number of requests to perform before returning failure.
-var KValue = 10
+var KValue = 20
 
 // Alpha is the concurrency factor for asynchronous requests.
 var AlphaValue = 3


### PR DESCRIPTION
This has needed to be done for a while. Since we require that we receive 16 records from the dht before making a decision, we should probably store more than 16 records on the dht for a given put call.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>