### PR TITLE
fix dht command key escaping

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -354,6 +354,8 @@ GetValue will return the value stored in the DHT at the given key.
 			return
 		}
 
+		log.Error("RESOLVE KEY: ", []byte(dhtkey))
+
 		go func() {
 			defer close(outChan)
 			for e := range events {
@@ -573,7 +575,7 @@ func escapeDhtKey(s string) (key.Key, error) {
 		return key.B58KeyDecode(s), nil
 	case 3:
 		k := key.B58KeyDecode(parts[2])
-		return key.Key(path.Join(append(parts[:2], k.String()))), nil
+		return key.Key(path.Join(append(parts[:2], string(k)))), nil
 	default:
 		return "", errors.New("invalid key")
 	}

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -354,8 +354,6 @@ GetValue will return the value stored in the DHT at the given key.
 			return
 		}
 
-		log.Error("RESOLVE KEY: ", []byte(dhtkey))
-
 		go func() {
 			defer close(outChan)
 			for e := range events {

--- a/core/commands/dht_test.go
+++ b/core/commands/dht_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-ipfs/namesys"
+	tu "github.com/ipfs/go-ipfs/thirdparty/testutil"
+)
+
+func TestKeyTranslation(t *testing.T) {
+	pid := tu.RandPeerIDFatal(t)
+	a, b := namesys.IpnsKeysForID(pid)
+
+	pkk, err := escapeDhtKey("/pk/" + pid.Pretty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ipnsk, err := escapeDhtKey("/ipns/" + pid.Pretty())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pkk != a {
+		t.Fatal("keys didnt match!")
+	}
+
+	if ipnsk != b {
+		t.Fatal("keys didnt match!")
+	}
+}

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -141,7 +141,6 @@ func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqn
 		return err
 	}
 
-	log.Error("KEY: ", []byte(namekey))
 	ttl, ok := checkCtxTTL(ctx)
 	if ok {
 		entry.Ttl = proto.Uint64(uint64(ttl.Nanoseconds()))

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -141,6 +141,7 @@ func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqn
 		return err
 	}
 
+	log.Error("KEY: ", []byte(namekey))
 	ttl, ok := checkCtxTTL(ctx)
 	if ok {
 		entry.Ttl = proto.Uint64(uint64(ttl.Nanoseconds()))


### PR DESCRIPTION
This broke at some point, i didnt notice. Now its fixed, and theres a test. (or will be soon, i realize as i type this that i forgot to add the test file, so hold on one second)

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>