### PR TITLE
add a pause to fix timing on t0065

### DIFF
--- a/test/sharness/t0065-active-requests.sh
+++ b/test/sharness/t0065-active-requests.sh
@@ -22,6 +22,7 @@ test_expect_success "invoc shows up in output" '
 test_expect_success "start longer running command" '
 	ipfs log tail &
 	LOGPID=$!
+	go-sleep 100ms
 '
 
 test_expect_success "long running command shows up" '


### PR DESCRIPTION
This failure: https://circleci.com/gh/ipfs/go-ipfs/2994

appears to be because the test thats failing gets run before the log tail command even gets to start.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>