### PR TITLE
merkledag: remove Batch

### DIFF
--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -13,7 +13,6 @@ type DagBuilderHelper struct {
 	recvdErr error
 	nextData []byte // the next item to return.
 	maxlinks int
-	batch    *dag.Batch
 }
 
 type DagBuilderParams struct {
@@ -31,7 +30,6 @@ func (dbp *DagBuilderParams) New(spl chunk.Splitter) *DagBuilderHelper {
 		dserv:    dbp.Dagserv,
 		spl:      spl,
 		maxlinks: dbp.Maxlinks,
-		batch:    dbp.Dagserv.Batch(),
 	}
 }
 
@@ -125,5 +123,5 @@ func (db *DagBuilderHelper) Maxlinks() int {
 }
 
 func (db *DagBuilderHelper) Close() error {
-	return db.batch.Commit()
+	return nil
 }


### PR DESCRIPTION
The Batch function from the DagService was not used. Remove it to simplify
code and allow IPLD implementation to take the place of merkledag.