### PR TITLE
Fixes range error by using > 0 length buffer.

### DIFF
--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -642,7 +642,7 @@ func actorWriteFile(d *Directory) error {
 		return nil
 	}
 
-	size := rand.Intn(1024)
+	size := rand.Intn(1024) + 1
 	buf := make([]byte, size)
 	randbo.New().Read(buf)
 


### PR DESCRIPTION
Addresses https://github.com/ipfs/go-ipfs/issues/2361.

This would happen once every blue moon when `rand.Intn(1024) == 0`.