### PR TITLE
Edit the ls.go description

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -16,10 +16,7 @@ const progressBarMinSize = 1024 * 1024 * 8 // show progress bar for outputs > 8M
 var CatCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Show IPFS object data.",
-		ShortDescription: `
-Retrieves the object named by <ipfs-or-ipns-path> and outputs the data
-it contains.
-`,
+		ShortDescription: "Displays the data contained by an IPFS or IPNS object(s) at the given path.",
 	},
 
 	Arguments: []cmds.Argument{

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -24,7 +24,7 @@ var GetCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Download IPFS objects.",
 		ShortDescription: `
-Retrieves the object named by <ipfs-or-ipns-path> and stores the data to disk.
+Stores to disk the data contained an IPFS or IPNS object(s) at the given path.
 
 By default, the output will be stored at ./<ipfs-path>, but an alternate path
 can be specified with '--output=<path>' or '-o=<path>'.

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -33,8 +33,7 @@ var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List links from an object.",
 		ShortDescription: `
-Retrieves the object named by <ipfs-or-ipns-path> and displays the links
-it contains, with the following format:
+Displays the links an IPFS or IPNS object(s) contains, with the following format:
 
   <link base58 hash> <link size in bytes> <link name>
 `,

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -34,10 +34,7 @@ type PinOutput struct {
 var addPinCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Pins objects to local storage.",
-		ShortDescription: `
-Retrieves the object named by <ipfs-path> and stores it locally
-on disk.
-`,
+		ShortDescription: "Stores an IPFS object(s) from a given path locally to disk.",
 	},
 
 	Arguments: []cmds.Argument{

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -35,12 +35,11 @@ var RefsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Lists links (references) from an object.",
 		ShortDescription: `
-Retrieves the object named by <ipfs-path> and displays the link
-hashes it contains, with the following format:
+Displays the link hashes an IPFS or IPNS object(s) contains, with the following format:
 
   <link base58 hash>
 
-Note: list all refs recursively with -r.
+Note: List all referencess recursively by using the flag '-r'.
 `,
 	},
 	Subcommands: map[string]*cmds.Command{

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -36,8 +36,7 @@ var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List directory contents for Unix filesystem objects.",
 		ShortDescription: `
-Retrieves the object named by <ipfs-or-ipns-path> and displays the
-contents.
+Displays the contents  of an IPFS or IPNS object(s) at the given path.
 
 The JSON output contains size information. For files, the child size
 is the total size of the file contents. For directories, the child


### PR DESCRIPTION
This should make it a bit easier to read. Cf https://github.com/ipfs/http-api-spec/pull/42#discussion_r53164138

Should also be applied to `cat`, `get`, and `unixfs/ls`, if this looks good to anyone. 

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>