### PR TITLE
refactor merkledag fetching methods

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -33,7 +33,7 @@ type PinOutput struct {
 
 var addPinCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Pins objects to local storage.",
+		Tagline:          "Pins objects to local storage.",
 		ShortDescription: "Stores an IPFS object(s) from a given path locally to disk.",
 	},
 

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -233,7 +233,7 @@ func (rw *RefWriter) writeRefsRecursive(n *dag.Node) (int, error) {
 	}
 
 	var count int
-	for i, ng := range rw.DAG.GetDAG(rw.Ctx, n) {
+	for i, ng := range dag.GetDAG(rw.Ctx, rw.DAG, n) {
 		lk := key.Key(n.Links[i].Hash)
 		if rw.skip(lk) {
 			continue

--- a/test/sharness/t0081-repo-pinning.sh
+++ b/test/sharness/t0081-repo-pinning.sh
@@ -238,9 +238,9 @@ test_expect_success "some are no longer there" '
 '
 
 test_expect_success "recursive pin fails without objects" '
-	ipfs pin rm "$HASH_DIR1" &&
-	test_must_fail ipfs pin add -r "$HASH_DIR1" --timeout=500ms 2>err_expected8 &&
-	grep "context deadline exceeded" err_expected8 ||
+	ipfs pin rm -r=false "$HASH_DIR1" &&
+	test_must_fail ipfs pin add -r "$HASH_DIR1" 2>err_expected8 &&
+	grep "pin: failed to fetch all nodes" err_expected8 ||
 	test_fsh cat err_expected8
 '
 
@@ -275,9 +275,9 @@ test_expect_success "test add nopin dir" '
 FICTIONAL_HASH="QmXV4f9v8a56MxWKBhP3ETsz4EaafudU1cKfPaaJnenc48"
 test_launch_ipfs_daemon
 test_expect_success "test unpinning a hash that's not pinned" "
-  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH --timeout=5s
-  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH/a --timeout=5s
-  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH/a/b --timeout=5s
+  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH --timeout=2s
+  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH/a --timeout=2s
+  test_expect_code 1 ipfs pin rm $FICTIONAL_HASH/a/b --timeout=2s
 "
 test_kill_ipfs_daemon
 

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -39,7 +39,7 @@ func (w *Writer) writeDir(nd *mdag.Node, fpath string) error {
 		return err
 	}
 
-	for i, ng := range w.Dag.GetDAG(w.ctx, nd) {
+	for i, ng := range mdag.GetDAG(w.ctx, w.Dag, nd) {
 		child, err := ng.Get(w.ctx)
 		if err != nil {
 			return err

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -90,7 +90,7 @@ func NewDagReader(ctx context.Context, n *mdag.Node, serv mdag.DAGService) (*Dag
 
 func NewDataFileReader(ctx context.Context, n *mdag.Node, pb *ftpb.Data, serv mdag.DAGService) *DagReader {
 	fctx, cancel := context.WithCancel(ctx)
-	promises := serv.GetDAG(fctx, n)
+	promises := mdag.GetDAG(fctx, serv, n)
 	return &DagReader{
 		node:     n,
 		serv:     serv,


### PR DESCRIPTION
I refactored the dagservice have one new `GetMany` method that just mimics the interface of the blockservices similar method. It takes some keys and returns a channel of nodes in no particular order.

I then removed the `GetDAG` and `GetNodes` methods from the dagservice interface and refactored them to `GetMany`. 

finally, I refactored `FetchGraph` to use `GetMany`, and in doing so, it has better error cases (can actually fail through from the blockservice layer) and uses wayyyy fewer goroutines. (though still a good number of them).

cc @noffle @lgierth for CR
cc @mildred since youre working on similar cleanup type stuff