### PR TITLE
files: make 'files ls' defaults to /

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -249,13 +249,21 @@ Examples:
 `,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("path", true, false, "Path to show listing for."),
+		cmds.StringArg("path", false, false, "Path to show listing for. Defaults to '/'."),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("l", "Use long listing format."),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		path, err := checkPath(req.Arguments()[0])
+		var arg string
+
+		if len(req.Arguments()) == 0 {
+			arg = "/"
+		} else {
+			arg = req.Arguments()[0]
+		}
+
+		path, err := checkPath(arg)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -51,6 +51,12 @@ test_files_api() {
 		ipfs files mkdir /cats
 	'
 
+	test_expect_success "'files ls' lists root by default" '
+		ipfs files ls >actual &&
+		echo "cats" >expected &&
+		test_cmp expected actual
+	'
+
 	test_expect_success "directory was created" '
 		verify_path_exists /cats
 	'


### PR DESCRIPTION
This fixes issue #2379 (`ipfs files ls` should default to '/' if path is not given).