### PR TITLE
force gx to use 0.4.0 gateways for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ COMMIT := $(shell git rev-parse --short HEAD)
 ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(COMMIT)"
 MAKEFLAGS += --no-print-directory
 
+
+IPFS_API = "https://v04x.ipfs.io"
+
 all: help
 
 godep:


### PR DESCRIPTION
This should help a bit with the random stalls we've been seeing, skip multireq altogether :D

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>