### PR TITLE
assert that you must build from inside your gopath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ vendor: godep
 install: build
 	cd cmd/ipfs && go install -ldflags=$(ldflags)
 
-build: deps 
+build: deps
 	cd cmd/ipfs && go build -i -ldflags=$(ldflags)
 
 nofuse: deps

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ gxgo_upgrade:
 	go get -u github.com/whyrusleeping/gx-go
 
 path_check:
-	@bin/check_go_path
+	@bin/check_go_path $(realpath $(shell pwd))
 
 gx_check:
 	@bin/check_gx_program "gx" "0.3" 'Upgrade or install gx using your package manager or run `make gx_upgrade`'

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ gxgo_upgrade:
 	go get -u github.com/whyrusleeping/gx-go
 
 path_check:
-	test "$(shell pwd)" = "$(GOPATH)/src/github.com/ipfs/go-ipfs" || (echo "go-ipfs must be built from within your \$$GOPATH directory." && false)
+	@bin/check_go_path
 
 gx_check:
 	@bin/check_gx_program "gx" "0.3" 'Upgrade or install gx using your package manager or run `make gx_upgrade`'

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ gx_check:
 	@bin/check_gx_program "gx" "0.3" 'Upgrade or install gx using your package manager or run `make gx_upgrade`'
 	@bin/check_gx_program "gx-go" "0.2" 'Upgrade or install gx-go using your package manager or run `make gxgo_upgrade`'
 
-deps: go_check gx_check
+deps: go_check gx_check path_check
 	gx --verbose install --global
 
 # saves/vendors third-party dependencies to Godeps/_workspace
@@ -47,7 +47,7 @@ vendor: godep
 install: build
 	cd cmd/ipfs && go install -ldflags=$(ldflags)
 
-build: deps path_check
+build: deps 
 	cd cmd/ipfs && go build -i -ldflags=$(ldflags)
 
 nofuse: deps

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ gx_upgrade:
 gxgo_upgrade:
 	go get -u github.com/whyrusleeping/gx-go
 
+path_check:
+	test "$(shell pwd)" = "$(GOPATH)/src/github.com/ipfs/go-ipfs" || (echo "go-ipfs must be built from within your \$$GOPATH directory." && false)
+
 gx_check:
 	@bin/check_gx_program "gx" "0.3" 'Upgrade or install gx using your package manager or run `make gx_upgrade`'
 	@bin/check_gx_program "gx-go" "0.2" 'Upgrade or install gx-go using your package manager or run `make gxgo_upgrade`'
@@ -44,7 +47,7 @@ vendor: godep
 install: build
 	cd cmd/ipfs && go install -ldflags=$(ldflags)
 
-build: deps
+build: deps path_check
 	cd cmd/ipfs && go build -i -ldflags=$(ldflags)
 
 nofuse: deps

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -1,20 +1,21 @@
 #!/bin/sh
 
+PWD=$1
+
+if [ -z "$PWD" ]; then
+	echo "must pass in your current working directory"
+	exit 1
+fi
+
 if [ -z "$GOPATH" ]; then
 	echo "GOPATH not set, you must have go configured properly to install ipfs"
 	exit 1
 fi
 
-if ! type -f realpath > /dev/null; then
-	echo "program 'realpath' not found, it is required for this check"
-	exit 1
-fi
-
-PWD=$(pwd)
-REALPWD=$(realpath "$PWD")
 EXPECTED="$GOPATH/src/github.com/ipfs/go-ipfs"
 
-if [ "$REALPWD" != "$EXPECTED" ]; then
+if [ "$PWD" != "$EXPECTED" ]; then
 	echo "go-ipfs must be built from within your \$GOPATH directory."
+	echo "expected '$EXPECTED' but got '$PWD'"
 	exit 1
 fi

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$GOPATH" ]; then
+	echo "GOPATH not set, you must have go configured properly to install ipfs"
+	exit 1
+fi
+
+if ! type -f realpath > /dev/null; then
+	echo "program 'realpath' not found, it is required for this check"
+	exit 1
+fi
+
+PWD=$(pwd)
+REALPWD=$(realpath "$PWD")
+EXPECTED="$GOPATH/src/github.com/ipfs/go-ipfs"
+
+if [ "$REALPWD" != "$EXPECTED" ]; then
+	echo "go-ipfs must be built from within your \$GOPATH directory."
+	exit 1
+fi


### PR DESCRIPTION
Make sure that the user cloned the code to the correct place, this is useful since go is very strict about paths.

cc @chriscool for some code review and @RichardLitt for doc stuff

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>