### PR TITLE
Pushes back minimum Go version to 1.5.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ godep:
 toolkit_upgrade: gx_upgrade gxgo_upgrade
 
 go_check:
-	@bin/check_go_version "1.5.2"
+	@bin/check_go_version "1.5.1"
 
 gx_upgrade:
 	go get -u github.com/whyrusleeping/gx


### PR DESCRIPTION
I've been using 1.5.1 for the last two months /wo issue.