### PR TITLE
Noted ability to specify multiple keys in `bitswap unwant`

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -31,7 +31,7 @@ var unwantCmd = &cmds.Command{
 		Tagline: "Remove a given block from your wantlist.",
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, true, "Key to remove from your wantlist.").EnableStdin(),
+		cmds.StringArg("key", true, true, "Key(s) to remove from your wantlist.").EnableStdin(),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		nd, err := req.InvocContext().GetNode()


### PR DESCRIPTION
You can include an array of keys, not just a single key, but this isn't specified anywhere in the help text.