### PR TITLE
`tar cat` should return appropriate headers

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -262,6 +262,10 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 		h.Set(channelHeader, "1")
 	}
 
+	if len(res.Request().Path()) == 2 && res.Request().Path()[0] == "cat" && res.Request().Path()[1] == "cat" {
+		mime = "application/x-tar"
+	}
+
 	// catch-all, set to text as default
 	if mime == "" {
 		mime = "text/plain"

--- a/commands/http/handler_test.go
+++ b/commands/http/handler_test.go
@@ -348,3 +348,15 @@ func TestAllowedMethod(t *testing.T) {
 		tc.test(t)
 	}
 }
+
+func TestTarThing(t *testing.T) {
+    tc := testCase{
+        Method: "POST",
+        Path:   "/tar/cat",
+        ResHeaders: map[string]string{
+            "Content-Type": "application/x-tar",
+        },
+    }
+
+    tc.test(t)
+}


### PR DESCRIPTION
I've added `application:x-tar` and a sharness test, although I can't figure out how to run the test.

License: MIT
Signed-off-by: Richard Littauer richard.littauer@gmail.com
