### PR TITLE
add a ipfs repo ls-roots command

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -149,13 +149,13 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 
 	n.Blocks = bserv.New(n.Blockstore, n.Exchange)
 	n.DAG = dag.NewDAGService(n.Blocks)
-	n.Pinning, err = pin.LoadPinner(n.Repo.Datastore(), n.DAG)
+	n.Pinning, err = pin.LoadPinner(n.Repo.Datastore(), n.Blockstore, n.DAG)
 	if err != nil {
 		// TODO: we should move towards only running 'NewPinner' explicity on
 		// node init instead of implicitly here as a result of the pinner keys
 		// not being found in the datastore.
 		// this is kinda sketchy and could cause data loss
-		n.Pinning = pin.NewPinner(n.Repo.Datastore(), n.DAG)
+		n.Pinning = pin.NewPinner(n.Repo.Datastore(), n.Blockstore, n.DAG)
 	}
 	n.Resolver = &path.Resolver{DAG: n.DAG}
 

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -113,7 +113,7 @@ var repoLsRootsCmd = &cmds.Command{
 		Tagline: "Display the top nodes stored locally",
 		ShortDescription: `
 'ipfs repo ls-roots' will display the top-level files or directory
-that are stored locally as well a some of their properties.
+that are stored locally as well as some of their properties.
 `,
 	},
 

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -8,6 +8,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	u "gx/ipfs/QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1/go-ipfs-util"
+	"github.com/ipfs/go-ipfs/unixfs"
 )
 
 var RepoCmd = &cmds.Command{
@@ -20,6 +21,7 @@ var RepoCmd = &cmds.Command{
 
 	Subcommands: map[string]*cmds.Command{
 		"gc": repoGcCmd,
+		"ls": repoLsCmd,
 	},
 }
 
@@ -84,6 +86,85 @@ order to reclaim hard disk space.
 				} else {
 					buf = bytes.NewBufferString(fmt.Sprintf("removed %s\n", obj.Key))
 				}
+				return buf, nil
+			}
+
+			return &cmds.ChannelMarshaler{
+				Channel:   outChan,
+				Marshaler: marshal,
+				Res:       res,
+			}, nil
+		},
+	},
+}
+
+type RepoLsOutput struct {
+	Hash string
+	Size uint64
+	Type string
+}
+
+var repoLsCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Totally need a documentation",
+		ShortDescription: `
+		I might agree on that
+		`,
+	},
+
+	Run: func(req cmds.Request, res cmds.Response) {
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		outChan := make(chan interface{})
+		res.SetOutput((<-chan interface{})(outChan))
+
+		go func() {
+			defer close(outChan)
+			for _, k := range n.Pinning.RecursiveKeys() {
+				node, err := n.DAG.Get(req.Context(), k)
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				unixFSNode, err := unixfs.FromBytes(node.Data);
+				if err != nil {
+					res.SetError(err, cmds.ErrNormal)
+					return
+				}
+
+				outChan <- &RepoLsOutput{
+					Hash: k.Pretty(),
+					Size: unixFSNode.GetFilesize(),
+					Type: unixFSNode.GetType().String(),
+				}
+			}
+		}()
+	},
+
+	Type: RepoLsOutput{},
+
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+			outChan, ok := res.Output().(<-chan interface{})
+			if !ok {
+				return nil, u.ErrCast()
+			}
+
+			marshal := func(v interface{}) (io.Reader, error) {
+				obj, ok := v.(*RepoLsOutput)
+				if !ok {
+					return nil, u.ErrCast()
+				}
+
+				buf := new(bytes.Buffer)
+
+				fmt.Fprintf(buf, "%s\t%s     \t%v\n", obj.Hash, obj.Type, obj.Size)
+
 				return buf, nil
 			}
 

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -36,7 +36,7 @@ func getDagservAndPinner(t *testing.T) dagservAndPinner {
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))
 	dserv := NewDAGService(blockserv)
-	mpin := pin.NewPinner(db, dserv)
+	mpin := pin.NewPinner(db, bs, dserv)
 	return dagservAndPinner{
 		ds: dserv,
 		mp: mpin,

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore"
+	bs "github.com/ipfs/go-ipfs/blocks/blockstore"
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	"github.com/ipfs/go-ipfs/blocks/set"
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	logging "gx/ipfs/Qmazh5oNUVsDZTs2g59rq8aYQqwpss8tcUWQzor5sCCEuH/go-log"
-	bs "github.com/ipfs/go-ipfs/blocks/blockstore"
 )
 
 var log = logging.Logger("pin")

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -13,6 +13,7 @@ import (
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	logging "gx/ipfs/Qmazh5oNUVsDZTs2g59rq8aYQqwpss8tcUWQzor5sCCEuH/go-log"
+	bs "github.com/ipfs/go-ipfs/blocks/blockstore"
 )
 
 var log = logging.Logger("pin")
@@ -64,12 +65,14 @@ type pinner struct {
 	// Track the keys used for storing the pinning state, so gc does
 	// not delete them.
 	internalPin map[key.Key]struct{}
+	rootNode    *mdag.Node
 	dserv       mdag.DAGService
+	bstore      bs.Blockstore
 	dstore      ds.Datastore
 }
 
 // NewPinner creates a new pinner using the given datastore as a backend
-func NewPinner(dstore ds.Datastore, serv mdag.DAGService) Pinner {
+func NewPinner(dstore ds.Datastore, bstore bs.Blockstore, serv mdag.DAGService) Pinner {
 
 	// Load set from given datastore...
 	rcset := set.NewSimpleBlockSet()
@@ -80,6 +83,7 @@ func NewPinner(dstore ds.Datastore, serv mdag.DAGService) Pinner {
 		recursePin: rcset,
 		directPin:  dirset,
 		dserv:      serv,
+		bstore:     bstore,
 		dstore:     dstore,
 	}
 }
@@ -234,7 +238,7 @@ func (p *pinner) RemovePinWithMode(key key.Key, mode PinMode) {
 }
 
 // LoadPinner loads a pinner and its keysets from the given datastore
-func LoadPinner(d ds.Datastore, dserv mdag.DAGService) (Pinner, error) {
+func LoadPinner(d ds.Datastore, bstore bs.Blockstore, dserv mdag.DAGService) (Pinner, error) {
 	p := new(pinner)
 
 	rootKeyI, err := d.Get(pinDatastoreKey)
@@ -279,10 +283,12 @@ func LoadPinner(d ds.Datastore, dserv mdag.DAGService) (Pinner, error) {
 		p.directPin = set.SimpleSetFromKeys(directKeys)
 	}
 
+	p.rootNode = root
 	p.internalPin = internalPin
 
 	// assign services
 	p.dserv = dserv
+	p.bstore = bstore
 	p.dstore = d
 
 	return p, nil
@@ -346,6 +352,18 @@ func (p *pinner) Flush() error {
 	if err := p.dstore.Put(pinDatastoreKey, []byte(k)); err != nil {
 		return fmt.Errorf("cannot store pin state: %v", err)
 	}
+
+	// cleanup old root node
+	if p.rootNode != nil {
+		for _, link := range p.rootNode.Links {
+			if child, err := link.GetNode(ctx, p.dserv); err == nil {
+				p.dserv.Remove(child)
+			}
+		}
+		p.dserv.Remove(p.rootNode)
+	}
+
+	p.rootNode = root
 	p.internalPin = internalPin
 	return nil
 }

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -45,7 +45,7 @@ func TestPinnerBasic(t *testing.T) {
 	dserv := mdag.NewDAGService(bserv)
 
 	// TODO does pinner need to share datastore with blockservice?
-	p := NewPinner(dstore, dserv)
+	p := NewPinner(dstore, bstore, dserv)
 
 	a, ak := randNode()
 	_, err := dserv.Add(a)
@@ -129,7 +129,7 @@ func TestPinnerBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	np, err := LoadPinner(dstore, dserv)
+	np, err := LoadPinner(dstore, bstore, dserv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestDuplicateSemantics(t *testing.T) {
 	dserv := mdag.NewDAGService(bserv)
 
 	// TODO does pinner need to share datastore with blockservice?
-	p := NewPinner(dstore, dserv)
+	p := NewPinner(dstore, bstore, dserv)
 
 	a, _ := randNode()
 	_, err := dserv.Add(a)
@@ -183,7 +183,7 @@ func TestFlush(t *testing.T) {
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
 	dserv := mdag.NewDAGService(bserv)
-	p := NewPinner(dstore, dserv)
+	p := NewPinner(dstore, bstore, dserv)
 	_, k := randNode()
 
 	p.PinWithMode(k, Recursive)
@@ -200,7 +200,7 @@ func TestPinRecursiveFail(t *testing.T) {
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 	dserv := mdag.NewDAGService(bserv)
 
-	p := NewPinner(dstore, dserv)
+	p := NewPinner(dstore, bstore, dserv)
 
 	a, _ := randNode()
 	b, _ := randNode()

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -219,6 +219,15 @@ test_expect_success "'ipfs refs --unique --recursive (bigger)'" '
 	test_sort_cmp expected actual || test_fsh cat refs_output
 '
 
+test_expect_success "'ipfs repo ls-roots' succeeds" '
+    ipfs repo ls-roots > ls-roots
+'
+
+test_expect_success "'ipfs repo ls-roots' looks good" '
+    grep "$HASH_WELCOME_DOCS" ls-roots &&
+    grep "$EMPTY_DIR" ls-roots
+'
+
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
This PR follow https://github.com/ipfs/go-ipfs/pull/1736 that can't be reopened.

Here is how it looks like now:

```
$ ipfs repo ls-root
QmRjdPNn6FVWV7szxCCuaCaBwvLuxLBEreeEiNuARyk4yS  46KB    Directory       recursive
QmRyWyKWmphamkMRnJVjUTzSFSAAZowYP4rnbgnfMXC9Mr  4.9MB   Directory       
QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn  4B      Directory       
QmVaL8gzpDomkn3Zipjo319SSWZpNM2gpNXWSFNFnSmwit  4.1KB   File            recursive
```

A couple of notes:
- Instead of just looking for pinned object, this command now find the roots of the DAG so also display "free-floating" objects in the repo
- This PR also make the pinner clean its old root node after each flush to avoid having them laying around until the next repo garbage collect. This is necessary as this command find the roots of the DAG
- As `Blockstore.AllKeysChan()` is not deterministic, the order of the result is not deterministic either. Is this a problem ?

I also got hit by https://github.com/ipfs/go-ipfs/issues/1554. Some keys are not retrieved by `Blockstore.AllKeysChan()` so it break the root finding algorithm and some extra objects are displayed.
