### PR TITLE
remove init -f option, its bad

### DIFF
--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -249,12 +249,6 @@ func Init(repoPath string, conf *config.Config) error {
 	return nil
 }
 
-// Remove recursively removes the FSRepo at |path|.
-func Remove(repoPath string) error {
-	repoPath = filepath.Clean(repoPath)
-	return os.RemoveAll(repoPath)
-}
-
 // LockedByOtherProcess returns true if the FSRepo is locked by another
 // process. If true, then the repo cannot be opened by this process.
 func LockedByOtherProcess(repoPath string) (bool, error) {

--- a/repo/fsrepo/fsrepo_test.go
+++ b/repo/fsrepo/fsrepo_test.go
@@ -3,6 +3,8 @@ package fsrepo
 import (
 	"bytes"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	datastore "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore"
@@ -27,10 +29,9 @@ func TestInitIdempotence(t *testing.T) {
 	}
 }
 
-func TestRemove(t *testing.T) {
-	t.Parallel()
-	path := testRepoPath("foo", t)
-	assert.Nil(Remove(path), t, "can remove a repository")
+func Remove(repoPath string) error {
+	repoPath = filepath.Clean(repoPath)
+	return os.RemoveAll(repoPath)
 }
 
 func TestCanManageReposIndependently(t *testing.T) {


### PR DESCRIPTION
After a discussion with @noffle, we decided its best not to have a `-f` option on init, git doesnt have one, and if we keep it, we need to not remove $IPFS_DIR recursively when we do.

ref #2478 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>