### PR TITLE
docker: start daemon with --enable-gc

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -19,4 +19,4 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
-exec ipfs daemon
+exec ipfs daemon --enable-gc


### PR DESCRIPTION
This somehow got lost on the way