### PR TITLE
Makes repo existance check more sensitive.

### DIFF
--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -580,13 +580,5 @@ func IsInitialized(path string) bool {
 // isInitializedUnsynced reports whether the repo is initialized. Caller must
 // hold the packageLock.
 func isInitializedUnsynced(repoPath string) bool {
-	if !configIsInitialized(repoPath) {
-		return false
-	}
-
-	if !util.FileExists(filepath.Join(repoPath, leveldbDirectory)) {
-		return false
-	}
-
-	return true
+	return configIsInitialized(repoPath)
 }


### PR DESCRIPTION
This makes the does-repo-exist check return true if 'config' exists OR
'datastore' exists, rather than a negated AND. This is helpful for js-ipfs or
other implementations which may not use a 'datastore' directory, since it
prevents false positives that could result in go-ipfs ovewriting another ipfs
implementation's repo.