### PR TITLE
Out of range in ipfs add

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -119,6 +119,7 @@ func (adder Adder) add(reader io.Reader) (*dag.Node, error) {
 	)
 }
 
+// return the final root node of the added data
 func (adder *Adder) RootNode() (*dag.Node, error) {
 	// for memoizing
 	if adder.root != nil {
@@ -142,6 +143,7 @@ func (adder *Adder) RootNode() (*dag.Node, error) {
 	return root, err
 }
 
+// Pin or update the pinning of the root node
 func (adder *Adder) PinRoot() error {
 	root, err := adder.RootNode()
 	if err != nil {
@@ -205,6 +207,8 @@ func (adder *Adder) Finalize() (*dag.Node, error) {
 	return root.GetNode()
 }
 
+// outputDirs iterate over directories and sends dagnode info
+// over the output channel
 func (adder *Adder) outputDirs(path string, fs mfs.FSNode) error {
 	nd, err := fs.GetNode()
 	if err != nil {
@@ -257,7 +261,7 @@ func Add(n *core.IpfsNode, r io.Reader) (string, error) {
 	return k.String(), nil
 }
 
-// AddR recursively adds files in |path|.
+// AddR recursively adds files in |root|.
 func AddR(n *core.IpfsNode, root string) (key string, err error) {
 	n.Blockstore.PinLock().Unlock()
 
@@ -327,6 +331,8 @@ func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *dag.No
 	return gopath.Join(k.String(), filename), dagnode, nil
 }
 
+// insert the node in the mutable fs
+// sends dagnode info over the output channel
 func (adder *Adder) addNode(node *dag.Node, path string) error {
 	// patch it into the root
 	if path == "" {
@@ -356,6 +362,7 @@ func (adder *Adder) addNode(node *dag.Node, path string) error {
 }
 
 // Add the given file while respecting the adder.
+// sends dagnode info over the output channel
 func (adder *Adder) AddFile(file files.File) error {
 	adder.unlocker = adder.node.Blockstore.PinLock()
 	defer func() {
@@ -365,6 +372,8 @@ func (adder *Adder) AddFile(file files.File) error {
 	return adder.addFile(file)
 }
 
+// store the file/dir in the datastore
+// sends dagnode info over the output channel
 func (adder *Adder) addFile(file files.File) error {
 	err := adder.maybePauseForGC()
 	if err != nil {
@@ -408,6 +417,8 @@ func (adder *Adder) addFile(file files.File) error {
 	return adder.addNode(dagnode, file.FileName())
 }
 
+// store the directory in the datastore throught the mutable fs
+// sends dagnode info over the output channel
 func (adder *Adder) addDir(dir files.File) error {
 	log.Infof("adding directory: %s", dir.FileName())
 

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	gopath "path"
 
-	ds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore"
-	syncds "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/ipfs/go-datastore/sync"
-	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	key "github.com/ipfs/go-ipfs/blocks/key"
-	bserv "github.com/ipfs/go-ipfs/blockservice"
-	"github.com/ipfs/go-ipfs/exchange/offline"
 	importer "github.com/ipfs/go-ipfs/importer"
 	"github.com/ipfs/go-ipfs/importer/chunk"
 	mfs "github.com/ipfs/go-ipfs/mfs"
@@ -474,13 +469,6 @@ func outputDagnode(out chan interface{}, name string, dn *dag.Node) error {
 	}
 
 	return nil
-}
-
-func NewMemoryDagService() dag.DAGService {
-	// build mem-datastore for editor's intermediary nodes
-	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
-	bsrv := bserv.New(bs, offline.Exchange(bs))
-	return dag.NewDAGService(bsrv)
 }
 
 // TODO: generalize this to more than unix-fs nodes.

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -183,7 +183,7 @@ func (adder *Adder) Finalize() (*dag.Node, error) {
 	}
 
 	var name string
-	if !adder.Wrap {
+	if !adder.Wrap && len(rootNode.Links) == 1 {
 		name = rootNode.Links[0].Name
 
 		dir, ok := adder.mr.GetValue().(*mfs.Directory)

--- a/mfs/doc.go
+++ b/mfs/doc.go
@@ -1,0 +1,12 @@
+// mfs stands for Mutable FileSystem
+//
+// package mfs implements an in memory model of a mutable ipfs filesystem.
+//
+// It consists of four main structs:
+// 1) The Filesystem
+//        The filesystem serves as a container and entry point for various mfs filesystems
+// 2) Root
+//        Root represents an individual filesystem mounted within the mfs system as a whole
+// 3) Directories
+// 4) Files
+package mfs

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -1,12 +1,3 @@
-// package mfs implements an in memory model of a mutable ipfs filesystem.
-//
-// It consists of four main structs:
-// 1) The Filesystem
-//        The filesystem serves as a container and entry point for various mfs filesystems
-// 2) Root
-//        Root represents an individual filesystem mounted within the mfs system as a whole
-// 3) Directories
-// 4) Files
 package mfs
 
 import (


### PR DESCRIPTION
I triggered an out of range in coreunix/add.go when adding a file through the API (I accidentally made a POST query without an actual file content).

Fixed it and documented/cleaned the code in the process. 
