### PR TITLE
Correctly set the content type for `object get --encoding=protobuf`

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -65,9 +65,10 @@ const (
 )
 
 var mimeTypes = map[string]string{
-	cmds.JSON: "application/json",
-	cmds.XML:  "application/xml",
-	cmds.Text: "text/plain",
+	cmds.Protobuf: "application/protobuf",
+	cmds.JSON:     "application/json",
+	cmds.XML:      "application/xml",
+	cmds.Text:     "text/plain",
 }
 
 type ServerConfig struct {

--- a/commands/response.go
+++ b/commands/response.go
@@ -36,9 +36,10 @@ type EncodingType string
 
 // Supported EncodingType constants.
 const (
-	JSON = "json"
-	XML  = "xml"
-	Text = "text"
+	JSON     = "json"
+	XML      = "xml"
+	Protobuf = "protobuf"
+	Text     = "text"
 	// TODO: support more encoding types
 )
 

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -222,7 +222,7 @@ This command outputs data in the following encodings:
 	},
 	Type: Node{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.EncodingType("protobuf"): func(res cmds.Response) (io.Reader, error) {
+		cmds.Protobuf: func(res cmds.Response) (io.Reader, error) {
 			node := res.Output().(*Node)
 			object, err := deserializeNode(node)
 			if err != nil {

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -266,12 +266,32 @@ test_object_cmd() {
 	'
 }
 
+test_object_content_type() {
+
+	  test_expect_success "'ipfs object get --encoding=protobuf' returns the correct content type" '
+    curl -sI "http://$API_ADDR/api/v0/object/get?arg=$HASH&encoding=protobuf" | grep -q "^Content-Type: application/protobuf"
+  '
+
+	  test_expect_success "'ipfs object get --encoding=json' returns the correct content type" '
+    curl -sI "http://$API_ADDR/api/v0/object/get?arg=$HASH&encoding=json" | grep -q "^Content-Type: application/json"
+  '
+
+	  test_expect_success "'ipfs object get --encoding=text' returns the correct content type" '
+    curl -sI "http://$API_ADDR/api/v0/object/get?arg=$HASH&encoding=text" | grep -q "^Content-Type: text/plain"
+  '
+
+	  test_expect_success "'ipfs object get --encoding=xml' returns the correct content type" '
+  curl -sI "http://$API_ADDR/api/v0/object/get?arg=$HASH&encoding=xml" | grep -q "^Content-Type: application/xml"
+  '
+}
+
 # should work offline
 test_object_cmd
 
 # should work online
 test_launch_ipfs_daemon
 test_object_cmd
+test_object_content_type
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
It used to default to `application/json` but is now correctly set to
`application/protobuf`.

fixes #2469

License: MIT
Signed-off-by: Steven Allen <steven@stebalien.com>