### PR TITLE
[WIP] Return an error when `object get --encoding=protobuf` fails

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -71,6 +71,10 @@ var mimeTypes = map[string]string{
 	cmds.Text:     "text/plain",
 }
 
+var errorMimeTypes = map[string]string{
+	cmds.Protobuf: "application/json",
+}
+
 type ServerConfig struct {
 	// Headers is an optional map of headers that is written out.
 	Headers map[string][]string
@@ -204,6 +208,12 @@ func guessMimeType(res cmds.Response) (string, error) {
 	}
 	if !found {
 		return "", errors.New("no encoding option set")
+	}
+
+	if res.Error() != nil {
+		if m, ok := errorMimeTypes[enc]; ok {
+			return m, nil
+		}
 	}
 
 	if m, ok := mimeTypes[enc]; ok {

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -216,16 +216,26 @@ This command outputs data in the following encodings:
 	Type: Node{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Protobuf: func(res cmds.Response) (io.Reader, error) {
-			node := res.Output().(*Node)
-			// deserialize the Data field as text as this was the standard behaviour
-			object, err := deserializeNode(node, "text")
-			if err != nil {
-				return nil, err
-			}
+			var marshaled []byte
 
-			marshaled, err := object.Marshal()
-			if err != nil {
-				return nil, err
+			if res.Error() != nil {
+				output, err := json.Marshal(res.Error())
+				if err != nil {
+					return nil, err
+				}
+				marshaled = append(output, '\n')
+			} else {
+				node := res.Output().(*Node)
+				// deserialize the Data field as text as this was the standard behaviour
+				object, err := deserializeNode(node, "text")
+				if err != nil {
+					return nil, err
+				}
+				output, err := object.Marshal()
+				if err != nil {
+					return nil, err
+				}
+				marshaled = output
 			}
 			return bytes.NewReader(marshaled), nil
 		},


### PR DESCRIPTION
When `--encoding=protobuf` was set, `object get` used to always return a 200 response and would leave the body blank on error. Now, it returns a JSON error.

fixes #2468

DO NOT MERGE (yet). This patch includes #2516 (which is a dependency).
