### PR TITLE
sharness/Makefile: clean all BINS when cleaning

### DIFF
--- a/test/sharness/Makefile
+++ b/test/sharness/Makefile
@@ -19,7 +19,7 @@ all: aggregate
 
 clean: clean-test-results
 	@echo "*** $@ ***"
-	-rm -rf bin/ipfs
+	-rm -rf $(BINS)
 
 clean-test-results:
 	@echo "*** $@ ***"


### PR DESCRIPTION
I think it is better to clean all the binaries.