### PR TITLE
Outputs added directories as they are traversed.

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -164,7 +164,7 @@ MerkleDAG.
 			}
 
 			// copy intermediary nodes from editor to our actual dagservice
-			_, err := fileAdder.Finalize(hash)
+			_, err := fileAdder.Finalize()
 			if err != nil {
 				return err
 			}

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -163,14 +163,14 @@ MerkleDAG.
 				}
 			}
 
-			if hash {
-				return nil
-			}
-
 			// copy intermediary nodes from editor to our actual dagservice
-			_, err := fileAdder.Finalize()
+			_, err := fileAdder.Finalize(hash)
 			if err != nil {
 				return err
+			}
+
+			if hash {
+				return nil
 			}
 
 			return fileAdder.PinRoot()

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -650,7 +650,7 @@ Examples:
 			flush = true
 		}
 
-		err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp, flush)
+		_, err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp, flush)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -650,7 +650,7 @@ Examples:
 			flush = true
 		}
 
-		_, err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp, flush)
+		err = mfs.Mkdir(n.FilesRoot, dirtomake, dashp, flush)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -349,7 +349,7 @@ func (adder *Adder) addNode(node *dag.Node, path string) error {
 
 	dir := gopath.Dir(path)
 	if dir != "." {
-		if _, err := mfs.Mkdir(adder.mr, dir, true, false); err != nil {
+		if err := mfs.Mkdir(adder.mr, dir, true, false); err != nil {
 			return err
 		}
 	}
@@ -420,7 +420,7 @@ func (adder *Adder) addFile(file files.File) error {
 func (adder *Adder) addDir(dir files.File) error {
 	log.Infof("adding directory: %s", dir.FileName())
 
-	_, err := mfs.Mkdir(adder.mr, dir.FileName(), true, false)
+	err := mfs.Mkdir(adder.mr, dir.FileName(), true, false)
 	if err != nil {
 		return err
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -207,11 +207,7 @@ func (adder *Adder) Finalize() (*dag.Node, error) {
 		return nil, err
 	}
 
-	rootNode, err = root.GetNode()
-	if err != nil {
-		return nil, err
-	}
-	return rootNode, nil
+	return root.GetNode()
 }
 
 func (adder *Adder) outputDirs(path string, fs mfs.FSNode) error {

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -186,7 +186,12 @@ func (adder *Adder) Finalize(write bool) (*dag.Node, error) {
 	if !adder.Wrap {
 		name = rootNode.Links[0].Name
 
-		root, err = adder.mr.GetValue().(*mfs.Directory).Child(name)
+		dir, ok := adder.mr.GetValue().(*mfs.Directory)
+		if !ok {
+			return nil, fmt.Errorf("root is not a directory")
+		}
+
+		root, err = dir.Child(name)
 		if err != nil {
 			return nil, err
 		}
@@ -221,7 +226,10 @@ func (adder *Adder) outputDirs(path string, fs mfs.FSNode) error {
 		return nil
 	}
 
-	dir := fs.(*mfs.Directory)
+	dir, ok := fs.(*mfs.Directory)
+	if !ok {
+		return fmt.Errorf("received FSNode of type TDir that was not a Directory")
+	}
 
 	for _, name := range dir.ListNames() {
 		child, err := dir.Child(name)

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -173,7 +173,7 @@ func (adder *Adder) PinRoot() error {
 	return adder.node.Pinning.Flush()
 }
 
-func (adder *Adder) Finalize(write bool) (*dag.Node, error) {
+func (adder *Adder) Finalize() (*dag.Node, error) {
 	root := adder.mr.GetValue()
 
 	// cant just call adder.RootNode() here as we need the name for printing
@@ -202,11 +202,9 @@ func (adder *Adder) Finalize(write bool) (*dag.Node, error) {
 		return nil, err
 	}
 
-	if write {
-		err = adder.mr.Close()
-		if err != nil {
-			return nil, err
-		}
+	err = adder.mr.Close()
+	if err != nil {
+		return nil, err
 	}
 
 	rootNode, err = root.GetNode()
@@ -293,7 +291,7 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 		return "", err
 	}
 
-	nd, err := fileAdder.Finalize(true)
+	nd, err := fileAdder.Finalize()
 	if err != nil {
 		return "", err
 	}
@@ -325,7 +323,7 @@ func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *dag.No
 		return "", nil, err
 	}
 
-	dagnode, err := fileAdder.Finalize(true)
+	dagnode, err := fileAdder.Finalize()
 	if err != nil {
 		return "", nil, err
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -328,7 +328,7 @@ func (adder *Adder) addNode(node *dag.Node, path string) error {
 
 	dir := gopath.Dir(path)
 	if dir != "." {
-		if err := mfs.Mkdir(adder.mr, dir, true, false); err != nil {
+		if _, err := mfs.Mkdir(adder.mr, dir, true, false); err != nil {
 			return err
 		}
 	}
@@ -399,7 +399,7 @@ func (adder *Adder) addFile(file files.File) error {
 func (adder *Adder) addDir(dir files.File) error {
 	log.Infof("adding directory: %s", dir.FileName())
 
-	err := mfs.Mkdir(adder.mr, dir.FileName(), true, false)
+	_, err := mfs.Mkdir(adder.mr, dir.FileName(), true, false)
 	if err != nil {
 		return err
 	}

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -116,6 +116,11 @@ func (d *Directory) childNode(name string) (FSNode, error) {
 		return nil, err
 	}
 
+	return d.cacheNode(name, nd)
+}
+
+// cacheNode caches a node into d.childDirs or d.files and returns the FSNode.
+func (d *Directory) cacheNode(name string, nd *dag.Node) (FSNode, error) {
 	i, err := ft.FromBytes(nd.Data)
 	if err != nil {
 		return nil, err
@@ -333,6 +338,17 @@ func (d *Directory) AddChild(name string, nd *dag.Node) error {
 	}
 
 	d.modTime = time.Now()
+
+	if len(nd.Links) == 0 {
+		nfi, err := NewFile(name, nd, d, d.dserv)
+		if err != nil {
+			return err
+		}
+		d.files[name] = nfi
+	} else {
+		ndir := NewDirectory(d.ctx, name, nd, d, d.dserv)
+		d.childDirs[name] = ndir
+	}
 
 	return nil
 }

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -100,9 +100,9 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 
 // Mkdir creates a directory at 'path' under the directory 'd', creating
 // intermediary directories as needed if 'mkparents' is set to true
-func Mkdir(r *Root, pth string, mkparents bool, flush bool) (*Directory, error) {
+func Mkdir(r *Root, pth string, mkparents bool, flush bool) error {
 	if pth == "" {
-		return nil, fmt.Errorf("no path given to Mkdir")
+		return fmt.Errorf("no path given to Mkdir")
 	}
 	parts := path.SplitList(pth)
 	if parts[0] == "" {
@@ -117,9 +117,9 @@ func Mkdir(r *Root, pth string, mkparents bool, flush bool) (*Directory, error) 
 	if len(parts) == 0 {
 		// this will only happen on 'mkdir /'
 		if mkparents {
-			return nil, nil
+			return nil
 		}
-		return nil, fmt.Errorf("cannot create directory '/': Already exists")
+		return fmt.Errorf("cannot create directory '/': Already exists")
 	}
 
 	cur := r.GetValue().(*Directory)
@@ -128,16 +128,16 @@ func Mkdir(r *Root, pth string, mkparents bool, flush bool) (*Directory, error) 
 		if err == os.ErrNotExist && mkparents {
 			mkd, err := cur.Mkdir(d)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			fsn = mkd
 		} else if err != nil {
-			return nil, err
+			return err
 		}
 
 		next, ok := fsn.(*Directory)
 		if !ok {
-			return nil, fmt.Errorf("%s was not a directory", path.Join(parts[:i]))
+			return fmt.Errorf("%s was not a directory", path.Join(parts[:i]))
 		}
 		cur = next
 	}
@@ -145,18 +145,18 @@ func Mkdir(r *Root, pth string, mkparents bool, flush bool) (*Directory, error) 
 	final, err := cur.Mkdir(parts[len(parts)-1])
 	if err != nil {
 		if !mkparents || err != os.ErrExist || final == nil {
-			return nil, err
+			return err
 		}
 	}
 
 	if flush {
 		err := final.Flush()
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return final, nil
+	return nil
 }
 
 func Lookup(r *Root, path string) (FSNode, error) {

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -102,7 +102,7 @@ func PutNode(r *Root, path string, nd *dag.Node) error {
 // intermediary directories as needed if 'mkparents' is set to true
 func Mkdir(r *Root, pth string, mkparents bool, flush bool) (*Directory, error) {
 	if pth == "" {
-		return nil, nil
+		return nil, fmt.Errorf("no path given to Mkdir")
 	}
 	parts := path.SplitList(pth)
 	if parts[0] == "" {

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -285,6 +285,23 @@ test_expect_success "'ipfs add -r' output looks good" '
 	test_cmp expected actual
 '
 
+test_expect_success "'ipfs add -rn' succeeds" '
+	mkdir mountdir/moons &&
+	echo "Hello Europa!" >mountdir/moons/europa.txt &&
+	echo "Hello Titan!" >mountdir/moons/titan.txt &&
+	ipfs add -rn mountdir/moons >actual
+'
+
+test_expect_success "'ipfs add -rn' output looks good" '
+	MOONS="QmUzSf98B1y5Aw5UcaV5SnAEDNzsppxfigbKjciy57hNRv" &&
+	EUROPA="Qmbjg7zWdqdMaK2BucPncJQDxiALExph5k3NkQv5RHpccu" &&
+	TITAN="QmZzppb9WHn552rmRqpPfgU5FEiHH6gDwi3MrB9cTdPwdb" &&
+	echo "added $EUROPA moons/europa.txt" >expected &&
+	echo "added $TITAN moons/titan.txt" >>expected &&
+	echo "added $MOONS moons" >>expected &&
+	test_cmp expected actual
+'
+
 test_expect_success "ipfs cat accept many hashes from stdin" '
 	{ echo "$MARS"; echo "$VENUS"; } | ipfs cat >actual
 '

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -286,19 +286,27 @@ test_expect_success "'ipfs add -r' output looks good" '
 '
 
 test_expect_success "'ipfs add -rn' succeeds" '
-	mkdir mountdir/moons &&
-	echo "Hello Europa!" >mountdir/moons/europa.txt &&
-	echo "Hello Titan!" >mountdir/moons/titan.txt &&
+	mkdir -p mountdir/moons/jupiter &&
+	mkdir -p mountdir/moons/saturn &&
+	echo "Hello Europa!" >mountdir/moons/jupiter/europa.txt &&
+	echo "Hello Titan!" >mountdir/moons/saturn/titan.txt &&
+	echo "hey youre no moon!" >mountdir/moons/mercury.txt &&
 	ipfs add -rn mountdir/moons >actual
 '
 
 test_expect_success "'ipfs add -rn' output looks good" '
-	MOONS="QmUzSf98B1y5Aw5UcaV5SnAEDNzsppxfigbKjciy57hNRv" &&
+	MOONS="QmVKvomp91nMih5j6hYBA8KjbiaYvEetU2Q7KvtZkLe9nQ" &&
 	EUROPA="Qmbjg7zWdqdMaK2BucPncJQDxiALExph5k3NkQv5RHpccu" &&
+  JUPITER="QmS5mZddhFPLWFX3w6FzAy9QxyYkaxvUpsWCtZ3r7jub9J" &&
+  SATURN="QmaMagZT4rTE7Nonw8KGSK4oe1bh533yhZrCo1HihSG8FK" &&
 	TITAN="QmZzppb9WHn552rmRqpPfgU5FEiHH6gDwi3MrB9cTdPwdb" &&
-	echo "added $EUROPA moons/europa.txt" >expected &&
-	echo "added $TITAN moons/titan.txt" >>expected &&
-	echo "added $MOONS moons" >>expected &&
+	MERCURY="QmUJjVtnN8YEeYcS8VmUeWffTWhnMQAkk5DzZdKnPhqUdK" &&
+  echo "added $EUROPA moons/jupiter/europa.txt" >expected &&
+  echo "added $MERCURY moons/mercury.txt" >>expected &&
+  echo "added $TITAN moons/saturn/titan.txt" >>expected &&
+  echo "added $JUPITER moons/jupiter" >>expected &&
+  echo "added $SATURN moons/saturn" >>expected &&
+  echo "added $MOONS moons" >>expected &&
 	test_cmp expected actual
 '
 


### PR DESCRIPTION
This also fixes a bug where adding with -n would prevent directories from
being outputted. Addresses https://github.com/ipfs/go-ipfs/issues/2530.

Bonus: directories no longer appear at the end of the list for `ipfs add` --
they're in order! :dancers:  