### PR TITLE
Adds Files API cmd to helptext

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -42,6 +42,7 @@ DATA STRUCTURE COMMANDS
 
     block         Interact with raw blocks in the datastore
     object        Interact with raw dag nodes
+    files         Interact with objects as if they were a unix filesystem
     file          Interact with Unix filesystem objects
 
 ADVANCED COMMANDS


### PR DESCRIPTION
We don't list `ipfs files` under the subcommands of `ipfs`.