### PR TITLE
repo: properly init Datastore config, and leave it be

### DIFF
--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -119,7 +119,6 @@ func PeriodicGC(ctx context.Context, node *core.IpfsNode) error {
 	}
 
 	if cfg.Datastore.GCPeriod == "" {
-		node.Repo.SetConfigKey("Datastore.GCPeriod", "1h")
 		cfg.Datastore.GCPeriod = "1h"
 	}
 

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -21,6 +21,11 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		return nil, err
 	}
 
+	datastore, err := datastoreConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	conf := &Config{
 
 		// setup the node's default addresses.
@@ -35,6 +40,7 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			Gateway: "/ip4/127.0.0.1/tcp/8080",
 		},
 
+		Datastore: datastore,
 		Bootstrap: BootstrapPeerStrings(bootstrapPeers),
 		Identity:  identity,
 		Discovery: Discovery{MDNS{
@@ -62,12 +68,12 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 	return conf, nil
 }
 
-func datastoreConfig() (*Datastore, error) {
+func datastoreConfig() (Datastore, error) {
 	dspath, err := DataStorePath("")
 	if err != nil {
-		return nil, err
+		return Datastore{}, err
 	}
-	return &Datastore{
+	return Datastore{
 		Path:               dspath,
 		Type:               "leveldb",
 		StorageMax:         "10GB",


### PR DESCRIPTION
We didn't previously initialize the Datastore config section.
The respective function exists, but was dead code up until now.

This lead to weird decisions like the GC code deciding on defaults,
and writing these to the config file. Don't want GC to touch the config.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>