### PR TITLE
clean up unused incfusever code

### DIFF
--- a/core/commands/incfusever/doc.go
+++ b/core/commands/incfusever/doc.go
@@ -1,7 +1,0 @@
-// Package incfusever is only here to prevent go src tools (like godep)
-// from thinking fuseversion is not a required package. Though we do not
-// actually use github.com/jbenet/go-fuse-version as a library, we
-// _may_ need its binary. We avoid it as much as possible as compiling
-// it _requires_ fuse headers. Users must be able to install go-ipfs
-// without also installing fuse.
-package incfusever

--- a/core/commands/incfusever/incfusever.go
+++ b/core/commands/incfusever/incfusever.go
@@ -1,9 +1,0 @@
-// +build !nofuse
-
-package incfusever
-
-import (
-	fuseversion "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-fuse-version"
-)
-
-var _ = fuseversion.LocalFuseSystems


### PR DESCRIPTION
fixes #2573 

Cleaned out all unused godeps back in #2557, without this in godeps, `core/commands/incfusever` fails to build. That code is unused, so i'm just going to remove it. Its only purpose was to prevent godeps from deleting the vendored go-fuse-version package.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>