### PR TITLE
Fix a typo in publish.go

### DIFF
--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -47,7 +47,7 @@ Publish an <ipfs-path> to another public key (not implemented):
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, false, "IPFS path of the obejct to be published.").EnableStdin(),
+		cmds.StringArg("ipfs-path", true, false, "IPFS path of the object to be published.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("resolve", "Resolve given path before publishing (default=true)."),


### PR DESCRIPTION
This typo can be seen by running `ipfs name publish --help`