### PR TITLE
Refactor Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,6 @@ else
   go_test=go test
 endif
 
-COMMIT := $(shell git rev-parse --short HEAD)
-ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(COMMIT)"
-MAKEFLAGS += --no-print-directory
-
-
 export IPFS_API ?= v04x.ipfs.io
 
 all: help
@@ -45,19 +40,19 @@ vendor: godep
 	godep save -r ./...
 
 install: deps
-	cd cmd/ipfs && go install -ldflags=$(ldflags)
+	make -C cmd/ipfs install
 
 build: deps
-	cd cmd/ipfs && go build -i -ldflags=$(ldflags)
+	make -C cmd/ipfs build
 
 nofuse: deps
-	cd cmd/ipfs && go install -tags nofuse -ldflags=$(ldflags)
+	make -C cmd/ipfs nofuse
 
 clean:
-	cd cmd/ipfs && go clean -ldflags=$(ldflags)
+	make -C cmd/ipfs clean
 
 uninstall:
-	cd cmd/ipfs && go clean -i -ldflags=$(ldflags)
+	make -C cmd/ipfs uninstall
 
 PHONY += all help godep toolkit_upgrade gx_upgrade gxgo_upgrade gx_check
 PHONY += go_check deps vendor install build nofuse clean uninstall

--- a/cmd/ipfs/Makefile
+++ b/cmd/ipfs/Makefile
@@ -1,7 +1,19 @@
+COMMIT := $(shell git rev-parse --short HEAD)
+ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(COMMIT)"
+
 all: install
 
-build:
-	cd ../../ && make build
-
 install:
-	cd ../../ && make install
+	go install -ldflags=$(ldflags)
+
+build:
+	go build -i -ldflags=$(ldflags)
+
+nofuse:
+	go install -tags nofuse -ldflags=$(ldflags)
+
+clean:
+	go clean -ldflags=$(ldflags)
+
+uninstall:
+	go clean -i -ldflags=$(ldflags)


### PR DESCRIPTION
Move the go commands that should run under cmd/ipfs in the Makefile in
cmd/ipfs rather than doing a "cd cmd/ipfs && go ..." in the root
Makefile.

The "cd cmd/ipfs && go ..." lines causes problems with GNU Emacs's
compilation mode.  With the current setup Emacs is unable to jump to
the location of the error outputted by go compiler as it can not find
the source file.  The problem is that the embedded "cd" command causes
Emacs's compilation mode to lose track of the current directory and
thus attempts to look for the source file in the wrong directory.