### PR TITLE
Adds --local option to 'ipfs mount'

### DIFF
--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -10,7 +10,9 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	nodeMount "github.com/ipfs/go-ipfs/fuse/node"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 	config "github.com/ipfs/go-ipfs/repo/config"
+	offroute "github.com/ipfs/go-ipfs/routing/offline"
 )
 
 var MountCmd = &cmds.Command{
@@ -112,6 +114,13 @@ baz
 		}
 		if !found {
 			nsdir = cfg.Mounts.IPNS // NB: be sure to not redeclare!
+		}
+
+		local, _, _ := req.Option("local").Bool()
+		if local {
+			node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.PrivateKey)
+
+			node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore(), 128)
 		}
 
 		err = nodeMount.Mount(node, fsdir, nsdir)

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -239,7 +239,7 @@ test_mount_ipfs() {
 	test_expect_success FUSE "'ipfs mount' succeeds" '
 		do_umount "$(pwd)/ipfs" || true &&
 		do_umount "$(pwd)/ipns" || true &&
-		ipfs mount >actual
+		ipfs mount --local >actual
 	'
 
 	test_expect_success FUSE "'ipfs mount' output looks good" '


### PR DESCRIPTION
Tests now pass on my local machine (they never did before here).

This is a hacky solution, but serves as a stub to get discussion going on The Right Way(tm) to nicely support `--local` across all commands.