### PR TITLE
Dockerfile: use go version 1.5.4-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV GX_IPFS   ""
 # The IPFS fs-repo within the container
 ENV IPFS_PATH /data/ipfs
 # Golang stuff
-ENV GO_VERSION 1.5.3-r0
+ENV GO_VERSION 1.5.4-r0
 ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -16,7 +16,7 @@ EXPOSE 8080
 
 ENV GX_IPFS   ""
 ENV IPFS_PATH /data/ipfs
-ENV GO_VERSION 1.5.3-r0
+ENV GO_VERSION 1.5.4-r0
 ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs


### PR DESCRIPTION
This error recently appeared when building the Dockerfile:

ERROR: unsatisfiable constraints:
  go-1.5.4-r0:
    breaks: world[go=1.5.3-r0]

It looks that now upstream requires go 1.5.4-r0 not 1.5.3-r0.

This should help fixing issue #2607.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>