### PR TITLE
Fix dot path parsing on Windows

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -405,8 +405,6 @@ const notRecursiveFmtStr = "'%s' is a directory, use the '-%s' flag to specify d
 const dirNotSupportedFmtStr = "Invalid path '%s', argument '%s' does not support directories"
 
 func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (files.File, error) {
-	fpath = filepath.ToSlash(filepath.Clean(fpath))
-
 	if fpath == "." {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -414,6 +412,8 @@ func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (fi
 		}
 		fpath = cwd
 	}
+
+	fpath = filepath.ToSlash(filepath.Clean(fpath))
 
 	stat, err := os.Lstat(fpath)
 	if err != nil {


### PR DESCRIPTION
Follow up to PR https://github.com/ipfs/go-ipfs/pull/2135.
When trying to add dot (current working directory) the input path was not previously standardized to forward slashes which would cause malformed directory listings like those in issue https://github.com/ipfs/go-ipfs/issues/1922.
This commit should sanitize the path in the same way it is done at other entry points in the parser and force the path to use forward slashes instead of the FS native delimiter.

Possibly related to issue https://github.com/ipfs/go-ipfs/issues/1691.