### PR TITLE
docker: allow IPFS_LOGGING to be passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ EXPOSE 8080
 ENV GX_IPFS   ""
 # The IPFS fs-repo within the container
 ENV IPFS_PATH /data/ipfs
+# The default logging level
+ENV IPFS_LOGGING ""
 # Golang stuff
 ENV GO_VERSION 1.5.4-r0
 ENV GOPATH     /go

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -16,6 +16,7 @@ EXPOSE 8080
 
 ENV GX_IPFS   ""
 ENV IPFS_PATH /data/ipfs
+ENV IPFS_LOGGING ""
 ENV GO_VERSION 1.5.4-r0
 ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH


### PR DESCRIPTION
This somehow got lost in the Dockerfile overhaul.