### PR TITLE
Capitalized `a`, lowercased `not`

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -442,7 +442,7 @@ You may only use keytypes that are supported in your ipfs binary: currently this
 
 Value is arbitrary text. Standard input can be used to provide value.
 
-NOTE: a value may NOT exceed 2048 bytes.
+NOTE: A value may not exceed 2048 bytes.
 `,
 	},
 


### PR DESCRIPTION
A should be capitalised, as it is a new clause; `not` should not be capitalized, as there is no value judgement (it is a statement), and the emphasis is offputting without adding any technical backing. I just do not think it is necessaary.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>