### PR TITLE
test-lib: make checking for docker silent

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -42,7 +42,7 @@ SHARNESS_LIB="lib/sharness/sharness.sh"
 # grab + output options
 test "$TEST_NO_FUSE" != 1 && test_set_prereq FUSE
 test "$TEST_EXPENSIVE" = 1 && test_set_prereq EXPENSIVE
-test "$TEST_NO_DOCKER" != 1 && type docker && test_set_prereq DOCKER
+test "$TEST_NO_DOCKER" != 1 && type docker >/dev/null 2>&1 && test_set_prereq DOCKER
 
 TEST_OS=$(uname -s | tr [a-z] [A-Z])
 


### PR DESCRIPTION
It is annoying to see `docker is /usr/bin/docker` at the beginning of the tests.