### PR TITLE
Update shell link to allow wget

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -44,7 +44,7 @@ properly written. It checks the following:
   and with licensing the work under the [MIT license](docs/LICENSE).
 
   To help you automatically add these trailers, you can run the
-  [setup_commit_msg_hook.sh](https://github.com/ipfs/community/blob/master/dev/tools/hooks/setup_commit_msg_hook.sh)
+  [setup_commit_msg_hook.sh](https://raw.githubusercontent.com/ipfs/community/master/dev/tools/hooks/setup_commit_msg_hook.sh)
   script which will setup a Git commit-msg hook that will add the above
   trailers to all the commit messages you write.
 


### PR DESCRIPTION
The link to the commit file shell link should be to the raw file. That makes it easier for peopel to wget it without caring about using GitHubs interface. Perhaps this should also be hosted on IPFS