### PR TITLE
Moved Tests up in Contribute.md

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -23,6 +23,8 @@ Please look and conform to our [Go Contribution Guidelines](https://github.com/i
 
 All commits in a PR must pass tests. If they don't, fix the commits and/or [squash them](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) so that they do pass the tests. This should be done so that we can use git-bisect easily.
 
+We use CI tests which run when you push to your branch. To run the tests locally, you can run any of these: `make build`, `make install`, `make test`, `go test ./...`, depending on what youre looking to do. Generally `go test ./...` is your best bet.
+
 ### Commit messages
 
 Commit messages must start with a short subject line, followed by an optional, 

--- a/contribute.md
+++ b/contribute.md
@@ -19,6 +19,10 @@ Please look and conform to our [Go Contribution Guidelines](https://github.com/i
 
 ## Repository specific guidelines:
 
+### Each Commit Must Pass Tests
+
+All commits in a PR must pass tests. If they don't, fix the commits and/or [squash them](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) so that they do pass the tests. This should be done so that we can use git-bisect easily.
+
 ### Commit messages
 
 Commit messages must start with a short subject line, followed by an optional, 
@@ -90,8 +94,3 @@ reasons why this is _the right thing to do_:
 License: MIT
 Signed-off-by: Juan Benet <juan@ipfs.io>
 ```
-
-### Each Commit Must Pass Tests
-
-All commits in a PR must pass tests. If they don't, fix the commits and/or [squash them](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Squashing-Commits) so that they do pass the tests. This should be done so that we can use git-bisect easily.
-


### PR DESCRIPTION
This should be more prominent. We also need a much better description of how to run tests - rigt now, we are dependant on Travis for the majority of testing, I believe. If there was a clear guide here on how to run the appropriate tests for each kind of PR, that would be fantastic.

We also really ought to have a section asking people to add all of the tests that they can think of.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>