### PR TITLE
Added Default(false) to verbose for `active` and `dht` cmds

### DIFF
--- a/core/commands/active.go
+++ b/core/commands/active.go
@@ -22,7 +22,7 @@ Lists running and recently run commands.
 		res.SetOutput(req.InvocContext().ReqLog.Report())
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("v", "verbose", "Print more verbose output."),
+		cmds.BoolOption("v", "verbose", "Print more verbose output.").Default(false),
 	},
 	Subcommands: map[string]*cmds.Command{
 		"clear":    clearInactiveCmd,

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -43,7 +43,7 @@ var queryDhtCmd = &cmds.Command{
 		cmds.StringArg("peerID", true, true, "The peerID to run the query against."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write debug information."),
+		cmds.BoolOption("verbose", "v", "Write extra information.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -135,7 +135,7 @@ var findProvidersDhtCmd = &cmds.Command{
 		cmds.StringArg("key", true, true, "The key to find providers for."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write debug information."),
+		cmds.BoolOption("verbose", "v", "Write extra information.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -236,7 +236,7 @@ var findPeerDhtCmd = &cmds.Command{
 		cmds.StringArg("peerID", true, true, "The ID of the peer to search for."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write debug information."),
+		cmds.BoolOption("verbose", "v", "Write extra information.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -339,7 +339,7 @@ There may be several different values for a given key stored in the DHT; in this
 		cmds.StringArg("key", true, true, "The key to find a value for."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write debug information."),
+		cmds.BoolOption("verbose", "v", "Write extra information.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -451,7 +451,7 @@ NOTE: A value may not exceed 2048 bytes.
 		cmds.StringArg("value", true, false, "The value to store.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("verbose", "v", "Write debug information."),
+		cmds.BoolOption("verbose", "v", "Write extra information.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()


### PR DESCRIPTION
This required no change of the code. I also changed the message from `debug` to `extra`, which I think is closer to the truth. Part of #2484.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>