### PR TITLE
Added Default logic to `name` cmd, and local option

### DIFF
--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -49,8 +49,8 @@ Resolve the value of a reference:
 		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption("recursive", "r", "Resolve until the result is not an IPNS name."),
-		cmds.BoolOption("nocache", "n", "Do not used cached entries."),
+		cmds.BoolOption("recursive", "r", "Resolve until the result is not an IPNS name.").Default(false),
+		cmds.BoolOption("nocache", "n", "Do not used cached entries.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 


### PR DESCRIPTION
Added Default logic per #2484, and also added the local option back in, because it exists in the code and should be shown as helptext, at least.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>