### PR TITLE
Added a note about the default values

### DIFF
--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -32,8 +32,9 @@ You may have to create /ipfs and /ipns before using 'ipfs mount':
 > ipfs mount
 `,
 		LongDescription: `
-Mount ipfs at a read-only mountpoint on the OS (default: /ipfs and /ipns).
-All ipfs objects will be accessible under that directory. Note that the
+Mount ipfs at a read-only mountpoint on the OS. The default, /ipfs and /ipns,
+are set in the configutation file, but can be overriden by the options.
+All ipfs objects will be accessible under this directory. Note that the
 root will not be listable, as it is virtual. Access known paths directly.
 
 You may have to create /ipfs and /ipns before using 'ipfs mount':


### PR DESCRIPTION
The /ipfs and /ipns paths can be overridden by the options; this wasn't
in the help text for the options, but should be somewhere. Long help
seemed appropriate.

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>