### PR TITLE
Set Cache-Control immutable

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -205,7 +205,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	modtime := time.Now()
 	if strings.HasPrefix(urlPath, ipfsPathPrefix) {
 		w.Header().Set("Etag", etag)
-		w.Header().Set("Cache-Control", "public, max-age=29030400")
+		w.Header().Set("Cache-Control", "public, max-age=29030400, immutable")
 
 		// set modtime to a really long time ago, since files are immutable and should stay cached
 		modtime = time.Unix(1, 0)


### PR DESCRIPTION
Given that /ipfs/ resources never change, we can easily benefit from this new cache control extension.

Support for this is about to land in Firefox 49:

https://bugzilla.mozilla.org/show_bug.cgi?id=1267474

For more details, there is a good blogpost about this here:

https://bitsup.blogspot.de/2016/05/cache-control-immutable.html

This header is ignored by clients that don't support it.