### PR TITLE
Set correct content-type for ipfs get

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -65,10 +65,30 @@ const (
 )
 
 var mimeTypes = map[string]string{
+	cmds.Gzip:     "application/gzip",
 	cmds.Protobuf: "application/protobuf",
 	cmds.JSON:     "application/json",
+	cmds.Tar:      "application/x-tar",
 	cmds.XML:      "application/xml",
 	cmds.Text:     "text/plain",
+}
+
+var xssSafeMimeTypes = []string{
+	mimeTypes[cmds.Gzip],
+	mimeTypes[cmds.JSON],
+	mimeTypes[cmds.Tar],
+	mimeTypes[cmds.Text],
+	mimeTypes[cmds.XML],
+	mimeTypes[cmds.Protobuf],
+}
+
+func xssSafeMimeType(mime string) bool {
+	for _, t := range xssSafeMimeTypes {
+		if t == mime {
+			return true
+		}
+	}
+	return false
 }
 
 type ServerConfig struct {
@@ -251,7 +271,9 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 	if _, ok := res.Output().(io.Reader); ok {
 		// set streams output type to text to avoid issues with browsers rendering
 		// html pages on priveleged api ports
-		mime = "text/plain"
+		if !xssSafeMimeType(mime) {
+			mime = mimeTypes[cmds.Text]
+		}
 		h.Set(streamHeader, "1")
 	}
 

--- a/commands/response.go
+++ b/commands/response.go
@@ -36,11 +36,12 @@ type EncodingType string
 
 // Supported EncodingType constants.
 const (
+	Gzip     = "gzip"
 	JSON     = "json"
-	XML      = "xml"
 	Protobuf = "protobuf"
+	Tar      = "tar"
 	Text     = "text"
-	// TODO: support more encoding types
+	XML      = "xml"
 )
 
 func marshalJson(value interface{}) (io.Reader, error) {

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -69,6 +69,12 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return
 		}
 
+		// set the correct mime type for tar stream
+		req.SetOption(cmds.EncShort, cmds.Tar)
+		if cmplvl != gzip.NoCompression {
+			req.SetOption(cmds.EncShort, cmds.Gzip)
+		}
+
 		archive, _, _ := req.Option("archive").Bool()
 		reader, err := uarchive.DagArchive(ctx, dn, p.String(), node.DAG, archive, cmplvl)
 		if err != nil {

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -131,6 +131,10 @@ test_get_fail() {
 	'
 }
 
+test_expect_success "ipfs get response has the correct content-type" '
+	curl -I "http://localhost:$PORT_API/api/v0/get?arg=$HASH" | grep "^Content-Type: application/x-tar"
+'
+
 # should work offline
 test_get_cmd
 


### PR DESCRIPTION
This is a version of #2004, with CR from @jbenet integrated in, and should close #1824

Related to https://github.com/ipfs/js-ipfs-api/issues/263.

License: MIT
Signed-off-by: Richard Littauer richard.littauer@gmail.com
