### PR TITLE
pin ls: Remove count option, add Default to quiet

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -188,8 +188,7 @@ Example:
 	},
 	Options: []cmds.Option{
 		cmds.StringOption("type", "t", "The type of pinned keys to list. Can be \"direct\", \"indirect\", \"recursive\", or \"all\".").Default("all"),
-		cmds.BoolOption("count", "n", "Show refcount when listing indirect pins."),
-		cmds.BoolOption("quiet", "q", "Write just hashes of objects."),
+		cmds.BoolOption("quiet", "q", "Write just hashes of objects.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()


### PR DESCRIPTION
'count' is never referenced in the code, and adds nothing when run with `ipfs pin ls` currently. I have removed it; add it again when there is actual logic to reflect. Also, added a Default(false) to quiet.

Part of #2484

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>