### PR TITLE
Show Synopsis in long help

### DIFF
--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -77,7 +77,11 @@ const usageFormat = "{{if .Usage}}{{.Usage}}{{else}}{{.Path}}{{if .ArgUsage}} {{
 const longHelpFormat = `USAGE
 {{.Indent}}{{template "usage" .}}
 
-{{if .Arguments}}ARGUMENTS
+{{if .Synopsis}}SYNOPSIS
+
+{{.Synopsis}}
+
+{{end}}{{if .Arguments}}ARGUMENTS
 
 {{.Arguments}}
 


### PR DESCRIPTION
I think that this is useful, even though it is also shown in the Arguments and Options section below. What do you think, @noffle?

License: MIT
Signed-off-by: Richard Littauer <richard.littauer@gmail.com>