### PR TITLE
Add logic for copying ShortDes to LongDesc if it is not present

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -258,6 +258,25 @@ func (c *Command) Subcommand(id string) *Command {
 	return c.Subcommands[id]
 }
 
+type CommandVisitor func(*Command)
+
+// Walks tree of all subcommands (including this one)
+func (c *Command) Walk(visitor CommandVisitor) {
+	visitor(c)
+	for _, cm := range c.Subcommands {
+		cm.Walk(visitor)
+	}
+}
+
+func (c *Command) ProcessHelp() {
+	c.Walk(func(cm *Command) {
+		ht := &cm.Helptext
+		if len(ht.LongDescription) == 0 {
+			ht.LongDescription = ht.ShortDescription
+		}
+	})
+}
+
 // checkArgValue returns an error if a given arg value is not valid for the
 // given Argument
 func checkArgValue(v string, found bool, def Argument) error {

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -155,3 +155,42 @@ func TestResolving(t *testing.T) {
 		t.Error("Returned command path is different than expected", cmds)
 	}
 }
+
+func TestWalking(t *testing.T) {
+	cmdA := &Command{
+		Subcommands: map[string]*Command{
+			"b": &Command{},
+			"B": &Command{},
+		},
+	}
+	i := 0
+	cmdA.Walk(func(c *Command) {
+		i = i + 1
+	})
+	if i != 3 {
+		t.Error("Command tree walk didn't work, expected 3 got:", i)
+	}
+}
+
+func TestHelpProcessing(t *testing.T) {
+	cmdB := &Command{
+		Helptext: HelpText{
+			ShortDescription: "This is other short",
+		},
+	}
+	cmdA := &Command{
+		Helptext: HelpText{
+			ShortDescription: "This is short",
+		},
+		Subcommands: map[string]*Command{
+			"a": cmdB,
+		},
+	}
+	cmdA.ProcessHelp()
+	if len(cmdA.Helptext.LongDescription) == 0 {
+		t.Error("LongDescription was not set on basis of ShortDescription")
+	}
+	if len(cmdB.Helptext.LongDescription) == 0 {
+		t.Error("LongDescription was not set on basis of ShortDescription")
+	}
+}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -153,6 +153,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 }
 
 func init() {
+	Root.ProcessHelp()
 	*RootRO = *Root
 
 	// sanitize readonly refs command


### PR DESCRIPTION
This is the best place for inserting it that I found.

Test in #2648 should be modified to run `Root.ProcessHelp()`.

Resolves #2691.

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>