### PR TITLE
Make t0030 use iptb for consistent test passing.

### DIFF
--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -15,13 +15,17 @@ if ! test_have_prereq FUSE; then
 	test_done
 fi
 
-test_init_ipfs
-test_launch_ipfs_daemon
+# start iptb + wait for peering
+NUM_NODES=5
+test_expect_success 'init iptb' '
+  iptb init -n $NUM_NODES --bootstrap=none --port=0
+'
+startup_cluster $NUM_NODES
+
 
 #  test mount failure before mounting properly.
-
 test_expect_success "'ipfs mount' fails when there is no mount dir" '
-	tmp_ipfs_mount() { ipfs mount -f=not_ipfs -n=not_ipns >output 2>output.err; } &&
+	tmp_ipfs_mount() { ipfsi 0 mount -f=not_ipfs -n=not_ipns >output 2>output.err; } &&
 	test_must_fail tmp_ipfs_mount
 '
 
@@ -30,17 +34,40 @@ test_expect_success "'ipfs mount' output looks good" '
 	test_should_contain "not_ipns\|not_ipfs" output.err
 '
 
-# now mount properly, and keep going
-test_mount_ipfs
+test_expect_success "setup and publish default IPNS value" '
+  mkdir "$(pwd)/ipfs" "$(pwd)/ipns" &&
+  ipfsi 0 name publish QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn
+'
+
+# make sure stuff is unmounted first
+# then mount properly
+test_expect_success FUSE "'ipfs mount' succeeds" '
+  do_umount "$(pwd)/ipfs" || true &&
+  do_umount "$(pwd)/ipns" || true &&
+  ipfsi 0 mount -f "$(pwd)/ipfs" -n "$(pwd)/ipns" >actual
+'
+
+test_expect_success FUSE "'ipfs mount' output looks good" '
+  echo "IPFS mounted at: $(pwd)/ipfs" >expected &&
+  echo "IPNS mounted at: $(pwd)/ipns" >>expected &&
+  test_cmp expected actual
+'
 
 test_expect_success "mount directories cannot be removed while active" '
 	test_must_fail rmdir ipfs ipns 2>/dev/null
 '
 
-test_kill_ipfs_daemon
+test_expect_success "unmount directories" '
+  do_umount "$(pwd)/ipfs" &&
+  do_umount "$(pwd)/ipns"
+'
 
 test_expect_success "mount directories can be removed after shutdown" '
 	rmdir ipfs ipns
+'
+
+test_expect_success 'stop iptb' '
+  iptb stop
 '
 
 test_done


### PR DESCRIPTION
This addresses t0030. t0040 still fails locally for the same reasons, but converting it is a big enough additional job that I wanted to get this PR in for now and tackel t0040 later.