### PR TITLE
build: specify a dist.ipfs.io hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ else
 endif
 
 
+dist_root=/ipfs/QmXZQzBAFuoELw3NtjQZHkWSdA332PyQUj6pQjuhEukvg8
 gx_bin=bin/gx-v0.7.0
 gx-go_bin=bin/gx-go-v1.2.0
 
@@ -27,13 +28,13 @@ go_check:
 
 bin/gx-v%:
 	@echo "installing gx $(@:bin/gx-%=%)"
-	@bin/dist_get gx $@ $(@:bin/gx-%=%)
+	@bin/dist_get ${dist_root} gx $@ $(@:bin/gx-%=%)
 	rm -f bin/gx
 	ln -s $(@:bin/%=%) bin/gx
 
 bin/gx-go-v%:
 	@echo "installing gx-go $(@:bin/gx-go-%=%)"
-	@bin/dist_get gx-go $@ $(@:bin/gx-go-%=%)
+	@bin/dist_get ${dist_root} gx-go $@ $(@:bin/gx-go-%=%)
 	rm -f bin/gx-go
 	ln -s $(@:bin/%=%) bin/gx-go
 

--- a/bin/dist_get
+++ b/bin/dist_get
@@ -85,20 +85,22 @@ get_go_vars() {
 }
 
 mkurl() {
-	m_name="$1"
-	m_vers="$2"
-	m_archive="$3"
+	m_root="$1"
+	m_name="$2"
+	m_vers="$3"
+	m_archive="$4"
 	m_govars=$(get_go_vars) || die "could not get go env vars"
 
-	echo "http://dist.ipfs.io/$m_name/$m_vers/${m_name}_${m_vers}_$m_govars.$m_archive"
+	echo "https://ipfs.io$m_root/$m_name/$m_vers/${m_name}_${m_vers}_$m_govars.$m_archive"
 }
 
-distname="$1"
-outpath="$2"
-version="$3"
+distroot="$1"
+distname="$2"
+outpath="$3"
+version="$4"
 
-if [ -z "$distname" ] || [ -z "$outpath" ] || [ -z "$version" ]; then
-	die "usage: dist_get <distname> <outpath> <version>"
+if [ -z "$distroot" ] || [ -z "$distname" ] || [ -z "$outpath" ] || [ -z "$version" ]; then
+	die "usage: dist_get <distroot> <distname> <outpath> <version>"
 fi
 
 case $version in
@@ -135,7 +137,7 @@ esac
 
 mkdir -p bin/tmp
 
-url=$(mkurl "$distname" "$version" "$archive")
+url=$(mkurl "$distroot" "$distname" "$version" "$archive")
 tmpfi="bin/tmp/$distname.$archive"
 
 download "$url" "$tmpfi"


### PR DESCRIPTION
build: specify a dist.ipfs.io hash

Right now bin/dist_get trusts whatever DNS resolver is active.
This change enables it to verify what it downloads.
Verification itself remains TODO.

This will work best with a unixfs-hash tool which is TODO too.
It'd just do the equivalent of `ipfs add -n -r <dirOrFile>`.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>
