### PR TITLE
Remove note about Go1.6 not being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ From there:
 
 #### Install Go
 
-First, you'll need Go. If you don't have it: [Download Go 1.5.2+](https://golang.org/dl/). **Go 1.6 is not yet supported.**
+Build process of ipfs requires at least Go 1.5, but we strongly recommend using 1.6.2. If you don't have it: [Download Go 1.6.2+](https://golang.org/dl/).
+
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
 


### PR DESCRIPTION
Recommend Go1.6.2
Note that Go1.5 is still supported

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>