### PR TITLE
metrics: add transport label to p2p_peers_total

### DIFF
--- a/core/corehttp/metrics_test.go
+++ b/core/corehttp/metrics_test.go
@@ -39,8 +39,11 @@ func TestPeersTotal(t *testing.T) {
 
 	node := &core.IpfsNode{PeerHost: hosts[0]}
 	collector := IpfsNodeCollector{Node: node}
-	actual := collector.PeersTotalValue()
-	if actual != 3 {
-		t.Fatalf("expected 3 peers, got %d", int(actual))
+	actual := collector.PeersTotalValues()
+	if len(actual) != 1 {
+		t.Fatalf("expected 1 peers transport, got %d", len(actual))
+	}
+	if actual["/ip4/tcp"] != float64(3) {
+		t.Fatalf("expected 3 peers, got %s", actual["/ip4/tcp"])
 	}
 }


### PR DESCRIPTION
Gives us per-transport peers counts:

	ipfs_p2p_peers_total{transport="/ip4/tcp"} 25
	ipfs_p2p_peers_total{transport="/ip6/tcp"} 13
	ipfs_p2p_peers_total{transport="/ip6/udp/utp"} 17

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>