### PR TITLE
docker: fix ipfs version --commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 	# We get the current commit using this hack,
 	# so that we don't have to copy all of .git/ into the build context.
 	# This saves us quite a bit of image size.
-	&& ref="$(cat .git/HEAD | cut -d' ' -f2)" \
-	&& commit="$(cat .git/$ref | head -c 7)" \
+	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
+	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
 	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
 	# Build and install IPFS and entrypoint script
 	&& cd $SRC_PATH/cmd/ipfs \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -44,8 +44,8 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 COPY . $SRC_PATH
 
 RUN cd $SRC_PATH \
-	&& ref="$(cat .git/HEAD | cut -d' ' -f2)" \
-	&& commit="$(cat .git/$ref | head -c 7)" \
+	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
+	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
 	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
 	&& cd $SRC_PATH/cmd/ipfs \
 	&& go build -ldflags "-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -66,6 +66,14 @@ test_expect_success "simple ipfs add/cat can be run in docker container" '
 	test_cmp expected actual
 '
 
+test_expect_success "version CurrentCommit is set" '
+	docker_exec "$DOC_ID" "wget --retry-connrefused --waitretry=1 --timeout=30 -t 30 \
+		-q -O - http://localhost:8080/version" | grep Commit | cut -d" " -f2 >actual &&
+	docker_exec "$DOC_ID" "ipfs version --commit" | cut -d- -f2 >expected &&
+	[ "$(cat expected | wc -c)" -gt "1" ] && # check there actually is a commit set
+	test_cmp expected actual
+'
+
 test_expect_success "stop docker container" '
 	docker_stop "$DOC_ID"
 '


### PR DESCRIPTION
The dockerfile assumes we're always on a branch, in which case it resolves the head ref in `.git/HEAD` via `.git/refs/`. Solarnet deploys are headless though, i.e. not on a branch but on a specific commit. In this case, Git puts that commit ref directly into `.git/HEAD`, so that the resolution step breaks.