### PR TITLE
docker: simplify git ref resolution, thanks @chriscool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git/
 !.git/HEAD
 !.git/refs/
+!.git/packed-refs
 cmd/ipfs/ipfs
 vendor/gx/
 test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,7 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 	# Invoke gx
 	&& cd $SRC_PATH \
 	&& gx --verbose install --global \
-	# We get the current commit using this hack,
-	# so that we don't have to copy all of .git/ into the build context.
-	# This saves us quite a bit of image size.
-	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
-	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
+	&& mkdir .git/objects && commit=$(git rev-parse --short HEAD) \
 	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
 	# Build and install IPFS and entrypoint script
 	&& cd $SRC_PATH/cmd/ipfs \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -44,8 +44,7 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 COPY . $SRC_PATH
 
 RUN cd $SRC_PATH \
-	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
-	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
+	&& mkdir .git/objects && commit=$(git rev-parse --short HEAD) \
 	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
 	&& cd $SRC_PATH/cmd/ipfs \
 	&& go build -ldflags "-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -70,7 +70,7 @@ test_expect_success "version CurrentCommit is set" '
 	docker_exec "$DOC_ID" "wget --retry-connrefused --waitretry=1 --timeout=30 -t 30 \
 		-q -O - http://localhost:8080/version" | grep Commit | cut -d" " -f2 >actual &&
 	docker_exec "$DOC_ID" "ipfs version --commit" | cut -d- -f2 >expected &&
-	[ "$(cat expected | wc -c)" -gt "1" ] && # check there actually is a commit set
+	test -s expected && # check there actually is a commit set
 	test_cmp expected actual
 '
 


### PR DESCRIPTION
`git rev-parse` simply needed `.git/packed-refs` and an empty `.git/objects/` directory.