### PR TITLE
build: include commit hash & version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 
+ARG IPFS_FULL_VERSION
+
 # Get the go-ipfs sourcecode
 COPY . $SRC_PATH
 
@@ -55,10 +57,12 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 	# This saves us quite a bit of image size.
 	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
 	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
-	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
+	&& ldflags="-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit \
+		-X github.com/ipfs/go-ipfs/repo/config.FullVersion=$IPFS_FULL_VERSION" \
+	&& echo "ldflags: $ldflags" \
 	# Build and install IPFS and entrypoint script
 	&& cd $SRC_PATH/cmd/ipfs \
-	&& go build -ldflags "-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
+	&& go build -ldflags "$ldflags" \
 	&& cp ipfs /usr/local/bin/ipfs \
 	&& cp $SRC_PATH/bin/container_daemon /usr/local/bin/start_ipfs \
 	&& chmod 755 /usr/local/bin/start_ipfs \

--- a/bin/genversion
+++ b/bin/genversion
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#
+# Calls git describe and extracts SemVer-compatible version and meta info
+# Assumes git tags are properly formatted: vX.Y.Z or vX.Y.Z-some-tag
+#
+# Examples:
+#
+#   $ genversion --version
+#   0.4.0-rc2
+#
+# or:
+#
+#   $ genversion --commit
+#   c148.91c6f0f.dirty
+#
+#   (148 commits ahead of the version 0.4.0-rc2, dirty workdir with HEAD at 91c6f0f)
+
+
+PRINT_VERSION=0
+PRINT_COMMIT=0
+
+test $# -ge 1 || PRINT_VERSION=1
+
+while test $# -gt 0; do
+    case "$1" in
+        "--version")
+            PRINT_VERSION=1
+            ;;
+        "--commit")
+            PRINT_COMMIT=1
+            ;;
+    esac
+    shift
+done
+
+
+string_join (){
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+if [[ "$PRINT_VERSION" == "1" ]] || [[ "$PRINT_COMMIT" == "1" ]]; then
+    DESCRIBE=( $(git describe --always --tags --match 'v*' --dirty --long | tr '-' '\n') )
+
+    FIELDS=${#DESCRIBE[@]}
+    if [[ "${DESCRIBE[$FIELDS-1]}" == "dirty" ]]; then
+        DIRTY=1
+        FIELDS=$FIELDS-1
+    fi
+    COMMIT_HASH=${DESCRIBE[$FIELDS-1]}
+    COMMIT_NO=${DESCRIBE[$FIELDS-2]}
+    VERSION=$(string_join - ${DESCRIBE[@]:0:$FIELDS-2})
+    VERSION=${VERSION:1}
+    HASH=${DESCRIBE[$FIELDS-1]}
+    COMMIT=$(printf "c%s.%s" ${DESCRIBE[$FIELDS-2]} ${HASH:1})
+
+    if [[ "$DIRTY" == "1" ]]; then
+        COMMIT="$COMMIT.dirty"
+    fi
+
+fi
+
+if [[ "$PRINT_VERSION" == "1" ]]; then
+    printf $VERSION
+fi
+
+if [[ "$PRINT_VERSION" == "1" ]] && [[ "$PRINT_COMMIT" == "1" ]]; then
+    printf "+"
+fi
+
+if [[ "$PRINT_COMMIT" == "1" ]]; then
+    printf $COMMIT
+fi
+
+echo
+

--- a/cmd/ipfs/Makefile
+++ b/cmd/ipfs/Makefile
@@ -1,5 +1,7 @@
+VERSION := $(shell ../../bin/genversion --version --commit)
 COMMIT := $(shell git rev-parse --short HEAD)
-ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(COMMIT)"
+ldflags = "-X "github.com/ipfs/go-ipfs/repo/config".FullVersion=$(VERSION) \
+-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=$(COMMIT)"
 
 all: install
 

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -13,6 +13,7 @@ import (
 type VersionOutput struct {
 	Version string
 	Commit  string
+	Full    string
 	Repo    string
 }
 
@@ -24,13 +25,15 @@ var VersionCmd = &cmds.Command{
 
 	Options: []cmds.Option{
 		cmds.BoolOption("number", "n", "Only show the version number.").Default(false),
-		cmds.BoolOption("commit", "Show the commit hash.").Default(false),
+		cmds.BoolOption("commit", "Show the commit hash. Deprecated.").Default(false),
+		cmds.BoolOption("full", "Show full version based on git tag & commit.").Default(false),
 		cmds.BoolOption("repo", "Show repo version.").Default(false),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		res.SetOutput(&VersionOutput{
 			Version: config.CurrentVersionNumber,
 			Commit:  config.CurrentCommit,
+			Full:    config.FullVersion,
 			Repo:    fsrepo.RepoVersion,
 		})
 	},
@@ -47,13 +50,24 @@ var VersionCmd = &cmds.Command{
 				return strings.NewReader(v.Repo + "\n"), nil
 			}
 
-			commit, _, err := res.Request().Option("commit").Bool()
-			commitTxt := ""
+			full, _, err := res.Request().Option("full").Bool()
 			if err != nil {
 				return nil, err
 			}
-			if commit {
-				commitTxt = "-" + v.Commit
+			commit, _, err := res.Request().Option("commit").Bool()
+			if err != nil {
+				return nil, err
+			}
+
+			commitTxt := ""
+			if full {
+				commitTxt = v.Full
+			} else {
+				if commit {
+					commitTxt = v.Version + "-" + v.Commit
+				} else {
+					commitTxt = v.Version
+				}
 			}
 
 			number, _, err := res.Request().Option("number").Bool()
@@ -61,10 +75,10 @@ var VersionCmd = &cmds.Command{
 				return nil, err
 			}
 			if number {
-				return strings.NewReader(fmt.Sprintln(v.Version + commitTxt)), nil
+				return strings.NewReader(fmt.Sprintln(commitTxt)), nil
 			}
 
-			return strings.NewReader(fmt.Sprintf("ipfs version %s%s\n", v.Version, commitTxt)), nil
+			return strings.NewReader(fmt.Sprintf("ipfs version %s\n", commitTxt)), nil
 		},
 	},
 	Type: VersionOutput{},

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -61,7 +61,7 @@ func GatewayOption(writable bool, prefixes []string) ServeOption {
 func VersionOption() ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "Commit: %s\n", config.CurrentCommit)
+			fmt.Fprintf(w, "Full Version: %s\n", config.FullVersion)
 			fmt.Fprintf(w, "Client Version: %s\n", id.ClientVersion)
 			fmt.Fprintf(w, "Protocol Version: %s\n", id.LibP2PVersion)
 		})

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -458,7 +458,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	config.CurrentCommit = "theshortcommithash"
+	config.FullVersion = "ipfsfullversion"
 
 	ns := mockNamesys{}
 	ts, _ := newTestServerAndNode(t, ns)
@@ -480,7 +480,7 @@ func TestVersion(t *testing.T) {
 	}
 	s := string(body)
 
-	if !strings.Contains(s, "Commit: theshortcommithash") {
+	if !strings.Contains(s, "Full Version: ipfsfullversion") {
 		t.Fatalf("response doesn't contain commit:\n%s", s)
 	}
 

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -2,6 +2,7 @@ package config
 
 // CurrentCommit is the current git commit, this is set as a ldflag in the Makefile
 var CurrentCommit string
+var FullVersion string
 
 // CurrentVersionNumber is the current application's version literal
 const CurrentVersionNumber = "0.4.2"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -43,12 +43,16 @@ RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
 
 COPY . $SRC_PATH
 
+ARG IPFS_FULL_VERSION
+
 RUN cd $SRC_PATH \
 	&& ref=$(cat .git/HEAD | grep ref | cut -d' ' -f2) \
 	&& commit=$(if [ -z "$ref" ]; then cat .git/HEAD; else cat ".git/$ref"; fi | head -c 7) \
-	&& echo "ldflags=-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
+	&& ldflags="-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit \
+		-X github.com/ipfs/go-ipfs/repo/config.FullVersion=$IPFS_FULL_VERSION" \
+	&& echo "ldflags: $ldflags" \
 	&& cd $SRC_PATH/cmd/ipfs \
-	&& go build -ldflags "-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=$commit" \
+	&& go build -ldflags "$ldflags" \
 	&& cp ipfs /usr/local/bin/ipfs \
 	&& cp $SRC_PATH/bin/container_daemon /usr/local/bin/start_ipfs \
 	&& chmod 755 /usr/local/bin/start_ipfs \

--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -48,7 +48,17 @@ shellquote() {
 
 # This takes a Dockerfile, and a build context directory
 docker_build() {
-    docker build --rm -f "$1" "$2"
+    ipfs_full_version=$($2/bin/genversion --version --commit)
+
+    # Workaround for docker < 1.9
+    if test "$TRAVIS" = true
+    then
+        cat "$1" | sed "s/^ARG IPFS_FULL_VERSION.*/ENV IPFS_FULL_VERSION=$ipfs_full_version/" > "$1.travis"
+        docker build --rm -f "$1.travis" "$2"
+        rm "$1.travis"
+    else
+        docker build --rm --build-arg IPFS_FULL_VERSION=$ipfs_full_version -f "$1" "$2"
+    fi
 }
 
 # This takes an image as argument and writes a docker ID on stdout

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -68,8 +68,8 @@ test_expect_success "simple ipfs add/cat can be run in docker container" '
 
 test_expect_success "version CurrentCommit is set" '
 	docker_exec "$DOC_ID" "wget --retry-connrefused --waitretry=1 --timeout=30 -t 30 \
-		-q -O - http://localhost:8080/version" | grep Commit | cut -d" " -f2 >actual &&
-	docker_exec "$DOC_ID" "ipfs version --commit" | cut -d- -f2 >expected &&
+		-q -O - http://localhost:8080/version" | grep "Full Version" | cut -d" " -f3 >actual &&
+	docker_exec "$DOC_ID" "ipfs version --full -n" >expected &&
 	[ "$(cat expected | wc -c)" -gt "1" ] && # check there actually is a commit set
 	test_cmp expected actual
 '


### PR DESCRIPTION
This is a revived PR corresponding to #2453 
@lgierth do you have an idea how to deprecate properly? Currently both `--commit` and `--full` work, no warnings issued.
- Added Full Version: ipfs version --full
- Removed Commit from :8080/version
- ipfs version --commit and commit field in /api/v0/version are deprecated

License: MIT
Signed-off-by: hutenosa hutenosa@mm.st
