### PR TITLE
Expose corenet API

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -604,9 +604,6 @@ func getApiClient(repoPath, apiAddrStr string) (cmdsHttp.Client, error) {
 		return nil, err
 	}
 
-<<<<<<< HEAD
-	return apiClientForAddr(addr)
-=======
 	client, err := apiClientForAddr(addr)
 	if err != nil {
 		return nil, err
@@ -664,7 +661,6 @@ func doVersionRequest(client cmdsHttp.Client) (*coreCmds.VersionOutput, error) {
 		return nil, errUnexpectedApiOutput
 	}
 	return ver, nil
->>>>>>> atn/master
 }
 
 func apiClientForAddr(addr ma.Multiaddr) (cmdsHttp.Client, error) {

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -28,7 +28,7 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 		return nil, cmd, path, err
 	}
 
-	req, err := cmds.NewRequest(path, opts, nil, nil, cmd, optDefs)
+	req, err := cmds.NewRequest(path, opts, nil, nil, cmd, optDefs, nil)
 	if err != nil {
 		return nil, cmd, path, err
 	}

--- a/commands/command.go
+++ b/commands/command.go
@@ -58,6 +58,7 @@ type Command struct {
 	PostRun    Function
 	Marshalers map[EncodingType]Marshaler
 	Helptext   HelpText
+	Interact   func(Request, io.ReadWriter) error
 
 	// External denotes that a command is actually an external binary.
 	// fewer checks and validations will be performed on such commands.
@@ -80,8 +81,8 @@ var ErrNoFormatter = ClientError("This command cannot be formatted to plain text
 var ErrIncorrectType = errors.New("The command returned a value with a different type than expected")
 
 // Call invokes the command for the given Request
-func (c *Command) Call(req Request) Response {
-	res := NewResponse(req)
+func (c *Command) Call(req Request, stdout, stderr io.Writer) Response {
+	res := NewResponse(req, stdout, stderr)
 
 	cmds, err := c.Resolve(req.Path())
 	if err != nil {

--- a/commands/command.go
+++ b/commands/command.go
@@ -48,6 +48,12 @@ type HelpText struct {
 	Subcommands     string // overrides SUBCOMMANDS section
 }
 
+type MessageIO interface {
+	Read(p []byte) (n int, err error)
+	Write(p []byte) (n int, err error)
+	ReadMessage() ([]byte, error)
+}
+
 // Command is a runnable command, with input arguments and options (flags).
 // It can also have Subcommands, to group units of work into sets.
 type Command struct {
@@ -58,7 +64,7 @@ type Command struct {
 	PostRun    Function
 	Marshalers map[EncodingType]Marshaler
 	Helptext   HelpText
-	Interact   func(Request, io.ReadWriter) error
+	Interact   func(Request, MessageIO) error
 
 	// External denotes that a command is actually an external binary.
 	// fewer checks and validations will be performed on such commands.

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -15,11 +16,16 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	config "github.com/ipfs/go-ipfs/repo/config"
 
+<<<<<<< HEAD
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
+=======
+	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	websocket "github.com/gorilla/websocket"
+>>>>>>> atn/master
 )
 
 const (
-	ApiUrlFormat = "http://%s%s/%s?%s"
+	ApiUrlFormat = "%s://%s%s/%s?%s"
 	ApiPath      = "/api/v0" // TODO: make configurable
 )
 
@@ -78,9 +84,20 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 		reader = fileReader
 	}
 
+	var protocol string
+	if req.Command().Interact != nil {
+		protocol = "ws"
+	} else {
+		protocol = "http"
+	}
+	
 	path := strings.Join(req.Path(), "/")
-	url := fmt.Sprintf(ApiUrlFormat, c.serverAddress, ApiPath, path, query)
+	url := fmt.Sprintf(ApiUrlFormat, protocol, c.serverAddress, ApiPath, path, query)
 
+	if req.Command().Interact != nil {
+		return streamingRequest(url, req)
+	}
+	
 	httpReq, err := http.NewRequest("POST", url, reader)
 	if err != nil {
 		return nil, err
@@ -116,6 +133,18 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 	}
 
 	return res, nil
+}
+
+func streamingRequest(url string, req cmds.Request) (cmds.Response, error) {
+	conn, httpRes, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil { return nil, err }
+	wsio := NewWebsocketIO(conn)
+	defer wsio.Close()
+	err = req.Command().Interact(req, wsio)
+	if err != nil {
+		return nil, err
+	}
+	return getResponse(httpRes, req)
 }
 
 func getQuery(req cmds.Request) (string, error) {
@@ -154,7 +183,7 @@ func getQuery(req cmds.Request) (string, error) {
 // getResponse decodes a http.Response to create a cmds.Response
 func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error) {
 	var err error
-	res := cmds.NewResponse(req)
+	res := cmds.NewResponse(req, os.Stdout, os.Stderr)
 
 	contentType := httpRes.Header.Get(contentTypeHeader)
 	contentType = strings.Split(contentType, ";")[0]

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -16,12 +16,8 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	config "github.com/ipfs/go-ipfs/repo/config"
 
-<<<<<<< HEAD
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
-=======
-	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	websocket "github.com/gorilla/websocket"
->>>>>>> atn/master
 )
 
 const (
@@ -137,7 +133,9 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 
 func streamingRequest(url string, req cmds.Request) (cmds.Response, error) {
 	conn, httpRes, err := websocket.DefaultDialer.Dial(url, nil)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	wsio := NewWebsocketIO(conn)
 	defer wsio.Close()
 	err = req.Command().Interact(req, wsio)

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -11,16 +11,11 @@ import (
 	"strings"
 	"sync"
 
-<<<<<<< HEAD
+	websocket "github.com/gorilla/websocket"
+
 	"github.com/ipfs/go-ipfs/repo/config"
 	cors "gx/ipfs/QmQzTLDsi3a37CJyMDBXnjiHKQpth3AGS1yqwU57FfLwfG/cors"
-	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
-=======
-	
-	cors "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/rs/cors"
-	context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
-	websocket "github.com/gorilla/websocket"
->>>>>>> atn/master
+	/*context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"*/
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	logging "gx/ipfs/QmaDNZ4QMdBdku1YZWBysufYyoQt1negQGNav6PLYarbY8/go-log"
@@ -151,18 +146,19 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(node.Context())
-	defer cancel()
-	if cn, ok := w.(http.CloseNotifier); ok {
-		clientGone := cn.CloseNotify()
-		go func() {
-			select {
-			case <-clientGone:
-			case <-ctx.Done():
-			}
-			cancel()
-		}()
-	}
+	ctx := node.Context()
+	/*ctx, cancel := context.WithCancel(node.Context())
+	  defer cancel()
+	  if cn, ok := w.(http.CloseNotifier); ok {
+	  	clientGone := cn.CloseNotify()
+	  	go func() {
+	  		select {
+	  		case <-clientGone:
+	  		case <-ctx.Done():
+	  		}
+	  		cancel()
+	  	}()
+	  }*/
 
 	if !allowOrigin(r, i.cfg) || !allowReferer(r, i.cfg) {
 		w.WriteHeader(http.StatusForbidden)
@@ -206,11 +202,8 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		req.SetStdin(wsio)
 		stdout = wsio
 		stderr = wsio
-	} else {	
-		stdout = nil
-		stderr = nil
 	}
-	
+
 	// call the command
 	res := i.root.Call(req, stdout, stderr)
 
@@ -221,7 +214,7 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				w.Header()[k] = v
 			}
 		}
-		
+
 		// now handle responding to the client properly
 		sendResponse(w, r, res, req)
 	}

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -118,11 +118,7 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
 	}
 
-<<<<<<< HEAD
-	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs)
-=======
-	req, err := cmds.NewRequest(path, opts, args, f, cmd, optDefs, nil)
->>>>>>> atn/master
+	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -118,7 +118,11 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
 	}
 
+<<<<<<< HEAD
 	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs)
+=======
+	req, err := cmds.NewRequest(path, opts, args, f, cmd, optDefs, nil)
+>>>>>>> atn/master
 	if err != nil {
 		return nil, err
 	}

--- a/commands/http/websocketio.go
+++ b/commands/http/websocketio.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"io"
+	"time"
+
+	websocket "github.com/gorilla/websocket"
+)
+
+type WebsocketIO struct {
+	conn *websocket.Conn
+	reader io.Reader
+}
+
+func NewWebsocketIO(conn *websocket.Conn) WebsocketIO {
+	return WebsocketIO{conn, nil}
+}
+
+func (wsio WebsocketIO) Read(buf []byte) (int, error) {
+	for {
+		if wsio.reader == nil {
+			_, reader, err := wsio.conn.NextReader()
+			closeError, ok := err.(*websocket.CloseError)
+			if ok && closeError.Code == 1000 {
+				return 0, io.EOF
+			}
+			if err != nil {
+				return 0, err 
+			}
+			wsio.reader = reader
+		}
+		n, err := wsio.reader.Read(buf)
+		if (err != nil) {
+			wsio.reader = nil
+			if n == 0 && err == io.EOF {
+				continue
+			}
+		}
+		return n, err
+	}
+}
+
+func (wsio WebsocketIO) Write(buf []byte) (int, error) {
+	err := wsio.conn.WriteMessage(websocket.BinaryMessage, buf)
+	if err != nil {
+		return 0, err
+	}
+	return len(buf), nil
+}
+
+func (wsio WebsocketIO) Close() error {
+	_ = wsio.conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		time.Now().Add(2 * time.Second))
+	return wsio.conn.Close()
+}

--- a/commands/request.go
+++ b/commands/request.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	// "os"
 	"reflect"
 	"strconv"
 	"time"

--- a/commands/request.go
+++ b/commands/request.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	// "os"
 	"reflect"
 	"strconv"
 	"time"
@@ -79,6 +79,7 @@ type Request interface {
 	SetInvocContext(Context)
 	Command() *Command
 	Values() map[string]interface{}
+	SetStdin(io.Reader)
 	Stdin() io.Reader
 
 	ConvertOptions() error
@@ -253,6 +254,10 @@ func (r *request) Values() map[string]interface{} {
 	return r.values
 }
 
+func (r *request) SetStdin(stdin io.Reader) {
+	r.stdin = stdin
+}
+
 func (r *request) Stdin() io.Reader {
 	return r.stdin
 }
@@ -304,12 +309,12 @@ func (r *request) ConvertOptions() error {
 
 // NewEmptyRequest initializes an empty request
 func NewEmptyRequest() (Request, error) {
-	return NewRequest(nil, nil, nil, nil, nil, nil)
+	return NewRequest(nil, nil, nil, nil, nil, nil, nil)
 }
 
 // NewRequest returns a request initialized with given arguments
 // An non-nil error will be returned if the provided option values are invalid
-func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd *Command, optDefs map[string]Option) (Request, error) {
+func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd *Command, optDefs map[string]Option, stdin io.Reader) (Request, error) {
 	if opts == nil {
 		opts = make(OptMap)
 	}
@@ -328,7 +333,7 @@ func NewRequest(path []string, opts OptMap, args []string, file files.File, cmd 
 		ctx:        ctx,
 		optionDefs: optDefs,
 		values:     values,
-		stdin:      os.Stdin,
+		stdin:      stdin,
 	}
 	err := req.ConvertOptions()
 	if err != nil {

--- a/commands/response.go
+++ b/commands/response.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"os"
+	// "os"
 	"strings"
 )
 
@@ -242,10 +242,10 @@ func (r *response) Stderr() io.Writer {
 }
 
 // NewResponse returns a response to match given Request
-func NewResponse(req Request) Response {
+func NewResponse(req Request, stdout, stderr io.Writer) Response {
 	return &response{
 		req:    req,
-		stdout: os.Stdout,
-		stderr: os.Stderr,
+		stdout: stdout,
+		stderr: stderr,
 	}
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -112,6 +112,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"update":    ExternalBinary(),
 	"version":   VersionCmd,
 	"bitswap":   BitswapCmd,
+	"service":   ServiceCmd,
 }
 
 // RootRO is the readonly version of Root

--- a/core/commands/service.go
+++ b/core/commands/service.go
@@ -1,0 +1,197 @@
+package commands
+
+import (
+	// "bytes"
+	"fmt"
+	"io"
+	"os"
+	// "reflect"
+	// "strings"
+	// "time"
+	exec "os/exec"
+
+	cmds "github.com/ipfs/go-ipfs/commands"
+	corenet "github.com/ipfs/go-ipfs/core/corenet"
+	// core "github.com/ipfs/go-ipfs/core"
+	peer "github.com/ipfs/go-ipfs/p2p/peer"
+	// u "github.com/ipfs/go-ipfs/util"
+
+	// ma "github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+	// context "github.com/ipfs/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+)
+
+var ServiceCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Remote services over IPFS",
+	},
+	Subcommands: map[string]*cmds.Command{
+		"listen": ListenCmd,
+		"dial": DialCmd,
+	},
+}
+
+var ListenCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Listen for connections",
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("Name", true, false, "Name of service to listen on"),
+		cmds.StringArg("Command", false, true, "Command to expose"),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("verbose", "v", "Be verbose"),
+		cmds.BoolOption("server", "s", "Keep serving requests until killed"),
+		cmds.BoolOption("unique", "u", "Disallow other listeners on same name"),
+		cmds.StringOption("proxy", "p", "multiaddr"),
+		cmds.StringOption("auth", "a", "reserved for future authentication or authorization"),
+	},
+	PreRun: func(req cmds.Request) error {
+		if req.Option("server").Found() { return fmt.Errorf("--server not implemented") }
+		if req.Option("unique").Found() { return fmt.Errorf("--unique not implemented") }
+		if req.Option("proxy").Found() { return fmt.Errorf("--proxy not implemented") }
+		if req.Option("auth").Found() { return fmt.Errorf("--auth not implemented") }
+
+		return nil
+	},
+	Interact: interactWithRemote,
+	Run: func(req cmds.Request, res cmds.Response) {
+		// ctx := req.Context()
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		list, err := corenet.Listen(n, "/app/" + req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		conn, err := list.Accept()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		defer conn.Close()
+		if val, _, _ := req.Option("verbose").Bool(); val {
+			fmt.Fprintf(res.Stdout(), "Connection from: %s\n", conn.Conn().RemotePeer())
+		}
+		err = Copy2(conn, req.Stdin(), res.Stdout(), conn)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		} 
+	},
+}
+
+var DialCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Dial a remote service",
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("NodeID", true, false, "IPFS node to connect to"),
+		cmds.StringArg("Name", true, false, "Name of service to connect to"),
+		cmds.StringArg("Command", false, true, "Command to expose"),
+	},
+	Options: []cmds.Option{
+		cmds.BoolOption("verbose", "v", "Be verbose"),
+		cmds.StringOption("proxy", "p", "multiaddr"),
+		cmds.StringOption("auth", "a", "reserved for future authentication or authorization"),
+	},
+	PreRun: func(req cmds.Request) error {
+		if req.Option("proxy").Found() { return fmt.Errorf("--proxy not implemented") }
+		if req.Option("auth").Found() { return fmt.Errorf("--auth not implemented") }
+
+		return nil
+	},
+	Interact: interactWithRemote,
+	Run: func(req cmds.Request, res cmds.Response) {
+		// ctx := req.Context()
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		target, err := peer.IDB58Decode(req.Arguments()[0])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		
+		conn, err := corenet.Dial(n, target, "/app/" + req.Arguments()[1])
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		if val, _, _ := req.Option("verbose").Bool(); val {
+			fmt.Fprintf(res.Stdout(), "Connected to: %s\n", target)
+		}
+		err = Copy2(conn, req.Stdin(), res.Stdout(), conn)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		} 
+	},
+}
+
+
+func Copy2(dst1 io.Writer, src1 io.Reader, dst2 io.Writer, src2 io.Reader) error {
+	done1 := make(chan error)
+	done2 := make(chan error)
+	go func() {
+		_, err := io.Copy(dst1, src1)
+		done1 <- err
+	}()
+	go func() {
+		_, err := io.Copy(dst2, src2)
+		done2 <- err
+	}()
+	ok := 0
+	for {
+		var err error
+		select {
+		case err = <-done1:
+		case err = <-done2:
+		}
+		if err != nil {
+			return err
+		} 
+		ok += 1 
+		if ok == 2 {
+			return nil
+		}
+	}
+}
+
+func interactWithRemote(req cmds.Request, conn io.ReadWriter) error {
+	n := len(req.Command().Arguments) - 1	
+	args := req.Arguments()
+	if len(args) > n {
+		path, err := exec.LookPath(args[n])
+		if err != nil { path = args[n] }
+		cmd := exec.Cmd{
+			Path: path,
+			Args: args[n+1:],
+			Stdin: conn,
+			Stdout: conn,
+			Stderr: conn,
+		}
+		return cmd.Run()
+	} else {
+		return Copy2(conn, os.Stdin, os.Stdout, conn)
+	}
+}


### PR DESCRIPTION
This is continuation of #2005 , still WIP.
What it allows is to communicate in real-time using ipfs identities and libp2p. Currently the implementation uses websockets to communicate with daemon, and it implements channels over them, so the listener can handle more than 1 client at a time. Usage is still much like it was in #2005, but quite a few internals changed. I managed to set-up TAP tunnel over IPFS between 2 hosts using little helper program, so I think I can say that it at least works.
What needs to be done:

- [ ] Get sign-off under @AtnNn commit from #2005
- [x] Clean up commit mess
- [ ] Implement/fix to closing connections
- [ ] Implement/fix graceful shutdown
- [ ] Cleanup code in few places
- [ ] Write tests
- [ ] Write docs

I'm opening this now so that people can see the progress and comment on what is done.