### PR TITLE
Fix commands --flags not showing flags via HTTP API

### DIFF
--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -17,8 +17,11 @@ import (
 type Command struct {
 	Name        string
 	Subcommands []Command
-	Options     []cmds.Option
-	ShowOptions bool
+	Options     []Option
+}
+
+type Option struct {
+	Names []string
 }
 
 const (
@@ -37,15 +40,15 @@ func CommandsCmd(root *cmds.Command) *cmds.Command {
 			cmds.BoolOption(flagsOptionName, "f", "Show command flags").Default(false),
 		},
 		Run: func(req cmds.Request, res cmds.Response) {
-			showOptions, _, _ := req.Option(flagsOptionName).Bool()
-			rootCmd := cmd2outputCmd("ipfs", root, showOptions)
+			rootCmd := cmd2outputCmd("ipfs", root)
 			res.SetOutput(&rootCmd)
 		},
 		Marshalers: cmds.MarshalerMap{
 			cmds.Text: func(res cmds.Response) (io.Reader, error) {
 				v := res.Output().(*Command)
+				showOptions, _, _ := res.Request().Option(flagsOptionName).Bool()
 				buf := new(bytes.Buffer)
-				for _, s := range cmdPathStrings(v) {
+				for _, s := range cmdPathStrings(v, showOptions) {
 					buf.Write([]byte(s + "\n"))
 				}
 				return buf, nil
@@ -55,35 +58,38 @@ func CommandsCmd(root *cmds.Command) *cmds.Command {
 	}
 }
 
-func cmd2outputCmd(name string, cmd *cmds.Command, showOptions bool) Command {
+func cmd2outputCmd(name string, cmd *cmds.Command) Command {
+	opts := make([]Option, len(cmd.Options))
+	for i, opt := range cmd.Options {
+		opts[i] = Option{opt.Names()}
+	}
+
 	output := Command{
 		Name:        name,
 		Subcommands: make([]Command, len(cmd.Subcommands)),
-		Options:     cmd.Options,
-		ShowOptions: showOptions,
+		Options:     opts,
 	}
 
 	i := 0
 	for name, sub := range cmd.Subcommands {
-		output.Subcommands[i] = cmd2outputCmd(name, sub, showOptions)
+		output.Subcommands[i] = cmd2outputCmd(name, sub)
 		i++
 	}
 
 	return output
 }
 
-func cmdPathStrings(cmd *Command) []string {
+func cmdPathStrings(cmd *Command, showOptions bool) []string {
 	var cmds []string
 
 	var recurse func(prefix string, cmd *Command)
 	recurse = func(prefix string, cmd *Command) {
 		newPrefix := prefix + cmd.Name
 		cmds = append(cmds, newPrefix)
-		if prefix != "" && cmd.ShowOptions {
-			for _, option := range cmd.Options {
-				names := option.Names()
+		if prefix != "" && showOptions {
+			for _, options := range cmd.Options {
 				var cmdOpts []string
-				for _, flag := range names {
+				for _, flag := range options.Names {
 					if len(flag) == 1 {
 						flag = "-" + flag
 					} else {

--- a/test/sharness/t0500-issues-and-regressions-offline.sh
+++ b/test/sharness/t0500-issues-and-regressions-offline.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+test_description="Tests for various fxed issues and regressions."
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+# Tests go here
+
+test_done

--- a/test/sharness/t0501-issues-and-regressions-online.sh
+++ b/test/sharness/t0501-issues-and-regressions-online.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+test_description="Tests for various fxed issues and regressions."
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_launch_ipfs_daemon
+
+# Tests go here
+
+test_expect_sucess "commands command with flag flags works via HTTP API - #2301" '
+	curl "http://$API_ADDR/api/v0/commands?flags" | grep "verbose"
+'
+
+test_kill_ipfs_daemon
+
+test_done
+


### PR DESCRIPTION
It was caused by the cmds.Option struct being Interface not struct
The solution is to create struct and copy interesting data over.

Also removed the "ShowOptions" field from being sent via the HTTP API.

This introduces small change to the API.
I will yet add tests for this bug.

Resolves #2301
License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>