### PR TITLE
Add CORS headers to Read Only Gateway Default config

### DIFF
--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -62,6 +62,11 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			RootRedirect: "",
 			Writable:     false,
 			PathPrefixes: []string{},
+			HTTPHeaders: map[string][]string{
+				"Access-Control-Allow-Origin":  []string{"*"},
+				"Access-Control-Allow-Methods": []string{"GET"},
+				"Access-Control-Allow-Headers": []string{"X-Requested-With"},
+			},
 		},
 	}
 

--- a/test/sharness/t0112-gateway-cors.sh
+++ b/test/sharness/t0112-gateway-cors.sh
@@ -7,10 +7,6 @@
 test_description="Test HTTP Gateway CORS Support"
 
 test_config_ipfs_cors_headers() {
-    ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
-    ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-    ipfs config --json Gateway.HTTPHeaders.Access-Control-Allow-Headers '["X-Requested-With"]'
-
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
     ipfs config --json API.HTTPHeaders.Access-Control-Allow-Headers '["X-Requested-With"]'


### PR DESCRIPTION
This will allow for weider use of local gateway from different sites.

For example: ipfs.pics could use JS to use either their global or user's local gateway.

I might work on piece of JS doing just that but I don't really like JS. :smile: 

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>