### PR TITLE
Fix/buffer err chan

### DIFF
--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -146,7 +146,7 @@ func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqn
 		entry.Ttl = proto.Uint64(uint64(ttl.Nanoseconds()))
 	}
 
-	errs := make(chan error)
+	errs := make(chan error, 2)
 
 	go func() {
 		errs <- PublishEntry(ctx, r, ipnskey, entry)

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -135,6 +135,9 @@ func checkCtxTTL(ctx context.Context) (time.Duration, bool) {
 }
 
 func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqnum uint64, eol time.Time, r routing.IpfsRouting, id peer.ID) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	namekey, ipnskey := IpnsKeysForID(id)
 	entry, err := CreateRoutingEntryData(k, value, seqnum, eol)
 	if err != nil {


### PR DESCRIPTION
If one of the other calls failed, it would return early leaving the other goroutine stranded waiting to return its error.

I also localized the context cancellation to more quickly clean up operations in failure situations.