### PR TITLE
docker: make dockerfile differences more obvious

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
-# There is a copy of this Dockerfile in test/sharness,
+# There is a copy of this Dockerfile called Dockerfile.fast,
 # which is optimized for build time, instead of image size.
 #
 # Please keep these two Dockerfiles in sync.

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,12 +1,10 @@
 FROM alpine:3.3
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
-# This is a copy of the root Dockerfile,
+# This is a copy of /Dockerfile,
 # except that we optimize for build time, instead of image size.
 #
 # Please keep these two Dockerfiles in sync.
-#
-# Only sections different from the root Dockerfile are commented.
 
 
 EXPOSE 4001

--- a/test/3nodetest/Makefile
+++ b/test/3nodetest/Makefile
@@ -25,7 +25,7 @@ bin/random: $(RANDOMSRC)/**/*.go
 # just build it every time... this part isn't
 # even the lengthy part, and it decreases pain.
 docker_ipfs_image:
-	docker build -t $(IMAGE_NAME) -f test/Dockerfile .
+	docker build -t $(IMAGE_NAME) -f Dockerfile.fast .
 	docker images | grep $(IMAGE_NAME)
 
 clean:

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -33,7 +33,7 @@ TEST_TESTS_DIR=$(dirname "$TEST_SCRIPTS_DIR")
 APP_ROOT_DIR=$(dirname "$TEST_TESTS_DIR")
 
 test_expect_success "docker image build succeeds" '
-	docker_build "$TEST_TESTS_DIR/Dockerfile" "$APP_ROOT_DIR" >actual ||
+	docker_build "$TEST_TESTS_DIR/../Dockerfile.fast" "$APP_ROOT_DIR" >actual ||
 	test_fsh echo "TEST_TESTS_DIR: $TEST_TESTS_DIR" ||
 	test_fsh echo "APP_ROOT_DIR : $APP_ROOT_DIR" ||
 	test_fsh cat actual


### PR DESCRIPTION
The two produce the same image, except one is optimized for image size, while the other is optimized for build time.