### PR TITLE
Makefile, bin: Support multiple GOPATH components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bin/gx-go-v%:
 gx_check: ${gx_bin} ${gx-go_bin}
 
 path_check:
-	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(GOPATH)/src/github.com/ipfs/go-ipfs)
+	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(addsuffix /src/github.com/ipfs/go-ipfs,$(subst :, ,$(GOPATH))))
 
 deps: go_check gx_check path_check
 	${gx_bin} --verbose install --global

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 PWD=$1
-EXPECTED=$2
 
 if [ -z "$PWD" ]; then
 	echo "must pass in your current working directory"
@@ -13,8 +12,13 @@ if [ -z "$GOPATH" ]; then
 	exit 1
 fi
 
-if [ "$PWD" != "$EXPECTED" ]; then
-	echo "go-ipfs must be built from within your \$GOPATH directory."
-	echo "expected '$EXPECTED' but got '$PWD'"
-	exit 1
-fi
+while [ ${#} -gt 1 ]; do
+	if [ "$PWD" = "$2" ]; then
+		exit 0
+	fi
+	shift
+done
+
+echo "go-ipfs must be built from within your \$GOPATH directory."
+echo "expected within '$GOPATH' but got '$PWD'"
+exit 1


### PR DESCRIPTION
Go's `GOPATH` environment variable can contain multiple paths, separated by a colon `:` similar to the `PATH` env var. In such cases Go uses the first path element to install any packages, however the remaining paths are still used to find dependencies. Because of this it's quite a common setup to have multiple paths listed in GOPATH (e.g. one for development and another for appengine, which has its special installer).

The current Makefile however erroneously assumes that `GOPATH` contains a single path element, and tries to locate go-ipfs within by appending a string to `GOPATH`, which is obviously cause an invalid path, and hence fail the `path_check` rule in the Makefile, even though the required condition is met.

~~This PR fixes it by moving path handling back into `bin/check_go_path`, which iterates over all the path components of `GOPATH`, trying each one of them for the go-ipfs match and only failing if none matches the requirements. Further it was kind of weird to pass in `PWD` as a parameter to a script, so I moved the first parameter's evaluation into the script as well.~~

This PR fixes it by splitting up GOPATH along the colon characters, appending the go-ipfs suffix to each component and resolving them individually. The possibly multiple resulting paths are passed to the path verification script to iterate over and check individually.