### PR TITLE
Change logic of stdin input to be last and only if required

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,7 +34,9 @@ environment variable:
     export IPFS_PATH=/path/to/ipfsrepo
 `,
 	},
-
+	Arguments: []cmds.Argument{
+		cmds.FileArg("default-config", false, false, "Initialize with the given configuration.").EnableStdin(),
+	},
 	Options: []cmds.Option{
 		cmds.IntOption("bits", "b", "Number of bits to use in the generated RSA private key.").Default(nBitsForKeypairDefault),
 		cmds.BoolOption("empty-repo", "e", "Don't add and pin help files to the local storage.").Default(false),
@@ -76,7 +79,24 @@ environment variable:
 			return
 		}
 
-		if err := doInit(os.Stdout, req.InvocContext().ConfigRoot, empty, nBitsForKeypair); err != nil {
+		var conf *config.Config
+
+		f := req.Files()
+		if f != nil {
+			confFile, err := f.NextFile()
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			conf = &config.Config{}
+			if err := json.NewDecoder(confFile).Decode(conf); err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+		}
+
+		if err := doInit(os.Stdout, req.InvocContext().ConfigRoot, empty, nBitsForKeypair, conf); err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
@@ -88,10 +108,10 @@ Reinitializing would overwrite your keys.
 `)
 
 func initWithDefaults(out io.Writer, repoRoot string) error {
-	return doInit(out, repoRoot, false, nBitsForKeypairDefault)
+	return doInit(out, repoRoot, false, nBitsForKeypairDefault, nil)
 }
 
-func doInit(out io.Writer, repoRoot string, empty bool, nBitsForKeypair int) error {
+func doInit(out io.Writer, repoRoot string, empty bool, nBitsForKeypair int, conf *config.Config) error {
 	if _, err := fmt.Fprintf(out, "initializing ipfs node at %s\n", repoRoot); err != nil {
 		return err
 	}
@@ -104,9 +124,12 @@ func doInit(out io.Writer, repoRoot string, empty bool, nBitsForKeypair int) err
 		return errRepoExists
 	}
 
-	conf, err := config.Init(out, nBitsForKeypair)
-	if err != nil {
-		return err
+	if conf == nil {
+		var err error
+		conf, err = config.Init(out, nBitsForKeypair)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := fsrepo.Init(repoRoot, conf); err != nil {

--- a/test/bin/.gitignore
+++ b/test/bin/.gitignore
@@ -8,3 +8,4 @@
 !checkflags
 !continueyn
 !verify-go-fmt.sh
+!time-out

--- a/test/bin/time-out
+++ b/test/bin/time-out
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# The Bash shell script executes a command with a time-out.
+# Upon time-out expiration SIGTERM (15) is sent to the process. If the signal
+# is blocked, then the subsequent SIGKILL (9) terminates it.
+#
+# Based on the Bash documentation example.
+
+# Hello Chet,
+# please find attached a "little easier"  :-)  to comprehend
+# time-out example.  If you find it suitable, feel free to include
+# anywhere: the very same logic as in the original examples/scripts, a
+# little more transparent implementation to my taste.
+#
+# Dmitry V Golovashkin <Dmitry.Golovashkin@sas.com>
+
+scriptName="${0##*/}"
+
+declare -i DEFAULT_TIMEOUT=9
+declare -i DEFAULT_INTERVAL=1
+declare -i DEFAULT_DELAY=1
+
+# Timeout.
+declare -i timeout=DEFAULT_TIMEOUT
+# Interval between checks if the process is still alive.
+declare -i interval=DEFAULT_INTERVAL
+# Delay between posting the SIGTERM signal and destroying the process by SIGKILL.
+declare -i delay=DEFAULT_DELAY
+
+function printUsage() {
+    cat <<EOF
+
+Synopsis
+    $scriptName [-t timeout] [-i interval] [-d delay] command
+    Execute a command with a time-out.
+    Upon time-out expiration SIGTERM (15) is sent to the process. If SIGTERM
+    signal is blocked, then the subsequent SIGKILL (9) terminates it.
+
+    -t timeout
+        Number of seconds to wait for command completion.
+        Default value: $DEFAULT_TIMEOUT seconds.
+
+    -i interval
+        Interval between checks if the process is still alive.
+        Positive integer, default value: $DEFAULT_INTERVAL seconds.
+
+    -d delay
+        Delay between posting the SIGTERM signal and destroying the
+        process by SIGKILL. Default value: $DEFAULT_DELAY seconds.
+
+As of today, Bash does not support floating point arithmetic (sleep does),
+therefore all delay/time values must be integers.
+EOF
+}
+
+# Options.
+while getopts ":t:i:d:" option; do
+    case "$option" in
+        t) timeout=$OPTARG ;;
+        i) interval=$OPTARG ;;
+        d) delay=$OPTARG ;;
+        *) printUsage; exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+# $# should be at least 1 (the command to execute), however it may be strictly
+# greater than 1 if the command itself has options.
+if (($# == 0 || interval <= 0)); then
+    printUsage
+    exit 1
+fi
+
+# kill -0 pid   Exit code indicates if a signal may be sent to $pid process.
+(
+    ((t = timeout))
+
+    while ((t > 0)); do
+        sleep $interval
+        kill -0 $$ || exit 0
+        ((t -= interval))
+    done
+
+    # Be nice, post SIGTERM first.
+    # The 'exit 0' below will be executed if any preceeding command fails.
+    kill -s SIGTERM $$ && kill -0 $$ || exit 0
+    sleep $delay
+    kill -s SIGKILL $$
+) 2> /dev/null &
+
+exec "$@"

--- a/test/bin/time-out
+++ b/test/bin/time-out
@@ -6,14 +6,6 @@
 #
 # Based on the Bash documentation example.
 
-# Hello Chet,
-# please find attached a "little easier"  :-)  to comprehend
-# time-out example.  If you find it suitable, feel free to include
-# anywhere: the very same logic as in the original examples/scripts, a
-# little more transparent implementation to my taste.
-#
-# Dmitry V Golovashkin <Dmitry.Golovashkin@sas.com>
-
 scriptName="${0##*/}"
 
 declare -i DEFAULT_TIMEOUT=9

--- a/test/sharness/t0022-init-default.sh
+++ b/test/sharness/t0022-init-default.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test init command with default config"
+
+. lib/test-lib.sh
+
+cfg_key="Addresses.API"
+cfg_val="/ip4/0.0.0.0/tcp/5001"
+
+# test that init succeeds
+test_expect_success "ipfs init succeeds" '
+	export IPFS_PATH="$(pwd)/.ipfs" &&
+	echo "IPFS_PATH: \"$IPFS_PATH\"" &&
+	BITS="2048" &&
+	ipfs init --bits="$BITS" >actual_init ||
+	test_fsh cat actual_init
+'
+
+test_expect_success ".ipfs/config has been created" '
+	test -f "$IPFS_PATH"/config ||
+	test_fsh ls -al .ipfs
+'
+
+test_expect_success "ipfs config succeeds" '
+	ipfs config $cfg_flags "$cfg_key" "$cfg_val"
+'
+
+test_expect_success "ipfs read config succeeds" '
+    IPFS_DEFAULT_CONFIG=$(cat "$IPFS_PATH"/config)
+'
+
+test_expect_success "clean up ipfs dir" '
+	rm -rf "$IPFS_PATH"
+'
+
+test_expect_success "ipfs init default config succeeds" '
+	echo $IPFS_DEFAULT_CONFIG | ipfs init - >actual_init ||
+	test_fsh cat actual_init
+'
+
+test_expect_success "ipfs config output looks good" '
+	echo "$cfg_val" >expected &&
+	ipfs config "$cfg_key" >actual &&
+	test_cmp expected actual
+'
+
+test_launch_ipfs_daemon
+
+test_kill_ipfs_daemon
+
+test_done

--- a/test/sharness/t0500-issues-and-regressions-offline.sh
+++ b/test/sharness/t0500-issues-and-regressions-offline.sh
@@ -8,4 +8,10 @@ test_init_ipfs
 
 # Tests go here
 
+test_expect_success "ipfs init with occupied input works - #2748" '
+	export IPFS_PATH="ipfs_path"
+	echo "" | time-out ipfs init &&
+	rm -rf ipfs_path
+'
+
 test_done


### PR DESCRIPTION
This PR changes how stdin is used while parsing arguments. Current behaviour is that stdin is used for non-required and variadic arguments which causes confusion.

After the change the stdin is used only in case of missing required argument or if explicitly mentioned by the user with `-`.

Question: Should we print on stderr when ipfs command is listening for stdin to clear up possible confusing hang even more?

Aims to resolve https://github.com/ipfs/go-ipfs/issues/2748

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>