### PR TITLE
Add flag to ls to not resolve type of subnodes

### DIFF
--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -46,7 +46,7 @@ format:
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("headers", "v", "Print table headers (Hash, Size, Name).").Default(false),
-		cmds.BoolOption("resolve-type", "Resolve linked objects to find ouy their types").Default(false),
+		cmds.BoolOption("resolve-type", "Resolve linked objects to find out their types.").Default(true),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		node, err := req.InvocContext().GetNode()


### PR DESCRIPTION
This makes ls return even if files referenced in the directory are not available.
It also introduces a `resolve-type` flag that forces the resolution of type.


Resolves https://github.com/ipfs/go-ipfs/issues/2820
 
License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>