### PR TITLE
In blockstore tests treat Close and Closing the same way

### DIFF
--- a/blocks/blockstore/blockstore_test.go
+++ b/blocks/blockstore/blockstore_test.go
@@ -190,8 +190,10 @@ func TestAllKeysRespectsContext(t *testing.T) {
 		select {
 		case <-done:
 			t.Fatal("sync is wrong")
+		// As time differentce between Closed and Closing is so small we have to check on
+		//  both those channels at the same time otherwise we get a race which causes
+		//  random test failures sometimes.
 		case <-results.Process().Closed():
-			t.Fatal("should not be closed") // should not be closed yet.
 		case <-results.Process().Closing():
 			// should be closing now!
 			t.Log("closing correctly at this point.")


### PR DESCRIPTION
This should prevent race condition that caused https://github.com/ipfs/go-ipfs/issues/2762

Resolves #2762 

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>