### PR TITLE
Fix DHT tests failing because of repeated addresses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ IPFS_MIN_GX_VERSION = 0.6
 IPFS_MIN_GX_GO_VERSION = 1.1
 
 ifeq ($(TEST_NO_FUSE),1)
-  go_test=go test -tags nofuse
+  go_test=IPFS_REUSEPORT=false go test -tags nofuse
 else
-  go_test=go test
+  go_test=IPFS_REUSEPORT=false go test
 endif
 
 
@@ -92,10 +92,10 @@ test_go_race:
 	$(go_test) ./... -race
 
 test_sharness_short:
-	cd test/sharness/ && make
+	make -C test/sharness/
 
 test_sharness_expensive:
-	cd test/sharness/ && TEST_EXPENSIVE=1 make
+	TEST_EXPENSIVE=1 make -C test/sharness/
 
 test_all_commits:
 	@echo "testing all commits between origin/master..HEAD"


### PR DESCRIPTION
Due to SO_REUSEPORT it is possible for a localhost:0
address to repeat. This causes failure in DHT tests
where we spun up a lot of nodes inside test.

As for a birthday paradox it is enough to use 140
ports to get 20% chance for collision which was causing
failure in our case.

The fix is to disable REUSE_PORT routine for the
tests and leave it running for sharness tests where
not that many addresses are used at the same time.

Resolves https://github.com/ipfs/go-ipfs/issues/2745 https://github.com/ipfs/go-ipfs/issues/2809 https://github.com/ipfs/go-ipfs/issues/188