### PR TITLE
pass reference to reader instead of using the one on the object

### DIFF
--- a/routing/dht/dht_net.go
+++ b/routing/dht/dht_net.go
@@ -230,9 +230,9 @@ func (ms *messageSender) SendRequest(ctx context.Context, pmes *pb.Message) (*pb
 
 func (ms *messageSender) ctxReadMsg(ctx context.Context, mes *pb.Message) error {
 	errc := make(chan error, 1)
-	go func() {
-		errc <- ms.r.ReadMsg(mes)
-	}()
+	go func(r ggio.ReadCloser) {
+		errc <- r.ReadMsg(mes)
+	}(ms.r)
 
 	select {
 	case err := <-errc:


### PR DESCRIPTION
this should address #2835. I was able to reproduce the issue last night without this fix, but havent been able to reproduce the issue this morning (with or without the fix)

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>