### PR TITLE
Revert "Makefile, bin: Support multiple GOPATH components"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bin/gx-go-v%:
 gx_check: ${gx_bin} ${gx-go_bin}
 
 path_check:
-	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(addsuffix /src/github.com/ipfs/go-ipfs,$(subst :, ,$(GOPATH))))
+	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(GOPATH)/src/github.com/ipfs/go-ipfs)
 
 deps: go_check gx_check path_check
 	${gx_bin} --verbose install --global

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 PWD=$1
+EXPECTED=$2
 
 if [ -z "$PWD" ]; then
 	echo "must pass in your current working directory"
@@ -12,13 +13,8 @@ if [ -z "$GOPATH" ]; then
 	exit 1
 fi
 
-while [ ${#} -gt 1 ]; do
-	if [ "$PWD" = "$2" ]; then
-		exit 0
-	fi
-	shift
-done
-
-echo "go-ipfs must be built from within your \$GOPATH directory."
-echo "expected within '$GOPATH' but got '$PWD'"
-exit 1
+if [ "$PWD" != "$EXPECTED" ]; then
+	echo "go-ipfs must be built from within your \$GOPATH directory."
+	echo "expected '$EXPECTED' but got '$PWD'"
+	exit 1
+fi


### PR DESCRIPTION
This reverts commit ff75bc0318579fa743a35d316c61d2f8c4ab92ce,
which broke building on windows. See ipfs/go-ipfs#2833.

cc @karalabe @djdv @jefft0