### PR TITLE
Gateway uses minimal IPFS Core API

### DIFF
--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -1,0 +1,60 @@
+package coreapi
+
+import (
+	"context"
+
+	core "github.com/ipfs/go-ipfs/core"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	dag "github.com/ipfs/go-ipfs/merkledag"
+	path "github.com/ipfs/go-ipfs/path"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
+	cid "gx/ipfs/QmfSc2xehWmWLnwwYR91Y8QF4xdASypTFVknutoKQS3GHp/go-cid"
+)
+
+type UnixfsAPI struct {
+	Context context.Context
+	Node    *core.IpfsNode
+}
+
+func (api *UnixfsAPI) resolve(p string) (*dag.Node, error) {
+	pp, err := path.ParsePath(p)
+	if err != nil {
+		return nil, err
+	}
+
+	dagnode, err := core.Resolve(api.Context, api.Node, pp)
+	if err == core.ErrNoNamesys {
+		return nil, coreiface.ErrOffline
+	} else if err != nil {
+		return nil, err
+	}
+	return dagnode, nil
+}
+
+func (api *UnixfsAPI) Cat(p string) (coreiface.Reader, error) {
+	dagnode, err := api.resolve(p)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := uio.NewDagReader(api.Context, dagnode, api.Node.DAG)
+	if err == uio.ErrIsDir {
+		return nil, coreiface.ErrIsDir
+	} else if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (api *UnixfsAPI) Ls(p string) ([]*coreiface.Link, error) {
+	dagnode, err := api.resolve(p)
+	if err != nil {
+		return nil, err
+	}
+
+	links := make([]*coreiface.Link, len(dagnode.Links))
+	for i, l := range dagnode.Links {
+		links[i] = &coreiface.Link{l.Name, l.Size, cid.NewCidV0(l.Hash)}
+	}
+	return links, nil
+}

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -2,9 +2,11 @@ package coreapi
 
 import (
 	"context"
+	"io"
 
 	core "github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
@@ -29,6 +31,14 @@ func (api *UnixfsAPI) resolve(p string) (*dag.Node, error) {
 		return nil, err
 	}
 	return dagnode, nil
+}
+
+func (api *UnixfsAPI) Add(r io.Reader) (*cid.Cid, error) {
+	k, err := coreunix.Add(api.Node, r)
+	if err != nil {
+		return nil, err
+	}
+	return cid.Decode(k)
 }
 
 func (api *UnixfsAPI) Cat(p string) (coreiface.Reader, error) {

--- a/core/coreapi/coreapi_test.go
+++ b/core/coreapi/coreapi_test.go
@@ -1,0 +1,118 @@
+package coreapi_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	core "github.com/ipfs/go-ipfs/core"
+	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
+	// coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
+	repo "github.com/ipfs/go-ipfs/repo"
+	config "github.com/ipfs/go-ipfs/repo/config"
+	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
+)
+
+// `ipfs object new unixfs-dir`
+var emptyUnixfsDir = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
+
+// `echo -n | ipfs add`
+var emptyUnixfsFile = "QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"
+
+func makeAPI(ctx context.Context) (*core.IpfsNode, *coreapi.UnixfsAPI, error) {
+	r := &repo.Mock{
+		C: config.Config{
+			Identity: config.Identity{
+				PeerID: "Qmfoo", // required by offline node
+			},
+		},
+		D: testutil.ThreadSafeCloserMapDatastore(),
+	}
+	node, err := core.NewNode(ctx, &core.BuildCfg{Repo: r})
+	if err != nil {
+		return nil, nil, err
+	}
+	api := &coreapi.UnixfsAPI{Node: node, Context: ctx}
+	return node, api, nil
+}
+
+func TestCatBasic(t *testing.T) {
+	node, api, err := makeAPI(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hello := "hello, world!"
+	hr := strings.NewReader(hello)
+	k, err := coreunix.Add(node, hr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := api.Cat(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, len(hello))
+	n, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF {
+		t.Error(err)
+	}
+	if string(buf) != hello {
+		t.Fatalf("expected [hello, world!], got [%s] [err=%s]", string(buf), n, err)
+	}
+}
+
+func TestCatEmptyFile(t *testing.T) {
+	node, api, err := makeAPI(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = coreunix.Add(node, strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := api.Cat(emptyUnixfsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 1) // non-zero so that Read() actually tries to read
+	n, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF {
+		t.Error(err)
+	}
+	if !bytes.HasPrefix(buf, []byte{0x00}) {
+		t.Fatalf("expected empty data, got [%s] [read=%d]", buf, n)
+	}
+}
+
+func TestCatDir(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestCatNonUnixfs(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestCatOffline(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestLs(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestLsEmpty(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestLsNonUnixfs(t *testing.T) {
+	t.Skip("TODO: implement me")
+}

--- a/core/coreapi/coreapi_test.go
+++ b/core/coreapi/coreapi_test.go
@@ -19,7 +19,8 @@ import (
 // `ipfs object new unixfs-dir`
 var emptyUnixfsDir = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
 
-// `echo -n | ipfs add`
+// echo -n | ipfs add
+// curl -X POST localhost:8080/ipfs/
 var emptyUnixfsFile = "QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"
 
 func makeAPI(ctx context.Context) (*core.IpfsNode, *coreapi.UnixfsAPI, error) {
@@ -37,6 +38,14 @@ func makeAPI(ctx context.Context) (*core.IpfsNode, *coreapi.UnixfsAPI, error) {
 	}
 	api := &coreapi.UnixfsAPI{Node: node, Context: ctx}
 	return node, api, nil
+}
+
+func testAddBasic(t *testing.T) {
+	t.Skip("TODO: implement me")
+}
+
+func TestAddEmpty(t *testing.T) {
+	t.Skip("TODO: implement me")
 }
 
 func TestCatBasic(t *testing.T) {

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -1,0 +1,54 @@
+package iface
+
+import (
+	"errors"
+	"io"
+
+	cid "gx/ipfs/QmfSc2xehWmWLnwwYR91Y8QF4xdASypTFVknutoKQS3GHp/go-cid"
+)
+
+// type CoreAPI interface {
+// 	ID() CoreID
+// 	Version() CoreVersion
+// }
+
+type Link struct {
+	Name string
+	Size uint64
+	Cid  *cid.Cid
+}
+
+type Reader interface {
+	io.ReadSeeker
+	io.Closer
+}
+
+type UnixfsAPI interface {
+	Cat(string) (Reader, error)
+	Ls(string) ([]*Link, error)
+}
+
+// type ObjectAPI interface {
+// 	New() (cid.Cid, Object)
+// 	Get(string) (Object, error)
+// 	Links(string) ([]*Link, error)
+// 	Data(string) (Reader, error)
+// 	Stat(string) (ObjectStat, error)
+// 	Put(Object) (cid.Cid, error)
+// 	SetData(string, Reader) (cid.Cid, error)
+// 	AppendData(string, Data) (cid.Cid, error)
+// 	AddLink(string, string, string) (cid.Cid, error)
+// 	RmLink(string, string) (cid.Cid, error)
+// }
+
+// type ObjectStat struct {
+// 	Cid            cid.Cid
+// 	NumLinks       int
+// 	BlockSize      int
+// 	LinksSize      int
+// 	DataSize       int
+// 	CumulativeSize int
+// }
+
+var ErrIsDir = errors.New("object is a directory")
+var ErrOffline = errors.New("can't resolve, ipfs node is offline")

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -19,11 +19,12 @@ type Link struct {
 }
 
 type Reader interface {
-	io.ReadSeeker
-	io.Closer
+	io.ReadCloser
+	io.Seeker
 }
 
 type UnixfsAPI interface {
+	Add(io.Reader) (*cid.Cid, error)
 	Cat(string) (Reader, error)
 	Ls(string) ([]*Link, error)
 }

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -1,11 +1,14 @@
 package corehttp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 
 	core "github.com/ipfs/go-ipfs/core"
+	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	id "gx/ipfs/Qmf4ETeAWXuThBfWwonVyFqGFSgTWepUDEr1txcctvpTXS/go-libp2p/p2p/protocol/identify"
 )
@@ -16,6 +19,8 @@ type GatewayConfig struct {
 	PathPrefixes []string
 }
 
+type apiOption func(context.Context) coreiface.UnixfsAPI
+
 func GatewayOption(paths ...string) ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		cfg, err := n.Repo.Config()
@@ -23,11 +28,15 @@ func GatewayOption(paths ...string) ServeOption {
 			return nil, err
 		}
 
+		apiOpt := func(ctx context.Context) coreiface.UnixfsAPI {
+			api := &coreapi.UnixfsAPI{Context: ctx, Node: n}
+			return api
+		}
 		gateway := newGatewayHandler(n, GatewayConfig{
 			Headers:      cfg.Gateway.HTTPHeaders,
 			Writable:     cfg.Gateway.Writable,
 			PathPrefixes: cfg.Gateway.PathPrefixes,
-		})
+		}, apiOpt)
 
 		for _, p := range paths {
 			mux.Handle(p+"/", gateway)
@@ -37,7 +46,7 @@ func GatewayOption(paths ...string) ServeOption {
 }
 
 func VersionOption() ServeOption {
-	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Commit: %s\n", config.CurrentCommit)
 			fmt.Fprintf(w, "Client Version: %s\n", id.ClientVersion)


### PR DESCRIPTION
This is a follow-up to ipfs/specs#85, which discusses an IPFS Core API. The immediate goal is to slim down the surface area between the gateway, and go-ipfs internals, so that the gateway can easily be extracted into its own package.

- (Disregard the first commit, it'll be rebased out once #2874 is merged.)
- 5e328bf starts a CoreAPI interface offering `Cat()` and `Ls()` alongside data structures and errors, as well as an implementation thereof.
- 8b6cf07 starts using the rump Core API for serving GET requests in the gateway.

A possible direction forward:

- The package `go-ipfs-core-api/interface` provides interfaces, data structures, and errors. Tools like ipget or pinbot can choose between implementations backed by the API server (:5001), or by a proper embedded IpfsNode.
- The package `go-ipfs-core-api` implements `go-ipfs-core-api/interface` backed by a proper IpfsNode. It depends on a lot of go-ipfs internals, like `core`, `merkledag`, `unixfs/io`.
- The existing package `go-ipfs-api` implements `go-ipfs-core-api/interface` backed by the API Server.
- `go-ipfs/core/commands` uses `go-ipfs-core-api` -- most of the logic there should live in the core-api.
- The gateway, FUSE, and whatever else there is also use either `go-ipfs-core-api` or `go-ipfs-api`.