### PR TITLE
raise file descriptor limit to 1024 by default

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -137,7 +137,7 @@ Headers.
 		cmds.BoolOption(unrestrictedApiAccessKwd, "This option has no effect since v0.4.3").Default(false),
 		cmds.BoolOption(unencryptTransportKwd, "Disable transport encryption (for debugging protocols)").Default(false),
 		cmds.BoolOption(enableGCKwd, "Enable automatic periodic repo garbage collection").Default(false),
-		cmds.BoolOption(adjustFDLimitKwd, "Check and raise file descriptor limits if needed").Default(false),
+		cmds.BoolOption(adjustFDLimitKwd, "Check and raise file descriptor limits if needed").Default(true),
 		cmds.BoolOption(offlineKwd, "Run offline. Do not connect to the rest of the network but provide local API.").Default(false),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.

--- a/cmd/ipfs/ulimit_unix.go
+++ b/cmd/ipfs/ulimit_unix.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-var ipfsFileDescNum = uint64(2048)
+var ipfsFileDescNum = uint64(1024)
 
 func init() {
 	if val := os.Getenv("IPFS_FD_MAX"); val != "" {


### PR DESCRIPTION
This changes the behaviour of the ipfs daemon to raise the file descriptor ulimit to 1024 if it is below 1024 when the daemon starts.

On linux, this will have no effect.
On OSX, this will raise the file descriptor limit every time the daemon is started (as the default there is 256).

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>