### PR TITLE
fix progress bar in add

### DIFF
--- a/commands/files/serialfile.go
+++ b/commands/files/serialfile.go
@@ -131,11 +131,16 @@ func (f *serialFile) Size() (int64, error) {
 	}
 
 	var du int64
-	err := filepath.Walk(f.FileName(), func(p string, fi os.FileInfo, err error) error {
+	err := filepath.Walk(f.FullPath(), func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if fi != nil && fi.Mode()&(os.ModeSymlink|os.ModeNamedPipe) == 0 {
 			du += fi.Size()
 		}
 		return nil
 	})
+
 	return du, err
 }

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -308,6 +308,9 @@ You can now refer to the added file in a gateway, like so:
 					bar.ShowBar = true
 					bar.ShowTimeLeft = true
 				}
+			case <-req.Context().Done():
+				res.SetError(req.Context().Err(), cmds.ErrNormal)
+				return
 			}
 		}
 	},

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -242,22 +242,13 @@ You can now refer to the added file in a gateway, like so:
 		}
 
 		var bar *pb.ProgressBar
-		var terminalWidth int
 		if progress {
 			bar = pb.New64(0).SetUnits(pb.U_BYTES)
 			bar.ManualUpdate = true
+			bar.ShowTimeLeft = false
+			bar.ShowPercent = false
+			bar.Output = res.Stderr()
 			bar.Start()
-
-			// the progress bar lib doesn't give us a way to get the width of the output,
-			// so as a hack we just use a callback to measure the output, then git rid of it
-			terminalWidth = 0
-			bar.Callback = func(line string) {
-				terminalWidth = len(line)
-				bar.Callback = nil
-				bar.Output = res.Stderr()
-				log.Infof("terminal width: %v\n", terminalWidth)
-			}
-			bar.Update()
 		}
 
 		var sizeChan chan int64


### PR DESCRIPTION
It turns out there was an actual bug in the computation of the add size. It was using the just filename, not the full path. So anytime you would try to add a path (as opposed to a single file or directory) it would fail out because it couldnt find what you were talking about.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>