### PR TITLE
docker: remove go version constraint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ENV IPFS_PATH /data/ipfs
 # The default logging level
 ENV IPFS_LOGGING ""
 # Golang stuff
-ENV GO_VERSION 1.6.2-r2
 ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
@@ -37,7 +36,7 @@ ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 # Get the go-ipfs sourcecode
 COPY . $SRC_PATH
 
-RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
+RUN apk add --update musl go git bash wget ca-certificates \
 	# Setup user and fs-repo directory
 	&& mkdir -p $IPFS_PATH \
 	&& adduser -D -h $IPFS_PATH -u 1000 ipfs \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -15,7 +15,6 @@ EXPOSE 8080
 ENV GX_IPFS   ""
 ENV IPFS_PATH /data/ipfs
 ENV IPFS_LOGGING ""
-ENV GO_VERSION 1.6.2-r2
 ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
@@ -29,7 +28,7 @@ ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 # and trigger a re-run of all following commands.
 COPY ./package.json $SRC_PATH/package.json
 
-RUN apk add --update musl go=$GO_VERSION git bash wget ca-certificates \
+RUN apk add --update musl go git bash wget ca-certificates \
 	&& mkdir -p $IPFS_PATH \
 	&& adduser -D -h $IPFS_PATH -u 1000 ipfs \
 	&& chown ipfs:ipfs $IPFS_PATH && chmod 755 $IPFS_PATH \


### PR DESCRIPTION
There's only ever one version of a given package
per Alpine release, so GO_VERSION is superfluous
and only breaks the build if the go packages is updated.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>