### PR TITLE
Automatically download and run migrations if needed

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -225,6 +225,7 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		return
 	case fsrepo.ErrNeedMigration:
 		domigrate, found, _ := req.Option(migrateKwd).Bool()
+		fmt.Println("Found old repo version, migrations need to be run.")
 
 		if !found {
 			err = migrate.TryMigrating(fsrepo.RepoVersion)

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -320,7 +320,7 @@ var repoVersionCmd = &cmds.Command{
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		res.SetOutput(&RepoVersion{
-			Version: fsrepo.RepoVersion,
+			Version: fmt.Sprint(fsrepo.RepoVersion),
 		})
 	},
 	Type: RepoVersion{},

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -35,7 +35,7 @@ var VersionCmd = &cmds.Command{
 		res.SetOutput(&VersionOutput{
 			Version: config.CurrentVersionNumber,
 			Commit:  config.CurrentCommit,
-			Repo:    fsrepo.RepoVersion,
+			Repo:    fmt.Sprint(fsrepo.RepoVersion),
 			System:  runtime.GOARCH + "/" + runtime.GOOS, //TODO: Precise version here
 			Golang:  runtime.Version(),
 		})

--- a/core/corerepo/stat.go
+++ b/core/corerepo/stat.go
@@ -1,6 +1,8 @@
 package corerepo
 
 import (
+	"fmt"
+
 	"github.com/ipfs/go-ipfs/core"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
@@ -40,6 +42,6 @@ func RepoStat(n *core.IpfsNode, ctx context.Context) (*Stat, error) {
 		NumObjects: count,
 		RepoSize:   usage,
 		RepoPath:   path,
-		Version:    "fs-repo@" + fsrepo.RepoVersion,
+		Version:    fmt.Sprintf("fs-repo@%d", fsrepo.RepoVersion),
 	}, nil
 }

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -43,8 +43,9 @@ a migration in reverse.
 See https://github.com/ipfs/fs-repo-migrations/blob/master/run.md for details.`
 
 var (
-	ErrNoVersion = errors.New("no version file found, please run 0-to-1 migration tool.\n" + migrationInstructions)
-	ErrOldRepo   = errors.New("ipfs repo found in old '~/.go-ipfs' location, please run migration tool.\n" + migrationInstructions)
+	ErrNoVersion     = errors.New("no version file found, please run 0-to-1 migration tool.\n" + migrationInstructions)
+	ErrOldRepo       = errors.New("ipfs repo found in old '~/.go-ipfs' location, please run migration tool.\n" + migrationInstructions)
+	ErrNeedMigration = errors.New("ipfs repo needs migration.")
 )
 
 type NoRepoError struct {
@@ -141,18 +142,7 @@ func open(repoPath string) (repo.Repo, error) {
 	}
 
 	if RepoVersion > ver {
-		r.lockfile.Close()
-
-		err := mfsr.TryMigrating(RepoVersion)
-		if err != nil {
-			return nil, err
-		}
-
-		r.lockfile, err = lockfile.Lock(r.path)
-		if err != nil {
-			return nil, fmt.Errorf("reacquiring lock: %s", err)
-		}
-
+		return nil, ErrNeedMigration
 	} else if ver > RepoVersion {
 		// program version too low for existing repo
 		return nil, fmt.Errorf(programTooLowMessage, RepoVersion, ver)

--- a/repo/fsrepo/migrations/mfsr.go
+++ b/repo/fsrepo/migrations/mfsr.go
@@ -61,7 +61,7 @@ func (v VersionFileNotFound) Error() string {
 }
 
 func TryMigrating(tovers int) error {
-	if !YesNoPrompt("run migrations automatically? [y/n]") {
+	if !YesNoPrompt("Run migrations automatically? [y/N]") {
 		return fmt.Errorf("please run the migrations manually")
 	}
 
@@ -70,7 +70,7 @@ func TryMigrating(tovers int) error {
 
 func YesNoPrompt(prompt string) bool {
 	var s string
-	for {
+	for i := 0; i < 3; i++ {
 		fmt.Printf("%s ", prompt)
 		fmt.Scanf("%s", &s)
 		switch s {
@@ -78,7 +78,11 @@ func YesNoPrompt(prompt string) bool {
 			return true
 		case "n", "N":
 			return false
+		case "":
+			return false
 		}
 		fmt.Println("Please press either 'y' or 'n'")
 	}
+
+	return false
 }

--- a/repo/fsrepo/migrations/mfsr.go
+++ b/repo/fsrepo/migrations/mfsr.go
@@ -59,30 +59,3 @@ type VersionFileNotFound string
 func (v VersionFileNotFound) Error() string {
 	return "no version file in repo at " + string(v)
 }
-
-func TryMigrating(tovers int) error {
-	if !YesNoPrompt("Run migrations automatically? [y/N]") {
-		return fmt.Errorf("please run the migrations manually")
-	}
-
-	return RunMigration(tovers)
-}
-
-func YesNoPrompt(prompt string) bool {
-	var s string
-	for i := 0; i < 3; i++ {
-		fmt.Printf("%s ", prompt)
-		fmt.Scanf("%s", &s)
-		switch s {
-		case "y", "Y":
-			return true
-		case "n", "N":
-			return false
-		case "":
-			return false
-		}
-		fmt.Println("Please press either 'y' or 'n'")
-	}
-
-	return false
-}

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -16,6 +16,12 @@ import (
 
 var DistPath = "https://ipfs.io/ipns/dist.ipfs.io"
 
+func init() {
+	if dist := os.Getenv("IPFS_DIST_PATH"); dist != "" {
+		DistPath = dist
+	}
+}
+
 const migrations = "fs-repo-migrations"
 
 func RunMigration(newv int) error {

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -1,0 +1,220 @@
+package mfsr
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var DistPath = "https://ipfs.io/ipns/dist.ipfs.io"
+
+const migrations = "fs-repo-migrations"
+
+func RunMigration(newv int) error {
+	migrateBin := "fs-repo-migrations"
+	fmt.Println("  => checking for migrations binary...")
+	_, err := exec.LookPath(migrateBin)
+	if err == nil {
+		// check to make sure migrations binary supports our target version
+		err = verifyMigrationSupportsVersion(migrateBin, newv)
+	}
+
+	if err != nil {
+		fmt.Println("  => usable migrations not found on system, fetching...")
+		loc, err := GetMigrations()
+		if err != nil {
+			return err
+		}
+
+		err = verifyMigrationSupportsVersion(loc, newv)
+		if err != nil {
+			return fmt.Errorf("could not find migrations binary that supports version %d", newv)
+		}
+
+		migrateBin = loc
+	}
+
+	cmd := exec.Command(migrateBin, "-to", fmt.Sprint(newv), "-y")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Printf("  => running migration: '%s -to %d -y'\n\n", migrateBin, newv)
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("migration failed: %s", err)
+	}
+
+	fmt.Println("  => migrations binary completed successfully")
+
+	return nil
+}
+
+func GetMigrations() (string, error) {
+	latest, err := GetLatestVersion(DistPath, migrations)
+	if err != nil {
+		return "", fmt.Errorf("getting latest version of fs-repo-migrations: %s", err)
+	}
+
+	dir, err := ioutil.TempDir("", "go-ipfs-migrate")
+	if err != nil {
+		return "", fmt.Errorf("tempdir: %s", err)
+	}
+
+	out := filepath.Join(dir, migrations)
+
+	err = GetBinaryForVersion(migrations, migrations, DistPath, latest, out)
+	if err != nil {
+		fmt.Printf("  => error getting migrations binary: %s\n", err)
+		fmt.Println("  => could not find or install fs-repo-migrations, please manually install it")
+		return "", fmt.Errorf("failed to find migrations binary")
+	}
+
+	err = os.Chmod(out, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	return out, nil
+}
+
+func verifyMigrationSupportsVersion(fsrbin string, vn int) error {
+	sn, err := migrationsVersion(fsrbin)
+	if err != nil {
+		return err
+	}
+
+	if sn >= vn {
+		return nil
+	}
+
+	return fmt.Errorf("migrations binary doesnt support version %d", vn)
+}
+
+func migrationsVersion(bin string) (int, error) {
+	out, err := exec.Command(bin, "-v").CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("failed to check migrations version: %s", err)
+	}
+
+	vs := strings.Trim(string(out), " \n\t")
+	vn, err := strconv.Atoi(vs)
+	if err != nil {
+		return 0, fmt.Errorf("migrations binary version check did not return a number")
+	}
+
+	return vn, nil
+}
+
+func GetVersions(ipfspath, dist string) ([]string, error) {
+	rc, err := httpFetch(ipfspath + "/" + dist + "/versions")
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	var out []string
+	scan := bufio.NewScanner(rc)
+	for scan.Scan() {
+		out = append(out, scan.Text())
+	}
+
+	return out, nil
+}
+
+func GetLatestVersion(ipfspath, dist string) (string, error) {
+	vs, err := GetVersions(ipfspath, dist)
+	if err != nil {
+		return "", err
+	}
+	var latest string
+	for i := len(vs) - 1; i >= 0; i-- {
+		if !strings.Contains(vs[i], "-dev") {
+			latest = vs[i]
+			break
+		}
+	}
+	if latest == "" {
+		return "", fmt.Errorf("couldnt find a non dev version in the list")
+	}
+	return vs[len(vs)-1], nil
+}
+
+func httpGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequest error: %s", err)
+	}
+
+	req.Header.Set("User-Agent", "go-ipfs")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http.DefaultClient.Do error: %s", err)
+	}
+
+	return resp, nil
+}
+
+func httpFetch(url string) (io.ReadCloser, error) {
+	fmt.Printf("fetching url: %s\n", url)
+	resp, err := httpGet(url)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		mes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading error body: %s", err)
+		}
+
+		return nil, fmt.Errorf("%s: %s", resp.Status, string(mes))
+	}
+
+	return resp.Body, nil
+}
+
+func GetBinaryForVersion(distname, binnom, root, vers, out string) error {
+	dir, err := ioutil.TempDir("", "go-ipfs-auto-migrate")
+	if err != nil {
+		return err
+	}
+
+	var archive string
+	switch runtime.GOOS {
+	case "windows":
+		archive = "zip"
+	default:
+		archive = "tar.gz"
+	}
+	finame := fmt.Sprintf("%s_%s_%s-%s.%s", distname, vers, runtime.GOOS, runtime.GOARCH, archive)
+	distpath := fmt.Sprintf("%s/%s/%s/%s", root, distname, vers, finame)
+
+	data, err := httpFetch(distpath)
+	if err != nil {
+		return err
+	}
+
+	arcpath := filepath.Join(dir, finame)
+	fi, err := os.Create(arcpath)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(fi, data)
+	if err != nil {
+		return err
+	}
+	fi.Close()
+
+	return unpackArchive(distname, binnom, arcpath, out, archive)
+}

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -27,7 +27,9 @@ const migrations = "fs-repo-migrations"
 func RunMigration(newv int) error {
 	migrateBin := "fs-repo-migrations"
 	fmt.Println("  => checking for migrations binary...")
-	_, err := exec.LookPath(migrateBin)
+
+	var err error
+	migrateBin, err = exec.LookPath(migrateBin)
 	if err == nil {
 		// check to make sure migrations binary supports our target version
 		err = verifyMigrationSupportsVersion(migrateBin, newv)

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var DistPath = "https://ipfs.io/ipns/dist.ipfs.io"
+var DistPath = "https://ipfs.io/ipfs/QmUnvqDuRyfe7HJuiMMHv77AMUFnjGyAU28LFPeTYwGmFF"
 
 func init() {
 	if dist := os.Getenv("IPFS_DIST_PATH"); dist != "" {

--- a/repo/fsrepo/migrations/unpack.go
+++ b/repo/fsrepo/migrations/unpack.go
@@ -1,0 +1,101 @@
+package mfsr
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+)
+
+func unpackArchive(dist, binnom, path, out, atype string) error {
+	switch atype {
+	case "zip":
+		return unpackZip(dist, binnom, path, out)
+	case "tar.gz":
+		return unpackTgz(dist, binnom, path, out)
+	default:
+		return fmt.Errorf("unrecognized archive type: %s", atype)
+	}
+}
+
+func unpackTgz(dist, binnom, path, out string) error {
+	fi, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fi.Close()
+
+	gzr, err := gzip.NewReader(fi)
+	if err != nil {
+		return err
+	}
+
+	defer gzr.Close()
+
+	var bin io.Reader
+	tarr := tar.NewReader(gzr)
+
+loop:
+	for {
+		th, err := tarr.Next()
+		switch err {
+		default:
+			return err
+		case io.EOF:
+			break loop
+		case nil:
+			// continue
+		}
+
+		if th.Name == dist+"/"+binnom {
+			bin = tarr
+			break
+		}
+	}
+
+	if bin == nil {
+		return fmt.Errorf("no binary found in downloaded archive")
+	}
+
+	return writeToPath(bin, out)
+}
+
+func writeToPath(rc io.Reader, out string) error {
+	binfi, err := os.Create(out)
+	if err != nil {
+		return fmt.Errorf("error opening tmp bin path '%s': %s", out, err)
+	}
+	defer binfi.Close()
+
+	_, err = io.Copy(binfi, rc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unpackZip(dist, binnom, path, out string) error {
+	zipr, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("error opening zipreader: %s", err)
+	}
+
+	defer zipr.Close()
+
+	var bin io.ReadCloser
+	for _, fis := range zipr.File {
+		if fis.Name == dist+"/"+binnom+".exe" {
+			rc, err := fis.Open()
+			if err != nil {
+				return fmt.Errorf("error extracting binary from archive: %s", err)
+			}
+
+			bin = rc
+		}
+	}
+
+	return writeToPath(bin, out)
+}

--- a/repo/mock.go
+++ b/repo/mock.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ipfs/go-ipfs/repo/config"
 )
 
-var errTODO = errors.New("TODO")
+var errTODO = errors.New("TODO: mock repo")
 
 // Mock is not thread-safe
 type Mock struct {

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Copyright (c) 2016 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test migrations auto update prompt"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_expect_success "setup mock migrations" '
+	mkdir bin &&
+	echo "#!/bin/bash" > bin/fs-repo-migrations &&
+	echo "echo 4" >> bin/fs-repo-migrations &&
+	chmod +x bin/fs-repo-migrations &&
+	export PATH="$(pwd)/bin":$PATH
+'
+
+test_expect_success "manually reset repo version to 3" '
+	echo "3" > "$IPFS_PATH"/version
+'
+
+test_expect_success "ipfs daemon --migrate=false fails" '
+	test_expect_code 1 ipfs daemon --migrate=false 2> false_out
+'
+
+test_expect_success "output looks good" '
+	grep "ipfs repo needs migration" false_out
+'
+
+test_expect_success "ipfs daemon --migrate=true runs migration" '
+	test_expect_code 1 ipfs daemon --migrate=true > true_out
+'
+
+test_expect_success "output looks good" '
+	grep "running migration" true_out > /dev/null &&
+	grep "binary completed successfully" true_out > /dev/null
+'
+
+test_expect_success "'ipfs daemon' prompts to auto migrate" '
+	test_expect_code 1 ipfs daemon > daemon_out 2> daemon_err
+'
+
+test_expect_success "output looks good" '
+	grep "Found old repo version" daemon_out > /dev/null &&
+	grep "Run migrations automatically?" daemon_out > /dev/null &&
+	grep "please run the migrations manually" daemon_err > /dev/null
+'
+
+test_done

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -27,7 +27,7 @@ test_expect_success "ipfs daemon --migrate=false fails" '
 '
 
 test_expect_success "output looks good" '
-	grep "ipfs repo needs migration" false_out
+	grep "please run the migrations manually" false_out
 '
 
 test_expect_success "ipfs daemon --migrate=true runs migration" '


### PR DESCRIPTION
This will prompt the user when a migration is needed to let ipfs try to automatically download and run the migrations.

If a version of the migrations tool is installed that is high enough, ipfs will use it instead of downloading its own.

Currently, the download its own function will fail as there is not a build of fs-repo-migrations with ipfs-3-to-4 up on the distributions page yet.

Resolves: https://github.com/ipfs/go-ipfs/issues/2907

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>