### PR TITLE
Increase channel buffer size in blockstore.AllKeysChan().

### DIFF
--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -196,7 +196,7 @@ func (bs *blockstore) AllKeysChan(ctx context.Context) (<-chan key.Key, error) {
 		}
 	}
 
-	output := make(chan key.Key)
+	output := make(chan key.Key, dsq.KeysOnlyBufSize)
 	go func() {
 		defer func() {
 			res.Process().Close() // ensure exit (signals early exit, too)


### PR DESCRIPTION
In order for AllKeysChan to really benefit from the larger buffer size for key only queries in the datastore it should increase it own channel buffer to the same size as the key only queries channel buffer.
