### PR TITLE
Add "ipfs block rm" command.

### DIFF
--- a/blocks/blockstore/arc_cache.go
+++ b/blocks/blockstore/arc_cache.go
@@ -32,7 +32,7 @@ func (b *arccache) DeleteBlock(k key.Key) error {
 	switch err {
 	case nil, ds.ErrNotFound, ErrNotFound:
 		b.arc.Add(k, false)
-		return nil
+		return err
 	default:
 		return err
 	}

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -82,16 +82,7 @@ test_expect_success "can't remove indirectly pinned block: output looks good" '
   grep -q "$FILE1HASH: pinned via $DIRHASH" block_rm_err
 '
 
-test_expect_success "multi-block 'ipfs block rm --ignore-pins' succeeds" '
-  ipfs block rm --ignore-pins $DIRHASH >actual_rm
-'
-
-test_expect_success "multi-block 'ipfs block rm --ignore-pins' output looks good" '
-  echo "removed $DIRHASH" > expected_rm &&
-  test_cmp expected_rm actual_rm
-'
-
-test_expect_success "fix up pins" '
+test_expect_success "remove pin" '
   ipfs pin rm -r $DIRHASH
 '
 

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -44,7 +44,7 @@ test_expect_success "'ipfs block rm' succeeds" '
 '
 
 test_expect_success "'ipfs block rm' output looks good" '
-  echo "deleted $HASH" > expected_rm &&
+  echo "removed $HASH" > expected_rm &&
   test_cmp expected_rm actual_rm
 '
 
@@ -71,7 +71,7 @@ test_expect_success "can't remove pinned block" '
 '
 
 test_expect_success "can't remove pinned block: output looks good" '
-  grep -q "$DIRHASH pinned via recursive" block_rm_err 
+  grep -q "$DIRHASH: pinned via recursive" block_rm_err 
 '
 
 test_expect_success "can't remove indirectly pinned block" '
@@ -79,7 +79,7 @@ test_expect_success "can't remove indirectly pinned block" '
 '
 
 test_expect_success "can't remove indirectly pinned block: output looks good" '
-  grep -q "$FILE1HASH pinned via $DIRHASH" block_rm_err 
+  grep -q "$FILE1HASH: pinned via $DIRHASH" block_rm_err 
 '
 
 test_expect_success "multi-block 'ipfs block rm --ignore-pins' succeeds" '
@@ -87,7 +87,7 @@ test_expect_success "multi-block 'ipfs block rm --ignore-pins' succeeds" '
 '
 
 test_expect_success "multi-block 'ipfs block rm --ignore-pins' output looks good" '
-  echo "deleted $DIRHASH" > expected_rm &&
+  echo "removed $DIRHASH" > expected_rm &&
   test_cmp expected_rm actual_rm
 '
 
@@ -100,9 +100,9 @@ test_expect_success "multi-block 'ipfs block rm' succeeds" '
 '
 
 test_expect_success "multi-block 'ipfs block rm' output looks good" '
-  echo "deleted $FILE1HASH" > expected_rm &&
-  echo "deleted $FILE2HASH" >> expected_rm &&
-  echo "deleted $FILE3HASH" >> expected_rm &&
+  echo "removed $FILE1HASH" > expected_rm &&
+  echo "removed $FILE2HASH" >> expected_rm &&
+  echo "removed $FILE3HASH" >> expected_rm &&
   test_cmp expected_rm actual_rm
 '
 

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -12,6 +12,10 @@ test_init_ipfs
 
 HASH="QmRKqGMAM6EZngbpjSqrvYzq5Qd8b1bSWymjSUY9zQSNDk"
 
+#
+# "block put tests"
+#
+
 test_expect_success "'ipfs block put' succeeds" '
 	echo "Hello Mars!" >expected_in &&
 	ipfs block put <expected_in >actual_out
@@ -22,6 +26,10 @@ test_expect_success "'ipfs block put' output looks good" '
 	test_cmp expected_out actual_out
 '
 
+#
+# "block get" tests
+#
+
 test_expect_success "'ipfs block get' succeeds" '
 	ipfs block get $HASH >actual_in
 '
@@ -29,6 +37,10 @@ test_expect_success "'ipfs block get' succeeds" '
 test_expect_success "'ipfs block get' output looks good" '
 	test_cmp expected_in actual_in
 '
+
+#
+# "block stat" tests
+#
 
 test_expect_success "'ipfs block stat' succeeds" '
   ipfs block stat $HASH >actual_stat
@@ -39,6 +51,10 @@ test_expect_success "'ipfs block stat' output looks good" '
   echo "Size: 12" >>expected_stat &&
   test_cmp expected_stat actual_stat
 '
+
+#
+# "block rm" tests
+#
 
 test_expect_success "'ipfs block rm' succeeds" '
   ipfs block rm $HASH >actual_rm
@@ -128,6 +144,34 @@ test_expect_success "non-pinned blocks removed" '
 test_expect_success "error reported on removing non-existent block" '
   grep -q "cannot remove $RANDOMHASH" block_rm_err
 '
+
+test_expect_success "'add some blocks' succeeds" '
+        echo "Hello Mars!" | ipfs block put &&
+        echo "Hello Venus!" | ipfs block put
+'
+
+test_expect_success "multi-block 'ipfs block rm -f' with non existent blocks succeed" '
+  ipfs block rm -f $HASH $RANDOMHASH $HASH2
+'
+
+test_expect_success "existent blocks removed" '
+  test_must_fail ipfs block stat $HASH &&
+  test_must_fail ipfs block stat $HASH2
+'
+
+test_expect_success "'add some blocks' succeeds" '
+        echo "Hello Mars!" | ipfs block put &&
+        echo "Hello Venus!" | ipfs block put
+'
+
+test_expect_success "multi-block 'ipfs block rm -q' produces no output" '
+  ipfs block rm -q $HASH $HASH2 > block_rm_out &&
+  test ! -s block_rm_out
+'
+
+#
+# Misc tests
+#
 
 test_expect_success "'ipfs block stat' with nothing from stdin doesnt crash" '
 	test_expect_code 1 ipfs block stat < /dev/null 2> stat_out

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -71,7 +71,7 @@ test_expect_success "can't remove pinned block" '
 '
 
 test_expect_success "can't remove pinned block: output looks good" '
-  grep -q "$DIRHASH: pinned via recursive" block_rm_err 
+  grep -q "$DIRHASH: pinned: recursive" block_rm_err
 '
 
 test_expect_success "can't remove indirectly pinned block" '
@@ -79,7 +79,7 @@ test_expect_success "can't remove indirectly pinned block" '
 '
 
 test_expect_success "can't remove indirectly pinned block: output looks good" '
-  grep -q "$FILE1HASH: pinned via $DIRHASH" block_rm_err 
+  grep -q "$FILE1HASH: pinned via $DIRHASH" block_rm_err
 '
 
 test_expect_success "multi-block 'ipfs block rm --ignore-pins' succeeds" '
@@ -100,10 +100,9 @@ test_expect_success "multi-block 'ipfs block rm' succeeds" '
 '
 
 test_expect_success "multi-block 'ipfs block rm' output looks good" '
-  echo "removed $FILE1HASH" > expected_rm &&
-  echo "removed $FILE2HASH" >> expected_rm &&
-  echo "removed $FILE3HASH" >> expected_rm &&
-  test_cmp expected_rm actual_rm
+  grep -F -q "removed $FILE1HASH" actual_rm &&
+  grep -F -q "removed $FILE2HASH" actual_rm &&
+  grep -F -q "removed $FILE3HASH" actual_rm
 '
 
 test_expect_success "'ipfs block stat' with nothing from stdin doesnt crash" '


### PR DESCRIPTION
This is a basic implementation for #2914.

It accepts multiple blocks to remove, however that does not provide any performance benifit just yet as it calls `pins.IsPinned()` for each block, which traverses every recursive pin to check for indirect pins.  This operation costs is O(P*N) where P is the number of pinned blocks and N is the number of blocks to be removed.  With a little effort this can be brought down to O(P) by checking for multiple pins at once.

Since the pin check is expensive it provides an option to ignore pins.  Removing a pinned block will break any command that checks for pins.  Right now if this happens recovering from the situation is very difficult.  At very least a command should be provided to list any broken or missing pins.  An additional optional command can be provided to attempt to repair recursive pins.

TODO:
- [x] Provide command to check for multiple pins at once

No longer relevant:
- [] Provide a `ipfs pin verify` command to list broken or missing pins

Optional and No longer relevant
- [] Provide a command to repair pins (I already wrote similar code in #2634)

