### PR TITLE
gateway: degrade error in gateway to log to reduce noise

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -168,7 +168,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		dir = true
 	case namesys.ErrResolveFailed:
 		// Don't log that error as it is just noise
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "Path Resolve error: %s", err.Error())
 		log.Info("Path Resolve error: %s", err.Error())
 		return

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -12,12 +12,12 @@ import (
 	"time"
 
 	core "github.com/ipfs/go-ipfs/core"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
-
-	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	"github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
@@ -165,6 +165,11 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	} else if err == coreiface.ErrOffline {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, "Could not resolve path. Node is in offline mode.")
+		return
+	} else if err == namesys.ErrResolveFailed {
+		// Don't log that error as it is just noise
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Path Resolve error: %s", err.Error())
 		return
 	} else if err != nil {
 		webError(w, "Path Resolve error", err, http.StatusBadRequest)
@@ -531,7 +536,8 @@ func webError(w http.ResponseWriter, message string, err error, defaultCode int)
 
 func webErrorWithCode(w http.ResponseWriter, message string, err error, code int) {
 	w.WriteHeader(code)
-	log.Errorf("%s: %s", message, err) // TODO(cryptix): log errors until we have a better way to expose these (counter metrics maybe)
+
+	log.Errorf("%s: %s", message, err) // TODO(cryptix): log until we have a better way to expose these (counter metrics maybe)
 	fmt.Fprintf(w, "%s: %s", message, err)
 }
 

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -136,7 +136,7 @@ func TestGatewayGet(t *testing.T) {
 		{"localhost:5001", "/", http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/" + k, http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/ipfs/" + k, http.StatusOK, "fnord"},
-		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusBadRequest, "Path Resolve error: " + namesys.ErrResolveFailed.Error()},
+		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusInternalServerError, "Path Resolve error: " + namesys.ErrResolveFailed.Error()},
 		{"localhost:5001", "/ipns/example.com", http.StatusOK, "fnord"},
 		{"example.com", "/", http.StatusOK, "fnord"},
 	} {


### PR DESCRIPTION
It logs all errors including expired IPNS keys and other non important
errors.

License: MIT
Signed-off-by: Jakub Sztandera kubuxu@protonmail.ch
