### PR TITLE
Build: Fix Makefile on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ bin/gx-go-v%:
 gx_check: ${gx_bin} ${gx-go_bin}
 
 path_check:
-	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(GOPATH)/src/github.com/ipfs/go-ipfs)
+	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(addsuffix /src/github.com/ipfs/go-ipfs,$(subst :, ,$(GOPATH))))
 
 deps: go_check gx_check path_check
 	${gx_bin} --verbose install --global

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ else
   go_test=IPFS_REUSEPORT=false go test
 endif
 
+ifeq ($(OS),Windows_NT)
+  GOPATH_DELIMITER = ;
+else
+  GOPATH_DELIMITER = :
+endif
 
 dist_root=/ipfs/QmXZQzBAFuoELw3NtjQZHkWSdA332PyQUj6pQjuhEukvg8
 gx_bin=bin/gx-v0.7.0
@@ -41,7 +46,7 @@ bin/gx-go-v%:
 gx_check: ${gx_bin} ${gx-go_bin}
 
 path_check:
-	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(addsuffix /src/github.com/ipfs/go-ipfs,$(subst :, ,$(GOPATH))))
+	@bin/check_go_path $(realpath $(shell pwd)) $(realpath $(addsuffix /src/github.com/ipfs/go-ipfs,$(subst $(GOPATH_DELIMITER), ,$(GOPATH))))
 
 deps: go_check gx_check path_check
 	${gx_bin} --verbose install --global

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 PWD=$1
-EXPECTED=$2
 
 if [ -z "$PWD" ]; then
 	echo "must pass in your current working directory"
@@ -13,8 +12,13 @@ if [ -z "$GOPATH" ]; then
 	exit 1
 fi
 
-if [ "$PWD" != "$EXPECTED" ]; then
-	echo "go-ipfs must be built from within your \$GOPATH directory."
-	echo "expected '$EXPECTED' but got '$PWD'"
-	exit 1
-fi
+while [ ${#} -gt 1 ]; do
+	if [ "$PWD" = "$2" ]; then
+		exit 0
+	fi
+	shift
+done
+
+echo "go-ipfs must be built from within your \$GOPATH directory."
+echo "expected within '$GOPATH' but got '$PWD'"
+exit 1


### PR DESCRIPTION
This request brings back in a reverted commit with a fix on top for platform delimiters.
Before this gets merged though I would like people to test it on various systems, it works for me in msys2 where it did not originally, but I only use a single GOPATH. If anyone could try building with this and report on the results I'd appreciate it.

@ChristianKniep 
Could you run this and see if you have any build issues? (In relation to https://github.com/ipfs/go-ipfs/issues/2947)

@jefft0
Could you run this inside of Cygwin? I'm not sure if Cygwin will get picked up as Windows or not with this condition.