### PR TITLE
mfs: fix copying into directory with no given filename

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -217,10 +217,16 @@ var FilesCpCmd = &cmds.Command{
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
+		src = strings.TrimRight(src, "/")
+
 		dst, err := checkPath(req.Arguments()[1])
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
+		}
+
+		if dst[len(dst)-1] == '/' {
+			dst += gopath.Base(src)
 		}
 
 		nd, err := getNodeFromPath(req.Context(), node, src)

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -89,6 +89,9 @@ func lookupDir(r *Root, path string) (*Directory, error) {
 // PutNode inserts 'nd' at 'path' in the given mfs
 func PutNode(r *Root, path string, nd *dag.Node) error {
 	dirp, filename := gopath.Split(path)
+	if filename == "" {
+		return fmt.Errorf("cannot create file with empty name")
+	}
 
 	pdir, err := lookupDir(r, dirp)
 	if err != nil {

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -460,6 +460,24 @@ test_files_api() {
 		ipfs files rm -r /test_dir &&
 		ipfs files rm -r /test_file
 	'
+
+	test_expect_success "make a directory and a file" '
+		ipfs files mkdir /adir &&
+		echo "blah" | ipfs files write --create /foobar
+	'
+
+	test_expect_success "copy a file into a directory" '
+		ipfs files cp /foobar /adir/
+	'
+
+	test_expect_success "file made it into directory" '
+		ipfs files ls /adir | grep foobar
+	'
+
+	test_expect_success "clean up" '
+		ipfs files rm -r /foobar &&
+		ipfs files rm -r /adir
+	'
 }
 
 # test offline and online


### PR DESCRIPTION
There was a bug where running `ipfs files cp /something /adirectory/` would make a file with a zero length name inside `/adirectory`

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>