### PR TITLE
Alias 'ipfs --version' to 'ipfs version'

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -103,9 +103,13 @@ func main() {
 	}
 
 	// Handle `ipfs help'
-	if len(os.Args) == 2 && os.Args[1] == "help" {
-		printHelp(false, os.Stdout)
-		os.Exit(0)
+	if len(os.Args) == 2 {
+		if os.Args[1] == "help" {
+			printHelp(false, os.Stdout)
+			os.Exit(0)
+		} else if os.Args[1] == "--version" {
+			os.Args[1] = "version"
+		}
 	}
 
 	// parse the commandline into a command invocation

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -16,9 +16,22 @@ test_expect_success "ipfs version succeeds" '
 	ipfs version >version.txt
 '
 
+test_expect_success "ipfs --version success" '
+    ipfs --version ||
+    test_fsh ipfs --version
+'
+
 test_expect_success "ipfs version output looks good" '
 	egrep "^ipfs version [0-9]+\.[0-9]+\.[0-9]" version.txt >/dev/null ||
 	test_fsh cat version.txt
+'
+
+test_expect_success "ipfs versions matches ipfs --version" '
+    ipfs version > version.txt &&
+    ipfs --version > version2.txt &&
+    diff version2.txt version.txt ||
+    test_fsh ipfs --version
+
 '
 
 test_expect_success "ipfs version --all has all required fields" '


### PR DESCRIPTION
Addresses Issue #2976. This is a pretty simple method since it looks like the main ipfs command pretty much just parses and launches the others. If you think it is likely that we'll have more 'alias' type things that people will want on ipfs (not its subcommands) in the future, I can probably write something (like a dict) mapping aliases to real commands. 