### PR TITLE
-enc is spelled with two dashes, not one

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -175,7 +175,7 @@ This command outputs data in the following encodings:
   * "protobuf"
   * "json"
   * "xml"
-(Specified by the "--encoding" or "-enc" flag)`,
+(Specified by the "--encoding" or "--enc" flag)`,
 	},
 
 	Arguments: []cmds.Argument{


### PR DESCRIPTION
Fixes #3012 .