### PR TITLE
don't cache entire mfs tree on add finalize

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -231,6 +231,8 @@ func (adder *Adder) outputDirs(path string, fsn mfs.FSNode) error {
 			if err != nil {
 				return err
 			}
+
+			fsn.Uncache(name)
 		}
 		nd, err := fsn.GetNode()
 		if err != nil {

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -152,6 +152,13 @@ func (d *Directory) Child(name string) (FSNode, error) {
 	return d.childUnsync(name)
 }
 
+func (d *Directory) Uncache(name string) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	delete(d.files, name)
+	delete(d.childDirs, name)
+}
+
 // childFromDag searches through this directories dag node for a child link
 // with the given name
 func (d *Directory) childFromDag(name string) (*dag.Node, error) {


### PR DESCRIPTION
This should prevent memory bloat during the finalize call of add

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>