### PR TITLE
bitswap: fix a minor data race

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -173,6 +173,7 @@ func (bs *Bitswap) rebroadcastWorker(parent context.Context) {
 		case <-broadcastSignal.C: // resend unfulfilled wantlist keys
 			log.Event(ctx, "Bitswap.Rebroadcast.active")
 			for _, e := range bs.wm.wl.Entries() {
+				e := e
 				bs.findKeys <- &e
 			}
 		case <-parent.Done():


### PR DESCRIPTION
race detector picked up a minor race condition, Since loop iteration reuses the same local variable, its not safe to take its address and use it concurrently. The fix is to rebind the variable into a controlled scope (creating a new variable) and taking the address of that to pass outwards.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>