### PR TITLE
commands: fix panic when stdin is empty for string args

### DIFF
--- a/commands/request.go
+++ b/commands/request.go
@@ -240,13 +240,19 @@ func (r *request) VarArgs(f func(string) error) error {
 		return err
 	}
 
+	var any bool
 	scan := bufio.NewScanner(fi)
 	for scan.Scan() {
+		any = true
 		err := f(scan.Text())
 		if err != nil {
 			return err
 		}
 	}
+	if !any {
+		return f("")
+	}
+
 	return nil
 }
 

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -39,4 +39,12 @@ test_expect_success "'ipfs block get' output looks good" '
   test_cmp expected_stat actual_stat
 '
 
+test_expect_success "'ipfs block stat' with nothing from stdin doesnt crash" '
+	test_expect_code 1 ipfs block stat < /dev/null 2> stat_out
+'
+
+test_expect_success "no panic in output" '
+	test_expect_code 1 grep "panic" stat_out
+'
+
 test_done


### PR DESCRIPTION
closes #3047 

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>