### PR TITLE
Feat/changelog 0.4.3 rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # go-ipfs changelog
 
+### 0.4.3-rc3 - 2016-08-09
+
+This release candidate fixes a panic that occurs when input from stdin was
+expected, but none was given: [ipfs/go-ipfs#3050](https://github.com/ipfs/go-ipfs/pull/3050)
+
 ### 0.4.3-rc2 - 2016-07-23
 
 This release includes bugfixes and fixes for regressions that were introduced

--- a/package.json
+++ b/package.json
@@ -195,5 +195,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-ipfs",
-  "version": "0.4.3-rc2"
+  "version": "0.4.3-rc3"
 }

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -4,6 +4,6 @@ package config
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.4.3-rc2"
+const CurrentVersionNumber = "0.4.3-rc3"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
This should be the final release candidate. Unless something horribly wrong is found, this is it.

We're also waiting on go1.7 to be officially released so that the binaries we release will work on macOS Sierra.