### PR TITLE
ipfs-test-lib: fix test_fsh arg quoting

### DIFF
--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -1,10 +1,23 @@
 # Generic test functions for go-ipfs
 
+# Quote arguments for sh eval
+shellquote() {
+	_space=''
+	for _arg
+	do
+		# On Mac OS, sed adds a newline character.
+		# With a printf wrapper the extra newline is removed.
+		printf "$_space'%s'" "$(printf "%s" "$_arg" | sed -e "s/'/'\\\\''/g;")"
+		_space=' '
+	done
+	printf '\n'
+}
+
 # Echo the args, run the cmd, and then also fail,
 # making sure a test case fails.
 test_fsh() {
     echo "> $@"
-    eval "$@"
+    eval $(shellquote "$@")
     echo ""
     false
 }
@@ -29,19 +42,6 @@ test_path_cmp() {
 	sed -e "s/\\\\/\//g" "$1" >"$1_std" &&
 	sed -e "s/\\\\/\//g" "$2" >"$2_std" &&
 	test_cmp "$1_std" "$2_std"
-}
-
-# Quote arguments for sh eval
-shellquote() {
-	_space=''
-	for _arg
-	do
-		# On Mac OS, sed adds a newline character.
-		# With a printf wrapper the extra newline is removed.
-		printf "$_space'%s'" "$(printf "%s" "$_arg" | sed -e "s/'/'\\\\''/g;")"
-		_space=' '
-	done
-	printf '\n'
 }
 
 # Docker


### PR DESCRIPTION
test_fsh() should quote its arguments before passing them
to `eval` otherwise there are problems when the arguments
contain spaces.

For example when running the following program:

```
#!/bin/sh

. ./ipfs-test-lib.sh

die () {
    printf >&2 "%s\n" "$@"
    exit 1
}

DIR1="test dir 1"
DIR2="test dir 2"

mkdir "$DIR1" "$DIR2" || die "Could not mkdir '$DIR1' '$DIR2'"

echo "in dir 1" >"$DIR1/file1" || die "Could not write into '$DIR1/file1'"
echo "in dir 2" >"$DIR2/file2" || die "Could not write into '$DIR2/file2'"

if test_cmp "$DIR1/file1" "$DIR2/file2"
then
    echo "test_cmp succeeded!"
else
    echo "test_cmp failed!"
fi

rm -rf "$DIR1" "$DIR2" || die "Could not rm -rf '$DIR1' '$DIR2'"

```

we get:

```
> diff -u test dir 1/file1 test dir 2/file2
diff: extra operand '1/file1'
diff: Try 'diff --help' for more information.

test_cmp failed!
```

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>