### PR TITLE
ipfs/cat: disable auto-gc check

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -5,7 +5,6 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
-	"github.com/ipfs/go-ipfs/core/corerepo"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
 
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
@@ -42,10 +41,13 @@ var CatCmd = &cmds.Command{
 			return
 		}
 
-		if err := corerepo.ConditionalGC(req.Context(), node, length); err != nil {
-			res.SetError(err, cmds.ErrNormal)
-			return
-		}
+		/*
+			if err := corerepo.ConditionalGC(req.Context(), node, length); err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+		*/
+
 		res.SetLength(length)
 
 		reader := io.MultiReader(readers...)


### PR DESCRIPTION
This functionality currently isnt very useful or reliable. Disabling it temporarily until we can refine the underlying code.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>