### PR TITLE
bitswap: don't re-provide blocks we've provided very recently

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -133,6 +133,7 @@ func (bs *Bitswap) provideCollector(ctx context.Context) {
 				log.Debug("newBlocks channel closed")
 				return
 			}
+
 			if keysOut == nil {
 				nextKey = blk.Key()
 				keysOut = bs.provideKeys


### PR DESCRIPTION
Lots of operations will store the same block multiple times in rapid succession, we have optimizations to avoid putting those to disk multiple times, but nothing to avoid providing them multiple times.

This is *a* solution. The other option is to use the same logic as the blockstore (if we have the block already, noop) for providing. The issue with that is that you would no longer be able to re-add a file as a way to re-provide it.

cc @jbenet @Kubuxu for feedback

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>