### PR TITLE
routing: rework interfaces to make separation easier

### DIFF
--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -20,7 +20,7 @@ import (
 var log = logging.Logger("bitswap_network")
 
 // NewFromIpfsHost returns a BitSwapNetwork supported by underlying IPFS host
-func NewFromIpfsHost(host host.Host, r routing.IpfsRouting) BitSwapNetwork {
+func NewFromIpfsHost(host host.Host, r routing.ContentRouting) BitSwapNetwork {
 	bitswapNetwork := impl{
 		host:    host,
 		routing: r,
@@ -36,7 +36,7 @@ func NewFromIpfsHost(host host.Host, r routing.IpfsRouting) BitSwapNetwork {
 // NetMessage objects, into the bitswap network interface.
 type impl struct {
 	host    host.Host
-	routing routing.IpfsRouting
+	routing routing.ContentRouting
 
 	// inbound messages from the network are forwarded to the receiver
 	receiver Receiver

--- a/exchange/reprovide/reprovide.go
+++ b/exchange/reprovide/reprovide.go
@@ -15,13 +15,13 @@ var log = logging.Logger("reprovider")
 
 type Reprovider struct {
 	// The routing system to provide values through
-	rsys routing.IpfsRouting
+	rsys routing.ContentRouting
 
 	// The backing store for blocks to be provided
 	bstore blocks.Blockstore
 }
 
-func NewReprovider(rsys routing.IpfsRouting, bstore blocks.Blockstore) *Reprovider {
+func NewReprovider(rsys routing.ContentRouting, bstore blocks.Blockstore) *Reprovider {
 	return &Reprovider{
 		rsys:   rsys,
 		bstore: bstore,

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -26,7 +26,7 @@ type mpns struct {
 }
 
 // NewNameSystem will construct the IPFS naming system based on Routing
-func NewNameSystem(r routing.IpfsRouting, ds ds.Datastore, cachesize int) NameSystem {
+func NewNameSystem(r routing.ValueStore, ds ds.Datastore, cachesize int) NameSystem {
 	return &mpns{
 		resolvers: map[string]resolver{
 			"dns":      newDNSResolver(),

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -37,12 +37,12 @@ var PublishPutValTimeout = time.Minute
 // ipnsPublisher is capable of publishing and resolving names to the IPFS
 // routing system.
 type ipnsPublisher struct {
-	routing routing.IpfsRouting
+	routing routing.ValueStore
 	ds      ds.Datastore
 }
 
 // NewRoutingPublisher constructs a publisher for the IPFS Routing name system.
-func NewRoutingPublisher(route routing.IpfsRouting, ds ds.Datastore) *ipnsPublisher {
+func NewRoutingPublisher(route routing.ValueStore, ds ds.Datastore) *ipnsPublisher {
 	if ds == nil {
 		panic("nil datastore")
 	}
@@ -134,7 +134,7 @@ func checkCtxTTL(ctx context.Context) (time.Duration, bool) {
 	return d, ok
 }
 
-func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqnum uint64, eol time.Time, r routing.IpfsRouting, id peer.ID) error {
+func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqnum uint64, eol time.Time, r routing.ValueStore, id peer.ID) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -181,7 +181,7 @@ func waitOnErrChan(ctx context.Context, errs chan error) error {
 	}
 }
 
-func PublishPublicKey(ctx context.Context, r routing.IpfsRouting, k key.Key, pubk ci.PubKey) error {
+func PublishPublicKey(ctx context.Context, r routing.ValueStore, k key.Key, pubk ci.PubKey) error {
 	log.Debugf("Storing pubkey at: %s", k)
 	pkbytes, err := pubk.Bytes()
 	if err != nil {
@@ -199,7 +199,7 @@ func PublishPublicKey(ctx context.Context, r routing.IpfsRouting, k key.Key, pub
 	return nil
 }
 
-func PublishEntry(ctx context.Context, r routing.IpfsRouting, ipnskey key.Key, rec *pb.IpnsEntry) error {
+func PublishEntry(ctx context.Context, r routing.ValueStore, ipnskey key.Key, rec *pb.IpnsEntry) error {
 	timectx, cancel := context.WithTimeout(ctx, PublishPutValTimeout)
 	defer cancel()
 

--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -31,7 +31,7 @@ var DefaultRebroadcastInterval = time.Hour * 4
 const DefaultRecordLifetime = time.Hour * 24
 
 type Republisher struct {
-	r  routing.IpfsRouting
+	r  routing.ValueStore
 	ds ds.Datastore
 	ps pstore.Peerstore
 
@@ -44,7 +44,7 @@ type Republisher struct {
 	entries   map[peer.ID]struct{}
 }
 
-func NewRepublisher(r routing.IpfsRouting, ds ds.Datastore, ps pstore.Peerstore) *Republisher {
+func NewRepublisher(r routing.ValueStore, ds ds.Datastore, ps pstore.Peerstore) *Republisher {
 	return &Republisher{
 		r:              r,
 		ps:             ps,

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -23,7 +23,7 @@ var log = logging.Logger("namesys")
 
 // routingResolver implements NSResolver for the main IPFS SFS-like naming
 type routingResolver struct {
-	routing routing.IpfsRouting
+	routing routing.ValueStore
 
 	cache *lru.Cache
 }
@@ -88,7 +88,7 @@ type cacheEntry struct {
 // to implement SFS-like naming on top.
 // cachesize is the limit of the number of entries in the lru cache. Setting it
 // to '0' will disable caching.
-func NewRoutingResolver(route routing.IpfsRouting, cachesize int) *routingResolver {
+func NewRoutingResolver(route routing.ValueStore, cachesize int) *routingResolver {
 	if route == nil {
 		panic("attempt to create resolver with nil routing system")
 	}


### PR DESCRIPTION
I've started to work on separating the content routing layer and the peer routing layer. The third bit that we glom into our current routing interface deals with direct values, i think thats what @diasdavid was starting to call the record store, but i'm not sure its the same scope. Definitely want some feedback here.

cc @jbenet @diasdavid 

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>