### PR TITLE
remove randbo dep, its no longer needed

### DIFF
--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -13,12 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-ipfs/path"
-	ds "gx/ipfs/QmNgqJarToRiq2GBaPJhkmW4B5BxS5B74E1rkGvv2JoaTp/go-datastore"
-	dssync "gx/ipfs/QmNgqJarToRiq2GBaPJhkmW4B5BxS5B74E1rkGvv2JoaTp/go-datastore/sync"
-	randbo "gx/ipfs/QmYvsG72GsfLgUeSojXArjnU6L4Wmwk7wuAxtNLuyXcc1T/randbo"
-	"gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
-
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	key "github.com/ipfs/go-ipfs/blocks/key"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
@@ -26,9 +20,14 @@ import (
 	importer "github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
+	"github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
+
+	ds "gx/ipfs/QmNgqJarToRiq2GBaPJhkmW4B5BxS5B74E1rkGvv2JoaTp/go-datastore"
+	dssync "gx/ipfs/QmNgqJarToRiq2GBaPJhkmW4B5BxS5B74E1rkGvv2JoaTp/go-datastore/sync"
 	u "gx/ipfs/QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1/go-ipfs-util"
+	"gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 )
 
 func emptyDirNode() *dag.Node {
@@ -552,7 +551,8 @@ func actorMakeFile(d *Directory) error {
 		return err
 	}
 
-	r := io.LimitReader(randbo.New(), int64(77*rand.Intn(123)))
+	rread := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := io.LimitReader(rread, int64(77*rand.Intn(123)))
 	_, err = io.Copy(wfd, r)
 	if err != nil {
 		return err
@@ -646,7 +646,7 @@ func actorWriteFile(d *Directory) error {
 
 	size := rand.Intn(1024) + 1
 	buf := make([]byte, size)
-	randbo.New().Read(buf)
+	rand.Read(buf)
 
 	s, err := fi.Size()
 	if err != nil {
@@ -858,7 +858,7 @@ func TestConcurrentReads(t *testing.T) {
 	d := mkdirP(t, rootdir, path)
 
 	buf := make([]byte, 2048)
-	randbo.New().Read(buf)
+	rand.Read(buf)
 
 	fi := fileNodeFromReader(t, ds, bytes.NewReader(buf))
 	err := d.AddChild("afile", fi)

--- a/package.json
+++ b/package.json
@@ -41,11 +41,6 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmYvsG72GsfLgUeSojXArjnU6L4Wmwk7wuAxtNLuyXcc1T",
-      "name": "randbo",
-      "version": "0.0.0"
-    },
-    {
       "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",
       "name": "gogo-protobuf",
       "version": "0.0.0"


### PR DESCRIPTION
I want to continue doing things like this as we find deps are no longer needed. A smaller dependency tree is a happier one 

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>