### PR TITLE
commands: replace <default> keyword with <<default>>

### DIFF
--- a/commands/option.go
+++ b/commands/option.go
@@ -47,8 +47,8 @@ func (o *option) Description() string {
 		o.description += "."
 	}
 	if o.defaultVal != nil {
-		if strings.Contains(o.description, "<default>") {
-			return strings.Replace(o.description, "<default>",
+		if strings.Contains(o.description, "<<default>>") {
+			return strings.Replace(o.description, "<<default>>",
 				fmt.Sprintf("Default: %v.", o.defaultVal), -1)
 		} else {
 			return fmt.Sprintf("%s Default: %v.", o.description, o.defaultVal)

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -52,7 +52,7 @@ Publish an <ipfs-path> to another public key (not implemented):
 	Options: []cmds.Option{
 		cmds.BoolOption("resolve", "Resolve given path before publishing.").Default(true),
 		cmds.StringOption("lifetime", "t",
-			`Time duration that the record will be valid for. <default>
+			`Time duration that the record will be valid for. <<default>>
     This accepts durations such as "300s", "1.5h" or "2h45m". Valid time units are
     "ns", "us" (or "µs"), "ms", "s", "m", "h".`).Default("24h"),
 		cmds.StringOption("ttl", "Time duration this record should be cached for (caution: experimental)."),


### PR DESCRIPTION
This way if we use <default> in description (we use thigns like <hash>
already), it won't conflict and modify the description in unwanted way.


Created because of: https://github.com/ipfs/go-ipfs/pull/2744#issuecomment-242655384

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>