### PR TITLE
cli: Fix stdin help text being show multiple times

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -251,7 +251,7 @@ func parseOpts(args []string, root *cmds.Command) (
 	return
 }
 
-const msgStdinInfo = "ipfs: Reading from %s; send Ctrl-d to stop.\n"
+const msgStdinInfo = "ipfs: Reading from %s; send Ctrl-d to stop."
 
 func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursive, hidden bool, root *cmds.Command) ([]string, []files.File, error) {
 	// ignore stdin on Windows
@@ -469,6 +469,7 @@ func newMessageReader(r io.ReadCloser, msg string) io.ReadCloser {
 func (r *messageReader) Read(b []byte) (int, error) {
 	if !r.done {
 		fmt.Fprintln(os.Stderr, r.message)
+		r.done = true
 	}
 
 	return r.r.Read(b)


### PR DESCRIPTION
Also remove '\n' from msgStdinInfo as we use Fprintln.

This PR branches of v0.4.3-rc3 and merges to version/0.4.3-rc4 which is short lived branch.
As a guide, please keep changes in this branch as minimal as possible to reduce merge conflicts.

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>