### PR TITLE
Directly Fix #2839

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -401,6 +401,10 @@ func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (fi
 		if err != nil {
 			return nil, err
 		}
+		cwd, err = filepath.EvalSymlinks(cwd)
+		if err != nil {
+			return nil, err
+		}
 		fpath = cwd
 	}
 

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -404,13 +404,7 @@ func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (fi
 		fpath = cwd
 	}
 
-	fpath = filepath.Clean(fpath)
-	fpath, err := filepath.EvalSymlinks(fpath)
-	if err != nil {
-		return nil, err
-	}
-	// Repeat ToSlash after EvalSymlinks as it turns path to platform specific
-	fpath = filepath.ToSlash(fpath)
+	fpath = filepath.ToSlash(filepath.Clean(fpath))
 
 	stat, err := os.Lstat(fpath)
 	if err != nil {

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -189,6 +189,18 @@ test_add_named_pipe() {
     '
 }
 
+test_add_pwd_is_symlink() {
+    test_expect_success "ipfs add -r adds directory content when ./ is symlink" '
+      mkdir hellodir &&
+      echo "World" > hellodir/world &&
+      ln -s hellodir hellolink &&
+      ( cd hellolink &&
+        ipfs add -r . > ../actual ) &&
+      grep "added Qma9CyFdG5ffrZCcYSin2uAETygB25cswVwEYYzwfQuhTe" actual &&
+      rm -r hellodir
+    '
+}
+
 test_launch_ipfs_daemon_and_mount
 
 test_expect_success "'ipfs add --help' succeeds" '
@@ -354,6 +366,8 @@ test_add_cat_expensive
 
 test_add_named_pipe " Post http://$API_ADDR/api/v0/add?encoding=json&progress=true&r=true&stream-channels=true:"
 
+test_add_pwd_is_symlink
+
 test_kill_ipfs_daemon
 
 # should work offline
@@ -370,6 +384,8 @@ test_expect_success "ipfs cat file fails" '
 '
 
 test_add_named_pipe ""
+
+test_add_pwd_is_symlink
 
 # Test daemon in offline mode
 test_launch_ipfs_daemon --offline

--- a/test/sharness/t0044-add-symlink.sh
+++ b/test/sharness/t0044-add-symlink.sh
@@ -44,6 +44,16 @@ test_add_symlinks() {
 		echo "QmWYN8SEXCgNT2PSjB6BnxAx6NJQtazWoBkTRH9GRfPFFQ" > badlink_exp &&
 		test_cmp badlink_exp badlink_out
 	'
+
+	test_expect_success "adding with symlink in middle of path is same as\
+adding with no symlink" '
+		mkdir -p files2/a/b/c &&
+		echo "some other text" > files2/a/b/c/foo &&
+		ln -s b files2/a/d
+		ipfs add -rq files2/a/b/c > no_sym &&
+		ipfs add -rq files2/a/d/c > sym &&
+		test_cmp no_sym sym
+	'
 }
 
 test_init_ipfs

--- a/test/sharness/t0044-add-symlink.sh
+++ b/test/sharness/t0044-add-symlink.sh
@@ -11,13 +11,9 @@ test_description="Test add -w"
 test_expect_success "creating files succeeds" '
 	mkdir -p files/foo &&
 	mkdir -p files/bar &&
-	mkdir -p files/badin
 	echo "some text" > files/foo/baz &&
-	ln -s ../foo/baz files/bar/baz &&
-	ln -s files/does/not/exist files/badin/bad &&
-	mkdir -p files2/a/b/c &&
-	echo "some other text" > files2/a/b/c/foo &&
-	ln -s b files2/a/d
+	ln -s files/foo/baz files/bar/baz &&
+	ln -s files/does/not/exist files/bad
 '
 
 test_add_symlinks() {
@@ -27,33 +23,26 @@ test_add_symlinks() {
 	'
 
 	test_expect_success "output looks good" '
-		echo QmQRgZT6xVFKJLVVpJDu3WcPkw2iqQ1jqK1F9jmdeq9zAv > filehash_exp &&
+		echo QmWdiHKoeSW8G1u7ATCgpx4yMoUhYaJBQGkyPLkS9goYZ8 > filehash_exp &&
 		test_cmp filehash_exp filehash_out
 	'
 
-	test_expect_success "adding a symlink adds the file itself" '
+	test_expect_success "adding a symlink adds the link itself" '
 		ipfs add -q files/bar/baz > goodlink_out
 	'
 
 	test_expect_success "output looks good" '
-		echo QmcPNXE5zjkWkM24xQ7Bi3VAm8fRxiaNp88jFsij7kSQF1 > goodlink_exp &&
+		echo "QmdocmZeF7qwPT9Z8SiVhMSyKA2KKoA2J7jToW6z6WBmxR" > goodlink_exp &&
 		test_cmp goodlink_exp goodlink_out
 	'
 
 	test_expect_success "adding a broken symlink works" '
-		ipfs add -qr files/badin | head -1 > badlink_out
+		ipfs add -q files/bad > badlink_out
 	'
 
 	test_expect_success "output looks good" '
 		echo "QmWYN8SEXCgNT2PSjB6BnxAx6NJQtazWoBkTRH9GRfPFFQ" > badlink_exp &&
 		test_cmp badlink_exp badlink_out
-	'
-
-	test_expect_success "adding with symlink in middle of path is same as\
-adding with no symlink" '
-		ipfs add -rq files2/a/b/c > no_sym &&
-		ipfs add -rq files2/a/d/c > sym &&
-		test_cmp no_sym sym
 	'
 }
 


### PR DESCRIPTION
Revert the original fix for #2839 and instead fix the original issue so that adding the current directory works as expected without changing the semantics of how symbolic links are handled.
