### PR TITLE
fdlimit: improve fdlimit autoraising tests

### DIFF
--- a/cmd/ipfs/ulimit_unix.go
+++ b/cmd/ipfs/ulimit_unix.go
@@ -30,17 +30,24 @@ func checkAndSetUlimit() error {
 		return fmt.Errorf("error getting rlimit: %s", err)
 	}
 
+	var setting bool
 	if rLimit.Cur < ipfsFileDescNum {
 		if rLimit.Max < ipfsFileDescNum {
+			log.Error("adjusting max")
 			rLimit.Max = ipfsFileDescNum
 		}
-		fmt.Printf("Adjusting current ulimit to %d.\n", ipfsFileDescNum)
+		fmt.Printf("Adjusting current ulimit to %d...\n", ipfsFileDescNum)
 		rLimit.Cur = ipfsFileDescNum
+		setting = true
 	}
 
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error setting ulimit: %s", err)
+	}
+
+	if setting {
+		fmt.Printf("Successfully raised file descriptor limit to %d.\n", ipfsFileDescNum)
 	}
 
 	return nil

--- a/package.json
+++ b/package.json
@@ -189,6 +189,12 @@
       "hash": "QmVvJ27GcLaLSXvcB4auk3Gn3xuWK5ti5ENkZ2pCoJEYW4",
       "name": "autobatch",
       "version": "0.2.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmdCL8M8DXJdSRnwhpDhukX5r8ydjxnzPJpaKrFudDA8yn",
+      "name": "hang-fds",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.4.0",

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,9 +60,17 @@ multihash_src:
 	$(eval MULTIHASH_HASH := $(shell cd .. && bin/gx deps find go-multihash))
 	$(eval MULTIHASH_SRC := gx/ipfs/$(MULTIHASH_HASH)/go-multihash)
 
+hang-fds_src:
+	$(eval HANG_FDS_HASH := $(shell cd .. && bin/gx deps find hang-fds))
+	$(eval HANG_FDS_SRC := gx/ipfs/$(HANG_FDS_HASH)/hang-fds)
+
 bin/multihash: multihash_src $(call find_go_files, $(MULTIHASH_SRC)) IPFS-BUILD-OPTIONS
 	@echo "*** installing $@ ***"
 	go build $(GOFLAGS) -o bin/multihash $(MULTIHASH_SRC)/multihash
+
+bin/hang-fds: hang-fds_src $(call find_go_files, $(HANG_FDS_SRC)) IPFS-BUILD-OPTIONS
+	@echo "*** installing $@ ***"
+	go build $(GOFLAGS) -o bin/hang-fds $(HANG_FDS_SRC)
 
 iptb_src:
 	$(eval IPTB_HASH := $(shell cd .. && bin/gx deps find iptb))

--- a/test/sharness/Makefile
+++ b/test/sharness/Makefile
@@ -8,7 +8,7 @@
 
 T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
 BINS = bin/random bin/multihash bin/ipfs bin/pollEndpoint \
-	   bin/iptb bin/go-sleep bin/random-files bin/go-timeout
+	   bin/iptb bin/go-sleep bin/random-files bin/go-timeout bin/hang-fds
 SHARNESS = lib/sharness/sharness.sh
 IPFS_ROOT = ../..
 

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -129,21 +129,13 @@ test_expect_success "daemon raised its fd limit" '
 	grep "raised file descriptor limit to 1024." actual_daemon > /dev/null
 '
 
-get_col_four() {
-	awk '{ print $4 }' $1
-}
+test_expect_success "daemon actually can handle 1024 file descriptors" '
+	hang-fds -hold=2s 1000 '$API_MADDR'
+'
 
-if [ `uname` == "Linux" ]; then
-	test_expect_success "get fd limit through /proc" '
-		cat /proc/$IPFS_PID/limits > limits &&
-		grep "Max open files" limits > fd_limits_line &&
-		limit=$(get_col_four fd_limits_line)
-	'
-
-	test_expect_success "limit from system looks good" '
-		test "$limit" -eq 1024
-	'
-fi
+test_expect_success "daemon didnt throw any errors" '
+	test_expect_code 1 grep "too many open files" daemon_err
+'
 
 test_kill_ipfs_daemon
 


### PR DESCRIPTION
Better tests for this, at least on linux we can check it externally. I don't know of a good way to do this on OSX