### PR TITLE
fsrepo: improve migrations copy

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -226,19 +226,25 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		return
 	case fsrepo.ErrNeedMigration:
 		domigrate, found, _ := req.Option(migrateKwd).Bool()
-		fmt.Println("Found old repo version, migrations need to be run.")
+		fmt.Println("Found outdated fs-repo, migrations need to be run.")
 
 		if !found {
-			domigrate = YesNoPrompt("Run migrations automatically? [y/N]")
+			domigrate = YesNoPrompt("Run migrations now? [y/N]")
 		}
 
 		if !domigrate {
-			res.SetError(fmt.Errorf("please run the migrations manually"), cmds.ErrNormal)
+			fmt.Println("Not running migrations of fs-repo now.")
+			fmt.Println("Please get fs-repo-migrations from https://dist.ipfs.io")
+			res.SetError(fmt.Errorf("fs-repo requires migration"), cmds.ErrNormal)
 			return
 		}
 
 		err = migrate.RunMigration(fsrepo.RepoVersion)
 		if err != nil {
+			fmt.Println("The migrations of fs-repo failed:")
+			fmt.Printf("  %s\n", err)
+			fmt.Println("If you think this is a bug, please file an issue and include this whole log output.")
+			fmt.Println("  https://github.com/ipfs/fs-repo-migrations")
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -23,11 +23,11 @@ test_expect_success "manually reset repo version to 3" '
 '
 
 test_expect_success "ipfs daemon --migrate=false fails" '
-	test_expect_code 1 ipfs daemon --migrate=false 2> false_out
+	test_expect_code 1 ipfs daemon --migrate=false > false_out
 '
 
 test_expect_success "output looks good" '
-	grep "please run the migrations manually" false_out
+	grep "Please get fs-repo-migrations from https://dist.ipfs.io" false_out
 '
 
 test_expect_success "ipfs daemon --migrate=true runs migration" '
@@ -35,8 +35,8 @@ test_expect_success "ipfs daemon --migrate=true runs migration" '
 '
 
 test_expect_success "output looks good" '
-	grep "running migration" true_out > /dev/null &&
-	grep "binary completed successfully" true_out > /dev/null
+	grep "Running: " true_out > /dev/null &&
+	grep "Success: fs-repo has been migrated to version 4." true_out > /dev/null
 '
 
 test_expect_success "'ipfs daemon' prompts to auto migrate" '
@@ -44,9 +44,9 @@ test_expect_success "'ipfs daemon' prompts to auto migrate" '
 '
 
 test_expect_success "output looks good" '
-	grep "Found old repo version" daemon_out > /dev/null &&
-	grep "Run migrations automatically?" daemon_out > /dev/null &&
-	grep "please run the migrations manually" daemon_err > /dev/null
+	grep "Found outdated fs-repo" daemon_out > /dev/null &&
+	grep "Run migrations now?" daemon_out > /dev/null &&
+	grep "Please get fs-repo-migrations from https://dist.ipfs.io" daemon_out > /dev/null
 '
 
 test_done


### PR DESCRIPTION
No:
```
$ cmd/ipfs/ipfs daemon
Initializing daemon...
Found outdated fs-repo, migrations need to be run.
Run migrations now? [y/N] n
Not running migrations of fs-repo now.
Please get fs-repo-migrations from https://dist.ipfs.io
Error: fs-repo requires migration
```

Programmatic No:
```
$ cmd/ipfs/ipfs daemon --migrate=false
Initializing daemon...
Found outdated fs-repo, migrations need to be run.
Not running migrations of fs-repo now.
Please get fs-repo-migrations from https://dist.ipfs.io
Error: fs-repo requires migration
```

Yes with 404: (e.g. when we haven't pushed a migration to dist.ipfs.io yet)
```
$ cmd/ipfs/ipfs daemon --migrate=true
Initializing daemon...
Found outdated fs-repo, migrations need to be run.
  => Looking for suitable fs-repo-migrations binary.
  => None found, downloading.
  => Failed to download fs-repo-migrations.
The migrations of fs-repo failed:
  failed to find latest fs-repo-migrations: GET https://ipfs.io/ipns/ipfs.io/fs-repo-migrations/versions error: 404 Not Found: Path Resolve error: no link named "fs-repo-migrations" under QmTzQ1JRkWErjk39mryYw2WVaphAZNAREyMchXzYQ7c15n
If you think this is a bug, please file an issue and include this whole log output.
  https://github.com/ipfs/fs-repo-migrations
Error: failed to find latest fs-repo-migrations: GET https://ipfs.io/ipns/ipfs.io/fs-repo-migrations/versions error: 404 Not Found: Path Resolve error: no link named "fs-repo-migrations" under QmTzQ1JRkWErjk39mryYw2WVaphAZNAREyMchXzYQ7c15n
```

Yes with fs-repo-migrations error: (this is an fs-repo v4 where I did `echo 3 > version`)
```
$ cmd/ipfs/ipfs daemon --migrate=true
Initializing daemon...
Found outdated fs-repo, migrations need to be run.
  => Looking for suitable fs-repo-migrations binary.
  => None found, downloading.
  => Running: /tmp/go-ipfs-migrate893559663/fs-repo-migrations -to 4 -y
Found fs-repo version 3 at /home/user/.ipfs
===> Running migration 3 to 4...
applying 3-to-4 repo migration
locking repo at "/home/user/.ipfs"
  - verifying version is '3'
  - opening datastore at "/home/user/.ipfs"
transfering blocks to new key format
[1 / 293]failed to decode: /home/user/.ipfs/blocks/CIQA4/CIQA42T54MUH5XHODGGRH6HT3XZRADGA2GY3BXMNOGWBUSKFH2QTQTI.data
ipfs migration:  migration 3 to 4 failed: encoding/hex: odd length hex string
  => Failed: /tmp/go-ipfs-migrate893559663/fs-repo-migrations -to 4 -y
The migrations of fs-repo failed:
  migration failed: exit status 1
If you think this is a bug, please file an issue and include this whole log output.
  https://github.com/ipfs/fs-repo-migrations
Error: migration failed: exit status 1
```

Yes with success:
```
$ IPFS_PATH=ipfspath cmd/ipfs/ipfs daemon
Initializing daemon...
Found outdated fs-repo, migrations need to be run.
Run migrations now? [y/N] y
  => Looking for suitable fs-repo-migrations binary.
  => None found, downloading.
  => Running: /tmp/go-ipfs-migrate455985879/fs-repo-migrations -to 4 -y
Found fs-repo version 3 at ipfspath
===> Running migration 3 to 4...
applying 3-to-4 repo migration
locking repo at "ipfspath"
  - verifying version is '3'
  - opening datastore at "ipfspath"
transfering blocks to new key format
[15 / 15] Approx time remaining: 203s  
transferring stored public key records
gathering keys...
got 1 keys, beginning transfer. This will take some time.
[1 / 1]
transferring stored ipns records
gathering keys...
got 1 keys, beginning transfer. This will take some time.
[1 / 1]
updated version file
===> Migration 3 to 4 succeeded!
  => Success: fs-repo has been migrated to 4.
Swarm listening on /ip4/10.230.22.40/tcp/4001
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/172.17.0.1/tcp/4001
Swarm listening on /ip4/192.168.4.219/tcp/4001
Swarm listening on /ip4/78.52.201.197/tcp/4001
Swarm listening on /ip6/::1/tcp/4001
Swarm listening on /ip6/fc3d:7777:a6a4:fcdb:f218:5856:5de:eb1a/tcp/4001
Swarm listening on /ip6/fd0a:562b:34e4:0:a4df:52b7:7446:2229/tcp/4001
Swarm listening on /ip6/fd0a:562b:34e4::b85/tcp/4001
API server listening on /ip4/127.0.0.1/tcp/5001
Gateway (readonly) server listening on /ip4/127.0.0.1/tcp/8080
Daemon is ready
```