### PR TITLE
Doc/cmds/log notice unused

### DIFF
--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -35,8 +35,7 @@ var logLevelCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Change the logging level.",
 		ShortDescription: `
-'ipfs log level' is a utility command used to change the logging
-output of a running daemon.
+Change the verbosity of one or all subsystems log output. Does NOT affect the event log.
 `,
 	},
 
@@ -91,9 +90,9 @@ subsystems of a running daemon.
 
 var logTailCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Read the logs.",
+		Tagline: "Read the event log.",
 		ShortDescription: `
-'ipfs log tail' is a utility command used to read log output as it is written.
+Outputs event log messages (NOT other log messages) as they are generated.
 `,
 	},
 

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -45,7 +45,7 @@ output of a running daemon.
 		// clash with a subsystem name
 		cmds.StringArg("subsystem", true, false, fmt.Sprintf("The subsystem logging identifier. Use '%s' for all subsystems.", logAllKeyword)),
 		cmds.StringArg("level", true, false, `The log level, with 'debug' the most verbose and 'critical' the least verbose.
-			One of: debug, info, notice, warning, error, critical.
+			One of: debug, info, warning, error, critical.
 		`),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -35,7 +35,7 @@ var logLevelCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Change the logging level.",
 		ShortDescription: `
-Change the verbosity of one or all subsystems log output. Does NOT affect the event log.
+Change the verbosity of one or all subsystems log output. This does not affect the event log.
 `,
 	},
 
@@ -92,7 +92,7 @@ var logTailCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Read the event log.",
 		ShortDescription: `
-Outputs event log messages (NOT other log messages) as they are generated.
+Outputs event log messages (not other log messages) as they are generated.
 `,
 	},
 


### PR DESCRIPTION
This removes the unused `notice` level from the help text, and also clarifies the distinction between the event log output and the other log output (at least, as best as *I* currently understand the distinction).