### PR TITLE
 	blockstore: fix PutMany with cache logic

### DIFF
--- a/blocks/blockstore/arc_cache_test.go
+++ b/blocks/blockstore/arc_cache_test.go
@@ -175,4 +175,10 @@ func TestPutManyCaches(t *testing.T) {
 
 	trap("has hit datastore", cd, t)
 	arc.Has(exampleBlock.Key())
+	untrap(cd)
+	arc.DeleteBlock(exampleBlock.Key())
+
+	arc.Put(exampleBlock)
+	trap("PunMany has hit datastore", cd, t)
+	arc.PutMany([]blocks.Block{exampleBlock})
 }


### PR DESCRIPTION
Thanks @whyrusleeping for noticing it.

Removed PutMany logic in bloom cache as it can't help with anything.
Fixed ARC cache to use filtered results instead of all blocks.

Also add test case for it.