### PR TITLE
Update release candidate branch to Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 language: go
 
 go:
-    - 1.5.2
+    - 1.7
 
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # There is a copy of this Dockerfile called Dockerfile.fast,
@@ -36,7 +36,7 @@ ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 # Get the go-ipfs sourcecode
 COPY . $SRC_PATH
 
-RUN apk add --update musl go git bash wget ca-certificates \
+RUN apk add --update musl-dev gcc go git bash wget ca-certificates \
 	# Setup user and fs-repo directory
 	&& mkdir -p $IPFS_PATH \
 	&& adduser -D -h $IPFS_PATH -u 1000 ipfs \
@@ -58,7 +58,7 @@ RUN apk add --update musl go git bash wget ca-certificates \
 	&& cp $SRC_PATH/bin/container_daemon /usr/local/bin/start_ipfs \
 	&& chmod 755 /usr/local/bin/start_ipfs \
 	# Remove all build-time dependencies
-	&& apk del --purge musl go git && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
+	&& apk del --purge musl-dev gcc go git && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
 
 # Call uid 1000 "ipfs"
 USER ipfs

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # This is a copy of /Dockerfile,
@@ -28,7 +28,7 @@ ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 # and trigger a re-run of all following commands.
 COPY ./package.json $SRC_PATH/package.json
 
-RUN apk add --update musl go git bash wget ca-certificates \
+RUN apk add --update musl-dev gcc go git bash wget ca-certificates \
 	&& mkdir -p $IPFS_PATH \
 	&& adduser -D -h $IPFS_PATH -u 1000 ipfs \
 	&& chown ipfs:ipfs $IPFS_PATH && chmod 755 $IPFS_PATH \
@@ -48,7 +48,7 @@ RUN cd $SRC_PATH \
 	&& cp ipfs /usr/local/bin/ipfs \
 	&& cp $SRC_PATH/bin/container_daemon /usr/local/bin/start_ipfs \
 	&& chmod 755 /usr/local/bin/start_ipfs \
-	&& apk del --purge musl go git && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
+	&& apk del --purge musl-dev gcc go git && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
 
 USER ipfs
 VOLUME $IPFS_PATH

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ else
   GOPATH_DELIMITER = :
 endif
 
-dist_root=/ipfs/QmUnvqDuRyfe7HJuiMMHv77AMUFnjGyAU28LFPeTYwGmFF
-gx_bin=bin/gx-v0.8.0
-gx-go_bin=bin/gx-go-v1.2.1
+dist_root=/ipfs/QmNZL8wNsvAGdVYr8uGeUE9aGfHjFpHegAWywQFEdSaJbp
+gx_bin=bin/gx-v0.9.0
+gx-go_bin=bin/gx-go-v1.3.0
 
 # use things in our bin before any other system binaries
 export PATH := bin:$(PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Minimum version numbers for software required to build IPFS
-IPFS_MIN_GO_VERSION = 1.5.2
+IPFS_MIN_GO_VERSION = 1.7
 IPFS_MIN_GX_VERSION = 0.6
 IPFS_MIN_GX_GO_VERSION = 1.1
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ From there:
 
 #### Install Go
 
-The build process for ipfs requires Go 1.5+, but we strongly recommend using 1.6.2. If you don't have it: [Download Go 1.6.2+](https://golang.org/dl/).
+The build process for ipfs requires Go 1.7 or higher. If you don't have it: [Download Go 1.7+](https://golang.org/dl/).
 
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
@@ -105,7 +105,7 @@ $ make install
 * Separate [instructions are available for building on Windows](docs/windows.md).
 * `git` is required in order for `go get` to fetch all dependencies.
 * Package managers often contain out-of-date `golang` packages.
-  Ensure that `go version` reports at least 1.5.2. See above for how to install go.
+  Ensure that `go version` reports at least 1.7. See above for how to install go.
 * If you are interested in development, please install the development
 dependencies as well.
 * *WARNING: Older versions of OSX FUSE (for Mac OS X) can cause kernel panics when mounting!*

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ machine:
 
   post:
     - sudo rm -rf /usr/local/go
-    - if [ ! -e go1.5.2.linux-amd64.tar.gz ]; then curl -o go1.5.2.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz; fi
-    - sudo tar -C /usr/local -xzf go1.5.2.linux-amd64.tar.gz
+    - if [ ! -e go1.7.linux-amd64.tar.gz ]; then curl -o go1.7.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz; fi
+    - sudo tar -C /usr/local -xzf go1.7.linux-amd64.tar.gz
 
   services:
     - docker
@@ -28,7 +28,7 @@ dependencies:
     - cd "$HOME/.go_workspace/src/$IMPORT_PATH" && make deps
 
   cache_directories:
-    - ~/go1.5.2.linux-amd64.tar.gz
+    - ~/go1.7.linux-amd64.tar.gz
     - "$HOME/.go_workspace/src/gx/ipfs"
 
 test:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "gx": {
     "dvcsimport": "github.com/ipfs/go-libp2p",
-    "goversion": "1.5.2"
+    "goversion": "1.7"
   },
   "gxDependencies": [
     {


### PR DESCRIPTION
It replays: https://github.com/ipfs/go-ipfs/pull/3111 on version/0.4.3-rc4