### PR TITLE
bitswap: Don't clear 'active' until Connect calls are finished

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -201,14 +201,18 @@ func (bs *Bitswap) providerQueryManager(ctx context.Context) {
 				child, cancel := context.WithTimeout(e.Ctx, providerRequestTimeout)
 				defer cancel()
 				providers := bs.network.FindProvidersAsync(child, e.Key, maxProvidersPerRequest)
+				wg := &sync.WaitGroup{}
 				for p := range providers {
+					wg.Add(1)
 					go func(p peer.ID) {
+						defer wg.Done()
 						err := bs.network.ConnectTo(child, p)
 						if err != nil {
 							log.Debug("failed to connect to provider %s: %s", p, err)
 						}
 					}(p)
 				}
+				wg.Wait()
 				activeLk.Lock()
 				delete(active, e.Key)
 				activeLk.Unlock()


### PR DESCRIPTION
This has been an issue for a long time, but for some reason the changes to making providers more efficient has made this a much larger problem.

I'm not 100% sure this will solve the excess cpu usage problem we're seeing on the gateways, but its definitely fixing a bug.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>