### PR TITLE
Fix minor typo in bitswap debug logging

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -169,7 +169,7 @@ func (bs *Bitswap) rebroadcastWorker(parent context.Context) {
 		case <-tick.C:
 			n := bs.wm.wl.Len()
 			if n > 0 {
-				log.Debug(n, "keys in bitswap wantlist")
+				log.Debug(n, " keys in bitswap wantlist")
 			}
 		case <-broadcastSignal.C: // resend unfulfilled wantlist keys
 			log.Event(ctx, "Bitswap.Rebroadcast.active")


### PR DESCRIPTION
While messing around I noticed the lack of a space in my log.
A bitswap debug message was logged like this:
```
21:35:05.951 DEBUG    bitswap: 15keys in bitswap wantlist workers.go:172
```
Notice the "15keys" concatenation error. This PR fixes that.

License: MIT
Signed-off-by: Mateusz Naściszewski <matin1111@wp.pl>