### PR TITLE
Fix whitespace discrepency in security-notes

### DIFF
--- a/assets/init-doc/security-notes
+++ b/assets/init-doc/security-notes
@@ -15,7 +15,7 @@ Please note the following:
   github issue, or email security@ipfs.io privately.
 
 - ipfs uses encryption for all communication, but it's NOT PROVEN SECURE
-  YET!  It may be totally broken. For now, the code is included to make
+  YET! It may be totally broken. For now, the code is included to make
   sure we benchmark our operations with encryption in mind. In the future,
   there will be an "unsafe" mode for high performance intranet apps.
   If this is a blocking feature for you, please contact us.


### PR DESCRIPTION
Just remove an extra space that found its way into one of the default text files. It bothered me, but I know it's a very minor thing - if it matters at all, even.
