### PR TITLE
metrics: introduce go-metrics-interface

### DIFF
--- a/blocks/blockstore/arc_cache.go
+++ b/blocks/blockstore/arc_cache.go
@@ -19,7 +19,7 @@ type arccache struct {
 	total metrics.Counter
 }
 
-func newARCCachedBS(bs Blockstore, ctx context.Context, lruSize int) (*arccache, error) {
+func newARCCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*arccache, error) {
 	arc, err := lru.NewARC(lruSize)
 	if err != nil {
 		return nil, err

--- a/blocks/blockstore/arc_cache.go
+++ b/blocks/blockstore/arc_cache.go
@@ -1,9 +1,11 @@
 package blockstore
 
 import (
-	"github.com/ipfs/go-ipfs/blocks"
 	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 
+	"github.com/ipfs/go-ipfs/blocks"
+
+	"gx/ipfs/QmRg1gKTHzc3CZXSKzem8aR4E3TubFhbgXwfVuWnSK5CC5/go-metrics-interface"
 	lru "gx/ipfs/QmVYxfoJQiZijTgPNHCHgHELvQpbsJNTg6Crmc3dQkj3yy/golang-lru"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
@@ -12,15 +14,21 @@ import (
 type arccache struct {
 	arc        *lru.ARCCache
 	blockstore Blockstore
+
+	hits  metrics.Counter
+	total metrics.Counter
 }
 
-func arcCached(bs Blockstore, lruSize int) (*arccache, error) {
+func newARCCachedBS(bs Blockstore, ctx context.Context, lruSize int) (*arccache, error) {
 	arc, err := lru.NewARC(lruSize)
 	if err != nil {
 		return nil, err
 	}
+	c := &arccache{arc: arc, blockstore: bs}
+	c.hits = metrics.NewCtx(ctx, "arc.hits_total", "Number of ARC cache hits").Counter()
+	c.total = metrics.NewCtx(ctx, "arc_total", "Total number of ARC cache requests").Counter()
 
-	return &arccache{arc: arc, blockstore: bs}, nil
+	return c, nil
 }
 
 func (b *arccache) DeleteBlock(k key.Key) error {
@@ -42,6 +50,7 @@ func (b *arccache) DeleteBlock(k key.Key) error {
 // if ok == false has is inconclusive
 // if ok == true then has respons to question: is it contained
 func (b *arccache) hasCached(k key.Key) (has bool, ok bool) {
+	b.total.Inc()
 	if k == "" {
 		// Return cache invalid so the call to blockstore happens
 		// in case of invalid key and correct error is created.
@@ -50,6 +59,7 @@ func (b *arccache) hasCached(k key.Key) (has bool, ok bool) {
 
 	h, ok := b.arc.Get(k)
 	if ok {
+		b.hits.Inc()
 		return h.(bool), true
 	}
 	return false, false

--- a/blocks/blockstore/arc_cache_test.go
+++ b/blocks/blockstore/arc_cache_test.go
@@ -140,7 +140,7 @@ func TestGetAndDeleteFalseShortCircuit(t *testing.T) {
 }
 
 func TestArcCreationFailure(t *testing.T) {
-	if arc, err := arcCached(nil, -1); arc != nil || err == nil {
+	if arc, err := newARCCachedBS(nil, context.TODO(), -1); arc != nil || err == nil {
 		t.Fatal("expected error and no cache")
 	}
 }

--- a/blocks/blockstore/arc_cache_test.go
+++ b/blocks/blockstore/arc_cache_test.go
@@ -140,7 +140,7 @@ func TestGetAndDeleteFalseShortCircuit(t *testing.T) {
 }
 
 func TestArcCreationFailure(t *testing.T) {
-	if arc, err := newARCCachedBS(nil, context.TODO(), -1); arc != nil || err == nil {
+	if arc, err := newARCCachedBS(context.TODO(), nil, -1); arc != nil || err == nil {
 		t.Fatal("expected error and no cache")
 	}
 }

--- a/blocks/blockstore/bloom_cache.go
+++ b/blocks/blockstore/bloom_cache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ipfs/go-ipfs/blocks"
 	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 
+	"gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
 	bloom "gx/ipfs/QmWQ2SJisXwcCLsUXLwYCKSfyExXjFRW2WbBH5sqCUnwX5/bbloom"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 )
@@ -18,6 +19,10 @@ func bloomCached(bs Blockstore, ctx context.Context, bloomSize, hashCount int) (
 		return nil, err
 	}
 	bc := &bloomcache{blockstore: bs, bloom: bl}
+	bc.hits = metrics.NewCtx(ctx, "bloom.hits_total",
+		"Number of cache hits in bloom cache").Counter()
+	bc.total = metrics.NewCtx(ctx, "bloom_total",
+		"Total number of requests to bloom cache").Counter()
 	bc.Invalidate()
 	go bc.Rebuild(ctx)
 
@@ -33,8 +38,8 @@ type bloomcache struct {
 	blockstore  Blockstore
 
 	// Statistics
-	hits   uint64
-	misses uint64
+	hits  metrics.Counter
+	total metrics.Counter
 }
 
 func (b *bloomcache) Invalidate() {
@@ -84,6 +89,7 @@ func (b *bloomcache) DeleteBlock(k key.Key) error {
 // if ok == false has is inconclusive
 // if ok == true then has respons to question: is it contained
 func (b *bloomcache) hasCached(k key.Key) (has bool, ok bool) {
+	b.total.Inc()
 	if k == "" {
 		// Return cache invalid so call to blockstore
 		// in case of invalid key is forwarded deeper
@@ -92,6 +98,7 @@ func (b *bloomcache) hasCached(k key.Key) (has bool, ok bool) {
 	if b.BloomActive() {
 		blr := b.bloom.HasTS([]byte(k))
 		if blr == false { // not contained in bloom is only conclusive answer bloom gives
+			b.hits.Inc()
 			return false, true
 		}
 	}

--- a/blocks/blockstore/bloom_cache.go
+++ b/blocks/blockstore/bloom_cache.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipfs/go-ipfs/blocks"
 	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 
-	"gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
+	"gx/ipfs/QmRg1gKTHzc3CZXSKzem8aR4E3TubFhbgXwfVuWnSK5CC5/go-metrics-interface"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	bloom "gx/ipfs/QmeiMCBkYHxkDkDfnDadzz4YxY5ruL5Pj499essE4vRsGM/bbloom"
 )

--- a/blocks/blockstore/bloom_cache.go
+++ b/blocks/blockstore/bloom_cache.go
@@ -7,8 +7,8 @@ import (
 	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 
 	"gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
-	bloom "gx/ipfs/QmWQ2SJisXwcCLsUXLwYCKSfyExXjFRW2WbBH5sqCUnwX5/bbloom"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
+	bloom "gx/ipfs/QmeiMCBkYHxkDkDfnDadzz4YxY5ruL5Pj499essE4vRsGM/bbloom"
 )
 
 // bloomCached returns Blockstore that caches Has requests using Bloom filter

--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -38,7 +38,7 @@ func CachedBlockstore(bs GCBlockstore,
 	ctx = metrics.CtxSubScope(ctx, "bs.cache")
 
 	if opts.HasARCCacheSize > 0 {
-		cbs, err = newARCCachedBS(cbs, ctx, opts.HasARCCacheSize)
+		cbs, err = newARCCachedBS(ctx, cbs, opts.HasARCCacheSize)
 	}
 	if opts.HasBloomFilterSize != 0 {
 		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize, opts.HasBloomFilterHashes)

--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -3,7 +3,7 @@ package blockstore
 import (
 	"errors"
 
-	"gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
+	"gx/ipfs/QmRg1gKTHzc3CZXSKzem8aR4E3TubFhbgXwfVuWnSK5CC5/go-metrics-interface"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 )
 

--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -3,6 +3,7 @@ package blockstore
 import (
 	"errors"
 
+	"gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 )
 
@@ -33,11 +34,14 @@ func CachedBlockstore(bs GCBlockstore,
 	if opts.HasBloomFilterSize != 0 && opts.HasBloomFilterHashes == 0 {
 		return nil, errors.New("bloom filter hash count can't be 0 when there is size set")
 	}
+
+	ctx = metrics.CtxSubScope(ctx, "bs.cache")
+
 	if opts.HasBloomFilterSize != 0 {
 		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize, opts.HasBloomFilterHashes)
 	}
 	if opts.HasARCCacheSize > 0 {
-		cbs, err = arcCached(cbs, opts.HasARCCacheSize)
+		cbs, err = newARCCachedBS(cbs, ctx, opts.HasARCCacheSize)
 	}
 
 	return cbs, err

--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -37,11 +37,11 @@ func CachedBlockstore(bs GCBlockstore,
 
 	ctx = metrics.CtxSubScope(ctx, "bs.cache")
 
-	if opts.HasBloomFilterSize != 0 {
-		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize, opts.HasBloomFilterHashes)
-	}
 	if opts.HasARCCacheSize > 0 {
 		cbs, err = newARCCachedBS(cbs, ctx, opts.HasARCCacheSize)
+	}
+	if opts.HasBloomFilterSize != 0 {
+		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize, opts.HasBloomFilterHashes)
 	}
 
 	return cbs, err

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -11,11 +11,6 @@ import (
 	"sort"
 	"sync"
 
-	"gx/ipfs/QmPpRcbNUXauP3zWZ1NJMLWpe4QnmEHrd2ba2D3yqWznw7/go-multiaddr-net"
-	_ "gx/ipfs/QmV3NSS3A1kX5s28r7yLczhDsXzkgo65cqRgKFXYunWZmD/metrics/runtime"
-
-	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
-
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	commands "github.com/ipfs/go-ipfs/core/commands"
@@ -25,10 +20,16 @@ import (
 	nodeMount "github.com/ipfs/go-ipfs/fuse/node"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	migrate "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
+
+	"gx/ipfs/QmPpRcbNUXauP3zWZ1NJMLWpe4QnmEHrd2ba2D3yqWznw7/go-multiaddr-net"
+	"gx/ipfs/QmR3KwhXCRLTNZB59vELb2HhEWrGy9nuychepxFtj3wWYa/client_golang/prometheus"
 	conn "gx/ipfs/QmUuwQUJmtvC6ReYcu7xaYKEUM3pD46H18dFn3LBhVt2Di/go-libp2p/p2p/net/conn"
+	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
 	util "gx/ipfs/QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1/go-ipfs-util"
 	pstore "gx/ipfs/QmdMfSLMDBDYhtc4oF3NYGCZr5dy4wQb6Ji26N4D4mdxa2/go-libp2p-peerstore"
-	prometheus "gx/ipfs/QmdhsRK1EK2fvAz2i2SH5DEfkL6seDuyMYEsxKa9Braim3/client_golang/prometheus"
+
+	_ "gx/ipfs/QmV3NSS3A1kX5s28r7yLczhDsXzkgo65cqRgKFXYunWZmD/metrics/runtime"
+	_ "gx/ipfs/QmWTHakXvEmW44Muyy1wGGzoWA4tntuuvd8BhBbmLYBzSx/go-metrics-prometheus"
 )
 
 const (
@@ -359,8 +360,7 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 	}
 
 	// initialize metrics collector
-	prometheus.MustRegisterOrGet(&corehttp.IpfsNodeCollector{Node: node})
-	prometheus.EnableCollectChecks(true)
+	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})
 
 	fmt.Printf("Daemon is ready\n")
 	// collect long-running errors and block for shutdown

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -28,8 +28,8 @@ import (
 	util "gx/ipfs/QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1/go-ipfs-util"
 	pstore "gx/ipfs/QmdMfSLMDBDYhtc4oF3NYGCZr5dy4wQb6Ji26N4D4mdxa2/go-libp2p-peerstore"
 
+	_ "gx/ipfs/QmSd7rE8qjihopcQpg7VXzcPX8X4FJ5XkXVkUQggmmWyvG/go-metrics-prometheus"
 	_ "gx/ipfs/QmV3NSS3A1kX5s28r7yLczhDsXzkgo65cqRgKFXYunWZmD/metrics/runtime"
-	_ "gx/ipfs/QmWTHakXvEmW44Muyy1wGGzoWA4tntuuvd8BhBbmLYBzSx/go-metrics-prometheus"
 )
 
 const (

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -23,12 +23,13 @@ import (
 
 	"gx/ipfs/QmPpRcbNUXauP3zWZ1NJMLWpe4QnmEHrd2ba2D3yqWznw7/go-multiaddr-net"
 	"gx/ipfs/QmR3KwhXCRLTNZB59vELb2HhEWrGy9nuychepxFtj3wWYa/client_golang/prometheus"
+
 	conn "gx/ipfs/QmUuwQUJmtvC6ReYcu7xaYKEUM3pD46H18dFn3LBhVt2Di/go-libp2p/p2p/net/conn"
+	mprome "gx/ipfs/QmXWro6iddJRbGWUoZDpTu6tjo5EXX4xJHHR9VczeoGZbw/go-metrics-prometheus"
 	ma "gx/ipfs/QmYzDkkgAEmrcNzFCiYo6L1dTX4EAG1gZkbtdbd9trL4vd/go-multiaddr"
 	util "gx/ipfs/QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1/go-ipfs-util"
 	pstore "gx/ipfs/QmdMfSLMDBDYhtc4oF3NYGCZr5dy4wQb6Ji26N4D4mdxa2/go-libp2p-peerstore"
 
-	_ "gx/ipfs/QmSd7rE8qjihopcQpg7VXzcPX8X4FJ5XkXVkUQggmmWyvG/go-metrics-prometheus"
 	_ "gx/ipfs/QmV3NSS3A1kX5s28r7yLczhDsXzkgo65cqRgKFXYunWZmD/metrics/runtime"
 )
 
@@ -360,6 +361,10 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 	}
 
 	// initialize metrics collector
+	err = mprome.Inject()
+	if err != nil {
+		log.Warningf("Injecting prometheus handler for metrics failed with message: %s\n", err.Error())
+	}
 	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})
 
 	fmt.Printf("Daemon is ready\n")

--- a/core/builder.go
+++ b/core/builder.go
@@ -18,8 +18,8 @@ import (
 	cfg "github.com/ipfs/go-ipfs/repo/config"
 
 	retry "gx/ipfs/QmPF5kxTYFkzhaY5LmkExood7aTTZBHWQC6cjdDQBuGrjp/retry-datastore"
+	metrics "gx/ipfs/QmRg1gKTHzc3CZXSKzem8aR4E3TubFhbgXwfVuWnSK5CC5/go-metrics-interface"
 	goprocessctx "gx/ipfs/QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP/goprocess/context"
-	metrics "gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
 	ci "gx/ipfs/QmVoi5es8D5fNHZDqoW6DgDAEPEV5hQp8GBz161vZXiwpQ/go-libp2p-crypto"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"

--- a/core/builder.go
+++ b/core/builder.go
@@ -16,14 +16,15 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 	repo "github.com/ipfs/go-ipfs/repo"
 	cfg "github.com/ipfs/go-ipfs/repo/config"
-	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 
 	retry "gx/ipfs/QmPF5kxTYFkzhaY5LmkExood7aTTZBHWQC6cjdDQBuGrjp/retry-datastore"
 	goprocessctx "gx/ipfs/QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP/goprocess/context"
+	metrics "gx/ipfs/QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe/go-metrics-interface"
 	ci "gx/ipfs/QmVoi5es8D5fNHZDqoW6DgDAEPEV5hQp8GBz161vZXiwpQ/go-libp2p-crypto"
 	context "gx/ipfs/QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt/go-net/context"
 	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
 	dsync "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
+	key "gx/ipfs/Qmce4Y4zg3sYr7xKM5UueS67vhNni6EeWgCRnb7MbLJMew/go-key"
 	pstore "gx/ipfs/QmdMfSLMDBDYhtc4oF3NYGCZr5dy4wQb6Ji26N4D4mdxa2/go-libp2p-peerstore"
 )
 
@@ -109,6 +110,7 @@ func NewNode(ctx context.Context, cfg *BuildCfg) (*IpfsNode, error) {
 	if err != nil {
 		return nil, err
 	}
+	ctx = metrics.CtxScope(ctx, "ipfs")
 
 	n := &IpfsNode{
 		mode:      offlineMode,

--- a/core/corehttp/metrics.go
+++ b/core/corehttp/metrics.go
@@ -4,9 +4,9 @@ import (
 	"net"
 	"net/http"
 
-	prometheus "gx/ipfs/QmdhsRK1EK2fvAz2i2SH5DEfkL6seDuyMYEsxKa9Braim3/client_golang/prometheus"
-
 	core "github.com/ipfs/go-ipfs/core"
+
+	prometheus "gx/ipfs/QmR3KwhXCRLTNZB59vELb2HhEWrGy9nuychepxFtj3wWYa/client_golang/prometheus"
 )
 
 // This adds the scraping endpoint which Prometheus uses to fetch metrics.

--- a/core/corehttp/metrics.go
+++ b/core/corehttp/metrics.go
@@ -53,6 +53,9 @@ func (c IpfsNodeCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (c IpfsNodeCollector) PeersTotalValues() map[string]float64 {
 	vals := make(map[string]float64)
+	if c.Node.PeerHost == nil {
+		return vals
+	}
 	for _, conn := range c.Node.PeerHost.Network().Conns() {
 		tr := ""
 		for _, proto := range conn.RemoteMultiaddr().Protocols() {

--- a/package.json
+++ b/package.json
@@ -170,9 +170,9 @@
     },
     {
       "author": "kubuxu",
-      "hash": "QmWQ2SJisXwcCLsUXLwYCKSfyExXjFRW2WbBH5sqCUnwX5",
+      "hash": "QmeiMCBkYHxkDkDfnDadzz4YxY5ruL5Pj499essE4vRsGM",
       "name": "bbloom",
-      "version": "0.0.2"
+      "version": "0.1.0"
     },
     {
       "author": "whyrusleeping",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmdhsRK1EK2fvAz2i2SH5DEfkL6seDuyMYEsxKa9Braim3",
+      "hash": "QmR3KwhXCRLTNZB59vELb2HhEWrGy9nuychepxFtj3wWYa",
       "name": "client_golang",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     {
       "hash": "Qma1FrGRasghpuETfCtsKdFtXKQffpNnakv3wG3QaMwCVi",
@@ -239,6 +239,18 @@
       "hash": "QmYrv4LgCC8FhG2Ab4bwuq5DqBdwMtx3hMb3KKJDZcr2d7",
       "name": "go-libp2p-loggables",
       "version": "1.0.11"
+    },
+    {
+      "author": "ipfs",
+      "hash": "QmWTHakXvEmW44Muyy1wGGzoWA4tntuuvd8BhBbmLYBzSx",
+      "name": "go-metrics-prometheus",
+      "version": "0.1.1"
+    },
+    {
+      "author": "ipfs",
+      "hash": "QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe",
+      "name": "go-metrics-interface",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -242,9 +242,9 @@
     },
     {
       "author": "ipfs",
-      "hash": "QmSd7rE8qjihopcQpg7VXzcPX8X4FJ5XkXVkUQggmmWyvG",
+      "hash": "QmXWro6iddJRbGWUoZDpTu6tjo5EXX4xJHHR9VczeoGZbw",
       "name": "go-metrics-prometheus",
-      "version": "0.1.2"
+      "version": "0.3.0"
     },
     {
       "author": "ipfs",

--- a/package.json
+++ b/package.json
@@ -242,15 +242,15 @@
     },
     {
       "author": "ipfs",
-      "hash": "QmWTHakXvEmW44Muyy1wGGzoWA4tntuuvd8BhBbmLYBzSx",
+      "hash": "QmSd7rE8qjihopcQpg7VXzcPX8X4FJ5XkXVkUQggmmWyvG",
       "name": "go-metrics-prometheus",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "author": "ipfs",
-      "hash": "QmVWBQQAz4Cd2XgW9KgQoqXXrU8KJoCb9WCrhWRFVBKvFe",
+      "hash": "QmRg1gKTHzc3CZXSKzem8aR4E3TubFhbgXwfVuWnSK5CC5",
       "name": "go-metrics-interface",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
It makes introducing metrics much easier.

The interface itself doesn't depend on prometheus, that means it is very light and without it (or other implementation) acts as a general noop.

Importing go-metrics-prometheus injects prometheus implementation.

Usage:
There are three most improtant functions in go-metrics-interface:

* `metrics.New(name, helptext)` - creates new metrics with given name and helptext
* `metrics.NewCtx(ctx, name, helptext)` - creates new metrics with given name and helptext in scope defined in the context
* `metric.CtxSubScope(ctx, name)` - returns context that is a subscope of scope defined in current ctx

As you can see it uses `context.Value` for passing the scope name of the metrics. In my opinion it is one of the better solutions as context is already required in many places, and it introduction in constructors chains isn't bad either.

Current problem I have is that `goprocess` doesn't have something like `context.Value` so passing scopes through `goprocess` is something I haven't figured out yet but it can be done later.


//cc @whyrusleeping @lgierth 