### PR TITLE
Refactoring install.sh

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -9,7 +9,7 @@ binpaths="/usr/local/bin /usr/bin"
 
 for binpath in $binpaths; do
   if mv -t "$binpath" "$bin" 2> /dev/null; then
-    echo "installed $binpath/$bin"
+    echo "Moved $bin to $binpath"
     exit 0
   fi
 done

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -11,7 +11,7 @@ binpaths="/usr/local/bin /usr/bin"
 is_write_perm_missing=""
 
 for binpath in $binpaths; do
-  if mv -t "$binpath" "$bin" 2> /dev/null; then
+  if mv "$bin" "$binpath/$bin" 2> /dev/null; then
     echo "Moved $bin to $binpath"
     exit 0
   else

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+# Installation script for ipfs. It tries to move $bin in one of the
+# directories stored in $binpaths.
 
 bin=ipfs
 binpaths="/usr/local/bin /usr/bin"
@@ -6,10 +9,6 @@ binpaths="/usr/local/bin /usr/bin"
 # This variable contains a nonzero length string in case the script fails
 # because of missing write permissions.
 is_write_perm_missing=""
-
-# this script is currently brain dead.
-# it merely tries two locations.
-# in the future maybe use value of $PATH.
 
 for binpath in $binpaths; do
   if mv -t "$binpath" "$bin" 2> /dev/null; then

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 
 bin=ipfs
+binpaths="/usr/local/bin /usr/bin"
 
 # this script is currently brain dead.
 # it merely tries two locations.
 # in the future maybe use value of $PATH.
 
-for binpath in /usr/local/bin /usr/bin; do
+for binpath in $binpaths; do
   if [ -d "$binpath" ]; then
     mv "$bin" "$binpath/$bin"
     echo "installed $binpath/$bin"
     exit 0
   fi
 done
+
+echo "cannot install $bin in one of the directories $binpaths"
+exit 1

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -3,6 +3,10 @@
 bin=ipfs
 binpaths="/usr/local/bin /usr/bin"
 
+# This variable contains a nonzero length string in case the script fails
+# because of missing write permissions.
+is_write_perm_missing=""
+
 # this script is currently brain dead.
 # it merely tries two locations.
 # in the future maybe use value of $PATH.
@@ -11,8 +15,21 @@ for binpath in $binpaths; do
   if mv -t "$binpath" "$bin" 2> /dev/null; then
     echo "Moved $bin to $binpath"
     exit 0
+  else
+    if [ -d "$binpath" -a ! -w "$binpath" ]; then
+      is_write_perm_missing=1
+    fi
   fi
 done
 
-echo "cannot install $bin in one of the directories $binpaths"
+echo "We cannot install $bin in one of the directories $binpaths"
+
+if [ -n "$is_write_perm_missing" ]; then
+  echo "It seems that we do not have the necessary write permissions."
+  echo "Perhaps try running this script as a privileged user:"
+  echo
+  echo "    sudo $0"
+  echo
+fi
+
 exit 1

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -6,16 +6,10 @@ bin=ipfs
 # it merely tries two locations.
 # in the future maybe use value of $PATH.
 
-binpath=/usr/local/bin
-if [ -d "$binpath" ]; then
-  mv "$bin" "$binpath/$bin"
-  echo "installed $binpath/$bin"
-  exit 0
-fi
-
-binpath=/usr/bin
-if [ -d "$binpath" ]; then
-  mv "$bin" "$binpath/$bin"
-  echo "installed $binpath/$bin"
-  exit 0
-fi
+for binpath in /usr/local/bin /usr/bin; do
+  if [ -d "$binpath" ]; then
+    mv "$bin" "$binpath/$bin"
+    echo "installed $binpath/$bin"
+    exit 0
+  fi
+done

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -8,8 +8,7 @@ binpaths="/usr/local/bin /usr/bin"
 # in the future maybe use value of $PATH.
 
 for binpath in $binpaths; do
-  if [ -d "$binpath" ]; then
-    mv -t "$binpath" "$bin"
+  if mv -t "$binpath" "$bin" 2> /dev/null; then
     echo "installed $binpath/$bin"
     exit 0
   fi

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -9,7 +9,7 @@ binpaths="/usr/local/bin /usr/bin"
 
 for binpath in $binpaths; do
   if [ -d "$binpath" ]; then
-    mv "$bin" "$binpath/$bin"
+    mv -t "$binpath" "$bin"
     echo "installed $binpath/$bin"
     exit 0
   fi


### PR DESCRIPTION
Hello,

I made little changes for the installation script `install.sh`. The enhancements are:

* I use a for loop for the binpaths (following the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle)
* An error message was added in the end to inform the user when the script couldn't be installed.