### PR TITLE
blockstore: change unit of bloom filter to byte from bits

### DIFF
--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -8,16 +8,16 @@ import (
 
 // Next to each option is it aproximate memory usage per unit
 type CacheOpts struct {
-	HasBloomFilterSize   int // 1 bit
+	HasBloomFilterSize   int // 1 byte
 	HasBloomFilterHashes int // No size, 7 is usually best, consult bloom papers
 	HasARCCacheSize      int // 32 bytes
 }
 
 func DefaultCacheOpts() CacheOpts {
 	return CacheOpts{
-		HasBloomFilterSize:   512 * 8 * 1024,
+		HasBloomFilterSize:   512 << 10,
 		HasBloomFilterHashes: 7,
-		HasARCCacheSize:      64 * 1024,
+		HasARCCacheSize:      64 << 10,
 	}
 }
 
@@ -34,7 +34,8 @@ func CachedBlockstore(bs GCBlockstore,
 		return nil, errors.New("bloom filter hash count can't be 0 when there is size set")
 	}
 	if opts.HasBloomFilterSize != 0 {
-		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize, opts.HasBloomFilterHashes)
+		// *8 because of bytes to bits conversion
+		cbs, err = bloomCached(cbs, ctx, opts.HasBloomFilterSize*8, opts.HasBloomFilterHashes)
 	}
 	if opts.HasARCCacheSize > 0 {
 		cbs, err = arcCached(cbs, opts.HasARCCacheSize)

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ Default: `false`
 A boolean value. If set to true, all block reads from disk will be hashed and verified. This will cause increased CPU utilization.
 
 - `BloomFilterSize`
-A number representing the size in bits of the blockstore's bloom filter. A value of zero represents the feature being disabled.
+A number representing the size in bytes of the blockstore's bloom filter. A value of zero represents the feature being disabled.
 
 Default: `0` 
 


### PR DESCRIPTION
License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>