### PR TITLE
dht: add missing protocol ID to newStream call

### DIFF
--- a/routing/dht/dht_net.go
+++ b/routing/dht/dht_net.go
@@ -141,7 +141,7 @@ func (ms *messageSender) prep() error {
 		return nil
 	}
 
-	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ProtocolDHT)
+	nstr, err := ms.dht.host.NewStream(ms.dht.ctx, ms.p, ProtocolDHT, ProtocolDHTOld)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


License: MIT
Signed-off-by: Jeromy <why@ipfs.io>