### PR TITLE
gateway: fix --writable flag :|

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -409,9 +409,9 @@ func serveHTTPApi(req cmds.Request) (error, <-chan error) {
 	if err != nil {
 		return fmt.Errorf("serveHTTPApi: Option(%s) failed: %s", unrestrictedApiAccessKwd, err), nil
 	}
-	gatewayOpt := corehttp.GatewayOption(corehttp.WebUIPaths...)
+	gatewayOpt := corehttp.GatewayOption(false, corehttp.WebUIPaths...)
 	if unrestricted {
-		gatewayOpt = corehttp.GatewayOption("/ipfs", "/ipns")
+		gatewayOpt = corehttp.GatewayOption(true, "/ipfs", "/ipns")
 	}
 
 	var opts = []corehttp.ServeOption{
@@ -480,8 +480,8 @@ func serveHTTPGateway(req cmds.Request) (error, <-chan error) {
 	if err != nil {
 		return fmt.Errorf("serveHTTPGateway: req.Option(%s) failed: %s", writableKwd, err), nil
 	}
-	if writableOptionFound {
-		cfg.Gateway.Writable = writable
+	if !writableOptionFound {
+		writable = cfg.Gateway.Writable
 	}
 
 	gwLis, err := manet.Listen(gatewayMaddr)
@@ -502,7 +502,7 @@ func serveHTTPGateway(req cmds.Request) (error, <-chan error) {
 		corehttp.CommandsROOption(*req.InvocContext()),
 		corehttp.VersionOption(),
 		corehttp.IPNSHostnameOption(),
-		corehttp.GatewayOption("/ipfs", "/ipns"),
+		corehttp.GatewayOption(writable, "/ipfs", "/ipns"),
 	}
 
 	if len(cfg.Gateway.RootRedirect) > 0 {

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -81,16 +81,10 @@ func run(ipfsPath, watchPath string) error {
 	}
 	defer node.Close()
 
-	cfg, err := node.Repo.Config()
-	if err != nil {
-		return err
-	}
-	cfg.Gateway.Writable = true
-
 	if *http {
 		addr := "/ip4/127.0.0.1/tcp/5001"
 		var opts = []corehttp.ServeOption{
-			corehttp.GatewayOption("/ipfs", "/ipns"),
+			corehttp.GatewayOption(true, "/ipfs", "/ipns"),
 			corehttp.WebUIOption,
 			corehttp.CommandsOption(cmdCtx(node, ipfsPath)),
 		}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -16,7 +16,7 @@ type GatewayConfig struct {
 	PathPrefixes []string
 }
 
-func GatewayOption(paths ...string) ServeOption {
+func GatewayOption(writable bool, paths ...string) ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		cfg, err := n.Repo.Config()
 		if err != nil {
@@ -25,7 +25,7 @@ func GatewayOption(paths ...string) ServeOption {
 
 		gateway := newGatewayHandler(n, GatewayConfig{
 			Headers:      cfg.Gateway.HTTPHeaders,
-			Writable:     cfg.Gateway.Writable,
+			Writable:     writable,
 			PathPrefixes: cfg.Gateway.PathPrefixes,
 		})
 

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -104,7 +104,7 @@ func newTestServerAndNode(t *testing.T, ns mockNamesys) (*httptest.Server, *core
 		ts.Listener,
 		VersionOption(),
 		IPNSHostnameOption(),
-		GatewayOption("/ipfs", "/ipns"),
+		GatewayOption(false, "/ipfs", "/ipns"),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -9,7 +9,22 @@ test_description="Test HTTP Gateway (Writable)"
 . lib/test-lib.sh
 
 test_init_ipfs
+
+test_launch_ipfs_daemon --writable
+test_expect_success "ipfs daemon --writable overrides config" '
+  curl -v -X POST http://$GWAY_ADDR/ipfs/ 2> outfile &&
+  grep "HTTP/1.1 201 Created" outfile &&
+  grep "Location: /ipfs/QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH" outfile
+'
+test_kill_ipfs_daemon
+
 test_config_ipfs_gateway_writable
+test_launch_ipfs_daemon --writable=false
+test_expect_success "ipfs daemon --writable=false overrides Writable=true config" '
+  curl -v -X POST http://$GWAY_ADDR/ipfs/ 2> outfile &&
+  grep "HTTP/1.1 405 Method Not Allowed" outfile
+'
+test_kill_ipfs_daemon
 test_launch_ipfs_daemon
 
 port=$GWAY_PORT

--- a/test/supernode_client/main.go
+++ b/test/supernode_client/main.go
@@ -109,7 +109,7 @@ func run() error {
 
 	opts := []corehttp.ServeOption{
 		corehttp.CommandsOption(cmdCtx(node, repoPath)),
-		corehttp.GatewayOption(),
+		corehttp.GatewayOption(false),
 	}
 
 	if *cat {


### PR DESCRIPTION
Broke it in #2874... my unproven assumption apparantly was that `cfg.Gateway.Writable = true` would somehow magically make it into other instances of the config retrieved via `Repo.Config()`...

We're not overloading the repo config with this anymore now. We also have a test for `--writable` now.