### PR TITLE
Initial Core API, and gateway integration

### DIFF
--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -1,0 +1,26 @@
+package coreapi
+
+import (
+	"context"
+
+	core "github.com/ipfs/go-ipfs/core"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	path "github.com/ipfs/go-ipfs/path"
+
+	ipld "gx/ipfs/QmU7bFWQ793qmvNy7outdCaMfSDNk8uqhx4VNrxYj5fj5g/go-ipld-node"
+)
+
+func resolve(ctx context.Context, n *core.IpfsNode, p string) (ipld.Node, error) {
+	pp, err := path.ParsePath(p)
+	if err != nil {
+		return nil, err
+	}
+
+	dagnode, err := core.Resolve(ctx, n.Namesys, n.Resolver, pp)
+	if err == core.ErrNoNamesys {
+		return nil, coreiface.ErrOffline
+	} else if err != nil {
+		return nil, err
+	}
+	return dagnode, nil
+}

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -1,0 +1,56 @@
+package iface
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	cid "gx/ipfs/QmXfiyr2RWEXpVDdaYnD2HNiBk6UBddsvEP4RPfXb6nGqY/go-cid"
+)
+
+// type CoreAPI interface {
+// 	ID() CoreID
+// 	Version() CoreVersion
+// }
+
+type Link struct {
+	Name string
+	Size uint64
+	Cid  *cid.Cid
+}
+
+type Reader interface {
+	io.ReadSeeker
+	io.Closer
+}
+
+type UnixfsAPI interface {
+	Cat(context.Context, string) (Reader, error)
+	Ls(context.Context, string) ([]*Link, error)
+}
+
+// type ObjectAPI interface {
+// 	New() (cid.Cid, Object)
+// 	Get(string) (Object, error)
+// 	Links(string) ([]*Link, error)
+// 	Data(string) (Reader, error)
+// 	Stat(string) (ObjectStat, error)
+// 	Put(Object) (cid.Cid, error)
+// 	SetData(string, Reader) (cid.Cid, error)
+// 	AppendData(string, Data) (cid.Cid, error)
+// 	AddLink(string, string, string) (cid.Cid, error)
+// 	RmLink(string, string) (cid.Cid, error)
+// }
+
+// type ObjectStat struct {
+// 	Cid            cid.Cid
+// 	NumLinks       int
+// 	BlockSize      int
+// 	LinksSize      int
+// 	DataSize       int
+// 	CumulativeSize int
+// }
+
+var ErrIsDir = errors.New("object is a directory")
+var ErrIsNonDag = errors.New("not a merkledag object")
+var ErrOffline = errors.New("can't resolve, ipfs node is offline")

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -1,0 +1,53 @@
+package coreapi
+
+import (
+	"context"
+
+	core "github.com/ipfs/go-ipfs/core"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	mdag "github.com/ipfs/go-ipfs/merkledag"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
+)
+
+type UnixfsAPI struct {
+	node *core.IpfsNode
+}
+
+func NewUnixfsAPI(n *core.IpfsNode) coreiface.UnixfsAPI {
+	api := &UnixfsAPI{n}
+	return api
+}
+
+func (api *UnixfsAPI) Cat(ctx context.Context, p string) (coreiface.Reader, error) {
+	dagnode, err := resolve(ctx, api.node, p)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := dagnode.(*mdag.ProtoNode)
+	if !ok {
+		return nil, coreiface.ErrIsNonDag
+	}
+
+	r, err := uio.NewDagReader(ctx, dagnode, api.node.DAG)
+	if err == uio.ErrIsDir {
+		return nil, coreiface.ErrIsDir
+	} else if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (api *UnixfsAPI) Ls(ctx context.Context, p string) ([]*coreiface.Link, error) {
+	dagnode, err := resolve(ctx, api.node, p)
+	if err != nil {
+		return nil, err
+	}
+
+	l := dagnode.Links()
+	links := make([]*coreiface.Link, len(l))
+	for i, l := range l {
+		links[i] = &coreiface.Link{l.Name, l.Size, l.Cid}
+	}
+	return links, nil
+}

--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -1,0 +1,229 @@
+package coreapi_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	core "github.com/ipfs/go-ipfs/core"
+	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
+	mdag "github.com/ipfs/go-ipfs/merkledag"
+	repo "github.com/ipfs/go-ipfs/repo"
+	config "github.com/ipfs/go-ipfs/repo/config"
+	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
+	unixfs "github.com/ipfs/go-ipfs/unixfs"
+)
+
+// `ipfs object new unixfs-dir`
+var emptyUnixfsDir = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn"
+
+// `echo -n | ipfs add`
+var emptyUnixfsFile = "QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"
+
+func makeAPI(ctx context.Context) (*core.IpfsNode, coreiface.UnixfsAPI, error) {
+	r := &repo.Mock{
+		C: config.Config{
+			Identity: config.Identity{
+				PeerID: "Qmfoo", // required by offline node
+			},
+		},
+		D: testutil.ThreadSafeCloserMapDatastore(),
+	}
+	node, err := core.NewNode(ctx, &core.BuildCfg{Repo: r})
+	if err != nil {
+		return nil, nil, err
+	}
+	api := coreapi.NewUnixfsAPI(node)
+	return node, api, nil
+}
+
+func TestCatBasic(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hello := "hello, world!"
+	hr := strings.NewReader(hello)
+	k, err := coreunix.Add(node, hr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := api.Cat(ctx, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, len(hello))
+	n, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF {
+		t.Error(err)
+	}
+	if string(buf) != hello {
+		t.Fatalf("expected [hello, world!], got [%s] [err=%s]", string(buf), n, err)
+	}
+}
+
+func TestCatEmptyFile(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = coreunix.Add(node, strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := api.Cat(ctx, emptyUnixfsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 1) // non-zero so that Read() actually tries to read
+	n, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF {
+		t.Error(err)
+	}
+	if !bytes.HasPrefix(buf, []byte{0x00}) {
+		t.Fatalf("expected empty data, got [%s] [read=%d]", buf, n)
+	}
+}
+
+func TestCatDir(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err := node.DAG.Add(unixfs.EmptyDirNode())
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = api.Cat(ctx, c.String())
+	if err != coreiface.ErrIsDir {
+		t.Fatalf("expected ErrIsDir, got: %s", err)
+	}
+}
+
+func TestCatNonUnixfs(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err := node.DAG.Add(new(mdag.ProtoNode))
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = api.Cat(ctx, c.String())
+	if !strings.Contains(err.Error(), "proto: required field") {
+		t.Fatalf("expected protobuf error, got: %s", err)
+	}
+}
+
+func TestCatOffline(t *testing.T) {
+	ctx := context.Background()
+	_, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = api.Cat(ctx, "/ipns/Qmfoobar")
+	if err != coreiface.ErrOffline {
+		t.Fatalf("expected ErrOffline, got: %", err)
+	}
+}
+
+func TestLs(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	r := strings.NewReader("content-of-file")
+	p, _, err := coreunix.AddWrapped(node, r, "name-of-file")
+	if err != nil {
+		t.Error(err)
+	}
+	parts := strings.Split(p, "/")
+	if len(parts) != 2 {
+		t.Errorf("unexpected path:", p)
+	}
+	k := parts[0]
+
+	links, err := api.Ls(ctx, k)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	if links[0].Size != 23 {
+		t.Fatalf("expected size = 23, got %d", links[0].Size)
+	}
+	if links[0].Name != "name-of-file" {
+		t.Fatalf("expected name = name-of-file, got %s", links[0].Name)
+	}
+	if links[0].Cid.String() != "QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr" {
+		t.Fatalf("expected cid = QmX3qQVKxDGz3URVC3861Z3CKtQKGBn6ffXRBBWGMFz9Lr, got %s", links[0].Cid.String())
+	}
+}
+
+func TestLsEmptyDir(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err := node.DAG.Add(unixfs.EmptyDirNode())
+	if err != nil {
+		t.Error(err)
+	}
+
+	links, err := api.Ls(ctx, c.String())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(links) != 0 {
+		t.Fatalf("expected 0 links, got %d", len(links))
+	}
+}
+
+// TODO(lgierth) this should test properly, with len(links) > 0
+func TestLsNonUnixfs(t *testing.T) {
+	ctx := context.Background()
+	node, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	c, err := node.DAG.Add(new(mdag.ProtoNode))
+	if err != nil {
+		t.Error(err)
+	}
+
+	links, err := api.Ls(ctx, c.String())
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(links) != 0 {
+		t.Fatalf("expected 0 links, got %d", len(links))
+	}
+}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	core "github.com/ipfs/go-ipfs/core"
+	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	id "gx/ipfs/QmcRa2qn6iCmap9bjp8jAwkvYAq13AUfxdY3rrYiaJbLum/go-libp2p/p2p/protocol/identify"
 )
@@ -27,7 +28,7 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 			Headers:      cfg.Gateway.HTTPHeaders,
 			Writable:     writable,
 			PathPrefixes: cfg.Gateway.PathPrefixes,
-		})
+		}, coreapi.NewUnixfsAPI(n))
 
 		for _, p := range paths {
 			mux.Handle(p+"/", gateway)
@@ -37,7 +38,7 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 }
 
 func VersionOption() ServeOption {
-	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Commit: %s\n", config.CurrentCommit)
 			fmt.Fprintf(w, "Client Version: %s\n", id.ClientVersion)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -16,9 +16,10 @@ import (
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
+
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
-	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	routing "gx/ipfs/QmQKEgGgYCDyk8VNY6A65FpuE4YwbspvjXHco1rdb75PVc/go-libp2p-routing"
@@ -36,12 +37,14 @@ const (
 type gatewayHandler struct {
 	node   *core.IpfsNode
 	config GatewayConfig
+	api    coreiface.UnixfsAPI
 }
 
-func newGatewayHandler(node *core.IpfsNode, conf GatewayConfig) *gatewayHandler {
+func newGatewayHandler(n *core.IpfsNode, c GatewayConfig, api coreiface.UnixfsAPI) *gatewayHandler {
 	i := &gatewayHandler{
-		node:   node,
-		config: conf,
+		node:   n,
+		config: c,
+		api:    api,
 	}
 	return i
 }
@@ -122,7 +125,6 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			case <-clientGone:
 			case <-ctx.Done():
 			}
-			cancel()
 		}()
 	}
 
@@ -154,27 +156,19 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		ipnsHostname = true
 	}
 
-	p, err := path.ParsePath(urlPath)
-	if err != nil {
-		webError(w, "Invalid Path Error", err, http.StatusBadRequest)
-		return
-	}
-
-	nd, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, p)
-	// If node is in offline mode the error code and message should be different
-	if err == core.ErrNoNamesys && !i.node.OnlineMode() {
+	dr, err := i.api.Cat(ctx, urlPath)
+	dir := false
+	if err == coreiface.ErrOffline {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, "Could not resolve path. Node is in offline mode.")
 		return
+	} else if err == coreiface.ErrIsDir {
+		dir = true
 	} else if err != nil {
 		webError(w, "Path Resolve error", err, http.StatusBadRequest)
 		return
-	}
-
-	pbnd, ok := nd.(*dag.ProtoNode)
-	if !ok {
-		webError(w, "Cannot read non protobuf nodes through gateway", dag.ErrNotProtobuf, http.StatusBadRequest)
-		return
+	} else {
+		defer dr.Close()
 	}
 
 	etag := gopath.Base(urlPath)
@@ -204,13 +198,6 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		w.Header().Set("Suborigin", pathRoot)
 	}
 
-	dr, err := uio.NewDagReader(ctx, pbnd, i.node.DAG)
-	if err != nil && err != uio.ErrIsDir {
-		// not a directory and still an error
-		internalWebError(w, err)
-		return
-	}
-
 	// set these headers _after_ the error, for we may just not have it
 	// and dont want the client to cache a 500 response...
 	// and only if it's /ipfs!
@@ -224,10 +211,15 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		modtime = time.Unix(1, 0)
 	}
 
-	if err == nil {
-		defer dr.Close()
+	if !dir {
 		name := gopath.Base(urlPath)
 		http.ServeContent(w, r, name, modtime, dr)
+		return
+	}
+
+	links, err := i.api.Ls(ctx, urlPath)
+	if err != nil {
+		internalWebError(w, err)
 		return
 	}
 
@@ -235,7 +227,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	var dirListing []directoryItem
 	// loop through files
 	foundIndex := false
-	for _, link := range nd.Links() {
+	for _, link := range links {
 		if link.Name == "index.html" {
 			log.Debugf("found index.html link for %s", urlPath)
 			foundIndex = true
@@ -254,19 +246,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			}
 
 			// return index page instead.
-			nd, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, p)
-			if err != nil {
-				internalWebError(w, err)
-				return
-			}
-
-			pbnd, ok := nd.(*dag.ProtoNode)
-			if !ok {
-				internalWebError(w, dag.ErrNotProtobuf)
-				return
-			}
-
-			dr, err := uio.NewDagReader(ctx, pbnd, i.node.DAG)
+			dr, err := i.api.Cat(ctx, p.String())
 			if err != nil {
 				internalWebError(w, err)
 				return


### PR DESCRIPTION
Okay then, this still misses a few tests but is otherwise good for review. This uses the planned extraction of the gateway as a welcome excuse to start working on the Go side of Core API things. We're implementing the unspecified UnixfsAPI here, for now `Cat()` and `Ls()`. Near-future pull requests will implement more of UnixfsAPI (e.g. `Add()`), and of the Object API (i.e. `SetData()`, `AddLink()`, `RmLink()`).

- `core/coreapi/interface` -- will eventually move to the interface-ipfs-core repo, when UnixfsAPI gets specced (out of scope right now)
- `core/coreapi` -- holds the actual implementation. There's kind of a weird construct around context wiring, for the purpose of being able to pass `net/http.Request.Context()`.

cc @kevina @Kubuxu @whyrusleeping for review.