### PR TITLE
Adder: Make sure errors from addAllAndPin make it to the client

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -186,7 +187,7 @@ You can now refer to the added file in a gateway, like so:
 			fileAdder.SetMfsRoot(mr)
 		}
 
-		addAllAndPin := func(f files.File) error {
+		addAllAndPin := func(f files.File) {
 			// Iterate over each top-level file and add individually. Otherwise the
 			// single files.File f is treated as a directory, affecting hidden file
 			// semantics.
@@ -196,33 +197,36 @@ You can now refer to the added file in a gateway, like so:
 					// Finished the list of files.
 					break
 				} else if err != nil {
-					return err
+					outChan <- &coreunix.AddedObject{Name: f.FullPath(), Error: err.Error()}
+					return
 				}
 				if err := fileAdder.AddFile(file); err != nil {
-					return err
+					outChan <- &coreunix.AddedObject{Name: f.FullPath(), Error: err.Error()}
+					return
 				}
 			}
 
 			// copy intermediary nodes from editor to our actual dagservice
 			_, err := fileAdder.Finalize()
 			if err != nil {
-				return err
+				outChan <- &coreunix.AddedObject{Error: err.Error()}
+				return
 			}
 
 			if hash {
-				return nil
+				return
 			}
 
-			return fileAdder.PinRoot()
+			err = fileAdder.PinRoot()
+			if err != nil {
+				outChan <- &coreunix.AddedObject{Error: err.Error()}
+				return
+			}
 		}
 
 		go func() {
 			defer close(outChan)
-			if err := addAllAndPin(req.Files()); err != nil {
-				res.SetError(err, cmds.ErrNormal)
-				return
-			}
-
+			addAllAndPin(req.Files())
 		}()
 	},
 	PostRun: func(req cmds.Request, res cmds.Response) {
@@ -285,7 +289,10 @@ You can now refer to the added file in a gateway, like so:
 					break LOOP
 				}
 				output := out.(*coreunix.AddedObject)
-				if len(output.Hash) > 0 {
+				if len(output.Error) > 0 {
+					res.SetError(errors.New(output.Error), cmds.ErrNormal)
+					return
+				} else if len(output.Hash) > 0 {
 					if progress {
 						// clear progress bar line before we print "added x" output
 						fmt.Fprintf(res.Stderr(), "\033[2K\r")

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -60,6 +60,7 @@ func (e *ignoreFileError) Error() string {
 
 type AddedObject struct {
 	Name  string
+	Error string `json:",omitempty"`
 	Hash  string `json:",omitempty"`
 	Bytes int64  `json:",omitempty"`
 }


### PR DESCRIPTION
Before the error would be printed by the daemon but not make it to the
client.

License: MIT
Signed-off-by: Kevin Atkinson <k@kevina.org>