### PR TITLE
bitswap: redo: don't re-provide blocks we've provided very recently

### DIFF
--- a/blocks/blockstore/arc_cache_test.go
+++ b/blocks/blockstore/arc_cache_test.go
@@ -85,7 +85,7 @@ func TestHasRequestTriggersCache(t *testing.T) {
 	}
 
 	untrap(cd)
-	err := arc.Put(exampleBlock)
+	err, _ := arc.Put(exampleBlock)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestGetFillsCache(t *testing.T) {
 
 	untrap(cd)
 
-	if err := arc.Put(exampleBlock); err != nil {
+	if err, _ := arc.Put(exampleBlock); err != nil {
 		t.Fatal(err)
 	}
 

--- a/blocks/blockstore/blockstore_test.go
+++ b/blocks/blockstore/blockstore_test.go
@@ -39,7 +39,7 @@ func TestPutThenGetBlock(t *testing.T) {
 	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
 	block := blocks.NewBlock([]byte("some data"))
 
-	err := bs.Put(block)
+	err, _ := bs.Put(block)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []k
 	keys := make([]key.Key, N)
 	for i := 0; i < N; i++ {
 		block := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
-		err := bs.Put(block)
+		err, _ := bs.Put(block)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -302,7 +302,7 @@ func (bs *Bitswap) HasBlock(blk blocks.Block) error {
 	default:
 	}
 
-	err := bs.blockstore.Put(blk)
+	err,_ := bs.blockstore.Put(blk)
 	if err != nil {
 		log.Errorf("Error writing block to datastore: %s", err)
 		return err

--- a/exchange/bitswap/decision/engine_test.go
+++ b/exchange/bitswap/decision/engine_test.go
@@ -139,7 +139,7 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	for _, letter := range alphabet {
 		block := blocks.NewBlock([]byte(letter))
-		if err := bs.Put(block); err != nil {
+		if err, _ := bs.Put(block); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/exchange/offline/offline.go
+++ b/exchange/offline/offline.go
@@ -30,7 +30,8 @@ func (e *offlineExchange) GetBlock(_ context.Context, k key.Key) (blocks.Block, 
 
 // HasBlock always returns nil.
 func (e *offlineExchange) HasBlock(b blocks.Block) error {
-	return e.bs.Put(b)
+	err, _ := e.bs.Put(b)
+	return err
 }
 
 // Close always returns nil.

--- a/test/integration/bitswap_wo_routing_test.go
+++ b/test/integration/bitswap_wo_routing_test.go
@@ -58,7 +58,7 @@ func TestBitswapWithoutRouting(t *testing.T) {
 	block1 := blocks.NewBlock([]byte("block1"))
 
 	// put 1 before
-	if err := nodes[0].Blockstore.Put(block0); err != nil {
+	if err, _ := nodes[0].Blockstore.Put(block0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +81,7 @@ func TestBitswapWithoutRouting(t *testing.T) {
 	}
 
 	// put 1 after
-	if err := nodes[1].Blockstore.Put(block1); err != nil {
+	if err, _ := nodes[1].Blockstore.Put(block1); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Pull request #3105 (bitswap: don't re-provide blocks we've provided very recently) broke adding files via the filestore (i.e., --no-copy, #2634).  The filestore code requires that all writes go through to the blockstore.  In addition the blockstore already checks if a block already exists.  This change avoids calling `Has()` is the blockservice and instead modifies the blockstore interface to return the blocks actually added.

#3105 also changed AddBlocks (now AddObjects) to just return the blocks added.  This pull request restores the original behavior.  At this point I am not even sure if this return value is used anywhere.