### PR TITLE
Adder: Fix multi-file add so it works as expected.

### DIFF
--- a/commands/files/slicefile.go
+++ b/commands/files/slicefile.go
@@ -23,6 +23,10 @@ func (f *SliceFile) IsDirectory() bool {
 	return true
 }
 
+func (f *SliceFile) NumFiles() int {
+	return len(f.files)
+}
+
 func (f *SliceFile) NextFile() (File, error) {
 	if f.n >= len(f.files) {
 		return nil, io.EOF

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -135,6 +135,7 @@ You can now refer to the added file in a gateway, like so:
 		silent, _, _ := req.Option(silentOptionName).Bool()
 		chunker, _, _ := req.Option(chunkerOptionName).String()
 		dopin, _, _ := req.Option(pinOptionName).Bool()
+		recursive, _, _ := req.Option(cmds.RecLong).Bool()
 
 		if hash {
 			nilnode, err := core.NewNode(n.Context(), &core.BuildCfg{
@@ -160,7 +161,8 @@ You can now refer to the added file in a gateway, like so:
 		outChan := make(chan interface{}, 8)
 		res.SetOutput((<-chan interface{})(outChan))
 
-		fileAdder, err := coreunix.NewAdder(req.Context(), n.Pinning, n.Blockstore, dserv)
+		useRoot := wrap || recursive
+		fileAdder, err := coreunix.NewAdder(req.Context(), n.Pinning, n.Blockstore, dserv, useRoot)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -80,6 +80,16 @@ You can now refer to the added file in a gateway, like so:
 		cmds.BoolOption(pinOptionName, "Pin this object when adding.").Default(true),
 	},
 	PreRun: func(req cmds.Request) error {
+		wrap, _, _ := req.Option(wrapOptionName).Bool()
+		recursive, _, _ := req.Option(cmds.RecLong).Bool()
+		sliceFile, ok := req.Files().(*files.SliceFile)
+		if !ok {
+			return fmt.Errorf("type assertion failed: req.Files().(*files.SliceFile)")
+		}
+		if !wrap && recursive && sliceFile.NumFiles() > 1 {
+			return fmt.Errorf("adding multiple directories without '-w' unsupported")
+		}
+
 		if quiet, _, _ := req.Option(quietOptionName).Bool(); quiet {
 			return nil
 		}

--- a/core/coreunix/add_test.go
+++ b/core/coreunix/add_test.go
@@ -56,7 +56,7 @@ func TestAddGCLive(t *testing.T) {
 
 	errs := make(chan error)
 	out := make(chan interface{})
-	adder, err := NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG)
+	adder, err := NewAdder(context.Background(), node.Pinning, node.Blockstore, node.DAG, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -285,7 +285,7 @@ test_expect_success "'ipfs add' with stdin input succeeds" '
 
 test_expect_success "'ipfs add' output looks good" '
 	HASH="QmZDhWpi8NvKrekaYYhxKCdNVGWsFFe1CREnAjP1QbPaB3" &&
-	echo "added $HASH $HASH" >expected &&
+	echo "added $HASH " >expected &&
 	test_cmp expected actual
 '
 

--- a/test/sharness/t0046-multifile-add.sh
+++ b/test/sharness/t0046-multifile-add.sh
@@ -20,11 +20,11 @@ test_expect_success "add files all at once" '
 	ipfs add -q fileA fileB fileC > hashes
 '
 
-test_expect_failure "unpin one of the files" '
+test_expect_success "unpin one of the files" '
 	ipfs pin rm `head -1 hashes` > pin-out
 '
 
-test_expect_failure "unpin output looks good" '
+test_expect_success "unpin output looks good" '
 	echo "unpinned `head -1 hashes`" > pin-expect
 	test_cmp pin-expect pin-out
 '
@@ -36,8 +36,18 @@ test_expect_success "create files with same name but in different directories" '
 	echo BA > dirB/fileA
 '
 
-test_expect_failure "add files with same name but in different directories" '
+test_expect_success "add files with same name but in different directories" '
 	ipfs add -q dirA/fileA dirB/fileA > hashes
+'
+
+cat <<EOF | LC_ALL=C sort > cat-expected
+AA
+BA
+EOF
+
+test_expect_success "check that both files are added" '
+	cat hashes | xargs ipfs cat | LC_ALL=C sort > cat-actual
+	test_cmp cat-expected cat-actual
 '
 
 test_done

--- a/test/sharness/t0046-multifile-add.sh
+++ b/test/sharness/t0046-multifile-add.sh
@@ -29,5 +29,15 @@ test_expect_failure "unpin output looks good" '
 	test_cmp pin-expect pin-out
 '
 
+test_expect_success "create files with same name but in different directories" '
+	mkdir dirA &&
+	mkdir dirB &&
+	echo AA > dirA/fileA &&
+	echo BA > dirB/fileA
+'
+
+test_expect_failure "add files with same name but in different directories" '
+	ipfs add -q dirA/fileA dirB/fileA > hashes
+'
 
 test_done

--- a/test/sharness/t0046-multifile-add.sh
+++ b/test/sharness/t0046-multifile-add.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test add and cat commands"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_expect_success "create some files" '
+	echo A > fileA &&
+	echo B > fileB &&
+	echo C > fileC
+'
+
+test_expect_success "add files all at once" '
+	ipfs add -q fileA fileB fileC > hashes
+'
+
+test_expect_failure "unpin one of the files" '
+	ipfs pin rm `head -1 hashes` > pin-out
+'
+
+test_expect_failure "unpin output looks good" '
+	echo "unpinned `head -1 hashes`" > pin-expect
+	test_cmp pin-expect pin-out
+'
+
+
+test_done

--- a/test/sharness/t0046-multifile-add.sh
+++ b/test/sharness/t0046-multifile-add.sh
@@ -50,4 +50,13 @@ test_expect_success "check that both files are added" '
 	test_cmp cat-expected cat-actual
 '
 
+test_expect_success "adding multiple directories fails cleanly" '
+	test_must_fail ipfs add -q -r dirA dirB
+'
+
+test_expect_success "adding multiple directories with -w is okay" '
+	ipfs add -q -r -w dirA dirB > hashes &&
+	ipfs ls `tail -1 hashes` > ls-res
+'
+
 test_done

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -29,11 +29,6 @@ test_expect_success "'ipfs repo gc' succeeds" '
 	ipfs repo gc >gc_out_actual
 '
 
-test_expect_success "'ipfs repo gc' looks good (patch root)" '
-	PATCH_ROOT=QmQXirSbubiySKnqaFyfs5YzziXRB5JEVQVjU6xsd7innr &&
-	grep "removed $PATCH_ROOT" gc_out_actual
-'
-
 test_expect_success "'ipfs repo gc' doesnt remove file" '
 	ipfs cat "$HASH" >out &&
 	test_cmp out afile
@@ -104,8 +99,7 @@ test_expect_success "remove direct pin" '
 
 test_expect_success "'ipfs repo gc' removes file" '
 	ipfs repo gc >actual7 &&
-	grep "removed $HASH" actual7 &&
-	grep "removed $PATCH_ROOT" actual7
+	grep "removed $HASH" actual7
 '
 
 test_expect_success "'ipfs refs local' no longer shows file" '
@@ -114,8 +108,7 @@ test_expect_success "'ipfs refs local' no longer shows file" '
 	grep "QmYCvbfNbCwFR45HiNP45rwJgvatpiW38D961L5qAhUM5Y" actual8 &&
 	grep "$EMPTY_DIR" actual8 &&
 	grep "$HASH_WELCOME_DOCS" actual8 &&
-	test_must_fail grep "$HASH" actual8 &&
-	test_must_fail grep "$PATCH_ROOT" actual8
+	test_must_fail grep "$HASH" actual8
 '
 
 test_expect_success "adding multiblock random file succeeds" '


### PR DESCRIPTION
If neither "-w" or "-r" is specified don't use an mfs-root.  Add and
pin each file separately.

Closes #2811

Part of #2634 

License: MIT
Signed-off-by: Kevin Atkinson k@kevina.org
