### PR TITLE
Distinguish between Offline and Local Mode.

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -304,6 +304,7 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		res.SetError(err, cmds.ErrNormal)
 		return
 	}
+	node.SetLocal(false)
 
 	printSwarmAddrs(node)
 

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -227,6 +227,7 @@ func (i *cmdInvocation) constructNodeFunc(ctx context.Context) func() (*core.Ipf
 		if err != nil {
 			return nil, err
 		}
+		n.SetLocal(true)
 		i.node = n
 		return i.node, nil
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -74,6 +74,7 @@ type mode int
 const (
 	// zero value is not a valid mode, must be explicitly set
 	invalidMode mode = iota
+	localMode
 	offlineMode
 	onlineMode
 )
@@ -116,6 +117,7 @@ type IpfsNode struct {
 	ctx  context.Context
 
 	mode mode
+	localModeSet bool
 }
 
 // Mounts defines what the node's mount state is. This should
@@ -390,6 +392,26 @@ func (n *IpfsNode) teardown() error {
 func (n *IpfsNode) OnlineMode() bool {
 	switch n.mode {
 	case onlineMode:
+		return true
+	default:
+		return false
+	}
+}
+
+func (n *IpfsNode) SetLocal(isLocal bool) {
+	if isLocal {
+		n.mode = localMode
+	}
+	n.localModeSet = true
+}
+
+func (n *IpfsNode) LocalMode() bool {
+	if !n.localModeSet {
+		// programmer error should not happen
+		panic("local mode not set")
+	}
+	switch n.mode {
+	case localMode:
 		return true
 	default:
 		return false


### PR DESCRIPTION
The filestore code (#2634) does not care if the daemon is in online or offline mode, it cares if it is running or not.  There is various tests throughout the code for this but no standardized way to get the information.  The p.r. attempts to rectify that.

For the full context see b34fd9c4c10c10139f5e692ab1add9e357a735a1.

License: MIT
Signed-off-by: Kevin Atkinson k@kevina.org