### PR TITLE
Update goprocess dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
       "version": "0.0.0"
     },
     {
-      "hash": "QmQopLATEYMNg7dVqZRNDfeE2S1yKy8zrRh5xnYiuqeZBn",
+      "author": "whyrusleeping",
+      "hash": "QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP",
       "name": "goprocess",
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     {
       "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",


### PR DESCRIPTION
Update goprocess dependency to 1.0.0 to avoid a version mismatch with what
go-datastore uses.

Part of #2634 