### PR TITLE
Explicitly specify the input file to tar with "-f -"

### DIFF
--- a/bin/dist_get
+++ b/bin/dist_get
@@ -52,7 +52,7 @@ unarchive() {
 		tar.gz)
 			if have_binary tar; then
 				echo "==> using 'tar' to extract binary from archive"
-				cat "$ua_infile" | tar -O -z -x "$ua_distname/$ua_distname" > "$ua_outfile"
+				cat "$ua_infile" | tar -O -z -x -f - "$ua_distname/$ua_distname" > "$ua_outfile"
 			else
 				die "no binary on system for extracting tar files"
 			fi


### PR DESCRIPTION
On FreeBSD the default one (if no -f is specified) is /dev/sa0,
not stdin.

License: MIT
Signed-off-by: Vasil Dimov <vd@FreeBSD.org>