### PR TITLE
resolves issue #3262

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -52,9 +52,7 @@ func (n *Node) Marshal() ([]byte, error) {
 
 func (n *Node) getPBNode() *pb.PBNode {
 	pbn := &pb.PBNode{}
-	if len(n.Links) > 0 {
-		pbn.Links = make([]*pb.PBLink, len(n.Links))
-	}
+	pbn.Links = make([]*pb.PBLink, 0, len(n.Links))
 
 	sort.Stable(LinkSlice(n.Links)) // keep links sorted
 	for i, l := range n.Links {

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -58,7 +58,7 @@ func (n *Node) getPBNode() *pb.PBNode {
 
 	sort.Stable(LinkSlice(n.Links)) // keep links sorted
 	for i, l := range n.Links {
-		pbn.Links[i] = &pb.PBLink{}
+		pbn.Links = append(pbn.Links, &pb.PBLink{})
 		pbn.Links[i].Name = &l.Name
 		pbn.Links[i].Tsize = &l.Size
 		pbn.Links[i].Hash = []byte(l.Hash)


### PR DESCRIPTION
It appears that the slice size of `n.Links` is being modified after the destination capacity of `pbn.Links` is set, thereby causing a panic when attempting to access an index out of range on the new slice.  By using append, we can avoid using mutexes and retain most of the original performance.