### PR TITLE
add experimental dht client mode flag

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -44,6 +44,7 @@ const (
 	offlineKwd                = "offline"
 	routingOptionKwd          = "routing"
 	routingOptionSupernodeKwd = "supernode"
+	routingOptionDHTClientKwd = "dhtclient"
 	unencryptTransportKwd     = "disable-transport-encryption"
 	unrestrictedApiAccessKwd  = "unrestricted-api"
 	writableKwd               = "writable"
@@ -280,7 +281,8 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		res.SetError(err, cmds.ErrNormal)
 		return
 	}
-	if routingOption == routingOptionSupernodeKwd {
+	switch routingOption {
+	case routingOptionSupernodeKwd:
 		servers, err := cfg.SupernodeRouting.ServerIPFSAddrs()
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
@@ -296,6 +298,8 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		}
 
 		ncfg.Routing = corerouting.SupernodeClient(infos...)
+	case routingOptionDHTClientKwd:
+		ncfg.Routing = core.DHTClientOption
 	}
 
 	node, err := core.NewNode(req.Context(), ncfg)

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -121,6 +121,17 @@ environment variable:
 
     export IPFS_PATH=/path/to/ipfsrepo
 
+Routing
+
+IPFS by default will use a DHT for content routing. There is a highly
+experimental alternative that operates the DHT in a 'client only' mode that can
+be enabled by running the daemon as:
+
+    ipfs daemon --routing=dhtclient
+
+This will later be transitioned into a config option once it gets out of the
+'experimental' stage.
+
 DEPRECATION NOTICE
 
 Previously, IPFS used an environment variable as seen below:

--- a/core/core.go
+++ b/core/core.go
@@ -638,9 +638,17 @@ func constructDHTRouting(ctx context.Context, host p2phost.Host, dstore repo.Dat
 	return dhtRouting, nil
 }
 
+func constructClientDHTRouting(ctx context.Context, host p2phost.Host, dstore repo.Datastore) (routing.IpfsRouting, error) {
+	dhtRouting := dht.NewDHTClient(ctx, host, dstore)
+	dhtRouting.Validator[IpnsValidatorTag] = namesys.IpnsRecordValidator
+	dhtRouting.Selector[IpnsValidatorTag] = namesys.IpnsSelectorFunc
+	return dhtRouting, nil
+}
+
 type RoutingOption func(context.Context, p2phost.Host, repo.Datastore) (routing.IpfsRouting, error)
 
 type DiscoveryOption func(context.Context, p2phost.Host) (discovery.Service, error)
 
 var DHTOption RoutingOption = constructDHTRouting
+var DHTClientOption RoutingOption = constructClientDHTRouting
 var NilRouterOption RoutingOption = nilrouting.ConstructNilRouting

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
       "version": "0.1.0"
     },
     {
-      "hash": "Qma1FrGRasghpuETfCtsKdFtXKQffpNnakv3wG3QaMwCVi",
+      "hash": "QmPxBCkNrrtx5cmg62TxiE3JUM2zTqTpps3diQ9PgNrcgn",
       "name": "iptb",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "hash": "QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku",

--- a/test/sharness/t0131-multinode-client-routing.sh
+++ b/test/sharness/t0131-multinode-client-routing.sh
@@ -22,21 +22,17 @@ check_file_fetch() {
 	'
 }
 
-check_dir_fetch() {
-	node=$1
-	ref=$2
-
-	test_expect_success "node can fetch all refs for dir" '
-		ipfsi $node refs -r $ref > /dev/null
-	'
-}
-
 run_single_file_test() {
 	test_expect_success "add a file on node1" '
 		random 1000000 > filea &&
 		FILEA_HASH=$(ipfsi 1 add -q filea)
 	'
 
+	check_file_fetch 9 $FILEA_HASH filea
+	check_file_fetch 8 $FILEA_HASH filea
+	check_file_fetch 7 $FILEA_HASH filea
+	check_file_fetch 6 $FILEA_HASH filea
+	check_file_fetch 5 $FILEA_HASH filea
 	check_file_fetch 4 $FILEA_HASH filea
 	check_file_fetch 3 $FILEA_HASH filea
 	check_file_fetch 2 $FILEA_HASH filea
@@ -44,35 +40,10 @@ run_single_file_test() {
 	check_file_fetch 0 $FILEA_HASH filea
 }
 
-run_random_dir_test() {
-	test_expect_success "create a bunch of random files" '
-		random-files -depth=4 -dirs=5 -files=8 foobar > /dev/null
-	'
-
-	test_expect_success "add those on node 2" '
-		DIR_HASH=$(ipfsi 2 add -r -q foobar | tail -n1)
-	'
-
-	check_dir_fetch 0 $DIR_HASH
-	check_dir_fetch 1 $DIR_HASH
-	check_dir_fetch 2 $DIR_HASH
-	check_dir_fetch 3 $DIR_HASH
-	check_dir_fetch 4 $DIR_HASH
-}
-
-run_advanced_test() {
-
-	run_single_file_test
-
-	run_random_dir_test
-
-	test_expect_success "shut down nodes" '
-		iptb stop
-	'
-}
+NNODES=10
 
 test_expect_success "set up testbed" '
-	iptb init -n 10 -p 0 -f --bootstrap=none
+	iptb init -n $NNODES -p 0 -f --bootstrap=none
 '
 
 test_expect_success "start up nodes" '
@@ -93,6 +64,10 @@ test_expect_success "retrieve that file on a client mode node" '
 	check_file_fetch 9 $FILE_HASH filea
 '
 
-run_advanced_test
+run_single_file_test
+
+test_expect_success "shut down nodes" '
+	iptb stop
+'
 
 test_done

--- a/test/sharness/t0131-multinode-client-routing.sh
+++ b/test/sharness/t0131-multinode-client-routing.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test client mode dht"
+
+. lib/test-lib.sh
+
+check_file_fetch() {
+	node=$1
+	fhash=$2
+	fname=$3
+
+	test_expect_success "can fetch file" '
+		ipfsi $node cat $fhash > fetch_out
+	'
+
+	test_expect_success "file looks good" '
+		test_cmp $fname fetch_out
+	'
+}
+
+check_dir_fetch() {
+	node=$1
+	ref=$2
+
+	test_expect_success "node can fetch all refs for dir" '
+		ipfsi $node refs -r $ref > /dev/null
+	'
+}
+
+run_single_file_test() {
+	test_expect_success "add a file on node1" '
+		random 1000000 > filea &&
+		FILEA_HASH=$(ipfsi 1 add -q filea)
+	'
+
+	check_file_fetch 4 $FILEA_HASH filea
+	check_file_fetch 3 $FILEA_HASH filea
+	check_file_fetch 2 $FILEA_HASH filea
+	check_file_fetch 1 $FILEA_HASH filea
+	check_file_fetch 0 $FILEA_HASH filea
+}
+
+run_random_dir_test() {
+	test_expect_success "create a bunch of random files" '
+		random-files -depth=4 -dirs=5 -files=8 foobar > /dev/null
+	'
+
+	test_expect_success "add those on node 2" '
+		DIR_HASH=$(ipfsi 2 add -r -q foobar | tail -n1)
+	'
+
+	check_dir_fetch 0 $DIR_HASH
+	check_dir_fetch 1 $DIR_HASH
+	check_dir_fetch 2 $DIR_HASH
+	check_dir_fetch 3 $DIR_HASH
+	check_dir_fetch 4 $DIR_HASH
+}
+
+run_advanced_test() {
+
+	run_single_file_test
+
+	run_random_dir_test
+
+	test_expect_success "shut down nodes" '
+		iptb stop
+	'
+}
+
+test_expect_success "set up testbed" '
+	iptb init -n 10 -p 0 -f --bootstrap=none
+'
+
+test_expect_success "start up nodes" '
+	iptb start [0-7] &&
+	iptb start [8-9] --args="--routing=dhtclient"
+'
+
+test_expect_success "connect up nodes" '
+	iptb connect [1-9] 0
+'
+
+test_expect_success "add a file on a node in client mode" '
+	random 1000000 > filea &&
+	FILE_HASH=$(ipfsi 8 add -q filea)
+'
+
+test_expect_success "retrieve that file on a client mode node" '
+	check_file_fetch 9 $FILE_HASH filea
+'
+
+run_advanced_test
+
+test_done


### PR DESCRIPTION
This allows you to start up an ipfs daemon with `--routing=dhtclient`. In that mode, your dht will not accept incoming requests, but will still be able to query the dht for providers and peer routing information.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>