### PR TITLE
Add the packaging metadata to build the ipfs snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_sharness_expensive
   - BUILD=1
 
+matrix:
+  exclude:
+    # Do not build the snap in macOS.
+    - os: osx
+      env: BUILD=1
+
 install:
   - make install
 
@@ -24,7 +30,7 @@ script:
   # Run the tests.
   - if [ -z "$BUILD" ]; then make $TEST_SUITE; fi
   # Build the snap.
-  - if [ ! -z "$BUILD" ]; then docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'cd /cwd; snapcraft'; fi
+  - if [ ! -z "$BUILD" ]; then docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'add-apt-repository -y ppa:gophers/archive && apt update && cd /cwd; snapcraft'; fi
 
 # For docker containers.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
 script:
   - make $TEST_SUITE
 
+after_success:
+  - docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'cd /cwd; snapcraft'
+
 # For docker containers
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   # Run the tests.
   - if [ -z "$BUILD" ]; then make $TEST_SUITE; fi
   # Build the snap.
-  - if [ ! -z "$BUILD" ]; then docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'add-apt-repository -y ppa:gophers/archive && apt update && cd /cwd; snapcraft'; fi
+  - if [ ! -z "$BUILD" ]; then docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'apt install software-properties-common -y && add-apt-repository -y ppa:gophers/archive && apt update && cd /cwd && snapcraft'; fi
 
 # For docker containers.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,18 @@ go:
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_sharness_expensive
+  - BUILD=1
 
 install:
   - make install
 
 script:
-  - make $TEST_SUITE
+  # Run the tests.
+  - if [ -z "$BUILD" ]; then make $TEST_SUITE; fi
+  # Build the snap.
+  - if [ ! -z "$BUILD" ]; then docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'cd /cwd; snapcraft'; fi
 
-after_success:
-  - docker run -v $(pwd):/cwd snapcore/snapcraft sh -c 'cd /cwd; snapcraft'
-
-# For docker containers
+# For docker containers.
 
 sudo: required
 

--- a/parts/plugins/x-ipfs.py
+++ b/parts/plugins/x-ipfs.py
@@ -1,0 +1,142 @@
+"""This is a modified version of snapcraft's go plugin.
+
+It uses go 1.7 from ppa:gophers/archive, because it is not yet published
+in the xenial archives.
+
+The go plugin can be used for go projects using `go get`.
+
+This plugin uses the common plugin keywords, for more information check the
+'plugins' topic.
+
+This plugin uses the common plugin keywords as well as those for "sources".
+For more information check the 'plugins' topic for the former and the
+'sources' topic for the latter.
+
+Additionally, this plugin uses the following plugin-specific keywords:
+
+    - go-importpath:
+      (string)
+      This entry tells the checked out `source` to live within a certain path
+      within `GOPATH`.
+
+"""
+
+import logging
+import os
+import shutil
+
+import snapcraft
+from snapcraft import common
+
+
+logger = logging.getLogger(__name__)
+
+
+class GoPlugin(snapcraft.BasePlugin):
+
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['go-importpath'] = {
+            'type': 'string',
+            'default': ''
+        }
+
+        schema['required'].append('go-importpath')
+
+        # Inform Snapcraft of the properties associated with pulling. If these
+        # change in the YAML Snapcraft will consider the pull step dirty.
+        schema['pull-properties'].append('go-importpath')
+
+        # Inform Snapcraft of the properties associated with building. If these
+        # change in the YAML Snapcraft will consider the build step dirty.
+        schema['build-properties'].extend(
+            ['source', 'go-importpath'])
+
+        return schema
+
+    def __init__(self, name, options, project):
+        super().__init__(name, options, project)
+        self.build_packages.extend(['golang-1.7-go', 'make'])
+        self._gopath = os.path.join(self.partdir, 'go')
+        self._gopath_src = os.path.join(self._gopath, 'src')
+        self._gopath_bin = os.path.join(self._gopath, 'bin')
+        self._gopath_pkg = os.path.join(self._gopath, 'pkg')
+
+    @property
+    def go_bin(self):
+        return '/usr/lib/go-1.7/bin/go'
+
+    def pull(self):
+        # use -d to only download (build will happen later)
+        # use -t to also get the test-deps
+        # since we are not using -u the sources will stick to the
+        # original checkout.
+        super().pull()
+        os.makedirs(self._gopath_src, exist_ok=True)
+
+        go_package = self.options.go_importpath
+        go_package_path = os.path.join(self._gopath_src, go_package)
+        if os.path.islink(go_package_path):
+            os.unlink(go_package_path)
+        os.makedirs(os.path.dirname(go_package_path), exist_ok=True)
+        shutil.copytree(self.sourcedir, go_package_path)
+        self._run(
+            [self.go_bin, 'get', '-t', '-d', './{}'.format(go_package)])
+
+    def clean_pull(self):
+        super().clean_pull()
+
+        # Remove the gopath (if present)
+        if os.path.exists(self._gopath):
+            shutil.rmtree(self._gopath)
+
+    def build(self):
+        super().build()
+
+        self._run(
+            ['make', '-C',
+             os.path.join(self._gopath_src,
+                          self.options.go_importpath),
+             'deps'])
+        self._run(
+            ['make', '-C',
+             os.path.join(self._gopath_src,
+                          self.options.go_importpath,
+                          'cmd', 'ipfs'),
+             'install'])
+        install_bin_path = os.path.join(self.installdir, 'bin')
+        os.makedirs(install_bin_path, exist_ok=True)
+        os.makedirs(self._gopath_bin, exist_ok=True)
+        for binary in os.listdir(os.path.join(self._gopath_bin)):
+            binary_path = os.path.join(self._gopath_bin, binary)
+            shutil.copy2(binary_path, install_bin_path)
+
+    def clean_build(self):
+        super().clean_build()
+
+        if os.path.isdir(self._gopath_bin):
+            shutil.rmtree(self._gopath_bin)
+
+        if os.path.isdir(self._gopath_pkg):
+            shutil.rmtree(self._gopath_pkg)
+
+    def _run(self, cmd, **kwargs):
+        env = self._build_environment()
+        cwd = kwargs.pop('cwd', self._gopath_src)
+        return self.run(cmd, cwd=cwd, env=env, *kwargs)
+
+    def _build_environment(self):
+        env = os.environ.copy()
+        env['GOPATH'] = self._gopath
+        env['PATH'] = '{}:{}'.format('/usr/lib/go-1.7/bin/', env['PATH'])
+        include_paths = []
+        for root in [self.installdir, self.project.stage_dir]:
+            include_paths.extend(
+                common.get_library_paths(root, self.project.arch_triplet))
+
+        flags = common.combine_paths(include_paths, '-L', ' ')
+        env['CGO_LDFLAGS'] = '{} {} {}'.format(
+            env.get('CGO_LDFLAGS', ''), flags, env.get('LDFLAGS', ''))
+
+        return env

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: ipfs
+version: master
+summary: global, versioned, peer-to-peer filesystem
+description: |
+  IPFS combines good ideas from Git, BitTorrent, Kademlia, SFS, and the Web.
+  It is like a single bittorrent swarm, exchanging git objects. IPFS provides
+  an interface as simple as the HTTP web, but with permanence built in. You
+  can also mount the world at /ipfs.
+
+grade: devel
+confinement: strict
+
+apps:
+  ipfs:
+    command: ipfs
+    plugs: [network, network-bind]
+
+parts:
+  ipfs:
+    source: .
+    plugin: ipfs
+    go-importpath: github.com/ipfs/go-ipfs

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,7 +7,6 @@ description: |
   an interface as simple as the HTTP web, but with permanence built in. You
   can also mount the world at /ipfs.
 
-grade: devel
 confinement: strict
 
 apps:


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.
