### PR TITLE
http api: makes sure header is sent even when r is not ready yet. fixes #3304

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -288,6 +288,7 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 		log.Error("err: ", err)
 		w.Header().Set(StreamErrHeader, sanitizedErrStr(err))
 	}
+
 }
 
 func flushCopy(w io.Writer, r io.Reader) error {
@@ -305,9 +306,6 @@ func flushCopy(w io.Writer, r io.Reader) error {
 		switch err {
 		case io.EOF:
 			if n <= 0 {
-				// flush when reader is drained
-				f.Flush()
-
 				return nil
 			}
 			// if data was returned alongside the EOF, pretend we didnt

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -298,6 +298,9 @@ func flushCopy(w io.Writer, r io.Reader) error {
 		return err
 	}
 	for {
+		// flush to send header when r is not ready yet
+		f.Flush()
+
 		n, err := r.Read(buf)
 		switch err {
 		case io.EOF:

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -299,20 +299,14 @@ func flushCopy(w io.Writer, r io.Reader) error {
 	}
 	for {
 		// flush to send header when r is not ready yet
-		err = f.Flush()
-		if err != nil {
-			return err
-		}
+		f.Flush()
 
 		n, err := r.Read(buf)
 		switch err {
 		case io.EOF:
 			if n <= 0 {
 				// flush when reader is drained
-				err = f.Flush()
-				if err != nil {
-					return err
-				}
+				f.Flush()
 
 				return nil
 			}


### PR DESCRIPTION
Otherwise API clients block on pubsub subscriptions until the first packet is sent (see, well, #3304).