### PR TITLE
Implement 'Raw Node' node type

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -37,8 +37,11 @@ func NewBlock(data []byte) *BasicBlock {
 // we are able to be confident that the data is correct
 func NewBlockWithCid(data []byte, c *cid.Cid) (*BasicBlock, error) {
 	if u.Debug {
-		// TODO: fix assumptions
-		chkc := cid.NewCidV0(u.Hash(data))
+		chkc, err := c.Prefix().Sum(data)
+		if err != nil {
+			return nil, err
+		}
+
 		if !chkc.Equals(c) {
 			return nil, ErrWrongHash
 		}

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -100,12 +100,16 @@ func (bs *blockstore) Get(k *cid.Cid) (blocks.Block, error) {
 	}
 
 	if bs.rehash {
-		rb := blocks.NewBlock(bdata)
-		if !rb.Cid().Equals(k) {
-			return nil, ErrHashMismatch
-		} else {
-			return rb, nil
+		rbcid, err := k.Prefix().Sum(bdata)
+		if err != nil {
+			return nil, err
 		}
+
+		if !rbcid.Equals(k) {
+			return nil, ErrHashMismatch
+		}
+
+		return blocks.NewBlockWithCid(bdata, rbcid)
 	} else {
 		return blocks.NewBlockWithCid(bdata, k)
 	}

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -23,15 +23,16 @@ import (
 var ErrDepthLimitExceeded = fmt.Errorf("depth limit exceeded")
 
 const (
-	quietOptionName    = "quiet"
-	silentOptionName   = "silent"
-	progressOptionName = "progress"
-	trickleOptionName  = "trickle"
-	wrapOptionName     = "wrap-with-directory"
-	hiddenOptionName   = "hidden"
-	onlyHashOptionName = "only-hash"
-	chunkerOptionName  = "chunker"
-	pinOptionName      = "pin"
+	quietOptionName     = "quiet"
+	silentOptionName    = "silent"
+	progressOptionName  = "progress"
+	trickleOptionName   = "trickle"
+	wrapOptionName      = "wrap-with-directory"
+	hiddenOptionName    = "hidden"
+	onlyHashOptionName  = "only-hash"
+	chunkerOptionName   = "chunker"
+	pinOptionName       = "pin"
+	rawLeavesOptionName = "raw-leaves"
 )
 
 var AddCmd = &cmds.Command{
@@ -78,6 +79,7 @@ You can now refer to the added file in a gateway, like so:
 		cmds.BoolOption(hiddenOptionName, "H", "Include files that are hidden. Only takes effect on recursive add.").Default(false),
 		cmds.StringOption(chunkerOptionName, "s", "Chunking algorithm to use."),
 		cmds.BoolOption(pinOptionName, "Pin this object when adding.").Default(true),
+		cmds.BoolOption(rawLeavesOptionName, "Use raw blocks for leaf nodes. (experimental)"),
 	},
 	PreRun: func(req cmds.Request) error {
 		if quiet, _, _ := req.Option(quietOptionName).Bool(); quiet {
@@ -135,6 +137,7 @@ You can now refer to the added file in a gateway, like so:
 		silent, _, _ := req.Option(silentOptionName).Bool()
 		chunker, _, _ := req.Option(chunkerOptionName).String()
 		dopin, _, _ := req.Option(pinOptionName).Bool()
+		rawblks, _, _ := req.Option(rawLeavesOptionName).Bool()
 
 		if hash {
 			nilnode, err := core.NewNode(n.Context(), &core.BuildCfg{
@@ -174,6 +177,7 @@ You can now refer to the added file in a gateway, like so:
 		fileAdder.Wrap = wrap
 		fileAdder.Pin = dopin
 		fileAdder.Silent = silent
+		fileAdder.RawLeaves = rawblks
 
 		if hash {
 			md := dagtest.Mock()

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,8 +17,8 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
-	context "context"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 var log = logging.Logger("cmds/files")
@@ -160,7 +161,12 @@ func statNode(ds dag.DAGService, fsn mfs.FSNode) (*Object, error) {
 
 	c := nd.Cid()
 
-	d, err := ft.FromBytes(nd.Data())
+	pbnd, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		return nil, dag.ErrNotProtobuf
+	}
+
+	d, err := ft.FromBytes(pbnd.Data())
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +251,7 @@ var FilesCpCmd = &cmds.Command{
 	},
 }
 
-func getNodeFromPath(ctx context.Context, node *core.IpfsNode, p string) (*dag.ProtoNode, error) {
+func getNodeFromPath(ctx context.Context, node *core.IpfsNode, p string) (node.Node, error) {
 	switch {
 	case strings.HasPrefix(p, "/ipfs/"):
 		np, err := path.ParsePath(p)

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -1,6 +1,7 @@
 package corehttp
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -9,14 +10,15 @@ import (
 	"testing"
 	"time"
 
-	context "context"
 	core "github.com/ipfs/go-ipfs/core"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
+	dag "github.com/ipfs/go-ipfs/merkledag"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
 	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
+
 	id "gx/ipfs/QmcRa2qn6iCmap9bjp8jAwkvYAq13AUfxdY3rrYiaJbLum/go-libp2p/p2p/protocol/identify"
 	ci "gx/ipfs/QmfWDLQjGjVe4fr5CoztYW2DYYjRysMJrFe1RCsXLPTf46/go-libp2p-crypto"
 )
@@ -178,11 +180,13 @@ func TestIPNSHostnameRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	_, dagn2, err := coreunix.AddWrapped(n, strings.NewReader("_"), "index.html")
 	if err != nil {
 		t.Fatal(err)
 	}
-	dagn1.AddNodeLink("foo", dagn2)
+
+	dagn1.(*dag.ProtoNode).AddNodeLink("foo", dagn2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +201,7 @@ func TestIPNSHostnameRedirect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	k := dagn1.Key()
+	k := dagn1.Cid()
 	t.Logf("k: %s\n", k)
 	ns["/ipns/example.net"] = path.FromString("/ipfs/" + k.String())
 
@@ -268,8 +272,8 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dagn2.AddNodeLink("bar", dagn3)
-	dagn1.AddNodeLink("foo? #<'", dagn2)
+	dagn2.(*dag.ProtoNode).AddNodeLink("bar", dagn3)
+	dagn1.(*dag.ProtoNode).AddNodeLink("foo? #<'", dagn2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +291,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	k := dagn1.Key()
+	k := dagn1.Cid()
 	t.Logf("k: %s\n", k)
 	ns["/ipns/example.net"] = path.FromString("/ipfs/" + k.String())
 

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -1,6 +1,7 @@
 package coreunix
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,16 +14,18 @@ import (
 	"github.com/ipfs/go-ipfs/commands/files"
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/exchange/offline"
-	importer "github.com/ipfs/go-ipfs/importer"
+	balanced "github.com/ipfs/go-ipfs/importer/balanced"
 	"github.com/ipfs/go-ipfs/importer/chunk"
+	ihelper "github.com/ipfs/go-ipfs/importer/helpers"
+	trickle "github.com/ipfs/go-ipfs/importer/trickle"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	mfs "github.com/ipfs/go-ipfs/mfs"
 	"github.com/ipfs/go-ipfs/pin"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 
-	context "context"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmXUuRadqDq5BuFWzVU6VuKaSjTcNm1gNCtLvvP1TJCW4z/go-cid"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
 	syncds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
 )
@@ -97,6 +100,7 @@ type Adder struct {
 	Hidden     bool
 	Pin        bool
 	Trickle    bool
+	RawLeaves  bool
 	Silent     bool
 	Wrap       bool
 	Chunker    string
@@ -111,22 +115,22 @@ func (adder *Adder) SetMfsRoot(r *mfs.Root) {
 }
 
 // Perform the actual add & pin locally, outputting results to reader
-func (adder Adder) add(reader io.Reader) (*dag.ProtoNode, error) {
+func (adder Adder) add(reader io.Reader) (node.Node, error) {
 	chnk, err := chunk.FromString(reader, adder.Chunker)
 	if err != nil {
 		return nil, err
 	}
+	params := ihelper.DagBuilderParams{
+		Dagserv:   adder.dagService,
+		RawLeaves: adder.RawLeaves,
+		Maxlinks:  ihelper.DefaultLinksPerBlock,
+	}
 
 	if adder.Trickle {
-		return importer.BuildTrickleDagFromReader(
-			adder.dagService,
-			chnk,
-		)
+		return trickle.TrickleLayout(params.New(chnk))
 	}
-	return importer.BuildDagFromReader(
-		adder.dagService,
-		chnk,
-	)
+
+	return balanced.BalancedLayout(params.New(chnk))
 }
 
 func (adder *Adder) RootNode() (*dag.ProtoNode, error) {
@@ -331,7 +335,7 @@ func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *dag.Pr
 	return gopath.Join(c.String(), filename), dagnode, nil
 }
 
-func (adder *Adder) addNode(node *dag.ProtoNode, path string) error {
+func (adder *Adder) addNode(node node.Node, path string) error {
 	// patch it into the root
 	if path == "" {
 		path = node.Cid().String()
@@ -456,7 +460,7 @@ func (adder *Adder) maybePauseForGC() error {
 }
 
 // outputDagnode sends dagnode info over the output channel
-func outputDagnode(out chan interface{}, name string, dn *dag.ProtoNode) error {
+func outputDagnode(out chan interface{}, name string, dn node.Node) error {
 	if out == nil {
 		return nil
 	}
@@ -482,7 +486,7 @@ func NewMemoryDagService() dag.DAGService {
 }
 
 // from core/commands/object.go
-func getOutput(dagnode *dag.ProtoNode) (*Object, error) {
+func getOutput(dagnode node.Node) (*Object, error) {
 	c := dagnode.Cid()
 
 	output := &Object{

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	core "github.com/ipfs/go-ipfs/core"
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 )
@@ -15,10 +14,5 @@ func Cat(ctx context.Context, n *core.IpfsNode, pstr string) (*uio.DagReader, er
 		return nil, err
 	}
 
-	dnpb, ok := dagNode.(*dag.ProtoNode)
-	if !ok {
-		return nil, dag.ErrNotProtobuf
-	}
-
-	return uio.NewDagReader(ctx, dnpb, n.DAG)
+	return uio.NewDagReader(ctx, dagNode, n.DAG)
 }

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -24,6 +24,7 @@ import (
 
 	fstest "github.com/ipfs/go-ipfs/Godeps/_workspace/src/bazil.org/fuse/fs/fstestutil"
 	cid "gx/ipfs/QmXUuRadqDq5BuFWzVU6VuKaSjTcNm1gNCtLvvP1TJCW4z/go-cid"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 )
 
@@ -33,7 +34,7 @@ func maybeSkipFuseTests(t *testing.T) {
 	}
 }
 
-func randObj(t *testing.T, nd *core.IpfsNode, size int64) (*dag.ProtoNode, []byte) {
+func randObj(t *testing.T, nd *core.IpfsNode, size int64) (node.Node, []byte) {
 	buf := make([]byte, size)
 	u.NewTimeSeededRand().Read(buf)
 	read := bytes.NewReader(buf)
@@ -74,7 +75,7 @@ func TestIpfsBasicRead(t *testing.T) {
 	defer mnt.Close()
 
 	fi, data := randObj(t, nd, 10000)
-	k := fi.Key()
+	k := fi.Cid()
 	fname := path.Join(mnt.Dir, k.String())
 	rbuf, err := ioutil.ReadFile(fname)
 	if err != nil {
@@ -254,7 +255,7 @@ func TestFileSizeReporting(t *testing.T) {
 	defer mnt.Close()
 
 	fi, data := randObj(t, nd, 10000)
-	k := fi.Key()
+	k := fi.Cid()
 
 	fname := path.Join(mnt.Dir, k.String())
 

--- a/importer/balanced/balanced_test.go
+++ b/importer/balanced/balanced_test.go
@@ -28,7 +28,12 @@ func buildTestDag(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error)
 		Maxlinks: h.DefaultLinksPerBlock,
 	}
 
-	return BalancedLayout(dbp.New(spl))
+	nd, err := BalancedLayout(dbp.New(spl))
+	if err != nil {
+		return nil, err
+	}
+
+	return nd.(*dag.ProtoNode), nil
 }
 
 func getTestDag(t *testing.T, ds dag.DAGService, size int64, blksize int64) (*dag.ProtoNode, []byte) {

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -105,7 +105,7 @@ func (n *UnixfsNode) GetChild(ctx context.Context, i int, ds dag.DAGService) (*U
 // the passed in DagBuilderHelper is used to store the child node an
 // pin it locally so it doesnt get lost
 func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
-	n.ufmt.AddBlockSize(child.DataSize())
+	n.ufmt.AddBlockSize(child.FileSize())
 
 	childnode, err := child.GetDagNode()
 	if err != nil {
@@ -137,7 +137,7 @@ func (n *UnixfsNode) SetData(data []byte) {
 	n.ufmt.Data = data
 }
 
-func (n *UnixfsNode) DataSize() uint64 {
+func (n *UnixfsNode) FileSize() uint64 {
 	if n.raw {
 		return uint64(len(n.rawnode.RawData()))
 	}

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -105,7 +105,7 @@ func (n *UnixfsNode) GetChild(ctx context.Context, i int, ds dag.DAGService) (*U
 // the passed in DagBuilderHelper is used to store the child node an
 // pin it locally so it doesnt get lost
 func (n *UnixfsNode) AddChild(child *UnixfsNode, db *DagBuilderHelper) error {
-	n.ufmt.AddBlockSize(child.ufmt.FileSize())
+	n.ufmt.AddBlockSize(child.DataSize())
 
 	childnode, err := child.GetDagNode()
 	if err != nil {
@@ -135,6 +135,13 @@ func (n *UnixfsNode) RemoveChild(index int, dbh *DagBuilderHelper) {
 
 func (n *UnixfsNode) SetData(data []byte) {
 	n.ufmt.Data = data
+}
+
+func (n *UnixfsNode) DataSize() uint64 {
+	if n.raw {
+		return uint64(len(n.rawnode.RawData()))
+	}
+	return n.ufmt.FileSize()
 }
 
 // getDagNode fills out the proper formatting for the unixfs node

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -12,14 +12,16 @@ import (
 	h "github.com/ipfs/go-ipfs/importer/helpers"
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
 	dag "github.com/ipfs/go-ipfs/merkledag"
+
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 var log = logging.Logger("importer")
 
 // Builds a DAG from the given file, writing created blocks to disk as they are
 // created
-func BuildDagFromFile(fpath string, ds dag.DAGService) (*dag.ProtoNode, error) {
+func BuildDagFromFile(fpath string, ds dag.DAGService) (node.Node, error) {
 	stat, err := os.Lstat(fpath)
 	if err != nil {
 		return nil, err
@@ -38,7 +40,7 @@ func BuildDagFromFile(fpath string, ds dag.DAGService) (*dag.ProtoNode, error) {
 	return BuildDagFromReader(ds, chunk.NewSizeSplitter(f, chunk.DefaultBlockSize))
 }
 
-func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error) {
+func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
@@ -47,7 +49,7 @@ func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, 
 	return bal.BalancedLayout(dbp.New(spl))
 }
 
-func BuildTrickleDagFromReader(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error) {
+func BuildTrickleDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -2,19 +2,21 @@ package importer
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"testing"
 
-	context "context"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
+
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 )
 
-func getBalancedDag(t testing.TB, size int64, blksize int64) (*dag.ProtoNode, dag.DAGService) {
+func getBalancedDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAGService) {
 	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildDagFromReader(ds, chunk.NewSizeSplitter(r, blksize))
@@ -24,7 +26,7 @@ func getBalancedDag(t testing.TB, size int64, blksize int64) (*dag.ProtoNode, da
 	return nd, ds
 }
 
-func getTrickleDag(t testing.TB, size int64, blksize int64) (*dag.ProtoNode, dag.DAGService) {
+func getTrickleDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAGService) {
 	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildTrickleDagFromReader(ds, chunk.NewSizeSplitter(r, blksize))
@@ -100,7 +102,7 @@ func BenchmarkTrickleReadFull(b *testing.B) {
 	runReadBench(b, nd, ds)
 }
 
-func runReadBench(b *testing.B, nd *dag.ProtoNode, ds dag.DAGService) {
+func runReadBench(b *testing.B, nd node.Node, ds dag.DAGService) {
 	for i := 0; i < b.N; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
 		read, err := uio.NewDagReader(ctx, nd, ds)

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -2,6 +2,7 @@ package trickle
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -9,7 +10,6 @@ import (
 	"os"
 	"testing"
 
-	"context"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	h "github.com/ipfs/go-ipfs/importer/helpers"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
@@ -17,6 +17,7 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
+
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 )
 
@@ -31,7 +32,12 @@ func buildTestDag(ds merkledag.DAGService, spl chunk.Splitter) (*merkledag.Proto
 		return nil, err
 	}
 
-	return nd, VerifyTrickleDagStructure(nd, ds, dbp.Maxlinks, layerRepeat)
+	pbnd, ok := nd.(*merkledag.ProtoNode)
+	if !ok {
+		return nil, merkledag.ErrNotProtobuf
+	}
+
+	return pbnd, VerifyTrickleDagStructure(pbnd, ds, dbp.Maxlinks, layerRepeat)
 }
 
 //Test where calls to read are smaller than the chunk size

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -36,7 +36,7 @@ func NodeWithData(d []byte) *ProtoNode {
 }
 
 // AddNodeLink adds a link to another node.
-func (n *ProtoNode) AddNodeLink(name string, that *ProtoNode) error {
+func (n *ProtoNode) AddNodeLink(name string, that node.Node) error {
 	n.encoded = nil
 
 	lnk, err := node.MakeLink(that)

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -1,0 +1,46 @@
+package merkledag
+
+import (
+	"github.com/ipfs/go-ipfs/blocks"
+
+	cid "gx/ipfs/QmXUuRadqDq5BuFWzVU6VuKaSjTcNm1gNCtLvvP1TJCW4z/go-cid"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
+	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
+)
+
+type RawNode struct {
+	blocks.Block
+}
+
+func NewRawNode(data []byte) *RawNode {
+	h := u.Hash(data)
+	c := cid.NewCidV1(cid.Raw, h)
+	blk, _ := blocks.NewBlockWithCid(data, c)
+
+	return &RawNode{blk}
+}
+
+func (rn *RawNode) Links() []*node.Link {
+	return nil
+}
+
+func (rn *RawNode) Resolve(path []string) (*node.Link, []string, error) {
+	return nil, nil, ErrLinkNotFound
+}
+
+func (rn *RawNode) Tree() []string {
+	return nil
+}
+
+func (rn *RawNode) Size() (uint64, error) {
+	return uint64(len(rn.RawData())), nil
+}
+
+func (rn *RawNode) Stat() (*node.NodeStat, error) {
+	return &node.NodeStat{
+		CumulativeSize: len(rn.RawData()),
+		DataSize:       len(rn.RawData()),
+	}, nil
+}
+
+var _ node.Node = (*RawNode)(nil)

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -1,17 +1,18 @@
 package dagutils
 
 import (
+	"context"
 	"errors"
-
-	context "context"
-	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
-	syncds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
 
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
+	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
+	syncds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
 )
 
 type Editor struct {
@@ -50,7 +51,7 @@ func (e *Editor) GetDagService() dag.DAGService {
 	return e.tmp
 }
 
-func addLink(ctx context.Context, ds dag.DAGService, root *dag.ProtoNode, childname string, childnd *dag.ProtoNode) (*dag.ProtoNode, error) {
+func addLink(ctx context.Context, ds dag.DAGService, root *dag.ProtoNode, childname string, childnd node.Node) (*dag.ProtoNode, error) {
 	if childname == "" {
 		return nil, errors.New("cannot create link with no name!")
 	}
@@ -76,7 +77,7 @@ func addLink(ctx context.Context, ds dag.DAGService, root *dag.ProtoNode, childn
 	return root, nil
 }
 
-func (e *Editor) InsertNodeAtPath(ctx context.Context, pth string, toinsert *dag.ProtoNode, create func() *dag.ProtoNode) error {
+func (e *Editor) InsertNodeAtPath(ctx context.Context, pth string, toinsert node.Node, create func() *dag.ProtoNode) error {
 	splpath := path.SplitList(pth)
 	nd, err := e.insertNodeAtPath(ctx, e.root, splpath, toinsert, create)
 	if err != nil {
@@ -86,7 +87,7 @@ func (e *Editor) InsertNodeAtPath(ctx context.Context, pth string, toinsert *dag
 	return nil
 }
 
-func (e *Editor) insertNodeAtPath(ctx context.Context, root *dag.ProtoNode, path []string, toinsert *dag.ProtoNode, create func() *dag.ProtoNode) (*dag.ProtoNode, error) {
+func (e *Editor) insertNodeAtPath(ctx context.Context, root *dag.ProtoNode, path []string, toinsert node.Node, create func() *dag.ProtoNode) (*dag.ProtoNode, error) {
 	if len(path) == 1 {
 		return addLink(ctx, e.tmp, root, path[0], toinsert)
 	}

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -1,6 +1,7 @@
 package mfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -9,11 +10,11 @@ import (
 	"sync"
 	"time"
 
-	context "context"
-
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	ufspb "github.com/ipfs/go-ipfs/unixfs/pb"
+
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 var ErrNotYetImplemented = errors.New("not yet implemented")
@@ -323,7 +324,7 @@ func (d *Directory) Flush() error {
 }
 
 // AddChild adds the node 'nd' under this directory giving it the name 'name'
-func (d *Directory) AddChild(name string, nd *dag.ProtoNode) error {
+func (d *Directory) AddChild(name string, nd node.Node) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -9,6 +9,8 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	mod "github.com/ipfs/go-ipfs/unixfs/mod"
+
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 type File struct {
@@ -19,12 +21,12 @@ type File struct {
 	desclock sync.RWMutex
 
 	dserv  dag.DAGService
-	node   *dag.ProtoNode
+	node   node.Node
 	nodelk sync.Mutex
 }
 
 // NewFile returns a NewFile object with the given parameters
-func NewFile(name string, node *dag.ProtoNode, parent childCloser, dserv dag.DAGService) (*File, error) {
+func NewFile(name string, node node.Node, parent childCloser, dserv dag.DAGService) (*File, error) {
 	return &File{
 		dserv:  dserv,
 		parent: parent,
@@ -44,18 +46,23 @@ func (fi *File) Open(flags int, sync bool) (FileDescriptor, error) {
 	node := fi.node
 	fi.nodelk.Unlock()
 
-	fsn, err := ft.FSNodeFromBytes(node.Data())
-	if err != nil {
-		return nil, err
-	}
+	switch node := node.(type) {
+	case *dag.ProtoNode:
+		fsn, err := ft.FSNodeFromBytes(node.Data())
+		if err != nil {
+			return nil, err
+		}
 
-	switch fsn.Type {
-	default:
-		return nil, fmt.Errorf("unsupported fsnode type for 'file'")
-	case ft.TSymlink:
-		return nil, fmt.Errorf("symlinks not yet supported")
-	case ft.TFile, ft.TRaw:
-		// OK case
+		switch fsn.Type {
+		default:
+			return nil, fmt.Errorf("unsupported fsnode type for 'file'")
+		case ft.TSymlink:
+			return nil, fmt.Errorf("symlinks not yet supported")
+		case ft.TFile, ft.TRaw:
+			// OK case
+		}
+	case *dag.RawNode:
+		// Ok as well.
 	}
 
 	switch flags {
@@ -85,16 +92,22 @@ func (fi *File) Open(flags int, sync bool) (FileDescriptor, error) {
 func (fi *File) Size() (int64, error) {
 	fi.nodelk.Lock()
 	defer fi.nodelk.Unlock()
-	pbd, err := ft.FromBytes(fi.node.Data())
-	if err != nil {
-		return 0, err
+	switch nd := fi.node.(type) {
+	case *dag.ProtoNode:
+		pbd, err := ft.FromBytes(nd.Data())
+		if err != nil {
+			return 0, err
+		}
+		return int64(pbd.GetFilesize()), nil
+	case *dag.RawNode:
+		return int64(len(nd.RawData())), nil
+	default:
+		return 0, fmt.Errorf("unrecognized node type in mfs/file.Size()")
 	}
-
-	return int64(pbd.GetFilesize()), nil
 }
 
 // GetNode returns the dag node associated with this file
-func (fi *File) GetNode() (*dag.ProtoNode, error) {
+func (fi *File) GetNode() (node.Node, error) {
 	fi.nodelk.Lock()
 	defer fi.nodelk.Unlock()
 	return fi.node, nil

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -794,7 +794,12 @@ func TestFlushing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fsnode, err := ft.FSNodeFromBytes(rnd.Data())
+	pbrnd, ok := rnd.(*dag.ProtoNode)
+	if !ok {
+		t.Fatal(dag.ErrNotProtobuf)
+	}
+
+	fsnode, err := ft.FSNodeFromBytes(pbrnd.Data())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -803,10 +808,10 @@ func TestFlushing(t *testing.T) {
 		t.Fatal("root wasnt a directory")
 	}
 
-	rnk := rnd.Key()
+	rnk := rnd.Cid()
 	exp := "QmWMVyhTuyxUrXX3ynz171jq76yY3PktfY9Bxiph7b9ikr"
-	if rnk.B58String() != exp {
-		t.Fatalf("dag looks wrong, expected %s, but got %s", exp, rnk.B58String())
+	if rnk.String() != exp {
+		t.Fatalf("dag looks wrong, expected %s, but got %s", exp, rnk.String())
 	}
 }
 

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -42,12 +42,12 @@ func getDagserv(t *testing.T) dag.DAGService {
 	return dag.NewDAGService(blockserv)
 }
 
-func getRandFile(t *testing.T, ds dag.DAGService, size int64) *dag.ProtoNode {
+func getRandFile(t *testing.T, ds dag.DAGService, size int64) node.Node {
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	return fileNodeFromReader(t, ds, r)
 }
 
-func fileNodeFromReader(t *testing.T, ds dag.DAGService, r io.Reader) *dag.ProtoNode {
+func fileNodeFromReader(t *testing.T, ds dag.DAGService, r io.Reader) node.Node {
 	nd, err := importer.BuildDagFromReader(ds, chunk.DefaultSplitter(r))
 	if err != nil {
 		t.Fatal(err)
@@ -125,7 +125,12 @@ func compStrArrs(a, b []string) bool {
 	return true
 }
 
-func assertFileAtPath(ds dag.DAGService, root *Directory, exp *dag.ProtoNode, pth string) error {
+func assertFileAtPath(ds dag.DAGService, root *Directory, expn node.Node, pth string) error {
+	exp, ok := expn.(*dag.ProtoNode)
+	if !ok {
+		return dag.ErrNotProtobuf
+	}
+
 	parts := path.SplitList(pth)
 	cur := root
 	for i, d := range parts[:len(parts)-1] {

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -7,8 +7,9 @@ import (
 	gopath "path"
 	"strings"
 
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 // Mv moves the file or directory at 'src' to 'dst'
@@ -87,7 +88,7 @@ func lookupDir(r *Root, path string) (*Directory, error) {
 }
 
 // PutNode inserts 'nd' at 'path' in the given mfs
-func PutNode(r *Root, path string, nd *dag.ProtoNode) error {
+func PutNode(r *Root, path string, nd node.Node) error {
 	dirp, filename := gopath.Split(path)
 	if filename == "" {
 		return fmt.Errorf("cannot create file with empty name")

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -10,6 +10,7 @@
 package mfs
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -17,9 +18,9 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
-	context "context"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmXUuRadqDq5BuFWzVU6VuKaSjTcNm1gNCtLvvP1TJCW4z/go-cid"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 var ErrNotExist = errors.New("no such rootfs")
@@ -41,7 +42,7 @@ const (
 
 // FSNode represents any node (directory, root, or file) in the mfs filesystem
 type FSNode interface {
-	GetNode() (*dag.ProtoNode, error)
+	GetNode() (node.Node, error)
 	Flush() error
 	Type() NodeType
 }

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -126,6 +126,21 @@ test_add_cat_5MB() {
     '
 }
 
+test_add_cat_raw() {
+	test_expect_success "add a small file with raw-leaves" '
+		echo "foobar" > afile &&
+		HASH=$(ipfs add -q --raw-leaves afile)
+	'
+
+	test_expect_success "cat that small file" '
+		ipfs cat $HASH > afile_out
+	'
+
+	test_expect_success "make sure it looks good" '
+		test_cmp afile afile_out
+	'
+}
+
 test_add_cat_expensive() {
     test_expect_success EXPENSIVE "generate 100MB file using go-random" '
     	random 104857600 42 >mountdir/bigfile
@@ -392,17 +407,21 @@ test_add_named_pipe " Post http://$API_ADDR/api/v0/add?encoding=json&progress=tr
 
 test_add_pwd_is_symlink
 
+test_add_cat_raw
+
 test_kill_ipfs_daemon
 
 # should work offline
 
 test_add_cat_file
 
+test_add_cat_raw
+
 test_expect_success "ipfs add --only-hash succeeds" '
     echo "unknown content for only-hash" | ipfs add --only-hash -q > oh_hash
 '
 
-#TODO: this doesn't work when online hence separated out from test_add_cat_file
+#TODO: this doesnt work when online hence separated out from test_add_cat_file
 test_expect_success "ipfs cat file fails" '
     test_must_fail ipfs cat $(cat oh_hash)
 '

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -87,6 +87,9 @@ test_add_cat_file() {
 }
 
 test_add_cat_5MB() {
+	ADD_FLAGS="$1"
+	EXP_HASH="$2"
+
     test_expect_success "generate 5MB file using go-random" '
     	random 5242880 41 >mountdir/bigfile
     '
@@ -98,17 +101,16 @@ test_add_cat_5MB() {
     '
 
     test_expect_success "'ipfs add bigfile' succeeds" '
-    	ipfs add mountdir/bigfile >actual ||
+    	ipfs add $ADD_FLAGS mountdir/bigfile >actual ||
 		test_fsh cat daemon_err
     '
 
     test_expect_success "'ipfs add bigfile' output looks good" '
-    	HASH="QmSr7FqYkxYWGoSfy8ZiaMWQ5vosb18DQGCzjwEQnVHkTb" &&
-    	echo "added $HASH bigfile" >expected &&
+    	echo "added $EXP_HASH bigfile" >expected &&
     	test_cmp expected actual
     '
     test_expect_success "'ipfs cat' succeeds" '
-    	ipfs cat "$HASH" >actual
+    	ipfs cat "$EXP_HASH" >actual
     '
 
     test_expect_success "'ipfs cat' output looks good" '
@@ -116,7 +118,7 @@ test_add_cat_5MB() {
     '
 
     test_expect_success FUSE "cat ipfs/bigfile succeeds" '
-    	cat "ipfs/$HASH" >actual
+    	cat "ipfs/$EXP_HASH" >actual
     '
 
     test_expect_success FUSE "cat ipfs/bigfile looks good" '
@@ -380,7 +382,9 @@ test_expect_success "go-random is installed" '
     type random
 '
 
-test_add_cat_5MB
+test_add_cat_5MB "" "QmSr7FqYkxYWGoSfy8ZiaMWQ5vosb18DQGCzjwEQnVHkTb"
+
+test_add_cat_5MB --raw-leaves "QmefsDaD3YVphd86mxjJfPLceKv8by98aB6J6sJxK13xS2"
 
 test_add_cat_expensive
 

--- a/test/sharness/t0084-repo-read-rehash.sh
+++ b/test/sharness/t0084-repo-read-rehash.sh
@@ -43,6 +43,11 @@ test_check_bad_blocks() {
 
 test_check_bad_blocks
 
+test_expect_success "can add and cat a raw-leaf file" '
+	HASH=$(echo "stuff" | ipfs add -q --raw-leaves) &&
+	ipfs cat $HASH > /dev/null
+'
+
 test_launch_ipfs_daemon
 test_check_bad_blocks
 test_kill_ipfs_daemon

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -2,17 +2,18 @@ package io
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 
-	"context"
-	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
-
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
+
+	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 )
 
 var ErrIsDir = errors.New("this dag node is a directory")
@@ -58,36 +59,45 @@ type ReadSeekCloser interface {
 
 // NewDagReader creates a new reader object that reads the data represented by
 // the given node, using the passed in DAGService for data retreival
-func NewDagReader(ctx context.Context, n *mdag.ProtoNode, serv mdag.DAGService) (*DagReader, error) {
-	pb := new(ftpb.Data)
-	if err := proto.Unmarshal(n.Data(), pb); err != nil {
-		return nil, err
-	}
-
-	switch pb.GetType() {
-	case ftpb.Data_Directory:
-		// Dont allow reading directories
-		return nil, ErrIsDir
-	case ftpb.Data_File, ftpb.Data_Raw:
-		return NewDataFileReader(ctx, n, pb, serv), nil
-	case ftpb.Data_Metadata:
-		if len(n.Links()) == 0 {
-			return nil, errors.New("incorrectly formatted metadata object")
-		}
-		child, err := n.Links()[0].GetNode(ctx, serv)
-		if err != nil {
+func NewDagReader(ctx context.Context, n node.Node, serv mdag.DAGService) (*DagReader, error) {
+	switch n := n.(type) {
+	case *mdag.RawNode:
+		return &DagReader{
+			buf: NewRSNCFromBytes(n.RawData()),
+		}, nil
+	case *mdag.ProtoNode:
+		pb := new(ftpb.Data)
+		if err := proto.Unmarshal(n.Data(), pb); err != nil {
 			return nil, err
 		}
 
-		childpb, ok := child.(*mdag.ProtoNode)
-		if !ok {
-			return nil, mdag.ErrNotProtobuf
+		switch pb.GetType() {
+		case ftpb.Data_Directory:
+			// Dont allow reading directories
+			return nil, ErrIsDir
+		case ftpb.Data_File, ftpb.Data_Raw:
+			return NewDataFileReader(ctx, n, pb, serv), nil
+		case ftpb.Data_Metadata:
+			if len(n.Links()) == 0 {
+				return nil, errors.New("incorrectly formatted metadata object")
+			}
+			child, err := n.Links()[0].GetNode(ctx, serv)
+			if err != nil {
+				return nil, err
+			}
+
+			childpb, ok := child.(*mdag.ProtoNode)
+			if !ok {
+				return nil, mdag.ErrNotProtobuf
+			}
+			return NewDagReader(ctx, childpb, serv)
+		case ftpb.Data_Symlink:
+			return nil, ErrCantReadSymlinks
+		default:
+			return nil, ft.ErrUnrecognizedType
 		}
-		return NewDagReader(ctx, childpb, serv)
-	case ftpb.Data_Symlink:
-		return nil, ErrCantReadSymlinks
 	default:
-		return nil, ft.ErrUnrecognizedType
+		return nil, fmt.Errorf("unrecognized node type")
 	}
 }
 

--- a/unixfs/test/utils.go
+++ b/unixfs/test/utils.go
@@ -2,6 +2,7 @@ package testu
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,7 @@ import (
 	mdagmock "github.com/ipfs/go-ipfs/merkledag/test"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
-	context "context"
+	node "gx/ipfs/QmZx42H5khbVQhV5odp66TApShV4XCujYazcvYduZ4TroB/go-ipld-node"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 )
 
@@ -27,7 +28,7 @@ func GetDAGServ() mdag.DAGService {
 	return mdagmock.Mock()
 }
 
-func GetNode(t testing.TB, dserv mdag.DAGService, data []byte) *mdag.ProtoNode {
+func GetNode(t testing.TB, dserv mdag.DAGService, data []byte) node.Node {
 	in := bytes.NewReader(data)
 	node, err := imp.BuildTrickleDagFromReader(dserv, SizeSplitterGen(500)(in))
 	if err != nil {
@@ -37,11 +38,11 @@ func GetNode(t testing.TB, dserv mdag.DAGService, data []byte) *mdag.ProtoNode {
 	return node
 }
 
-func GetEmptyNode(t testing.TB, dserv mdag.DAGService) *mdag.ProtoNode {
+func GetEmptyNode(t testing.TB, dserv mdag.DAGService) node.Node {
 	return GetNode(t, dserv, []byte{})
 }
 
-func GetRandomNode(t testing.TB, dserv mdag.DAGService, size int64) ([]byte, *mdag.ProtoNode) {
+func GetRandomNode(t testing.TB, dserv mdag.DAGService, size int64) ([]byte, node.Node) {
 	in := io.LimitReader(u.NewTimeSeededRand(), size)
 	buf, err := ioutil.ReadAll(in)
 	if err != nil {


### PR DESCRIPTION
This PR implements a 'Raw Node' dag node that is essentially just a block. Among other things, this allows us to make unixfs not have leaf nodes with extra framing and fit nicely inside multiples of 1024 and 4096.

A new flag `--raw-leaves` has been added to `ipfs add` that enables this functionality.

Do note that if you create objects with this flag, you will not be able to transfer them to other peers who are running any version before this (meaning those objects will not be able to be processed by ipfs 0.4.3 nodes).

This depends on the previous PR that turns the merkledag.Node into an interface. 