### PR TITLE
cli: refactor to expose argument parsing functionality

### DIFF
--- a/commands/cli/cmd_suggestion.go
+++ b/commands/cli/cmd_suggestion.go
@@ -30,6 +30,10 @@ func (s suggestionSlice) Less(i, j int) bool {
 }
 
 func suggestUnknownCmd(args []string, root *cmds.Command) []string {
+	if root == nil {
+		return nil
+	}
+
 	arg := args[0]
 	var suggestions []string
 	sortableSuggestions := make(suggestionSlice, 0)

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -36,27 +36,6 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 		return nil, cmd, path, err
 	}
 
-	// if -r is provided, and it is associated with the package builtin
-	// recursive path option, allow recursive file paths
-	recursiveOpt := req.Option(cmds.RecShort)
-	recursive := false
-	if recursiveOpt != nil && recursiveOpt.Definition() == cmds.OptionRecursivePath {
-		recursive, _, err = recursiveOpt.Bool()
-		if err != nil {
-			return req, nil, nil, u.ErrCast()
-		}
-	}
-
-	// if '--hidden' is provided, enumerate hidden paths
-	hiddenOpt := req.Option("hidden")
-	hidden := false
-	if hiddenOpt != nil {
-		hidden, _, err = hiddenOpt.Bool()
-		if err != nil {
-			return req, nil, nil, u.ErrCast()
-		}
-	}
-
 	// This is an ugly hack to maintain our current CLI interface while fixing
 	// other stdin usage bugs. Let this serve as a warning, be careful about the
 	// choices you make, they will haunt you forever.
@@ -67,7 +46,7 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 		}
 	}
 
-	stringArgs, fileArgs, err := parseArgs(stringVals, stdin, cmd.Arguments, recursive, hidden, root)
+	stringArgs, fileArgs, err := ParseArgs(req, stringVals, stdin, cmd.Arguments, root)
 	if err != nil {
 		return req, cmd, path, err
 	}
@@ -84,6 +63,32 @@ func Parse(input []string, stdin *os.File, root *cmds.Command) (cmds.Request, *c
 	}
 
 	return req, cmd, path, nil
+}
+
+func ParseArgs(req cmds.Request, inputs []string, stdin *os.File, argDefs []cmds.Argument, root *cmds.Command) ([]string, []files.File, error) {
+	var err error
+
+	// if -r is provided, and it is associated with the package builtin
+	// recursive path option, allow recursive file paths
+	recursiveOpt := req.Option(cmds.RecShort)
+	recursive := false
+	if recursiveOpt != nil && recursiveOpt.Definition() == cmds.OptionRecursivePath {
+		recursive, _, err = recursiveOpt.Bool()
+		if err != nil {
+			return nil, nil, u.ErrCast()
+		}
+	}
+
+	// if '--hidden' is provided, enumerate hidden paths
+	hiddenOpt := req.Option("hidden")
+	hidden := false
+	if hiddenOpt != nil {
+		hidden, _, err = hiddenOpt.Bool()
+		if err != nil {
+			return nil, nil, u.ErrCast()
+		}
+	}
+	return parseArgs(inputs, stdin, argDefs, recursive, hidden, root)
 }
 
 // Parse a command line made up of sub-commands, short arguments, long arguments and positional arguments


### PR DESCRIPTION
This is just a small refactor to expose some functionality needed by the filestore (#2634).

Hopefully it is uncontroversial, if you need more an an explanation let me know.
