### PR TITLE
make path resolver no longer require whole node for construction

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -214,7 +214,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		// this is kinda sketchy and could cause data loss
 		n.Pinning = pin.NewPinner(n.Repo.Datastore(), n.DAG, internalDag)
 	}
-	n.Resolver = &path.Resolver{DAG: n.DAG}
+	n.Resolver = path.NewBasicResolver(n.DAG)
 
 	err = n.loadFilesRoot()
 	if err != nil {

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -16,6 +16,7 @@ import (
 	mfs "github.com/ipfs/go-ipfs/mfs"
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	node "gx/ipfs/QmU7bFWQ793qmvNy7outdCaMfSDNk8uqhx4VNrxYj5fj5g/go-ipld-node"
@@ -259,11 +260,15 @@ func getNodeFromPath(ctx context.Context, node *core.IpfsNode, p string) (node.N
 			return nil, err
 		}
 
-		nd, err := core.Resolve(ctx, node, np)
+		resolver := &path.Resolver{
+			DAG:         node.DAG,
+			ResolveOnce: uio.ResolveUnixfsOnce,
+		}
+
+		nd, err := core.Resolve(ctx, node.Namesys, resolver, np)
 		if err != nil {
 			return nil, err
 		}
-
 		pbnd, ok := nd.(*dag.ProtoNode)
 		if !ok {
 			return nil, dag.ErrNotProtobuf

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -64,7 +64,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		}
 		p := path.Path(req.Arguments()[0])
 		ctx := req.Context()
-		dn, err := core.Resolve(ctx, node, p)
+		dn, err := core.Resolve(ctx, node.Namesys, node.Resolver, p)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -11,6 +11,7 @@ import (
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
 
 	node "gx/ipfs/QmU7bFWQ793qmvNy7outdCaMfSDNk8uqhx4VNrxYj5fj5g/go-ipld-node"
@@ -74,7 +75,18 @@ The JSON output contains type information.
 
 		var dagnodes []node.Node
 		for _, fpath := range paths {
-			dagnode, err := core.Resolve(req.Context(), nd, path.Path(fpath))
+			p, err := path.ParsePath(fpath)
+			if err != nil {
+				res.SetError(err, cmds.ErrNormal)
+				return
+			}
+
+			r := &path.Resolver{
+				DAG:         nd.DAG,
+				ResolveOnce: uio.ResolveUnixfsOnce,
+			}
+
+			dagnode, err := core.Resolve(req.Context(), nd.Namesys, r, p)
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return

--- a/core/commands/object/diff.go
+++ b/core/commands/object/diff.go
@@ -74,13 +74,13 @@ Example:
 
 		ctx := req.Context()
 
-		obj_a, err := core.Resolve(ctx, node, pa)
+		obj_a, err := core.Resolve(ctx, node.Namesys, node.Resolver, pa)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
 
-		obj_b, err := core.Resolve(ctx, node, pb)
+		obj_b, err := core.Resolve(ctx, node.Namesys, node.Resolver, pb)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -94,7 +94,7 @@ is the raw data of the object.
 			return
 		}
 
-		node, err := core.Resolve(req.Context(), n, fpath)
+		node, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -140,7 +140,7 @@ multihash.
 		}
 
 		fpath := path.Path(req.Arguments()[0])
-		node, err := core.Resolve(req.Context(), n, fpath)
+		node, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -204,7 +204,7 @@ This command outputs data in the following encodings:
 
 		fpath := path.Path(req.Arguments()[0])
 
-		object, err := core.Resolve(req.Context(), n, fpath)
+		object, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -277,7 +277,7 @@ var ObjectStatCmd = &cmds.Command{
 
 		fpath := path.Path(req.Arguments()[0])
 
-		object, err := core.Resolve(req.Context(), n, fpath)
+		object, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -73,7 +73,7 @@ the limit will not be respected by the network.
 			return
 		}
 
-		rootnd, err := core.Resolve(req.Context(), nd, root)
+		rootnd, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, root)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -141,7 +141,7 @@ Example:
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd, rp)
+		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rp)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -205,7 +205,7 @@ Removes a link by the given name from root.
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd, rootp)
+		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rootp)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -280,7 +280,7 @@ to a file containing 'bar', and returns the hash of the new object.
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd, rootp)
+		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rootp)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -312,7 +312,7 @@ to a file containing 'bar', and returns the hash of the new object.
 
 		e := dagutils.NewDagEditor(rtpb, nd.DAG)
 
-		childnd, err := core.Resolve(req.Context(), nd, childp)
+		childnd, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, childp)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -277,7 +277,7 @@ func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsN
 			return nil, err
 		}
 
-		dagNode, err := core.Resolve(ctx, n, pth)
+		dagNode, err := core.Resolve(ctx, n.Namesys, n.Resolver, pth)
 		if err != nil {
 			return nil, err
 		}

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -135,7 +135,7 @@ func publish(ctx context.Context, n *core.IpfsNode, k crypto.PrivKey, ref path.P
 
 	if opts.verifyExists {
 		// verify the path exists
-		_, err := core.Resolve(ctx, n, ref)
+		_, err := core.Resolve(ctx, n.Namesys, n.Resolver, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -198,8 +198,13 @@ var refsMarshallerMap = cmds.MarshalerMap{
 
 func objectsForPaths(ctx context.Context, n *core.IpfsNode, paths []string) ([]node.Node, error) {
 	objects := make([]node.Node, len(paths))
-	for i, p := range paths {
-		o, err := core.Resolve(ctx, n, path.Path(p))
+	for i, sp := range paths {
+		p, err := path.ParsePath(sp)
+		if err != nil {
+			return nil, err
+		}
+
+		o, err := core.Resolve(ctx, n.Namesys, n.Resolver, p)
 		if err != nil {
 			return nil, err
 		}

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -99,7 +99,7 @@ Resolve the value of an IPFS DAG path:
 			return
 		}
 
-		node, err := core.Resolve(req.Context(), n, p)
+		node, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, p)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -95,7 +95,7 @@ var tarCatCmd = &cmds.Command{
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd, p)
+		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, p)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -12,6 +12,7 @@ import (
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
 )
 
@@ -87,7 +88,13 @@ possible, please use 'ipfs ls' instead.
 
 		for _, fpath := range paths {
 			ctx := req.Context()
-			merkleNode, err := core.Resolve(ctx, node, path.Path(fpath))
+
+			resolver := &path.Resolver{
+				DAG:         node.DAG,
+				ResolveOnce: uio.ResolveUnixfsOnce,
+			}
+
+			merkleNode, err := core.Resolve(ctx, node.Namesys, resolver, path.Path(fpath))
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return

--- a/core/core.go
+++ b/core/core.go
@@ -60,7 +60,7 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
-	uio "github.com/ipfs/go-ipfs/unixfs/io"
+	ft "github.com/ipfs/go-ipfs/unixfs"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 )
 
@@ -504,7 +504,7 @@ func (n *IpfsNode) loadFilesRoot() error {
 
 	switch {
 	case err == ds.ErrNotFound || val == nil:
-		nd = uio.NewEmptyDirectory()
+		nd = ft.EmptyDirNode()
 		_, err := n.DAG.Add(nd)
 		if err != nil {
 			return fmt.Errorf("failure writing to dagstore: %s", err)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -17,6 +17,7 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
 	path "github.com/ipfs/go-ipfs/path"
+	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
@@ -153,7 +154,13 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		ipnsHostname = true
 	}
 
-	nd, err := core.Resolve(ctx, i.node, path.Path(urlPath))
+	p, err := path.ParsePath(urlPath)
+	if err != nil {
+		webError(w, "Invalid Path Error", err, http.StatusBadRequest)
+		return
+	}
+
+	nd, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, p)
 	// If node is in offline mode the error code and message should be different
 	if err == core.ErrNoNamesys && !i.node.OnlineMode() {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -240,8 +247,14 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 				return
 			}
 
+			p, err := path.ParsePath(urlPath + "/index.html")
+			if err != nil {
+				internalWebError(w, err)
+				return
+			}
+
 			// return index page instead.
-			nd, err := core.Resolve(ctx, i.node, path.Path(urlPath+"/index.html"))
+			nd, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, p)
 			if err != nil {
 				internalWebError(w, err)
 				return
@@ -356,7 +369,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	var newnode node.Node
 	if rsegs[len(rsegs)-1] == "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn" {
-		newnode = uio.NewEmptyDirectory()
+		newnode = ft.EmptyDirNode()
 	} else {
 		putNode, err := i.newDagFromReader(r.Body)
 		if err != nil {
@@ -372,7 +385,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var newcid *cid.Cid
-	rnode, err := core.Resolve(ctx, i.node, rootPath)
+	rnode, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, rootPath)
 	switch ev := err.(type) {
 	case path.ErrNoLink:
 		// ev.Node < node where resolve failed
@@ -397,7 +410,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		e := dagutils.NewDagEditor(pbnd, i.node.DAG)
-		err = e.InsertNodeAtPath(ctx, newPath, newnode, uio.NewEmptyDirectory)
+		err = e.InsertNodeAtPath(ctx, newPath, newnode, ft.EmptyDirNode)
 		if err != nil {
 			webError(w, "putHandler: InsertNodeAtPath failed", err, http.StatusInternalServerError)
 			return

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -27,7 +27,12 @@ import (
 func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
 	dagnodes := make([]node.Node, 0)
 	for _, fpath := range paths {
-		dagnode, err := core.Resolve(ctx, n, path.Path(fpath))
+		p, err := path.ParsePath(fpath)
+		if err != nil {
+			return nil, err
+		}
+
+		dagnode, err := core.Resolve(ctx, n.Namesys, n.Resolver, p)
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Cat(ctx context.Context, n *core.IpfsNode, pstr string) (*uio.DagReader, error) {
-	dagNode, err := core.Resolve(ctx, n, path.Path(pstr))
+	dagNode, err := core.Resolve(ctx, n.Namesys, n.Resolver, path.Path(pstr))
 	if err != nil {
 		return nil, err
 	}

--- a/core/pathresolver_test.go
+++ b/core/pathresolver_test.go
@@ -14,17 +14,17 @@ func TestResolveNoComponents(t *testing.T) {
 		t.Fatal("Should have constructed a mock node", err)
 	}
 
-	_, err = core.Resolve(n.Context(), n, path.Path("/ipns/"))
+	_, err = core.Resolve(n.Context(), n.Namesys, n.Resolver, path.Path("/ipns/"))
 	if err != path.ErrNoComponents {
 		t.Fatal("Should error with no components (/ipns/).", err)
 	}
 
-	_, err = core.Resolve(n.Context(), n, path.Path("/ipfs/"))
+	_, err = core.Resolve(n.Context(), n.Namesys, n.Resolver, path.Path("/ipfs/"))
 	if err != path.ErrNoComponents {
 		t.Fatal("Should error with no components (/ipfs/).", err)
 	}
 
-	_, err = core.Resolve(n.Context(), n, path.Path("/../.."))
+	_, err = core.Resolve(n.Context(), n.Namesys, n.Resolver, path.Path("/../.."))
 	if err != path.ErrBadPath {
 		t.Fatal("Should error with invalid path.", err)
 	}

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -94,7 +94,7 @@ func loadRoot(ctx context.Context, rt *keyRoot, ipfs *core.IpfsNode, name string
 		return nil, err
 	}
 
-	node, err := core.Resolve(ctx, ipfs, p)
+	node, err := core.Resolve(ctx, ipfs.Namesys, ipfs.Resolver, p)
 	if err != nil {
 		log.Errorf("looking up %s: %s", p, err)
 		return nil, err

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -55,7 +55,7 @@ func TestRecurivePathResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resolver := &path.Resolver{DAG: dagService}
+	resolver := path.NewBasicResolver(dagService)
 	node, err := resolver.ResolvePath(ctx, p)
 	if err != nil {
 		t.Fatal(err)

--- a/unixfs/io/resolve.go
+++ b/unixfs/io/resolve.go
@@ -1,0 +1,46 @@
+package io
+
+import (
+	"context"
+
+	dag "github.com/ipfs/go-ipfs/merkledag"
+	ft "github.com/ipfs/go-ipfs/unixfs"
+
+	node "gx/ipfs/QmU7bFWQ793qmvNy7outdCaMfSDNk8uqhx4VNrxYj5fj5g/go-ipld-node"
+)
+
+func ResolveUnixfsOnce(ctx context.Context, ds dag.DAGService, nd node.Node, name string) (*node.Link, error) {
+	pbnd, ok := nd.(*dag.ProtoNode)
+	if !ok {
+		lnk, _, err := nd.ResolveLink([]string{name})
+		return lnk, err
+	}
+
+	upb, err := ft.FromBytes(pbnd.Data())
+	if err != nil {
+		// Not a unixfs node, use standard object traversal code
+		lnk, _, err := nd.ResolveLink([]string{name})
+		return lnk, err
+	}
+
+	switch upb.GetType() {
+	/*
+		case ft.THAMTShard:
+			s, err := hamt.NewHamtFromDag(ds, nd)
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO: optimized routine on HAMT for returning a dag.Link to avoid extra disk hits
+			out, err := s.Find(ctx, name)
+			if err != nil {
+				return nil, err
+			}
+
+			return dag.MakeLink(out)
+	*/
+	default:
+		lnk, _, err := nd.ResolveLink([]string{name})
+		return lnk, err
+	}
+}


### PR DESCRIPTION
This is some preliminiary work before we can get sharding in. Resolving a path now requires a certain bit of context and logic around what the path actually refers to (unixfs vs normal dag traversal)

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>