### PR TITLE
add: [Windows] Drive root parse fix

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 
@@ -260,7 +259,7 @@ const msgStdinInfo = "ipfs: Reading from %s; send Ctrl-d to stop."
 
 func parseArgs(inputs []string, stdin *os.File, argDefs []cmds.Argument, recursive, hidden bool, root *cmds.Command) ([]string, []files.File, error) {
 	// ignore stdin on Windows
-	if runtime.GOOS == "windows" {
+	if osh.IsWindows() {
 		stdin = nil
 	}
 

--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -11,7 +11,9 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	files "github.com/ipfs/go-ipfs/commands/files"
+
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	osh "gx/ipfs/QmXuBJ7DR6k3rmUEKtvVMhwjmXDuJgXXPUt4LQXKBMsU93/go-os-helper"
 	u "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
 )
 
@@ -398,8 +400,20 @@ func getArgDef(i int, argDefs []cmds.Argument) *cmds.Argument {
 
 const notRecursiveFmtStr = "'%s' is a directory, use the '-%s' flag to specify directories"
 const dirNotSupportedFmtStr = "Invalid path '%s', argument '%s' does not support directories"
+const winDriveLetterFmtStr = "%q is a drive letter, not a drive path"
 
 func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (files.File, error) {
+	// resolve Windows relative dot paths like `X:.\somepath`
+	if osh.IsWindows() {
+		if len(fpath) >= 3 && fpath[1:3] == ":." {
+			var err error
+			fpath, err = filepath.Abs(fpath)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if fpath == "." {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -412,7 +426,7 @@ func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (fi
 		fpath = cwd
 	}
 
-	fpath = filepath.ToSlash(filepath.Clean(fpath))
+	fpath = filepath.Clean(fpath)
 
 	stat, err := os.Lstat(fpath)
 	if err != nil {
@@ -426,6 +440,10 @@ func appendFile(fpath string, argDef *cmds.Argument, recursive, hidden bool) (fi
 		if !recursive {
 			return nil, fmt.Errorf(notRecursiveFmtStr, fpath, cmds.RecShort)
 		}
+	}
+
+	if osh.IsWindows() {
+		return windowsParseFile(fpath, hidden, stat)
 	}
 
 	return files.NewSerialFile(path.Base(fpath), fpath, hidden, stat)
@@ -479,4 +497,33 @@ func (r *messageReader) Read(b []byte) (int, error) {
 
 func (r *messageReader) Close() error {
 	return r.r.Close()
+}
+
+func windowsParseFile(fpath string, hidden bool, stat os.FileInfo) (files.File, error) {
+	// special cases for Windows drive roots i.e. `X:\` and their long form `\\?\X:\`
+	// drive path must be preserved as `X:\` (or it's longform) and not converted to `X:`, `X:.`, `\`, or `/` here
+	switch len(fpath) {
+	case 3:
+		// `X:` is cleaned to `X:.` which may not be the expected behaviour by the user, they'll need to provide more specific input
+		if fpath[1:3] == ":." {
+			return nil, fmt.Errorf(winDriveLetterFmtStr, fpath[:2])
+		}
+		// `X:\` needs to preserve the `\`, path.Base(filepath.ToSlash(fpath)) results in `X:` which is not valid
+		if fpath[1:3] == ":\\" {
+			return files.NewSerialFile(fpath, fpath, hidden, stat)
+		}
+	case 6:
+		// `\\?\X:` long prefix form of `X:`, still ambiguous
+		if fpath[:4] == "\\\\?\\" && fpath[5] == ':' {
+			return nil, fmt.Errorf(winDriveLetterFmtStr, fpath)
+		}
+	case 7:
+		// `\\?\X:\` long prefix form is translated into short form `X:\`
+		if fpath[:4] == "\\\\?\\" && fpath[5] == ':' && fpath[6] == '\\' {
+			fpath = string(fpath[4]) + ":\\"
+			return files.NewSerialFile(fpath, fpath, hidden, stat)
+		}
+	}
+
+	return files.NewSerialFile(path.Base(filepath.ToSlash(fpath)), fpath, hidden, stat)
 }


### PR DESCRIPTION
Previously when adding the root of a drive on Windows (either directly through `X:\` or via `.` while in `X:`), ipfs would prefix everything and not handle directories properly in a manner simillar to this issue:https://github.com/ipfs/go-ipfs/issues/1922
![ipfs root of drive problem](https://cloud.githubusercontent.com/assets/13862850/19696073/b33f608a-9ab3-11e6-8a87-7de21c42d0c9.png)

This does not happen with paths or files underneath the root, it's just when adding the root itself. 👻 
This can be fixed by preserving the full path `X:\` instead of using `X:` as a base when specifying the root of a drive only. As an aside it would not be valid to use `/` instead, since `/` is relative to the drive in your working directory on Windows, not an absolute path. Using `/` while adding `Y:\` from `X:\` would either give you N contents from `X`: or panic if `X:` contains less items in the root than `Y:` does. Preserving the full path doesn't have this issue.

I make sure not to act on paths starting with `/` and check for a backslash, to my knowledge a valid input path like that should only show up on Windows.
Using long path prefix form `\\?\x:` will still give the incorrect behavior, I don't think it's necessary to check for this but it could be caught in the same way, then converted from the long form to the short form `X:\`

Any issues with this and should long form be handled too?
