### PR TITLE
namesys: return right after errors

### DIFF
--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -147,13 +147,16 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 		if err != nil {
 			log.Warning("RoutingResolve get failed.")
 			resp <- err
+			return
 		}
 
 		entry = new(pb.IpnsEntry)
 		err = proto.Unmarshal(val, entry)
 		if err != nil {
 			resp <- err
+			return
 		}
+
 		resp <- nil
 	}()
 
@@ -162,7 +165,9 @@ func (r *routingResolver) resolveOnce(ctx context.Context, name string) (path.Pa
 		pubk, err := routing.GetPublicKey(r.routing, ctx, hash)
 		if err != nil {
 			resp <- err
+			return
 		}
+
 		pubkey = pubk
 		resp <- nil
 	}()


### PR DESCRIPTION
Previously, if this errored, the possibility for goroutines to get stuck sending a second result down the channel existed. This should prevent that from happening.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>