### PR TITLE
Separate out the G.C. Locking from the Blockstore interface.

### DIFF
--- a/blocks/blockstore/arc_cache_test.go
+++ b/blocks/blockstore/arc_cache_test.go
@@ -13,7 +13,7 @@ import (
 
 var exampleBlock = blocks.NewBlock([]byte("foo"))
 
-func testArcCached(bs GCBlockstore, ctx context.Context) (*arccache, error) {
+func testArcCached(bs Blockstore, ctx context.Context) (*arccache, error) {
 	if ctx == nil {
 		ctx = context.TODO()
 	}

--- a/blocks/blockstore/bloom_cache_test.go
+++ b/blocks/blockstore/bloom_cache_test.go
@@ -14,7 +14,7 @@ import (
 	syncds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
 )
 
-func testBloomCached(bs GCBlockstore, ctx context.Context) (*bloomcache, error) {
+func testBloomCached(bs Blockstore, ctx context.Context) (*bloomcache, error) {
 	if ctx == nil {
 		ctx = context.TODO()
 	}

--- a/blocks/blockstore/caching.go
+++ b/blocks/blockstore/caching.go
@@ -22,8 +22,8 @@ func DefaultCacheOpts() CacheOpts {
 	}
 }
 
-func CachedBlockstore(bs GCBlockstore,
-	ctx context.Context, opts CacheOpts) (cbs GCBlockstore, err error) {
+func CachedBlockstore(bs Blockstore,
+	ctx context.Context, opts CacheOpts) (cbs Blockstore, err error) {
 	cbs = bs
 
 	if opts.HasBloomFilterSize < 0 || opts.HasBloomFilterHashes < 0 ||

--- a/blockservice/blockservice_test.go
+++ b/blockservice/blockservice_test.go
@@ -36,14 +36,14 @@ func TestWriteThroughWorks(t *testing.T) {
 	}
 }
 
-var _ blockstore.GCBlockstore = (*PutCountingBlockstore)(nil)
+var _ blockstore.Blockstore = (*PutCountingBlockstore)(nil)
 
 type PutCountingBlockstore struct {
-	blockstore.GCBlockstore
+	blockstore.Blockstore
 	PutCounter int
 }
 
 func (bs *PutCountingBlockstore) Put(block blocks.Block) error {
 	bs.PutCounter++
-	return bs.GCBlockstore.Put(block)
+	return bs.Blockstore.Put(block)
 }

--- a/core/builder.go
+++ b/core/builder.go
@@ -179,10 +179,12 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		opts.HasBloomFilterSize = 0
 	}
 
-	n.Blockstore, err = bstore.CachedBlockstore(bs, ctx, opts)
+	cbs, err := bstore.CachedBlockstore(bs, ctx, opts)
 	if err != nil {
 		return err
 	}
+
+	n.Blockstore = bstore.NewGCBlockstore(cbs, bstore.NewGCLocker())
 
 	rcfg, err := n.Repo.Config()
 	if err != nil {

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -22,7 +22,7 @@ import (
 	"gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore/sync"
 )
 
-func getMockDagServAndBstore(t testing.TB) (mdag.DAGService, blockstore.GCBlockstore) {
+func getMockDagServAndBstore(t testing.TB) (mdag.DAGService, blockstore.Blockstore) {
 	dstore := ds.NewMapDatastore()
 	tsds := sync.MutexWrap(dstore)
 	bstore := blockstore.NewBlockstore(tsds)


### PR DESCRIPTION
Factored out of #3257 (Add support for multiple blockstores).

License: MIT
Signed-off-by: Kevin Atkinson <k@kevina.org>