### PR TITLE
merkledag: optimize DagService GetLinks for Raw Nodes.

### DIFF
--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -114,6 +114,9 @@ func decodeBlock(b blocks.Block) (node.Node, error) {
 }
 
 func (n *dagService) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
+	if c.Type() == cid.Raw {
+		return nil, nil
+	}
 	node, err := n.Get(ctx, c)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A Raw Node can not possible have links, so there is no need to retrieve the node.

I mentioned this is this comment https://github.com/ipfs/go-ipfs/pull/3307#issuecomment-254061659.
Right now there are no tests for this and this doesn't need to go in right away, I just wanted to do this before I forgot about it.
