### PR TITLE
respect contexts when returning diagnostics responses

### DIFF
--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -191,7 +191,11 @@ func (d *Diagnostics) getDiagnosticFromPeers(ctx context.Context, peers map[peer
 				return
 			}
 			for d := range out {
-				respdata <- d
+				select {
+				case respdata <- d:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}(p)
 	}


### PR DESCRIPTION
Noticed a few of these building up in long running stack dumps. Easy enough fix.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>