### PR TITLE
no longer hard code gomaxprocs

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"runtime"
 	"runtime/pprof"
 	"strings"
 	"sync"
@@ -66,7 +65,6 @@ type cmdInvocation struct {
 // - if anything fails, print error, maybe with help
 func main() {
 	rand.Seed(time.Now().UnixNano())
-	runtime.GOMAXPROCS(3) // FIXME rm arbitrary choice for n
 	ctx := logging.ContextWithLoggable(context.Background(), loggables.Uuid("session"))
 	var err error
 	var invoc cmdInvocation


### PR DESCRIPTION
This hasnt been needed since go started auto-detecting the correct number of processors to use.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>