### PR TITLE
Put config keys in proper case

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -38,13 +38,13 @@ file inside your IPFS repository.
 
 Examples:
 
-Get the value of the 'datastore.path' key:
+Get the value of the 'Datastore.Path' key:
 
-  $ ipfs config datastore.path
+  $ ipfs config Datastore.Path
 
-Set the value of the 'datastore.path' key:
+Set the value of the 'Datastore.Path' key:
 
-  $ ipfs config datastore.path ~/.ipfs/datastore
+  $ ipfs config Datastore.Path ~/.ipfs/datastore
 `,
 	},
 


### PR DESCRIPTION
"datastore.path" should be "Datastore.Path"

  License: MIT
  Signed-off-by: David Brennan <david.n.brennan@gmail.com>