### PR TITLE
Revert "http api: makes sure header is sent even when r is not ready …

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -288,7 +288,6 @@ func sendResponse(w http.ResponseWriter, r *http.Request, res cmds.Response, req
 		log.Error("err: ", err)
 		w.Header().Set(StreamErrHeader, sanitizedErrStr(err))
 	}
-
 }
 
 func flushCopy(w io.Writer, r io.Reader) error {
@@ -299,9 +298,6 @@ func flushCopy(w io.Writer, r io.Reader) error {
 		return err
 	}
 	for {
-		// flush to send header when r is not ready yet
-		f.Flush()
-
 		n, err := r.Read(buf)
 		switch err {
 		case io.EOF:
@@ -324,6 +320,8 @@ func flushCopy(w io.Writer, r io.Reader) error {
 		if nw != n {
 			return fmt.Errorf("http write failed to write full amount: %d != %d", nw, n)
 		}
+
+		f.Flush()
 	}
 	return nil
 }


### PR DESCRIPTION
…yet. fixes #3304 (#3305)"

This reverts commit 68d8a298c58ed950bd44118cc5e6d1ffc2def395.

This broke ipfs add from js-ipfs-api. Related discussion on the commit page and at #3336.