### PR TITLE
configuration for labels-and-milestones sync tool

### DIFF
--- a/tools/labels-and-milestones/.gitignore
+++ b/tools/labels-and-milestones/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/labels-and-milestones/README.md
+++ b/tools/labels-and-milestones/README.md
@@ -1,0 +1,37 @@
+# labels-and-milestones Sync for go-ipfs
+
+> Sync labels and milestones across Github repositories
+
+This is a fork of [haadcode/labels-and-milestones](https://github.com/haadcode/labels-and-milestones). We are using it in a particular way. Check out the Readme in that repo for the "normal" usage instructions.
+
+## Requirements
+
+- Set `GITHUB_TOKEN` env var to Github personal access token
+- Install node/npm
+- Clone this repo
+
+## Install
+
+First install dependencies
+
+```bash
+npm install
+```
+
+## Configure
+
+Edit `go-ipfs-milestones.config.json` to list the repositories you want to sync to along with thethe Milestones and labels you want to sync.
+
+## Run the Sync Tool
+
+Then run the sync tool, providing the config file you want to use
+
+```bash
+npm run sync-milestones
+```
+
+This command will read `go-ipfs-milestones.config.json` and sync the labels and milestones to the target repos.
+
+#### Running via CI
+
+This will need some work. See [haadcode/labels-and-milestones](https://github.com/haadcode/labels-and-milestones) for more info.

--- a/tools/labels-and-milestones/go-ipfs-milestones.config.json
+++ b/tools/labels-and-milestones/go-ipfs-milestones.config.json
@@ -1,0 +1,79 @@
+[
+  {
+    "repositories": [
+      "ipfs/go-ipfs",
+      "ipfs/go-cid",
+      "ipfs/go-datastore",
+      "ipfs/go-ds-flatfs",
+      "ipfs/go-ds-measure",
+      "ipfs/go-ipfs-api",
+      "ipfs/go-ipfs-util",
+      "ipfs/go-key",
+      "ipfs/go-log",
+      "libp2p/go-libp2p",
+      "libp2p/go-libp2p-crypto",
+      "libp2p/go-libp2p-loggable",
+      "libp2p/go-libp2p-peer",
+      "libp2p/go-libp2p-peerstore",
+      "libp2p/go-libp2p-secio",
+      "libp2p/go-libp2p-transport",
+      "whyrusleeping/go-libp2p-pubsub"
+    ],
+    "milestones": [
+      {
+        "title": "ipld integration",
+        "state": "open",
+        "description": "integration of the ipld data format into go-ipfs",
+        "due_on": "2016-10-29"
+      },
+      {
+        "title": "IPFS Core API",
+        "state": "open",
+        "description": "This milestone's goal is to extract the gateway code into its own tool. This will facilitate the implementation of the Core API in go-ipfs. In the past months we've established a core set of commands that IPFS nodes can support. The JS implementation (js-ipfs and js-ipfs-api) is already compliant, and this milestone is all about starting to make the Go implementation (go-ipfs and go-ipfs-api) compliant. Check out https://github.com/ipfs/interface-ipfs-core",
+        "due_on": "2016-10-31"
+      },
+      {
+        "title": "Directory Sharding",
+        "state": "open",
+        "description": "ipfs unixfs currently can't handle large directories. We need to shard directories after they get to a certain size.",
+        "due_on": "2016-11-08"
+      },
+      {
+        "title": "ipfs 0.4.5",
+        "state": "open",
+        "description": "Release version 0.4.5 of go-ipfs",
+        "due_on": "2016-11-19"
+      },
+      {
+        "title": "Filestore implementation",
+        "state": "open",
+        "description": "",
+        "due_on": "2016-12-05"
+      },
+      {
+        "title": "Dont Kill Routers",
+        "state": "open",
+        "description": "Ipfs should strive not to kill peoples home internet connection. This milestone is for tracking router killer issues beyond the normal bandwidth problems.",
+        "due_on": "2016-12-12"
+      },
+      {
+        "title": "Reduce Resource Consumption",
+        "state": "open",
+        "description": "A milestone for reducing resource consumption down to a reasonable level within a fixed time scale (Q4 2016)",
+        "due_on": "2017-01-02"
+      },
+      {
+        "title": "Improve Developer Experience",
+        "state": "open",
+        "description": "We want to significantly improve the experience developers have using ipfs. This includes making the codebase more approachable, making tutorials, and making our tooling as perfect as we can get it.",
+        "due_on": "2017-01-02"
+      },
+      {
+        "title": "Improve Performance",
+        "state": "open",
+        "description": "IPFS is decently fast, but its nowhere near where we want it. This milestore is to get us to speed things up a bit.",
+        "due_on": "2017-01-09"
+      }
+    ]
+  }
+]

--- a/tools/labels-and-milestones/package.json
+++ b/tools/labels-and-milestones/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "go-ipfs-milestone-sync",
+  "version": "1.0.0",
+  "description": "Milestone and label sync for go-ipfs project",
+  "main": "index.js",
+  "scripts": {
+    "sync-milestones": "./node_modules/.bin/github-sync-labels-milestones -v -c go-ipfs-milestones.config.json -t $GITHUB_TOKEN",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Haad",
+  "license": "MIT",
+  "dependencies": {
+    "github-sync-labels-milestones": "0.2.1"
+  }
+}


### PR DESCRIPTION
I'm not convinced that this is where we want to store these config files for each project. I just set it up to imitate what @haadcode did in https://github.com/haadcode/orbit/tree/master/tools/roadmap-generator

This adds the labels-and-milestones sync tool with configs for the go-ipfs Q4 roadmap.

For more info, see ipfs/pm#257