### PR TITLE
Roadmap generator and Generated Q4 Roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,67 +1,72 @@
-# go-ipfs Q2 roadmap
-NOTE: No specific order is implied in this list.
+# go-ipfs - Roadmap
 
-- [ ] fix random test failures
-  - check issues for label 'test_failure'
-- [ ] Improve memory usage 
-  - [ ] Goal: ipfs doesnt run out of memory on mars for 1 month
-  - [ ] identify where most memory usage comes from
-  - [ ] find and fix leaks
-  - [ ] add more IPFS_LOW_MEM knobs
-    - [ ] dht query parallelism
-	- [ ] libp2p dial concurrency
-- [ ] unixfs sharding 
-  - [ ] revive old branch for this
-- [ ] go-iprs
-  - [ ] ipld?
-- [ ] gateway code in its own repo
-  - [ ] move ipfs/go-ipfs/commands to ipfs/commands
-  - [ ] move ipfs/go-ipfs/core/corehttp to ipfs/gateway
-  - [ ] vendor all back in with gx
-- [ ] fix progress bars
-  - [ ] no negative infinity! (before total size is computed)
-  - [ ] 'ipfs get' progress bar working
-- [ ] Reduce idle bandwidth usage 
-  - [ ] Goal: idle < 100kbps
-    - [ ] measure current idle BW loads to make sure this is reasonable
-  - [ ] investigate why dht is so chatty
-    - watch ipfs log tail
-  - [ ] make fewer calls to findpeer and findprovs
-    - [ ] identify where all these calls are made
-  - [ ] fix 'ipfs stats bw' discrepancy
-  - [ ] have test (using mocknet?) that tests bandwidth usage
-- [ ] Make bitswap waste less bandwidth
-  - [ ] Goal: 50% reduction in duplicate block sends
-    - [ ] Test to measure this
-  - [ ] reintroduce pluggable strategy
-- [ ] Fix Providers Problem 
-  - [ ] Goal: 10x bandwidth reduction from providing
-  - [ ] provide-many redo
-- [ ] Reduce bitswap RTT 
-  - [ ] decide on pathing language
-- [ ] Improve Disk performance 
-  - [ ] Goal: 1TB repo working nicely
-  - [ ] Goal: 2x improvement in 'ipfs-whatever' ops/s
-  - [ ] large repo perf #2405
-  - [ ] investigate flatfs calls
-    - [ ] reduce number of useless calls
-  - [ ] dagservice lru caching
-    - [ ] configurable size
-  - [ ] blockstore 'has block' bloom filter cache
-  - [ ] improve query perf
-  - [ ] different datastore backends
-    - [ ] datastore config PR
-	- [ ] introduce sql-datastore
-- [ ] NAT Traversal (go-ipfs side)
-  - [ ] DHT FindPeers only returns first result
-- Misc Issues (great place to start contibuting!)
-  - [ ] user friendly dht output #2494
-  - [ ] config file validations #2491
-  - [ ] object patch error bug #2473
-  - [ ] 'hash only' for ipfs files stat #2461
-  - [ ] ipfs repo fsck #2457
-  - [ ] command to list all logging subsystems #2434
-  - [ ] offline mode for daemon #2393
-  - [ ] fix dial filters for ipv6 #2329
-  - [ ] 'ipfs object diff'
-    - using code from merkledag/utils/diff.go
+This document describes the current status and the upcoming milestones of the go-ipfs project.
+
+*Updated: Tue, 15 Nov 2016 19:08:06 GMT*
+
+## Status and Progress
+
+[![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=Backlog&title=Backlog)](http://waffle.io/ipfs/go-ipfs) [![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=In%20Progress&title=In%20Progress)](http://waffle.io/ipfs/go-ipfs) [![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=Done&title=Done)](http://waffle.io/ipfs/go-ipfs)
+
+See details of current progress on [Orbit's project board](https://waffle.io/haadcode/orbit)
+
+#### Milestone Summary
+
+| Status | Milestone | Goals | ETA |
+| :---: | :--- | :---: | :---: |
+| 🚀 | **[ipld integration](#ipld-integration)** | 2 / 2 | Fri Oct 28 2016 |
+| 🚀 | **[IPFS Core API](#ipfs-core-api)** | 0 / 0 | Sun Oct 30 2016 |
+| 🚀 | **[Directory Sharding](#directory-sharding)** | 1 / 2 | Mon Nov 07 2016 |
+| 🚀 | **[ipfs 0.4.5](#ipfs-0.4.5)** | 0 / 2 | Fri Nov 18 2016 |
+| 🚀 | **[Filestore implementation](#filestore-implementation)** | 5 / 9 | Sun Dec 04 2016 |
+| 🚀 | **[Dont Kill Routers](#dont-kill-routers)** | 0 / 1 | Sun Dec 11 2016 |
+
+## Milestones and Goals
+
+#### ipld integration
+
+> integration of the ipld data format into go-ipfs
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**2 / 2** goals completed **(100%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Oct 28 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=ipld%20integration) for the list of goals this milestone has.
+#### IPFS Core API
+
+> This milestone's goal is to extract the gateway code into its own tool. This will facilitate the implementation of the Core API in go-ipfs.
+
+In the past months we've established a core set of commands that IPFS nodes can support. The JS implementation (js-ipfs and js-ipfs-api) is already compliant, and this milestone is all about starting to make the Go implementation (go-ipfs and go-ipfs-api) compliant. Check out https://github.com/ipfs/interface-ipfs-core
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 0** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Sun Oct 30 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=IPFS%20Core%20API) for the list of goals this milestone has.
+#### Directory Sharding
+
+> ipfs unixfs currently can't handle large directories. We need to shard directories after they get to a certain size.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**1 / 2** goals completed **(50%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Mon Nov 07 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=Directory%20Sharding) for the list of goals this milestone has.
+#### ipfs 0.4.5
+
+> Version 0.4.5 of go-ipfs
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 2** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Fri Nov 18 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=ipfs%200.4.5) for the list of goals this milestone has.
+#### Filestore implementation
+
+> 
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**5 / 9** goals completed **(55%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Sun Dec 04 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=Filestore%20implementation) for the list of goals this milestone has.
+#### Dont Kill Routers
+
+> Ipfs should strive not to kill peoples home internet connection. 
+
+This milestone is for tracking router killer issues beyond the normal bandwidth problems.
+
+🚀 &nbsp;**OPEN** &nbsp;&nbsp;📉 &nbsp;&nbsp;**0 / 1** goals completed **(0%)** &nbsp;&nbsp;📅 &nbsp;&nbsp;**Sun Dec 11 2016**
+
+See [milestone goals](https://waffle.io/ipfs/go-ipfs?milestone=Dont%20Kill%20Routers) for the list of goals this milestone has.
+

--- a/tools/roadmap-generator/.gitignore
+++ b/tools/roadmap-generator/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+ROADMAP.md

--- a/tools/roadmap-generator/README.md
+++ b/tools/roadmap-generator/README.md
@@ -1,0 +1,26 @@
+# go-ipfs Roadmap Generator
+
+This directory contains tools for generating this project's roadmap.
+
+Uses [roadmap-generator](https://github.com/haadcode/roadmap-generator).
+
+## Requirements
+- Node.js v6.x
+- Npm v3.x
+- GITHUB_TOKEN environment variable set
+  - See [Creating an access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for help.
+
+## Install
+```
+npm install
+```
+## Configure
+
+Put configuration in `go-ipfs-roadmap.conf.js`
+
+## Generate Roadmap
+```
+npm run roadmap
+```
+
+This will generate ROADMAP.md file in this directory. You can copy the ROADMAP.md file to the project's root directory and commit it to Git.

--- a/tools/roadmap-generator/go-ipfs-roadmap.conf.js
+++ b/tools/roadmap-generator/go-ipfs-roadmap.conf.js
@@ -1,0 +1,48 @@
+'use strict'
+
+module.exports = {
+  // Name of the organization or project this roadmap is generated for
+  organization: 'go-ipfs',
+
+  // Include open and closed milestones where due date is after milestonesStartDate
+  milestonesStartDate: '2016-10-01T00:00:00Z', // ISO formatted timestamp
+
+  // Include open and closed milestones where due date is before milestonesEndDate
+  milestonesEndDate: '2016-12-30T00:00:00Z', // ISO formatted timestamp
+
+  // Github repository to open open a Pull Request with the generated roadmap
+  targetRepo: "ipfs/go-ipfs", // 'owner/repo'
+
+  // List of projects that this roadmap covers
+  projects: [
+    {
+      name: "go-ipfs",
+      // Repositories that this project consists of.
+      repos: [
+        "ipfs/go-ipfs",
+        "ipfs/go-cid",
+        "ipfs/go-datastore",
+        "ipfs/go-ds-flatfs",
+        "ipfs/go-ds-measure",
+        "ipfs/go-ipfs-api",
+        "ipfs/go-ipfs-util",
+        "ipfs/go-key",
+        "ipfs/go-log",
+        "libp2p/go-libp2p",
+        "libp2p/go-libp2p-crypto",
+        "libp2p/go-libp2p-loggable",
+        "libp2p/go-libp2p-peer",
+        "libp2p/go-libp2p-peerstore",
+        "libp2p/go-libp2p-secio",
+        "libp2p/go-libp2p-transport",
+        "whyrusleeping/go-libp2p-pubsub"
+      ],
+      // WIP
+      links: {
+        status: `## Status and Progress\n
+[![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=Backlog&title=Backlog)](http://waffle.io/ipfs/go-ipfs) [![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=In%20Progress&title=In%20Progress)](http://waffle.io/ipfs/go-ipfs) [![Project Status](https://badge.waffle.io/ipfs/go-ipfs.svg?label=Done&title=Done)](http://waffle.io/ipfs/go-ipfs)\n
+See details of current progress on [Orbit's project board](https://waffle.io/haadcode/orbit)\n\n`
+      }
+    },
+  ]
+}

--- a/tools/roadmap-generator/package.json
+++ b/tools/roadmap-generator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "go-ipfs-roadmap-generator",
+  "version": "1.0.0",
+  "description": "Roadmap generator for go-ipfs project",
+  "main": "index.js",
+  "scripts": {
+    "roadmap": "node ./node_modules/.bin/roadmap-generator go-ipfs-roadmap.conf.js -s > ROADMAP.md",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Haad",
+  "license": "MIT",
+  "dependencies": {
+    "roadmap-generator": "0.0.3"
+  }
+}


### PR DESCRIPTION
* adds the roadmap-generator tool with configs for the go-ipfs Q4 roadmap.
* adds the generated ROADMAP.md

**Please check that the ROADMAP.md is accurate before merging!**

As with #3389, I'm not convinced that this is where we want to store these config files for each project. I just set it up to imitate what @haadcode did in https://github.com/haadcode/orbit/tree/master/tools/roadmap-generator

For more info, see ipfs/pm#257