### PR TITLE
(WIP) Feat/floodsub-unsubscribe

### DIFF
--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -147,6 +147,7 @@ func (i internalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			select {
 			case <-clientGone:
 			case <-ctx.Done():
+				log.Debug("connection closed: %s", r.URL)
 			}
 			cancel()
 		}()

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -16,7 +16,7 @@ import (
 	pstore "gx/ipfs/QmXXCcQ7CLg5a81Ui9TTR35QcR4y7ZyihxwfjqaHfUVcVo/go-libp2p-peerstore"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 	cid "gx/ipfs/QmcEcrBAMrwMyhSjXt4yfyPpzgSuV8HLHavnfmiKCSRqZU/go-cid"
-	floodsub "gx/ipfs/QmV6wterKiFaRLnprAE4vLu1C86iJA7mBy4bFnz5Q7UujG/floodsub"
+	floodsub "gx/ipfs/QmTJmZrciNELFZ9byA4bqHdtUas1LV9NqM1w37tBTtbvU5/floodsub"
 )
 
 var PubsubCmd = &cmds.Command{

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -16,7 +16,7 @@ import (
 	pstore "gx/ipfs/QmXXCcQ7CLg5a81Ui9TTR35QcR4y7ZyihxwfjqaHfUVcVo/go-libp2p-peerstore"
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 	cid "gx/ipfs/QmcEcrBAMrwMyhSjXt4yfyPpzgSuV8HLHavnfmiKCSRqZU/go-cid"
-	floodsub "gx/ipfs/Qmd6gKBjErWcfJLJ22wDJu1z2EqbFKb4wheNobZJtSxf8M/floodsub"
+	floodsub "gx/ipfs/QmV6wterKiFaRLnprAE4vLu1C86iJA7mBy4bFnz5Q7UujG/floodsub"
 )
 
 var PubsubCmd = &cmds.Command{
@@ -35,6 +35,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 	Subcommands: map[string]*cmds.Command{
 		"pub":   PubsubPubCmd,
 		"sub":   PubsubSubCmd,
+		"unsub": PubsubUnsubCmd,
 		"ls":    PubsubLsCmd,
 		"peers": PubsubPeersCmd,
 	},
@@ -87,16 +88,22 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 		res.SetOutput((<-chan interface{})(out))
 
 		ctx := req.Context()
+		var counter = 0
 		go func() {
 			defer close(out)
+			log.Debug("Starting pubsub/sub stream")
+			out <- string("{}")
 			for {
 				select {
 				case msg, ok := <-msgs:
+					counter ++
 					if !ok {
 						return
 					}
+					log.Debug("pubsub/sub messages: %d", counter)
 					out <- msg
 				case <-ctx.Done():
+					log.Debug("Closed pubsub/sub stream")
 					n.Floodsub.Unsub(topic)
 				}
 			}
@@ -301,6 +308,54 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 		res.SetOutput(&stringList{out})
 	},
 	Type: stringList{},
+	Marshalers: cmds.MarshalerMap{
+		cmds.Text: stringListMarshaler,
+	},
+}
+
+var PubsubUnsubCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Unsubscribe from a topic.",
+		ShortDescription: `
+ipfs pubsub unsub unsubscribes from a topic you are currently subscribed to.
+
+This is an experimental feature. It is not intended in its current state
+to be used in a production environment.
+
+To use, the daemon must be run with '--enable-pubsub-experiment'.
+`,
+	},
+	Arguments: []cmds.Argument{
+		cmds.StringArg("topic", true, false, "String name of topic to unsubscribe from."),
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		// Must be online!
+		if !n.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		if n.Floodsub == nil {
+			res.SetError(fmt.Errorf("experimental pubsub feature not enabled. Run daemon with --enable-pubsub-experiment to use."), cmds.ErrNormal)
+			return
+		}
+
+		topic := req.Arguments()[0]
+		ok, err := n.Floodsub.Unsub(topic)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		res.SetOutput(ok)
+	},
+	// Type: stringList{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: stringListMarshaler,
 	},

--- a/core/core.go
+++ b/core/core.go
@@ -41,6 +41,7 @@ import (
 	mamask "gx/ipfs/QmSMZwvs3n4GBikZ7hKzT17c3bk65FmyZo2JqtJ16swqCv/multiaddr-filter"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	b58 "gx/ipfs/QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf/go-base58"
+	floodsub "gx/ipfs/QmTJmZrciNELFZ9byA4bqHdtUas1LV9NqM1w37tBTtbvU5/floodsub"
 	swarm "gx/ipfs/QmU9ePpXRQgGpPpMAm1CsgU9KptrtgZERrVBGB7Ek5cM2D/go-libp2p-swarm"
 	ma "gx/ipfs/QmUAQaWbKxGCUTuoQVvvicbQNZ9APF5pDGWyAZSe93AtKH/go-multiaddr"
 	discovery "gx/ipfs/QmUYzZRJcuUxLSnSzF1bSyw1jYbNAULkBrbS6rnr7F72uK/go-libp2p/p2p/discovery"
@@ -56,7 +57,6 @@ import (
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 	ds "gx/ipfs/QmbzuUusHqaLLoNTDEVLcSF6vZDHZDLPC7p4bztRvvkXxU/go-datastore"
 	cid "gx/ipfs/QmcEcrBAMrwMyhSjXt4yfyPpzgSuV8HLHavnfmiKCSRqZU/go-cid"
-	floodsub "gx/ipfs/Qmd6gKBjErWcfJLJ22wDJu1z2EqbFKb4wheNobZJtSxf8M/floodsub"
 	peer "gx/ipfs/QmfMmLGoKzCHDN7cGgk64PJr4iipzidDRME8HABSJqvmhC/go-libp2p-peer"
 	ic "gx/ipfs/QmfWDLQjGjVe4fr5CoztYW2DYYjRysMJrFe1RCsXLPTf46/go-libp2p-crypto"
 )

--- a/package.json
+++ b/package.json
@@ -266,9 +266,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmd6gKBjErWcfJLJ22wDJu1z2EqbFKb4wheNobZJtSxf8M",
+      "hash": "QmTJmZrciNELFZ9byA4bqHdtUas1LV9NqM1w37tBTtbvU5",
       "name": "floodsub",
-      "version": "0.7.4"
+      "version": "0.8.2"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
This PR will add pubsub/unsub (unsubscribe) command to manually cancel subscriptions.

This PR is connected to https://github.com/libp2p/go-floodsub/pull/12.

I'm still unsure what the best approach is here for cancelling the subscriptions as a whole, but this works for me to move forward with js-ipfs-api integration (ie. I can test it).

I don't expect this to be merged necessarily, but leaving this here for reference and future discussions.
