### PR TITLE
"block rm": make channel large enough to avoid blocking

### DIFF
--- a/blocks/blockstore/util/remove.go
+++ b/blocks/blockstore/util/remove.go
@@ -27,7 +27,10 @@ type RmBlocksOpts struct {
 	Force  bool
 }
 
-func RmBlocks(blocks bs.GCBlockstore, pins pin.Pinner, out chan<- interface{}, cids []*cid.Cid, opts RmBlocksOpts) error {
+func RmBlocks(blocks bs.GCBlockstore, pins pin.Pinner, cids []*cid.Cid, opts RmBlocksOpts) (<-chan interface{}, error) {
+	// make the channel large enough to hold any result to avoid
+	// blocking while holding the GCLock	
+	out := make(chan interface{}, len(cids))
 	go func() {
 		defer close(out)
 
@@ -47,7 +50,7 @@ func RmBlocks(blocks bs.GCBlockstore, pins pin.Pinner, out chan<- interface{}, c
 			}
 		}
 	}()
-	return nil
+	return out, nil
 }
 
 func FilterPinned(pins pin.Pinner, out chan<- interface{}, cids []*cid.Cid) []*cid.Cid {

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -256,8 +256,7 @@ It takes a list of base58 encoded multihashs to remove.
 
 			cids = append(cids, c)
 		}
-		outChan := make(chan interface{})
-		err = util.RmBlocks(n.Blockstore, n.Pinning, outChan, cids, util.RmBlocksOpts{
+		ch, err := util.RmBlocks(n.Blockstore, n.Pinning, cids, util.RmBlocksOpts{
 			Quiet: quiet,
 			Force: force,
 		})
@@ -265,7 +264,7 @@ It takes a list of base58 encoded multihashs to remove.
 			res.SetError(err, cmds.ErrNormal)
 			return
 		}
-		res.SetOutput((<-chan interface{})(outChan))
+		res.SetOutput(ch)
 	},
 	PostRun: func(req cmds.Request, res cmds.Response) {
 		if res.Error() != nil {


### PR DESCRIPTION
Make the channel for the output of RmBlocks large enough to hold any result to avoid blocking while holding the GCLock.  Otherwise if you remove a large number of blocks and do something like:
```
  ipfs block rm ... | less
```
The GCLock will be held indefinitely blocking all pinning related operations.

