### PR TITLE
Issue #3419: Do not recursively resolve DAG just to obtain a CID

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -269,6 +269,11 @@ type RefKeyList struct {
 
 func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsNode) (map[string]RefKeyObject, error) {
 
+	mode, ok := pin.StringToPinMode(typeStr)
+	if !ok {
+		return nil, fmt.Errorf("Invalid pin mode '%s'", typeStr)
+	}
+
 	keys := make(map[string]RefKeyObject)
 
 	for _, p := range args {
@@ -277,17 +282,11 @@ func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsN
 			return nil, err
 		}
 
-		dagNode, err := core.Resolve(ctx, n.Namesys, n.Resolver, pth)
+		c, err := core.ResolveToCid(ctx, n, pth)
 		if err != nil {
 			return nil, err
 		}
 
-		mode, ok := pin.StringToPinMode(typeStr)
-		if !ok {
-			return nil, fmt.Errorf("Invalid pin mode '%s'", typeStr)
-		}
-
-		c := dagNode.Cid()
 		pinType, pinned, err := n.Pinning.IsPinnedWithType(c, mode)
 		if err != nil {
 			return nil, err

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -271,7 +271,7 @@ func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsN
 
 	mode, ok := pin.StringToPinMode(typeStr)
 	if !ok {
-		return nil, fmt.Errorf("Invalid pin mode '%s'", typeStr)
+		return nil, fmt.Errorf("invalid pin mode '%s'", typeStr)
 	}
 
 	keys := make(map[string]RefKeyObject)
@@ -293,7 +293,7 @@ func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsN
 		}
 
 		if !pinned {
-			return nil, fmt.Errorf("Path '%s' is not pinned", p)
+			return nil, fmt.Errorf("path '%s' is not pinned", p)
 		}
 
 		switch pinType {


### PR DESCRIPTION
Resolve() tries to fetch the object to check if it has to recursively do something with children (I think). It's overkill here (I think). See #3419 