### PR TITLE
merkledag: retain cid types when roundtripping through a ProtoNode

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -7,7 +7,6 @@ import (
 	pb "github.com/ipfs/go-ipfs/merkledag/pb"
 
 	node "gx/ipfs/QmRSU5EqqWVZSNdbU51yXmVoF1uNw3JgTNB6RaiL7DZM16/go-ipld-node"
-	mh "gx/ipfs/QmYDds3421prZgqKbLpEK7T9Aa2eVdQ7o3YarX1LVLdP2J/go-multihash"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
@@ -84,13 +83,10 @@ func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
 	}
 
 	if n.cached == nil {
-		if n.prefix.MhType == 0 { // unset
-			n.prefix.Codec = cid.DagProtobuf
-			n.prefix.MhLength = -1
-			n.prefix.MhType = mh.SHA2_256
-			n.prefix.Version = 0
+		if n.Prefix.Codec == 0 { // unset
+			n.Prefix = defaultCidPrefix
 		}
-		c, err := n.prefix.Sum(n.encoded)
+		c, err := n.Prefix.Sum(n.encoded)
 		if err != nil {
 			return nil, err
 		}

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -7,7 +7,7 @@ import (
 	pb "github.com/ipfs/go-ipfs/merkledag/pb"
 
 	node "gx/ipfs/QmRSU5EqqWVZSNdbU51yXmVoF1uNw3JgTNB6RaiL7DZM16/go-ipld-node"
-	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
+	mh "gx/ipfs/QmYDds3421prZgqKbLpEK7T9Aa2eVdQ7o3YarX1LVLdP2J/go-multihash"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 
@@ -84,7 +84,18 @@ func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
 	}
 
 	if n.cached == nil {
-		n.cached = cid.NewCidV0(u.Hash(n.encoded))
+		if n.prefix.MhType == 0 { // unset
+			n.prefix.Codec = cid.DagProtobuf
+			n.prefix.MhLength = -1
+			n.prefix.MhType = mh.SHA2_256
+			n.prefix.Version = 0
+		}
+		c, err := n.prefix.Sum(n.encoded)
+		if err != nil {
+			return nil, err
+		}
+
+		n.cached = c
 	}
 
 	return n.encoded, nil

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -103,6 +103,7 @@ func decodeBlock(b blocks.Block) (node.Node, error) {
 		}
 
 		decnd.cached = b.Cid()
+		decnd.prefix = b.Cid().Prefix()
 		return decnd, nil
 	case cid.Raw:
 		return NewRawNode(b.RawData()), nil

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -103,7 +103,7 @@ func decodeBlock(b blocks.Block) (node.Node, error) {
 		}
 
 		decnd.cached = b.Cid()
-		decnd.prefix = b.Cid().Prefix()
+		decnd.Prefix = b.Cid().Prefix()
 		return decnd, nil
 	case cid.Raw:
 		return NewRawNode(b.RawData()), nil

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -22,6 +22,9 @@ type ProtoNode struct {
 	encoded []byte
 
 	cached *cid.Cid
+
+	// prefix specifies cid version and hashing function
+	prefix cid.Prefix
 }
 
 type LinkSlice []*node.Link

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -23,8 +23,15 @@ type ProtoNode struct {
 
 	cached *cid.Cid
 
-	// prefix specifies cid version and hashing function
-	prefix cid.Prefix
+	// Prefix specifies cid version and hashing function
+	Prefix cid.Prefix
+}
+
+var defaultCidPrefix = cid.Prefix{
+	Codec:    cid.DagProtobuf,
+	MhLength: -1,
+	MhType:   mh.SHA2_256,
+	Version:  0,
 }
 
 type LinkSlice []*node.Link
@@ -222,9 +229,22 @@ func (n *ProtoNode) Loggable() map[string]interface{} {
 }
 
 func (n *ProtoNode) Cid() *cid.Cid {
-	h := n.Multihash()
+	if n.encoded != nil && n.cached != nil {
+		return n.cached
+	}
 
-	return cid.NewCidV0(h)
+	if n.Prefix.Codec == 0 {
+		n.Prefix = defaultCidPrefix
+	}
+
+	c, err := n.Prefix.Sum(n.RawData())
+	if err != nil {
+		// programmer error
+		panic(err)
+	}
+
+	n.cached = c
+	return c
 }
 
 func (n *ProtoNode) String() string {

--- a/merkledag/test/utils.go
+++ b/merkledag/test/utils.go
@@ -10,7 +10,10 @@ import (
 )
 
 func Mock() dag.DAGService {
+	return dag.NewDAGService(Bserv())
+}
+
+func Bserv() bsrv.BlockService {
 	bstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	bserv := bsrv.New(bstore, offline.Exchange(bstore))
-	return dag.NewDAGService(bserv)
+	return bsrv.New(bstore, offline.Exchange(bstore))
 }


### PR DESCRIPTION
Should address #3431

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>