### PR TITLE
bitswap: add a deadline to sendmsg calls

### DIFF
--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -38,7 +38,7 @@ type BitSwapNetwork interface {
 }
 
 type MessageSender interface {
-	SendMsg(bsmsg.BitSwapMessage) error
+	SendMsg(context.Context, bsmsg.BitSwapMessage) error
 	Close() error
 }
 

--- a/exchange/bitswap/testnet/virtual.go
+++ b/exchange/bitswap/testnet/virtual.go
@@ -119,8 +119,8 @@ type messagePasser struct {
 	ctx    context.Context
 }
 
-func (mp *messagePasser) SendMsg(m bsmsg.BitSwapMessage) error {
-	return mp.net.SendMessage(mp.ctx, mp.local, mp.target, m)
+func (mp *messagePasser) SendMsg(ctx context.Context, m bsmsg.BitSwapMessage) error {
+	return mp.net.SendMessage(ctx, mp.local, mp.target, m)
 }
 
 func (mp *messagePasser) Close() error {

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -196,7 +196,7 @@ func (mq *msgQueue) doWork(ctx context.Context) {
 
 	// send wantlist updates
 	for { // try to send this message until we fail.
-		err := mq.sender.SendMsg(wlm)
+		err := mq.sender.SendMsg(ctx, wlm)
 		if err == nil {
 			return
 		}


### PR DESCRIPTION
Bitswap occasionally gets stuck because writes hang (yamux....). this should at least keep bitswap from getting stuck here due to yamux:

ref: https://ipfs.io/ipfs/QmQn8YDTHWJzF7GVKUKanBzoxbzd5jQpwsgM2PfFVTKuGR

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>