### PR TITLE
bitswap: increase wantlist resend delay to one minute

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -57,7 +57,7 @@ func init() {
 	}
 }
 
-var rebroadcastDelay = delay.Fixed(time.Second * 10)
+var rebroadcastDelay = delay.Fixed(time.Minute)
 
 // New initializes a BitSwap instance that communicates over the provided
 // BitSwapNetwork. This function registers the returned instance as the network


### PR DESCRIPTION
I honestly thought this was removed a while ago, but here it is (see line 299). I'm going to bump this up to once per minute to make sure nothing weird starts happening. Then later we can completely remove it.

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>