### PR TITLE
Revert Add Defaults to `ipfs add` / Fix default logic of `--progress` option

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -37,11 +37,9 @@ const (
 
 var AddCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Add a file to ipfs.",
+		Tagline: "Add a file or directory to ipfs.",
 		ShortDescription: `
-Adds contents of <path> to ipfs. Use -r to add directories.
-Note that directories are added recursively, to form the ipfs
-MerkleDAG.
+Adds contents of <path> to ipfs. Use -r to add directories (recursively).
 `,
 		LongDescription: `
 Adds contents of <path> to ipfs. Use -r to add directories.
@@ -70,15 +68,15 @@ You can now refer to the added file in a gateway, like so:
 	},
 	Options: []cmds.Option{
 		cmds.OptionRecursivePath, // a builtin option that allows recursive paths (-r, --recursive)
-		cmds.BoolOption(quietOptionName, "q", "Write minimal output.").Default(false),
-		cmds.BoolOption(silentOptionName, "Write no output.").Default(false),
+		cmds.BoolOption(quietOptionName, "q", "Write minimal output."),
+		cmds.BoolOption(silentOptionName, "Write no output."),
 		cmds.BoolOption(progressOptionName, "p", "Stream progress data."),
-		cmds.BoolOption(trickleOptionName, "t", "Use trickle-dag format for dag generation.").Default(false),
-		cmds.BoolOption(onlyHashOptionName, "n", "Only chunk and hash - do not write to disk.").Default(false),
-		cmds.BoolOption(wrapOptionName, "w", "Wrap files with a directory object.").Default(false),
-		cmds.BoolOption(hiddenOptionName, "H", "Include files that are hidden. Only takes effect on recursive add.").Default(false),
+		cmds.BoolOption(trickleOptionName, "t", "Use trickle-dag format for dag generation."),
+		cmds.BoolOption(onlyHashOptionName, "n", "Only chunk and hash - do not write to disk."),
+		cmds.BoolOption(wrapOptionName, "w", "Wrap files with a directory object."),
+		cmds.BoolOption(hiddenOptionName, "H", "Include files that are hidden. Only takes effect on recursive add."),
 		cmds.StringOption(chunkerOptionName, "s", "Chunking algorithm to use."),
-		cmds.BoolOption(pinOptionName, "Pin this object when adding.").Default(true),
+		cmds.BoolOption(pinOptionName, "Pin this object when adding.  Default: true."),
 		cmds.BoolOption(rawLeavesOptionName, "Use raw blocks for leaf nodes. (experimental)"),
 	},
 	PreRun: func(req cmds.Request) error {
@@ -86,6 +84,7 @@ You can now refer to the added file in a gateway, like so:
 			return nil
 		}
 
+		// ipfs cli progress bar defaults to true
 		_, found, _ := req.Option(progressOptionName).Bool()
 		if !found {
 			req.SetOption(progressOptionName, true)
@@ -136,8 +135,12 @@ You can now refer to the added file in a gateway, like so:
 		hidden, _, _ := req.Option(hiddenOptionName).Bool()
 		silent, _, _ := req.Option(silentOptionName).Bool()
 		chunker, _, _ := req.Option(chunkerOptionName).String()
-		dopin, _, _ := req.Option(pinOptionName).Bool()
+		dopin, pin_found, _ := req.Option(pinOptionName).Bool()
 		rawblks, _, _ := req.Option(rawLeavesOptionName).Bool()
+
+		if !pin_found { // default
+			dopin = true
+		}
 
 		if hash {
 			nilnode, err := core.NewNode(n.Context(), &core.BuildCfg{
@@ -246,7 +249,7 @@ You can now refer to the added file in a gateway, like so:
 			return
 		}
 
-		progress, _, err := req.Option(progressOptionName).Bool()
+		progress, prgFound, err := req.Option(progressOptionName).Bool()
 		if err != nil {
 			res.SetError(u.ErrCast(), cmds.ErrNormal)
 			return
@@ -258,12 +261,15 @@ You can now refer to the added file in a gateway, like so:
 			return
 		}
 
-		if !quiet && !silent {
-			progress = true
+		var showProgressBar bool
+		if prgFound {
+			showProgressBar = progress
+		} else if !quiet && !silent {
+			showProgressBar = true
 		}
 
 		var bar *pb.ProgressBar
-		if progress {
+		if showProgressBar {
 			bar = pb.New64(0).SetUnits(pb.U_BYTES)
 			bar.ManualUpdate = true
 			bar.ShowTimeLeft = false
@@ -290,7 +296,7 @@ You can now refer to the added file in a gateway, like so:
 				}
 				output := out.(*coreunix.AddedObject)
 				if len(output.Hash) > 0 {
-					if progress {
+					if showProgressBar {
 						// clear progress bar line before we print "added x" output
 						fmt.Fprintf(res.Stderr(), "\033[2K\r")
 					}
@@ -303,7 +309,7 @@ You can now refer to the added file in a gateway, like so:
 				} else {
 					log.Debugf("add progress: %v %v\n", output.Name, output.Bytes)
 
-					if !progress {
+					if !showProgressBar {
 						continue
 					}
 
@@ -319,11 +325,11 @@ You can now refer to the added file in a gateway, like so:
 					totalProgress = bar.Add64(delta)
 				}
 
-				if progress {
+				if showProgressBar {
 					bar.Update()
 				}
 			case size := <-sizeChan:
-				if progress {
+				if showProgressBar {
 					bar.Total = size
 					bar.ShowPercent = true
 					bar.ShowBar = true

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -76,7 +76,7 @@ You can now refer to the added file in a gateway, like so:
 		cmds.BoolOption(wrapOptionName, "w", "Wrap files with a directory object."),
 		cmds.BoolOption(hiddenOptionName, "H", "Include files that are hidden. Only takes effect on recursive add."),
 		cmds.StringOption(chunkerOptionName, "s", "Chunking algorithm to use."),
-		cmds.BoolOption(pinOptionName, "Pin this object when adding.  Default: true."),
+		cmds.BoolOption(pinOptionName, "Pin this object when adding.").Default(true),
 		cmds.BoolOption(rawLeavesOptionName, "Use raw blocks for leaf nodes. (experimental)"),
 	},
 	PreRun: func(req cmds.Request) error {
@@ -135,12 +135,8 @@ You can now refer to the added file in a gateway, like so:
 		hidden, _, _ := req.Option(hiddenOptionName).Bool()
 		silent, _, _ := req.Option(silentOptionName).Bool()
 		chunker, _, _ := req.Option(chunkerOptionName).String()
-		dopin, pin_found, _ := req.Option(pinOptionName).Bool()
+		dopin, _, _ := req.Option(pinOptionName).Bool()
 		rawblks, _, _ := req.Option(rawLeavesOptionName).Bool()
-
-		if !pin_found { // default
-			dopin = true
-		}
 
 		if hash {
 			nilnode, err := core.NewNode(n.Context(), &core.BuildCfg{


### PR DESCRIPTION
This 
* reverts #2657 
* adds (back) the .Default(true) for the `--pin` option
* cleans up the default logic of the `--progress option`

Note: #2657 broke `--progress=false`.  After #2657 when `--progress=false` a useless progress bar is displayed:
```
$ ipfs add --progress=false afile 
added QmbWib2kLXUBpG8GZjRfmB3rEVE75SYCnN44AeLNz5Qe5V afile
 0 B / 96.00 MB [----------------------------------------------------------------------------------------------]   0.00%
```
This pull request fixes that.

The last commit "add cmd: clean up default logic of --progress option" correctly does what I think @RichardLitt was originally trying to do in 03dd669430474ae8396e6fe9eba9e47f01c0ed75 (part of  #2657).  If necessary it can be separated out into its own pull request.
