### PR TITLE
Do not require CI to pass for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,11 @@
 codecov:
   ci:
     - "ci/circle-ci"
-    - "!js-ipfs-ap"
-    - "!teamcity"
-    - "!continuous-integration/travis-ci/pr"
-    - "!continuous-integration/travis-ci/push"
+    - "!travis-ci.org"
+    - "!ci.ipfs.team:8111"
+    - "!ci.ipfs.team"
   notify:
+    require_ci_to_pass: no
     after_n_builds: 1
 coverage:
   range: "50...100"


### PR DESCRIPTION
If travis fail (or is cancelled) or random build failure happens, or
js-ipfs-api test is down for a long time we still want the coverage.


WIP

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>