### PR TITLE
makefile: use functions properly

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,7 @@ clean:
 
 bins: $(BINS)
 
-find_go_files = $(shell find $(1) -name "*.go")
+find_go_files = $(shell find $1 -name "*.go")
 
 # Non gx dependencies
 


### PR DESCRIPTION
Should solve the logs we see on OSX

But now I have no idea how it worked before

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>