### PR TITLE
swarm/peers: print 'n/a' instead of zero latency

### DIFF
--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -94,7 +94,12 @@ var swarmPeersCmd = &cmds.Command{
 			}
 
 			if verbose || latency {
-				ci.Latency = n.Peerstore.LatencyEWMA(pid).String()
+				lat := n.Peerstore.LatencyEWMA(pid)
+				if lat == 0 {
+					ci.Latency = "n/a"
+				} else {
+					ci.Latency = lat.String()
+				}
 			}
 			if verbose || streams {
 				strs, err := c.GetStreams()


### PR DESCRIPTION
closes #3125 

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>