### PR TITLE
Remove GC timeout, fix GC tests

### DIFF
--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -194,19 +194,7 @@ func (gc *GC) maybeGC(ctx context.Context, offset uint64) error {
 		if err := GarbageCollect(gc.Node, ctx); err != nil {
 			return err
 		}
-		newStorage, err := gc.Repo.GetStorageUsage()
-		if err != nil {
-			return err
-		}
-		log.Infof("Repo GC done. Released %s\n", humanize.Bytes(uint64(storage-newStorage)))
-		if newStorage > gc.StorageGC {
-			log.Warningf("post-GC: Watermark still exceeded")
-			if newStorage > gc.StorageMax {
-				err := ErrMaxStorageExceeded
-				log.Error(err)
-				return err
-			}
-		}
+		log.Infof("Repo GC done. See `ipfs repo stat` to see how much space got freed.\n")
 	}
 	return nil
 }

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -190,11 +190,8 @@ func (gc *GC) maybeGC(ctx context.Context, offset uint64) error {
 		// Do GC here
 		log.Info("Watermark exceeded. Starting repo GC...")
 		defer log.EventBegin(ctx, "repoGC").Done()
-		// 1 minute is sufficient for ~1GB unlink() blocks each of 100kb in SSD
-		_ctx, cancel := context.WithTimeout(ctx, time.Duration(gc.SlackGB)*time.Minute)
-		defer cancel()
 
-		if err := GarbageCollect(gc.Node, _ctx); err != nil {
+		if err := GarbageCollect(gc.Node, ctx); err != nil {
 			return err
 		}
 		newStorage, err := gc.Repo.GetStorageUsage()


### PR DESCRIPTION
Closes #3436 #2129

commit a9b8c8bbd5e243f12d44f67fdb46b80f7f096c5e
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Dec 9 17:26:53 2016 +0100

    gc: remove wonky timeout
    
    This timeout was:
    - unneccessary
    - based on a metric that doesn't make sense
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 8f0c7ee3b02ad0a56358d46f32abd7729e05a791
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Dec 9 17:28:31 2016 +0100

    gc: remove unneccessary full repo scan
    
    GetStorageUsage() is super expensive as it involves a full repo scan,
    and it's already bad enough that we have do it once.
    
    The call that's being removed here is purely for cosmetical purposes:
    printing the number of bytes freed by the GC run. Let's drop it.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>

commit 49802ebac9526740fb0d3dad2c39fe0b132589ba
Author: Lars Gierth <larsg@systemli.org>
Date:   Fri Dec 9 18:04:55 2016 +0100

    gc: fix and re-enable sharness tests
    
    I'm bumping up the waiting time significantly.
    I prefer a slightly slower test to no test at all.
    
    License: MIT
    Signed-off-by: Lars Gierth <larsg@systemli.org>
