### PR TITLE
merkledag: fix json marshalling of pbnode

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -60,7 +60,9 @@ func (n *ProtoNode) getPBNode() *pb.PBNode {
 		pbn.Links[i] = &pb.PBLink{}
 		pbn.Links[i].Name = &l.Name
 		pbn.Links[i].Tsize = &l.Size
-		pbn.Links[i].Hash = l.Cid.Bytes()
+		if l.Cid != nil {
+			pbn.Links[i].Hash = l.Cid.Bytes()
+		}
 	}
 
 	if len(n.data) > 0 {

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -229,6 +229,22 @@ func (n *ProtoNode) Loggable() map[string]interface{} {
 	}
 }
 
+func (n *ProtoNode) UnmarshalJSON(b []byte) error {
+	s := struct {
+		Data  []byte       `json:"data"`
+		Links []*node.Link `json:"links"`
+	}{}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	n.data = s.Data
+	n.links = s.Links
+	return nil
+}
+
 func (n *ProtoNode) MarshalJSON() ([]byte, error) {
 	out := map[string]interface{}{
 		"data":  n.data,

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -2,6 +2,7 @@ package merkledag
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	node "gx/ipfs/QmRSU5EqqWVZSNdbU51yXmVoF1uNw3JgTNB6RaiL7DZM16/go-ipld-node"
@@ -226,6 +227,15 @@ func (n *ProtoNode) Loggable() map[string]interface{} {
 	return map[string]interface{}{
 		"node": n.String(),
 	}
+}
+
+func (n *ProtoNode) MarshalJSON() ([]byte, error) {
+	out := map[string]interface{}{
+		"data":  n.data,
+		"links": n.links,
+	}
+
+	return json.Marshal(out)
 }
 
 func (n *ProtoNode) Cid() *cid.Cid {

--- a/merkledag/node_test.go
+++ b/merkledag/node_test.go
@@ -1,6 +1,7 @@
 package merkledag_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -126,5 +127,34 @@ func TestNodeCopy(t *testing.T) {
 
 	if nd.Data() == nil {
 		t.Fatal("should be different objects")
+	}
+}
+
+func TestJsonRoundtrip(t *testing.T) {
+	nd := new(ProtoNode)
+	nd.SetLinks([]*node.Link{
+		{Name: "a"},
+		{Name: "c"},
+		{Name: "b"},
+	})
+	nd.SetData([]byte("testing"))
+
+	jb, err := nd.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nn := new(ProtoNode)
+	err = nn.UnmarshalJSON(jb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(nn.Data(), nd.Data()) {
+		t.Fatal("data wasnt the same")
+	}
+
+	if !nn.Cid().Equals(nd.Cid()) {
+		t.Fatal("objects differed after marshaling")
 	}
 }

--- a/test/sharness/t0053-dag.sh
+++ b/test/sharness/t0053-dag.sh
@@ -46,6 +46,19 @@ test_dag_cmd() {
 		test_cmp file2 out2 &&
 		test_cmp file3 out3
 	'
+
+	test_expect_success "add a normal file" '
+		HASH=$(echo "foobar" | ipfs add -q)
+	'
+
+	test_expect_success "can view protobuf object with dag get" '
+		ipfs dag get $HASH > dag_get_pb_out
+	'
+
+	test_expect_success "output looks correct" '
+		echo "{\"data\":\"CAISB2Zvb2JhcgoYBw==\",\"links\":[]}" > dag_get_pb_exp &&
+		test_cmp dag_get_pb_exp dag_get_pb_out
+	'
 }
 
 # should work offline


### PR DESCRIPTION
previously `ipfs dag get` of a protobuf hash resulted in very unexpected output

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>