### PR TITLE
RFC: Handle Symbolic links in the Gateway

### DIFF
--- a/core/coreapi/interface/errors.go
+++ b/core/coreapi/interface/errors.go
@@ -3,6 +3,7 @@ package iface
 import "errors"
 
 var (
-	ErrIsDir   = errors.New("object is a directory")
-	ErrOffline = errors.New("can't resolve, ipfs node is offline")
+	ErrIsDir     = errors.New("object is a directory")
+	ErrOffline   = errors.New("can't resolve, ipfs node is offline")
+	ErrIsSymLink = errors.New("object is a symbolic link")
 )

--- a/core/coreapi/interface/unixfs.go
+++ b/core/coreapi/interface/unixfs.go
@@ -17,4 +17,7 @@ type UnixfsAPI interface {
 
 	// Ls returns the list of links in a directory
 	Ls(context.Context, Path) ([]*ipld.Link, error)
+
+	// ReadSymLink returns the contents of a symbolic link
+	ReadSymLink(context.Context, Path) (string, error)
 }

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -193,6 +193,46 @@ test_expect_success "GET compact blocks succeeds" '
   test_cmp expected actual
 '
 
+#
+#
+#
+
+test_expect_success "create dir with symbolic links" '
+  mkdir dirwlinks/ &&
+  ( cd dirwlinks &&
+    echo "A Simple File" > afile &&
+    ln -s afile linktofile &&
+    mkdir adir &&
+    echo "Another File" > adir/bfile &&
+    ln -s adir linktodir
+  )
+'
+
+test_expect_success "add dir with symbolic links" '
+  DIRHASH=$(ipfs add -Q -r dirwlinks)
+  echo $DIRHASH
+'
+
+test_expect_success "getting afile works" '
+  curl -L -o actual "http://127.0.0.1:$port/ipfs/$DIRHASH/afile" &&
+  test_cmp dirwlinks/afile actual
+'
+
+test_expect_success "getting linktofile works" '
+  curl -L -o actual "http://127.0.0.1:$port/ipfs/$DIRHASH/linktofile" &&
+  test_cmp dirwlinks/afile actual
+'
+
+test_expect_success "getting adir/bfile works" '
+  curl -L -o actual "http://127.0.0.1:$port/ipfs/$DIRHASH/adir/bfile" &&
+  test_cmp dirwlinks/adir/bfile actual
+'
+
+test_expect_failure "getting linktodir/bfile works" '
+  curl -L -o actual "http://127.0.0.1:$port/ipfs/$DIRHASH/linktodir/bfile" &&
+  test_cmp dirwlinks/adir/bfile actual
+'
+
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
Per @Kubuxu @lgierth request.

Closes https://github.com/ipfs/go-ipfs-gateway/issues/6

This is _one_ way to handle it.

Another would be to just have the `Cat` API call resolve the symbolic link.  Another would be to have the gateway resolve the link instead of using a HTTP Redirect.

I like the HTTP redirect because it is simple and better interacts with the browsers cache.  It also avoids any possible security problems from a malicious symbolic link.