### PR TITLE
Fixes nc on macOS not closing socket when the stdin sends EOF

### DIFF
--- a/test/sharness/t0235-cli-request.sh
+++ b/test/sharness/t0235-cli-request.sh
@@ -11,7 +11,9 @@ test_description="test http requests made by cli"
 test_init_ipfs
 
 test_expect_success "can make http request against nc server" '
-	go-sleep 0.5s | nc -l 5005 > nc_out &
+	nc -ld 5005 > nc_out &
+	NCPID=$!
+	go-sleep 0.5s && kill "$NCPID" &
 	ipfs cat /ipfs/Qmabcdef --api /ip4/127.0.0.1/tcp/5005 || true
 '
 


### PR DESCRIPTION
Uses `-d` option that is supported both by BSD and GNU nc.

Resolves: https://github.com/ipfs/go-ipfs/issues/3496

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>