### PR TITLE
Test/routing/offline 

### DIFF
--- a/routing/offline/offline_test.go
+++ b/routing/offline/offline_test.go
@@ -46,3 +46,34 @@ func TestOfflineRouterStorage(t *testing.T) {
 	}
 }
 
+func TestOfflineRouterLocal(t *testing.T) {
+	ctx := context.Background()
+
+	nds := ds.NewMapDatastore()
+	privkey, _, _ := testutil.RandTestKeyPair(128)
+	offline := NewOfflineRouter(nds, privkey)
+
+	id, _ := testutil.RandPeerID()
+	_, err := offline.FindPeer(ctx, id)
+	if err != ErrOffline {
+		t.Fatal("OfflineRouting should alert that its offline")
+	}
+
+	cid, _ := testutil.RandCidV0()
+	pChan := offline.FindProvidersAsync(ctx, cid, 1)
+	p, ok := <-pChan
+	if ok {
+		t.Fatalf("FindProvidersAsync did not return a closed channel. Instead we got %+v !", p)
+	}
+
+	cid, _ = testutil.RandCidV0()
+	err = offline.Provide(ctx, cid)
+	if err != ErrOffline {
+		t.Fatal("OfflineRouting should alert that its offline")
+	}
+
+	err = offline.Bootstrap(ctx)
+	if err != nil {
+		t.Fatal("You shouldn't be able to bootstrap offline routing.")
+	}
+}

--- a/thirdparty/testutil/gen.go
+++ b/thirdparty/testutil/gen.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
+	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 	peer "gx/ipfs/QmfMmLGoKzCHDN7cGgk64PJr4iipzidDRME8HABSJqvmhC/go-libp2p-peer"
 	ci "gx/ipfs/QmfWDLQjGjVe4fr5CoztYW2DYYjRysMJrFe1RCsXLPTf46/go-libp2p-crypto"
 
@@ -48,6 +49,14 @@ func RandPeerID() (peer.ID, error) {
 	}
 	h := u.Hash(buf)
 	return peer.ID(h), nil
+}
+
+func RandCidV0() (*cid.Cid, error) {
+	buf := make([]byte, 16)
+	if _, err := io.ReadFull(u.NewTimeSeededRand(), buf); err != nil {
+		return &cid.Cid{}, err
+	}
+	return cid.NewCidV0(buf), nil
 }
 
 func RandPeerIDFatal(t testing.TB) peer.ID {


### PR DESCRIPTION
PR for the ongoing coverage effort (https://github.com/ipfs/go-ipfs/issues/3053).

This PR creates tests for the offline routing package and puts coverage at %78.9.  I'm putting together a PR next week to remove some of the cruft in this package (`FindProviders`) at which point coverage will be at %81.1.
