### PR TITLE
gateway: disable Suborigins as it conflicts the spec

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -199,19 +199,6 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	// expose those headers
 	w.Header().Set("Access-Control-Expose-Headers", "X-Stream-Output, X-Chunked-Output")
 
-	// Suborigin header, sandboxes apps from each other in the browser (even
-	// though they are served from the same gateway domain).
-	//
-	// Omited if the path was treated by IPNSHostnameOption(), for example
-	// a request for http://example.net/ would be changed to /ipns/example.net/,
-	// which would turn into an incorrect Suborigin: example.net header.
-	//
-	// NOTE: This is not yet widely supported by browsers.
-	if !ipnsHostname {
-		pathRoot := strings.SplitN(urlPath, "/", 4)[2]
-		w.Header().Set("Suborigin", pathRoot)
-	}
-
 	// set these headers _after_ the error, for we may just not have it
 	// and dont want the client to cache a 500 response...
 	// and only if it's /ipfs!


### PR DESCRIPTION
The Suborigins spec was changed and we have to adjust, the spec is still
unstable and it might change in future. Currently the only browser
supporting it (Chrome) errors out on it as it doesn't confront spec it
uses.

See https://github.com/ipfs/specs/issues/131

Part of https://github.com/ipfs/go-ipfs/issues/3209

Proper solution requires: deciding on suborigin prefix, propagating go-multibase changes and exposing cdi.EncodeWithBase.

We can do that but I would want this to be fixed in 0.4.5 and we want to release very soon.

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>