### PR TITLE
commands: fix opt.Description panic when desc was empty

### DIFF
--- a/commands/option.go
+++ b/commands/option.go
@@ -43,7 +43,10 @@ func (o *option) Type() reflect.Kind {
 }
 
 func (o *option) Description() string {
-	if o.description[len(o.description)-1] != '.' {
+	if len(o.description) == 0 {
+		return ""
+	}
+	if !strings.HasSuffix(o.description, ".") {
 		o.description += "."
 	}
 	if o.defaultVal != nil {

--- a/commands/option_test.go
+++ b/commands/option_test.go
@@ -1,6 +1,9 @@
 package commands
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestOptionValueExtractBoolNotFound(t *testing.T) {
 	t.Log("ensure that no error is returned when value is not found")
@@ -25,5 +28,18 @@ func TestOptionValueExtractWrongType(t *testing.T) {
 	_, _, err = optval.Int()
 	if err == nil {
 		t.Fatal("No error returned. Failure.")
+	}
+}
+
+func TestLackOfDescriptionOfOptionDoesNotPanic(t *testing.T) {
+	opt := BoolOption("a", "")
+	opt.Description()
+}
+
+func TestDotIsAddedInDescripton(t *testing.T) {
+	opt := BoolOption("a", "desc without dot")
+	dest := opt.Description()
+	if !strings.HasSuffix(dest, ".") {
+		t.Fatal("dot should have been added at the end of description")
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/ipfs/go-ipfs/issues/3520

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>