### PR TITLE
sharness: don't run go-ipfs instance with default config

### DIFF
--- a/test/sharness/t0022-init-default.sh
+++ b/test/sharness/t0022-init-default.sh
@@ -48,8 +48,4 @@ test_expect_success "ipfs config output looks good" '
 	test_cmp expected actual
 '
 
-test_launch_ipfs_daemon --offline
-
-test_kill_ipfs_daemon
-
 test_done


### PR DESCRIPTION
It conflicts with already running instance on the Dev's machine so
running this test requires disabling the normal ipfs.

The launch of ipfs here doesn't test much as we compare the config,
after initing from it and we also launch from default config in many
other cases (with few variables changed to not conflict with already
running standalone ipfs instance).