### PR TITLE
Colorful help (#340) and some help refactoring

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -166,7 +166,7 @@ Headers.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
 		// cmds.StringOption(swarmAddrKwd, "Address for the swarm socket (overrides config)"),
 	},
-	Subcommands: map[string]*cmds.Command{},
+	Subcommands: []*cmds.CmdInfo{},
 	Run:         daemonFunc,
 }
 

--- a/cmd/ipfs/ipfs.go
+++ b/cmd/ipfs/ipfs.go
@@ -20,23 +20,38 @@ var commandsClientCmd = commands.CommandsCmd(Root)
 
 // Commands in localCommands should always be run locally (even if daemon is running).
 // They can override subcommands in commands.Root by defining a subcommand with the same name.
-var localCommands = []*cmds.CmdInfo{
-	{"daemon", daemonCmd, ""},
-	{"init", initCmd, ""},
-	{"commands", commandsClientCmd, ""},
+// The key in  this map is the position in the help text. As with the whole subcommand, the
+// explicit positioning here takes precedence over the implicit one in commands.Root.Subcommands.
+var localCommands = map[uint]*cmds.CmdInfo{
+	10: {"daemon", daemonCmd, "ADVANCED COMMANDS"},
+	0:  {"init", initCmd, "BASIC COMMANDS"},
+	32: {"commands", commandsClientCmd, "TOOL COMMANDS"},
 }
 var localMap = make(map[*cmds.Command]bool)
+
+func localCommandExists(name string) bool {
+	for _, v := range localCommands {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 func init() {
 	// setting here instead of in literal to prevent initialization loop
 	// (some commands make references to Root)
-	Root.Subcommands = localCommands
 
-	// copy all subcommands from commands.Root into this root (if they aren't already present)
-	for _, globalCmdInfo := range commands.Root.Subcommands {
-		if Root.Subcommand(globalCmdInfo.Name) == nil {
-			Root.Subcommands = append(Root.Subcommands, globalCmdInfo)
+	// copy all subcommands which don't exist in localCommands from commands.Root into this root
+	for _, v := range commands.Root.Subcommands {
+		if !localCommandExists(v.Name) {
+			Root.Subcommands = append(Root.Subcommands, v)
 		}
+	}
+
+	// add local commands to this root in the right position
+	for k, v := range localCommands {
+		Root.Subcommands = append(Root.Subcommands[:k], append([]*cmds.CmdInfo{v}, Root.Subcommands[k:]...)...)
 	}
 
 	for _, v := range localCommands {

--- a/cmd/ipfs/ipfs.go
+++ b/cmd/ipfs/ipfs.go
@@ -20,10 +20,10 @@ var commandsClientCmd = commands.CommandsCmd(Root)
 
 // Commands in localCommands should always be run locally (even if daemon is running).
 // They can override subcommands in commands.Root by defining a subcommand with the same name.
-var localCommands = map[string]*cmds.Command{
-	"daemon":   daemonCmd,
-	"init":     initCmd,
-	"commands": commandsClientCmd,
+var localCommands = []*cmds.CmdInfo{
+	{"daemon", daemonCmd, ""},
+	{"init", initCmd, ""},
+	{"commands", commandsClientCmd, ""},
 }
 var localMap = make(map[*cmds.Command]bool)
 
@@ -33,14 +33,14 @@ func init() {
 	Root.Subcommands = localCommands
 
 	// copy all subcommands from commands.Root into this root (if they aren't already present)
-	for k, v := range commands.Root.Subcommands {
-		if _, found := Root.Subcommands[k]; !found {
-			Root.Subcommands[k] = v
+	for _, globalCmdInfo := range commands.Root.Subcommands {
+		if Root.Subcommand(globalCmdInfo.Name) == nil {
+			Root.Subcommands = append(Root.Subcommands, globalCmdInfo)
 		}
 	}
 
 	for _, v := range localCommands {
-		localMap[v] = true
+		localMap[v.Cmd] = true
 	}
 }
 

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -366,9 +366,8 @@ func commandDetails(path []string, root *cmds.Command) (*cmdDetails, error) {
 	// find the last command in path that has a cmdDetailsMap entry
 	cmd := root
 	for _, cmp := range path {
-		var found bool
-		cmd, found = cmd.Subcommands[cmp]
-		if !found {
+		cmd = cmd.Subcommand(cmp)
+		if cmd == nil {
 			return nil, fmt.Errorf("subcommand %s should be in root", cmp)
 		}
 

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -86,12 +86,19 @@ func main() {
 	// this is a local helper to print out help text.
 	// there's some considerations that this makes easier.
 	printHelp := func(long bool, w io.Writer) {
+		useColor := false
+		for _, str := range os.Args {
+			if str == "--color" {
+				useColor = true
+			}
+		}
+
 		helpFunc := cmdsCli.ShortHelp
 		if long {
 			helpFunc = cmdsCli.LongHelp
 		}
 
-		helpFunc("ipfs", Root, invoc.path, w)
+		helpFunc("ipfs", Root, invoc.path, w, useColor)
 	}
 
 	// this is a message to tell the user how to get the help text

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -86,19 +86,12 @@ func main() {
 	// this is a local helper to print out help text.
 	// there's some considerations that this makes easier.
 	printHelp := func(long bool, w io.Writer) {
-		useColor := false
-		for _, str := range os.Args {
-			if str == "--color" {
-				useColor = true
-			}
-		}
-
 		helpFunc := cmdsCli.ShortHelp
 		if long {
 			helpFunc = cmdsCli.LongHelp
 		}
 
-		helpFunc("ipfs", Root, invoc.path, w, useColor)
+		helpFunc("ipfs", Root, invoc.path, invoc.req, w)
 	}
 
 	// this is a message to tell the user how to get the help text

--- a/commands/cli/cmd_suggestion.go
+++ b/commands/cli/cmd_suggestion.go
@@ -50,9 +50,9 @@ func suggestUnknownCmd(args []string, root *cmds.Command) []string {
 	}
 
 	// Start with a simple strings.Contains check
-	for name, _ := range root.Subcommands {
-		if strings.Contains(arg, name) {
-			suggestions = append(suggestions, name)
+	for _, cInfo := range root.Subcommands {
+		if strings.Contains(arg, cInfo.Name) {
+			suggestions = append(suggestions, cInfo.Name)
 		}
 	}
 
@@ -61,10 +61,10 @@ func suggestUnknownCmd(args []string, root *cmds.Command) []string {
 		return suggestions
 	}
 
-	for name, _ := range root.Subcommands {
-		lev := levenshtein.DistanceForStrings([]rune(arg), []rune(name), options)
+	for _, cInfo := range root.Subcommands {
+		lev := levenshtein.DistanceForStrings([]rune(arg), []rune(cInfo.Name), options)
 		if lev <= MIN_LEVENSHTEIN {
-			sortableSuggestions = append(sortableSuggestions, &suggestion{name, lev})
+			sortableSuggestions = append(sortableSuggestions, &suggestion{cInfo.Name, lev})
 		}
 	}
 	sort.Sort(sortableSuggestions)

--- a/commands/cli/helptext.go
+++ b/commands/cli/helptext.go
@@ -352,31 +352,19 @@ func subcommandText(cmd *cmds.Command, rootName string, path []string) []string 
 		prefix += " "
 	}
 
-	// Sorting fixes changing order bug #2981.
-	sortedNames := make([]string, 0)
-	for name := range cmd.Subcommands {
-		sortedNames = append(sortedNames, name)
-	}
-	sort.Strings(sortedNames)
-
-	subcmds := make([]*cmds.Command, len(cmd.Subcommands))
 	lines := make([]string, len(cmd.Subcommands))
 
-	for i, name := range sortedNames {
-		sub := cmd.Subcommands[name]
-		usage := usageText(sub)
+	for i, cInfo := range cmd.Subcommands {
+		usage := usageText(cInfo.Cmd)
 		if len(usage) > 0 {
 			usage = " " + usage
 		}
-		lines[i] = prefix + name + usage
-		subcmds[i] = sub
+		lines[i] = prefix + cInfo.Name + usage
 	}
-
 	lines = align(lines)
-	for i, sub := range subcmds {
-		lines[i] += " - " + sub.Helptext.Tagline
+	for i, cInfo := range cmd.Subcommands {
+		lines[i] += " - " + cInfo.Cmd.Helptext.Tagline
 	}
-
 	return lines
 }
 

--- a/commands/cli/helptext_test.go
+++ b/commands/cli/helptext_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"bytes"
 	cmds "github.com/ipfs/go-ipfs/commands"
+	"github.com/ipfs/go-ipfs/core/commands"
 )
 
 func TestSynopsisGenerator(t *testing.T) {
@@ -42,4 +44,41 @@ func TestSynopsisGenerator(t *testing.T) {
 	if !strings.Contains(syn, "[--]") {
 		t.Fatal("Synopsis should contain options finalizer")
 	}
+}
+
+func TestColorOutput(t *testing.T) {
+	opt := cmds.BoolOption("color", "Use colors in console output.").Default(false)
+	opts := map[string]cmds.Option{"color": opt}
+	colorReq, _ := cmds.NewRequest(nil, cmds.OptMap{"color": true}, []string{}, nil, nil, opts)
+	buf := new(bytes.Buffer)
+
+	LongHelp("ipfs", commands.Root, []string{}, colorReq, buf)
+	colorFullLongHelp := buf.String()
+	cyanCount := strings.Count(colorFullLongHelp, formatCyan)
+	resetCount := strings.Count(colorFullLongHelp, formatReset)
+	if cyanCount == 0 {
+		t.Fatal("Colorful long help should contain the cyan escape code")
+	}
+	if resetCount == 0 {
+		t.Fatal("Colorful long help should contain the reset escape code")
+	}
+	if resetCount < cyanCount {
+		t.Fatal("There should be at least as many reset escape codes as cyan escape codes")
+	}
+
+	buf = new(bytes.Buffer)
+	ShortHelp("ipfs", commands.Root, []string{}, colorReq, buf)
+	colorFullShortHelp := buf.String()
+	cyanCount = strings.Count(colorFullShortHelp, formatCyan)
+	resetCount = strings.Count(colorFullShortHelp, formatReset)
+	if cyanCount == 0 {
+		t.Fatal("Colorful shot help should contain the cyan escape code")
+	}
+	if resetCount == 0 {
+		t.Fatal("Colorful shot help should contain the reset escape code")
+	}
+	if resetCount < cyanCount {
+		t.Fatal("There should be at least as many reset escape codes as cyan escape codes")
+	}
+
 }

--- a/commands/cli/parse_test.go
+++ b/commands/cli/parse_test.go
@@ -72,8 +72,8 @@ func TestOptionParsing(t *testing.T) {
 			commands.StringOption("string", "s", "a string"),
 			commands.BoolOption("bool", "b", "a bool"),
 		},
-		Subcommands: map[string]*commands.Command{
-			"test": subCmd,
+		Subcommands: []*commands.CmdInfo{
+			{"test", subCmd, ""},
 		},
 	}
 
@@ -142,62 +142,72 @@ func TestArgumentParsing(t *testing.T) {
 		t.Skip("stdin handling doesnt yet work on windows")
 	}
 	rootCmd := &commands.Command{
-		Subcommands: map[string]*commands.Command{
-			"noarg": {},
-			"onearg": {
+		Subcommands: []*commands.CmdInfo{
+			{"noarg", &commands.Command{}, ""},
+			{"onearg", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg"),
-				},
+				}},
+				"",
 			},
-			"twoargs": {
+			{"twoargs", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg"),
 					commands.StringArg("b", true, false, "another arg"),
-				},
+				}},
+				"",
 			},
-			"variadic": {
+			{"variadic", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, true, "some arg"),
-				},
+				}},
+				"",
 			},
-			"optional": {
+			{"optional", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("b", false, true, "another arg"),
-				},
+				}},
+				"",
 			},
-			"optionalsecond": {
+			{"optionalsecond", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg"),
 					commands.StringArg("b", false, false, "another arg"),
-				},
+				}},
+				"",
 			},
-			"reversedoptional": {
+			{"reversedoptional", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", false, false, "some arg"),
 					commands.StringArg("b", true, false, "another arg"),
-				},
+				}},
+				"",
 			},
-			"stdinenabled": {
+			{"stdinenabled", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, true, "some arg").EnableStdin(),
-				},
+				}},
+				"",
 			},
-			"stdinenabled2args": &commands.Command{
+			{"stdinenabled2args", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg"),
 					commands.StringArg("b", true, true, "another arg").EnableStdin(),
-				},
+				}},
+				"",
 			},
-			"stdinenablednotvariadic": &commands.Command{
+			{"stdinenablednotvariadic", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg").EnableStdin(),
-				},
+				}},
+				"",
 			},
-			"stdinenablednotvariadic2args": &commands.Command{
+			{"stdinenablednotvariadic2args", &commands.Command{
 				Arguments: []commands.Argument{
 					commands.StringArg("a", true, false, "some arg"),
 					commands.StringArg("b", true, false, "another arg").EnableStdin(),
-				},
+				}},
+				"",
 			},
 		},
 	}

--- a/commands/command.go
+++ b/commands/command.go
@@ -75,7 +75,13 @@ type Command struct {
 	//
 	// ie. If command Run returns &Block{}, then Command.Type == &Block{}
 	Type        interface{}
-	Subcommands map[string]*Command
+	Subcommands []*CmdInfo
+}
+
+type CmdInfo struct {
+	Name  string
+	Cmd   *Command
+	Group string
 }
 
 // ErrNotCallable signals a command that cannot be called.
@@ -266,7 +272,12 @@ func (c *Command) CheckArguments(req Request) error {
 
 // Subcommand returns the subcommand with the given id
 func (c *Command) Subcommand(id string) *Command {
-	return c.Subcommands[id]
+	for _, cInfo := range c.Subcommands {
+		if cInfo.Name == id {
+			return cInfo.Cmd
+		}
+	}
+	return nil
 }
 
 type CommandVisitor func(*Command)
@@ -274,8 +285,8 @@ type CommandVisitor func(*Command)
 // Walks tree of all subcommands (including this one)
 func (c *Command) Walk(visitor CommandVisitor) {
 	visitor(c)
-	for _, cm := range c.Subcommands {
-		cm.Walk(visitor)
+	for _, cInfo := range c.Subcommands {
+		cInfo.Cmd.Walk(visitor)
 	}
 }
 

--- a/commands/command.go
+++ b/commands/command.go
@@ -39,6 +39,8 @@ type HelpText struct {
 	Tagline               string            // used in <cmd usage>
 	ShortDescription      string            // used in DESCRIPTION
 	SynopsisOptionsValues map[string]string // mappings for synopsis generator
+	// optional
+	AdditionalHelp string // can be used to add additional information
 
 	// optional - whole section overrides
 	Usage           string // overrides USAGE section

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -103,8 +103,8 @@ func TestRegistration(t *testing.T) {
 			IntOption("beep", "number of beeps"),
 		},
 		Run: noop,
-		Subcommands: map[string]*Command{
-			"a": cmdA,
+		Subcommands: []*CmdInfo{
+			{"a", cmdA, ""},
 		},
 	}
 
@@ -130,20 +130,20 @@ func TestRegistration(t *testing.T) {
 func TestResolving(t *testing.T) {
 	cmdC := &Command{}
 	cmdB := &Command{
-		Subcommands: map[string]*Command{
-			"c": cmdC,
+		Subcommands: []*CmdInfo{
+			{"c", cmdC, ""},
 		},
 	}
 	cmdB2 := &Command{}
 	cmdA := &Command{
-		Subcommands: map[string]*Command{
-			"b": cmdB,
-			"B": cmdB2,
+		Subcommands: []*CmdInfo{
+			{"b", cmdB, ""},
+			{"B", cmdB2, ""},
 		},
 	}
 	cmd := &Command{
-		Subcommands: map[string]*Command{
-			"a": cmdA,
+		Subcommands: []*CmdInfo{
+			{"a", cmdA, ""},
 		},
 	}
 
@@ -158,9 +158,9 @@ func TestResolving(t *testing.T) {
 
 func TestWalking(t *testing.T) {
 	cmdA := &Command{
-		Subcommands: map[string]*Command{
-			"b": &Command{},
-			"B": &Command{},
+		Subcommands: []*CmdInfo{
+			{"b", &Command{}, ""},
+			{"B", &Command{}, ""},
 		},
 	}
 	i := 0
@@ -182,8 +182,8 @@ func TestHelpProcessing(t *testing.T) {
 		Helptext: HelpText{
 			ShortDescription: "This is short",
 		},
-		Subcommands: map[string]*Command{
-			"a": cmdB,
+		Subcommands: []*CmdInfo{
+			{"a", cmdB, ""},
 		},
 	}
 	cmdA.ProcessHelp()

--- a/commands/http/handler_test.go
+++ b/commands/http/handler_test.go
@@ -58,8 +58,8 @@ func getTestServer(t *testing.T, origins []string) *httptest.Server {
 	}
 
 	cmdRoot := &cmds.Command{
-		Subcommands: map[string]*cmds.Command{
-			"version": ipfscmd.VersionCmd,
+		Subcommands: []*cmds.CmdInfo{
+			{"version", ipfscmd.VersionCmd, ""},
 		},
 	}
 

--- a/core/commands/active.go
+++ b/core/commands/active.go
@@ -24,9 +24,9 @@ Lists running and recently run commands.
 	Options: []cmds.Option{
 		cmds.BoolOption("verbose", "v", "Print extra information.").Default(false),
 	},
-	Subcommands: map[string]*cmds.Command{
-		"clear":    clearInactiveCmd,
-		"set-time": setRequestClearCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"clear", clearInactiveCmd, ""},
+		{"set-time", setRequestClearCmd, ""},
 	},
 	Marshalers: map[cmds.EncodingType]cmds.Marshaler{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -20,11 +20,11 @@ var BitswapCmd = &cmds.Command{
 		Tagline:          "Interact with the bitswap agent.",
 		ShortDescription: ``,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"wantlist": showWantlistCmd,
-		"stat":     bitswapStatCmd,
-		"unwant":   unwantCmd,
-		"ledger":   ledgerCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"wantlist", showWantlistCmd, ""},
+		{"stat", bitswapStatCmd, ""},
+		{"unwant", unwantCmd, ""},
+		{"ledger", ledgerCmd, ""},
 	},
 }
 

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -35,11 +35,11 @@ multihash.
 `,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"stat": blockStatCmd,
-		"get":  blockGetCmd,
-		"put":  blockPutCmd,
-		"rm":   blockRmCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"stat", blockStatCmd, ""},
+		{"get", blockGetCmd, ""},
+		{"put", blockPutCmd, ""},
+		{"rm", blockRmCmd, ""},
 	},
 }
 

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -31,10 +31,10 @@ Running 'ipfs bootstrap' with no arguments will run 'ipfs bootstrap list'.
 	Marshalers: bootstrapListCmd.Marshalers,
 	Type:       bootstrapListCmd.Type,
 
-	Subcommands: map[string]*cmds.Command{
-		"list": bootstrapListCmd,
-		"add":  bootstrapAddCmd,
-		"rm":   bootstrapRemoveCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"list", bootstrapListCmd, ""},
+		{"add", bootstrapAddCmd, ""},
+		{"rm", bootstrapRemoveCmd, ""},
 	},
 }
 
@@ -53,8 +53,8 @@ in the bootstrap list).
 	Options: []cmds.Option{
 		cmds.BoolOption("default", "Add default bootstrap nodes. (Deprecated, use 'default' subcommand instead)"),
 	},
-	Subcommands: map[string]*cmds.Command{
-		"default": bootstrapAddDefaultCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"default", bootstrapAddDefaultCmd, ""},
 	},
 
 	Run: func(req cmds.Request, res cmds.Response) {
@@ -192,8 +192,8 @@ var bootstrapRemoveCmd = &cmds.Command{
 	Options: []cmds.Option{
 		cmds.BoolOption("all", "Remove all bootstrap peers. (Deprecated, use 'all' subcommand)"),
 	},
-	Subcommands: map[string]*cmds.Command{
-		"all": bootstrapRemoveAllCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"all", bootstrapRemoveAllCmd, ""},
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		all, _, err := req.Option("all").Bool()

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -72,7 +72,7 @@ func cmd2outputCmd(name string, cmd *cmds.Command) Command {
 
 	i := 0
 	for _, cInfo := range cmd.Subcommands {
-		output.Subcommands[i] = cmd2outputCmd(name, cInfo.Cmd)
+		output.Subcommands[i] = cmd2outputCmd(cInfo.Name, cInfo.Cmd)
 		i++
 	}
 

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -71,8 +71,8 @@ func cmd2outputCmd(name string, cmd *cmds.Command) Command {
 	}
 
 	i := 0
-	for name, sub := range cmd.Subcommands {
-		output.Subcommands[i] = cmd2outputCmd(name, sub)
+	for _, cInfo := range cmd.Subcommands {
+		output.Subcommands[i] = cmd2outputCmd(name, cInfo.Cmd)
 		i++
 	}
 

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -127,10 +127,10 @@ Set the value of the 'Datastore.Path' key:
 		},
 	},
 	Type: ConfigField{},
-	Subcommands: map[string]*cmds.Command{
-		"show":    configShowCmd,
-		"edit":    configEditCmd,
-		"replace": configReplaceCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"show", configShowCmd, ""},
+		{"edit", configEditCmd, ""},
+		{"replace", configReplaceCmd, ""},
 	},
 }
 

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -23,10 +23,7 @@ This subcommand is currently an experimental feature, but it is intended
 to deprecate and replace the existing 'ipfs object' command moving forward.
 		`,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"put": DagPutCmd,
-		"get": DagGetCmd,
-	},
+	Subcommands: []*cmds.CmdInfo{{"put", DagPutCmd, ""}, {"get", DagGetCmd, ""}},
 }
 
 type OutputObject struct {

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -30,13 +30,13 @@ var DhtCmd = &cmds.Command{
 		ShortDescription: ``,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"query":     queryDhtCmd,
-		"findprovs": findProvidersDhtCmd,
-		"findpeer":  findPeerDhtCmd,
-		"get":       getValueDhtCmd,
-		"put":       putValueDhtCmd,
-		"provide":   provideRefDhtCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"query", queryDhtCmd, ""},
+		{"findprovs", findProvidersDhtCmd, ""},
+		{"findpeer", findPeerDhtCmd, ""},
+		{"get", getValueDhtCmd, ""},
+		{"put", putValueDhtCmd, ""},
+		{"provide", provideRefDhtCmd, ""},
 	},
 }
 

--- a/core/commands/diag.go
+++ b/core/commands/diag.go
@@ -45,10 +45,10 @@ var DiagCmd = &cmds.Command{
 		Tagline: "Generate diagnostic reports.",
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"net":  diagNetCmd,
-		"sys":  sysDiagCmd,
-		"cmds": ActiveReqsCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"net", diagNetCmd, ""},
+		{"sys", sysDiagCmd, ""},
+		{"cmds", ActiveReqsCmd, ""},
 	},
 }
 

--- a/core/commands/external.go
+++ b/core/commands/external.go
@@ -17,6 +17,10 @@ func ExternalBinary() *cmds.Command {
 			cmds.StringArg("args", false, true, "Arguments for subcommand."),
 		},
 		External: true,
+		Helptext: cmds.HelpText{
+			Tagline:          "Download and apply go-ipfs updates",
+			ShortDescription: `Download and apply go-ipfs updates.`,
+		},
 		Run: func(req cmds.Request, res cmds.Response) {
 			binname := strings.Join(append([]string{"ipfs"}, req.Path()...), "-")
 			_, err := exec.LookPath(binname)

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -44,16 +44,16 @@ operations.
 	Options: []cmds.Option{
 		cmds.BoolOption("f", "flush", "Flush target and ancestors after write.").Default(true),
 	},
-	Subcommands: map[string]*cmds.Command{
-		"read":  FilesReadCmd,
-		"write": FilesWriteCmd,
-		"mv":    FilesMvCmd,
-		"cp":    FilesCpCmd,
-		"ls":    FilesLsCmd,
-		"mkdir": FilesMkdirCmd,
-		"stat":  FilesStatCmd,
-		"rm":    FilesRmCmd,
-		"flush": FilesFlushCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"read", FilesReadCmd, ""},
+		{"write", FilesWriteCmd, ""},
+		{"mv", FilesMvCmd, ""},
+		{"cp", FilesCpCmd, ""},
+		{"ls", FilesLsCmd, ""},
+		{"mkdir", FilesMkdirCmd, ""},
+		{"stat", FilesStatCmd, ""},
+		{"rm", FilesRmCmd, ""},
+		{"flush", FilesFlushCmd, ""},
 	},
 }
 

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -17,9 +17,9 @@ var KeyCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Create and manipulate keypairs",
 	},
-	Subcommands: map[string]*cmds.Command{
-		"gen":  KeyGenCmd,
-		"list": KeyListCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"gen", KeyGenCmd, ""},
+		{"list", KeyListCmd, ""},
 	},
 }
 

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -24,10 +24,10 @@ output of a running daemon.
 `,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"level": logLevelCmd,
-		"ls":    logLsCmd,
-		"tail":  logTailCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"level", logLevelCmd, ""},
+		{"ls", logLsCmd, ""},
+		{"tail", logTailCmd, ""},
 	},
 }
 

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -51,8 +51,8 @@ Resolve the value of a reference:
 `,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"publish": PublishCmd,
-		"resolve": IpnsCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"publish", PublishCmd, ""},
+		{"resolve", IpnsCmd, ""},
 	},
 }

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -50,15 +50,15 @@ var ObjectCmd = &cmds.Command{
 directly.`,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"data":  ObjectDataCmd,
-		"diff":  ObjectDiffCmd,
-		"get":   ObjectGetCmd,
-		"links": ObjectLinksCmd,
-		"new":   ObjectNewCmd,
-		"patch": ObjectPatchCmd,
-		"put":   ObjectPutCmd,
-		"stat":  ObjectStatCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"data", ObjectDataCmd, ""},
+		{"diff", ObjectDiffCmd, ""},
+		{"get", ObjectGetCmd, ""},
+		{"links", ObjectLinksCmd, ""},
+		{"new", ObjectNewCmd, ""},
+		{"patch", ObjectPatchCmd, ""},
+		{"put", ObjectPutCmd, ""},
+		{"stat", ObjectStatCmd, ""},
 	},
 }
 

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -24,11 +24,11 @@ result. This is the Merkle-DAG version of modifying an object.
 `,
 	},
 	Arguments: []cmds.Argument{},
-	Subcommands: map[string]*cmds.Command{
-		"append-data": patchAppendDataCmd,
-		"add-link":    patchAddLinkCmd,
-		"rm-link":     patchRmLinkCmd,
-		"set-data":    patchSetDataCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"append-data", patchAppendDataCmd, ""},
+		{"add-link", patchAddLinkCmd, ""},
+		{"rm-link", patchRmLinkCmd, ""},
+		{"set-data", patchSetDataCmd, ""},
 	},
 }
 

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -22,10 +22,10 @@ var PinCmd = &cmds.Command{
 		Tagline: "Pin (and unpin) objects to local storage.",
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"add": addPinCmd,
-		"rm":  rmPinCmd,
-		"ls":  listPinCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"add", addPinCmd, ""},
+		{"rm", rmPinCmd, ""},
+		{"ls", listPinCmd, ""},
 	},
 }
 

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -33,11 +33,11 @@ to be used in a production environment.
 To use, the daemon must be run with '--enable-pubsub-experiment'.
 `,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"pub":   PubsubPubCmd,
-		"sub":   PubsubSubCmd,
-		"ls":    PubsubLsCmd,
-		"peers": PubsubPeersCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"pub", PubsubPubCmd, ""},
+		{"sub", PubsubSubCmd, ""},
+		{"ls", PubsubLsCmd, ""},
+		{"peers", PubsubPeersCmd, ""},
 	},
 }
 

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -44,8 +44,8 @@ with the following format:
 NOTE: List all references recursively by using the flag '-r'.
 `,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"local": RefsLocalCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"local", RefsLocalCmd, ""},
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("ipfs-path", true, true, "Path to the object(s) to list refs from.").EnableStdin(),

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -30,12 +30,12 @@ var RepoCmd = &cmds.Command{
 `,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"gc":      repoGcCmd,
-		"stat":    repoStatCmd,
-		"fsck":    RepoFsckCmd,
-		"version": repoVersionCmd,
-		"verify":  repoVerifyCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"gc", repoGcCmd, ""},
+		{"stat", repoStatCmd, ""},
+		{"fsck", RepoFsckCmd, ""},
+		{"version", repoVersionCmd, ""},
+		{"verify", repoVerifyCmd, ""},
 	},
 }
 

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -22,58 +22,15 @@ var Root = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:  "Global p2p merkle-dag filesystem.",
 		Synopsis: "ipfs [--config=<config> | -c] [--debug=<debug> | -D] [--help=<help>] [-h=<h>] [--local=<local> | -L] [--api=<api>] <command> ...",
-		Subcommands: `
-BASIC COMMANDS
-  init          Initialize ipfs local configuration
-  add <path>    Add a file to IPFS
-  cat <ref>     Show IPFS object data
-  get <ref>     Download IPFS objects
-  ls <ref>      List links from an object
-  refs <ref>    List hashes of links from an object
-
-DATA STRUCTURE COMMANDS
-  block         Interact with raw blocks in the datastore
-  object        Interact with raw dag nodes
-  files         Interact with objects as if they were a unix filesystem
-  dag           Interact with IPLD documents (experimental)
-
-ADVANCED COMMANDS
-  daemon        Start a long-running daemon process
-  mount         Mount an IPFS read-only mountpoint
-  resolve       Resolve any type of name
-  name          Publish or resolve IPNS names
-  dns           Resolve DNS links
-  pin           Pin objects to local storage
-  repo          Manipulate the IPFS repository
-  stats         Various operational stats
-
-NETWORK COMMANDS
-  id            Show info about IPFS peers
-  bootstrap     Add or remove bootstrap peers
-  swarm         Manage connections to the p2p network
-  dht           Query the DHT for values or peers
-  ping          Measure the latency of a connection
-  diag          Print diagnostics
-
-TOOL COMMANDS
-  config        Manage configuration
-  version       Show ipfs version information
-  update        Download and apply go-ipfs updates
-  commands      List all available commands
-
-Use 'ipfs <command> --help' to learn more about each command.
-
-ipfs uses a repository in the local file system. By default, the repo is located
+		AdditionalHelp: `ipfs uses a repository in the local file system. By default, the repo is located
 at ~/.ipfs. To change the repo location, set the $IPFS_PATH environment variable:
 
   export IPFS_PATH=/path/to/ipfsrepo
 
 EXIT STATUS
-
-The CLI will exit with one of the following values:
-
-0     Successful execution.
-1     Failed executions.
+  The CLI will exit with one of the following values:
+    0     Successful execution.
+    1     Failed executions.
 `,
 	},
 	Options: []cmds.Option{
@@ -90,39 +47,39 @@ The CLI will exit with one of the following values:
 var CommandsDaemonCmd = CommandsCmd(Root)
 
 var rootSubcommands = []*cmds.CmdInfo{
-	{"add", AddCmd, ""},
-	{"block", BlockCmd, ""},
-	{"bootstrap", BootstrapCmd, ""},
-	{"cat", CatCmd, ""},
-	{"commands", CommandsDaemonCmd, ""},
-	{"config", ConfigCmd, ""},
-	{"dag", dag.DagCmd, ""},
-	{"dht", DhtCmd, ""},
-	{"diag", DiagCmd, ""},
-	{"dns", DNSCmd, ""},
-	{"files", files.FilesCmd, ""},
-	{"get", GetCmd, ""},
-	{"id", IDCmd, ""},
-	{"key", KeyCmd, ""},
-	{"log", LogCmd, ""},
-	{"ls", LsCmd, ""},
-	{"mount", MountCmd, ""},
-	{"name", NameCmd, ""},
-	{"object", ocmd.ObjectCmd, ""},
-	{"pin", PinCmd, ""},
-	{"ping", PingCmd, ""},
-	{"pubsub", PubsubCmd, ""},
-	{"refs", RefsCmd, ""},
-	{"repo", RepoCmd, ""},
-	{"resolve", ResolveCmd, ""},
-	{"stats", StatsCmd, ""},
-	{"swarm", SwarmCmd, ""},
-	{"tar", TarCmd, ""},
-	{"tour", tourCmd, ""},
-	{"file", unixfs.UnixFSCmd, ""},
-	{"update", ExternalBinary(), ""},
-	{"version", VersionCmd, ""},
-	{"bitswap", BitswapCmd, ""},
+	{"add", AddCmd, "BASIC COMMANDS"},
+	{"cat", CatCmd, "BASIC COMMANDS"},
+	{"get", GetCmd, "BASIC COMMANDS"},
+	{"ls", LsCmd, "BASIC COMMANDS"},
+	{"refs", RefsCmd, "BASIC COMMANDS"},
+	{"tour", tourCmd, "BASIC COMMANDS"},
+	{"block", BlockCmd, "DATA STRUCTURE COMMANDS"},
+	{"object", ocmd.ObjectCmd, "DATA STRUCTURE COMMANDS"},
+	{"files", files.FilesCmd, "DATA STRUCTURE COMMANDS"},
+	{"mount", MountCmd, "ADVANCED COMMANDS"},
+	{"resolve", ResolveCmd, "ADVANCED COMMANDS"},
+	{"name", NameCmd, "ADVANCED COMMANDS"},
+	{"dns", DNSCmd, "ADVANCED COMMANDS"},
+	{"pin", PinCmd, "ADVANCED COMMANDS"},
+	{"repo", RepoCmd, "ADVANCED COMMANDS"},
+	{"dag", dag.DagCmd, "ADVANCED COMMANDS"},
+	{"key", KeyCmd, "ADVANCED COMMANDS"},
+	{"pubsub", PubsubCmd, "ADVANCED COMMANDS"},
+	{"log", LogCmd, "ADVANCED COMMANDS"},
+	{"stats", StatsCmd, "ADVANCED COMMANDS"},
+	{"tar", TarCmd, "ADVANCED COMMANDS"},
+	{"file", unixfs.UnixFSCmd, "ADVANCED COMMANDS"},
+	{"bitswap", BitswapCmd, "ADVANCED COMMANDS"},
+	{"id", IDCmd, "NETWORK COMMANDS"},
+	{"bootstrap", BootstrapCmd, "NETWORK COMMANDS"},
+	{"swarm", SwarmCmd, "NETWORK COMMANDS"},
+	{"dht", DhtCmd, "NETWORK COMMANDS"},
+	{"ping", PingCmd, "NETWORK COMMANDS"},
+	{"diag", DiagCmd, "NETWORK COMMANDS"},
+	{"commands", CommandsDaemonCmd, "TOOL COMMANDS"},
+	{"config", ConfigCmd, "TOOL COMMANDS"},
+	{"version", VersionCmd, "TOOL COMMANDS"},
+	{"update", ExternalBinary(), "TOOL COMMANDS"},
 }
 
 // RootRO is the readonly version of Root

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -39,6 +39,7 @@ EXIT STATUS
 		cmds.BoolOption("help", "Show the full command help text.").Default(false),
 		cmds.BoolOption("h", "Show a short version of the command help text.").Default(false),
 		cmds.BoolOption("local", "L", "Run the command locally, instead of using the daemon.").Default(false),
+		cmds.BoolOption("color", "Use colors in console output.").Default(false),
 		cmds.StringOption(ApiOption, "Use a specific API instance (defaults to /ip4/127.0.0.1/tcp/5001)"),
 	},
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -89,40 +89,40 @@ The CLI will exit with one of the following values:
 // commandsDaemonCmd is the "ipfs commands" command for daemon
 var CommandsDaemonCmd = CommandsCmd(Root)
 
-var rootSubcommands = map[string]*cmds.Command{
-	"add":       AddCmd,
-	"block":     BlockCmd,
-	"bootstrap": BootstrapCmd,
-	"cat":       CatCmd,
-	"commands":  CommandsDaemonCmd,
-	"config":    ConfigCmd,
-	"dag":       dag.DagCmd,
-	"dht":       DhtCmd,
-	"diag":      DiagCmd,
-	"dns":       DNSCmd,
-	"files":     files.FilesCmd,
-	"get":       GetCmd,
-	"id":        IDCmd,
-	"key":       KeyCmd,
-	"log":       LogCmd,
-	"ls":        LsCmd,
-	"mount":     MountCmd,
-	"name":      NameCmd,
-	"object":    ocmd.ObjectCmd,
-	"pin":       PinCmd,
-	"ping":      PingCmd,
-	"pubsub":    PubsubCmd,
-	"refs":      RefsCmd,
-	"repo":      RepoCmd,
-	"resolve":   ResolveCmd,
-	"stats":     StatsCmd,
-	"swarm":     SwarmCmd,
-	"tar":       TarCmd,
-	"tour":      tourCmd,
-	"file":      unixfs.UnixFSCmd,
-	"update":    ExternalBinary(),
-	"version":   VersionCmd,
-	"bitswap":   BitswapCmd,
+var rootSubcommands = []*cmds.CmdInfo{
+	{"add", AddCmd, ""},
+	{"block", BlockCmd, ""},
+	{"bootstrap", BootstrapCmd, ""},
+	{"cat", CatCmd, ""},
+	{"commands", CommandsDaemonCmd, ""},
+	{"config", ConfigCmd, ""},
+	{"dag", dag.DagCmd, ""},
+	{"dht", DhtCmd, ""},
+	{"diag", DiagCmd, ""},
+	{"dns", DNSCmd, ""},
+	{"files", files.FilesCmd, ""},
+	{"get", GetCmd, ""},
+	{"id", IDCmd, ""},
+	{"key", KeyCmd, ""},
+	{"log", LogCmd, ""},
+	{"ls", LsCmd, ""},
+	{"mount", MountCmd, ""},
+	{"name", NameCmd, ""},
+	{"object", ocmd.ObjectCmd, ""},
+	{"pin", PinCmd, ""},
+	{"ping", PingCmd, ""},
+	{"pubsub", PubsubCmd, ""},
+	{"refs", RefsCmd, ""},
+	{"repo", RepoCmd, ""},
+	{"resolve", ResolveCmd, ""},
+	{"stats", StatsCmd, ""},
+	{"swarm", SwarmCmd, ""},
+	{"tar", TarCmd, ""},
+	{"tour", tourCmd, ""},
+	{"file", unixfs.UnixFSCmd, ""},
+	{"update", ExternalBinary(), ""},
+	{"version", VersionCmd, ""},
+	{"bitswap", BitswapCmd, ""},
 }
 
 // RootRO is the readonly version of Root
@@ -132,40 +132,29 @@ var CommandsDaemonROCmd = CommandsCmd(RootRO)
 
 var RefsROCmd = &cmds.Command{}
 
-var rootROSubcommands = map[string]*cmds.Command{
-	"block": &cmds.Command{
-		Subcommands: map[string]*cmds.Command{
-			"stat": blockStatCmd,
-			"get":  blockGetCmd,
-		},
-	},
-	"cat":      CatCmd,
-	"commands": CommandsDaemonROCmd,
-	"dns":      DNSCmd,
-	"get":      GetCmd,
-	"ls":       LsCmd,
-	"name": &cmds.Command{
-		Subcommands: map[string]*cmds.Command{
-			"resolve": IpnsCmd,
-		},
-	},
-	"object": &cmds.Command{
-		Subcommands: map[string]*cmds.Command{
-			"data":  ocmd.ObjectDataCmd,
-			"links": ocmd.ObjectLinksCmd,
-			"get":   ocmd.ObjectGetCmd,
-			"stat":  ocmd.ObjectStatCmd,
-			"patch": ocmd.ObjectPatchCmd,
-		},
-	},
-	"dag": &cmds.Command{
-		Subcommands: map[string]*cmds.Command{
-			"get": dag.DagGetCmd,
-		},
-	},
-	"refs":    RefsROCmd,
-	"resolve": ResolveCmd,
-	"version": VersionCmd,
+var rootROSubcommands = []*cmds.CmdInfo{
+	{"block",
+		&cmds.Command{Subcommands: []*cmds.CmdInfo{{"stat", blockStatCmd, ""}, {"get", blockGetCmd, ""}}},
+		""},
+	{"cat", CatCmd, ""},
+	{"commands", CommandsDaemonROCmd, ""},
+	{"dns", DNSCmd, ""},
+	{"get", GetCmd, ""},
+	{"ls", LsCmd, ""},
+	{"name", &cmds.Command{Subcommands: []*cmds.CmdInfo{{"resolve", IpnsCmd, ""}}}, ""},
+	{"object",
+		&cmds.Command{Subcommands: []*cmds.CmdInfo{
+			{"data", ocmd.ObjectDataCmd, ""},
+			{"links", ocmd.ObjectLinksCmd, ""},
+			{"get", ocmd.ObjectGetCmd, ""},
+			{"stat", ocmd.ObjectStatCmd, ""},
+			{"patch", ocmd.ObjectPatchCmd, ""},
+		}},
+		""},
+	{"dag", &cmds.Command{Subcommands: []*cmds.CmdInfo{{"get", dag.DagGetCmd, ""}}}, ""},
+	{"refs", RefsROCmd, ""},
+	{"resolve", ResolveCmd, ""},
+	{"version", VersionCmd, ""},
 }
 
 func init() {
@@ -174,7 +163,7 @@ func init() {
 
 	// sanitize readonly refs command
 	*RefsROCmd = *RefsCmd
-	RefsROCmd.Subcommands = map[string]*cmds.Command{}
+	RefsROCmd.Subcommands = []*cmds.CmdInfo{}
 
 	Root.Subcommands = rootSubcommands
 	RootRO.Subcommands = rootROSubcommands

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -26,10 +26,10 @@ for your IPFS node.
 for your IPFS node.`,
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"bw":      statBwCmd,
-		"repo":    repoStatCmd,
-		"bitswap": bitswapStatCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"bw", statBwCmd, ""},
+		{"repo", repoStatCmd, ""},
+		{"bitswap", bitswapStatCmd, ""},
 	},
 }
 

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -37,12 +37,12 @@ component that opens, listens for, and maintains connections to other
 ipfs peers in the internet.
 `,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"addrs":      swarmAddrsCmd,
-		"connect":    swarmConnectCmd,
-		"disconnect": swarmDisconnectCmd,
-		"filters":    swarmFiltersCmd,
-		"peers":      swarmPeersCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"addrs", swarmAddrsCmd, ""},
+		{"connect", swarmConnectCmd, ""},
+		{"disconnect", swarmDisconnectCmd, ""},
+		{"filters", swarmFiltersCmd, ""},
+		{"peers", swarmPeersCmd, ""},
 	},
 }
 
@@ -196,8 +196,8 @@ var swarmAddrsCmd = &cmds.Command{
 'ipfs swarm addrs' lists all addresses this node is aware of.
 `,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"local": swarmAddrsLocalCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"local", swarmAddrsLocalCmd, ""},
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 
@@ -495,9 +495,9 @@ Where the above is equivalent to the standard CIDR:
 Filters default to those specified under the "Swarm.AddrFilters" config key.
 `,
 	},
-	Subcommands: map[string]*cmds.Command{
-		"add": swarmFiltersAddCmd,
-		"rm":  swarmFiltersRmCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"add", swarmFiltersAddCmd, ""},
+		{"rm", swarmFiltersRmCmd, ""},
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -17,9 +17,9 @@ var TarCmd = &cmds.Command{
 		Tagline: "Utility functions for tar files in ipfs.",
 	},
 
-	Subcommands: map[string]*cmds.Command{
-		"add": tarAddCmd,
-		"cat": tarCatCmd,
+	Subcommands: []*cmds.CmdInfo{
+		{"add", tarAddCmd, ""},
+		{"cat", tarCatCmd, ""},
 	},
 }
 

--- a/core/commands/tour.go
+++ b/core/commands/tour.go
@@ -27,10 +27,10 @@ IPFS very quickly. To start, run:
 	Arguments: []cmds.Argument{
 		cmds.StringArg("id", false, false, "The id of the topic you would like to tour."),
 	},
-	Subcommands: map[string]*cmds.Command{
-		"list":    cmdIpfsTourList,
-		"next":    cmdIpfsTourNext,
-		"restart": cmdIpfsTourRestart,
+	Subcommands: []*cmds.CmdInfo{
+		{"list", cmdIpfsTourList, ""},
+		{"next", cmdIpfsTourNext, ""},
+		{"restart", cmdIpfsTourRestart, ""},
 	},
 	Run: tourRunFunc,
 }

--- a/core/commands/unixfs/unixfs.go
+++ b/core/commands/unixfs/unixfs.go
@@ -16,8 +16,5 @@ by IPFS objects, which hides ipfs implementation details like layout
 objects (e.g. fanout and chunking).
 `,
 	},
-
-	Subcommands: map[string]*cmds.Command{
-		"ls": LsCmd,
-	},
+	Subcommands: []*cmds.CmdInfo{{"ls", LsCmd, ""}},
 }

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -47,8 +47,8 @@ test_expect_success "ipfs help succeeds" '
 '
 
 test_expect_success "ipfs help output looks good" '
-	egrep -i "^Usage" help.txt >/dev/null &&
-	egrep "ipfs <command>" help.txt >/dev/null ||
+	egrep -i "^USAGE" help.txt >/dev/null &&
+	egrep "Use '\''ipfs --help'\''" help.txt >/dev/null ||
 	test_fsh cat help.txt
 '
 

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -80,4 +80,8 @@ test_expect_success "'ipfs commands --flags' output looks good" '
 	grep "ipfs repo gc --quiet / ipfs repo gc -q" commands.txt
 '
 
+test_expect_success "'ipfs --color' succeeds" '
+	ipfs --color >commands.txt
+'
+
 test_done


### PR DESCRIPTION
Hello, 
this PR is related to issue #340 but also does some other things.

## `Subcommand` map is now an array of `CmdInfos`
- Having an array allows people to change the position of commands in the help text (maps are not ordered).
- Commands now may have a command group. (needed for the main help message but also useful for other commands with many sub-commands)

## HelpText now has an `AdditionalHelp` field
- AdditionalHelp is displayed on the bottom of the help text. It is currently only used in the main help message, but may also be useful for other things.

## There is now a --color command line flag
- Colorful can be enabled with `--color`
- There are no checks if stdout is a tty. If you use --color, you get color! (e.g. when someone wants to pipe it into `less -R`)



This PR touches a lot of files, but most changes are just simple gofmt transformations in order to switch from the `Subcommand` map to the `Subcommand` array.

Cheers from 33c3,
Julian