### PR TITLE
docker: More convenient access to ipfs commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,4 @@ VOLUME $IPFS_PATH
 # 1. There's an fs-repo, and initializes one if there isn't.
 # 2. The API and Gateway are accessible from outside the container.
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
+CMD ["daemon"]

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,3 +53,4 @@ RUN cd $SRC_PATH \
 USER ipfs
 VOLUME $IPFS_PATH
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
+CMD ["daemon"]

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -19,4 +19,4 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
-exec ipfs daemon "$@"
+exec ipfs "$@"


### PR DESCRIPTION
I had to run `ipfs repo fsck` on my repo inside a docker container, what I had to do:
```
docker run --entrypoint ipfs myipfs repo fsck
```
This is because `/usr/local/bin/start_ipfs` is set as an entrypoint and it explicitly starts `ipfs daemon`.

This change keeps start_ipfs as an entrypoint (since it's only doing some docker specific checks), but doesn't restrict you in what you can do.

The above command becomes this:
```
docker run myipfs repo fsck
```

While, starting the ipfs daemon still looks the same:
```
docker run myipfs
```

Bad news (sort of): people already passing arguments to the docker image have to edit their setup from this
```
docker run myipfs --some-flags
```
to this:
```
docker run myipfs daemon --some-flags
```

I still think this is the better approach since overwriting the entrypoint is sort of the non-obvious way for docker beginners (making the ipfs docker image harder to use for beginners).