### PR TITLE
`make source` for installation in unsupported systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,15 @@ windows_build_check:
 	GOOS=windows GOARCH=amd64 go build -o .test.ipfs.exe ./cmd/ipfs
 	rm -f .test.ipfs.exe
 
+source:
+	@echo "note: this command has yet to be tested to build in the system you are using"
+	@echo "installing gx"
+	go get -u github.com/whyrusleeping/gx
+	go get -u github.com/whyrusleeping/gx-go
+	gx --verbose install --global >/dev/null 2>&1
+	@echo "installing go-ipfs"
+	go install ./cmd/ipfs
+
 PHONY += test test_short test_expensive
 
 ##############################################################

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ windows_build_check:
 	GOOS=windows GOARCH=amd64 go build -o .test.ipfs.exe ./cmd/ipfs
 	rm -f .test.ipfs.exe
 
-source:
+install_unsupported:
 	@echo "note: this command has yet to be tested to build in the system you are using"
 	@echo "installing gx"
 	go get -u github.com/whyrusleeping/gx

--- a/README.md
+++ b/README.md
@@ -82,21 +82,9 @@ export PATH=$PATH:$GOPATH/bin
 
 #### Download and Compile IPFS
 
-go-ipfs differs from the vanilla `go get` flow: it uses
-[gx](https://github.com/whyrusleeping/gx)/[gx-go](https://github.com/whyrusleeping/gx-go)
-for dependency management.
-
-First download `go-ipfs` without installing:
-
 ```
 $ go get -u -d github.com/ipfs/go-ipfs
-
 $ cd $GOPATH/src/github.com/ipfs/go-ipfs
-```
-
-Then install `go-ipfs` and its dependencies, including `gx` and `gx-go`:
-
-```
 $ make install
 ```
 
@@ -109,7 +97,8 @@ following instead of `make install`:
 $ make source
 ```
 
-Note: This process may break if [gx](https://github.com/whyrusleeping/gx) or any of its dependencies break as `go get`
+Note: This process may break if [gx](https://github.com/whyrusleeping/gx) (used for
+dependency management) or any of its dependencies break as `go get`
 will always select the latest code for every dependency, often resulting in
 mismatched APIs.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If your operating system isn't officially supported, but you still want to try
 building ipfs anyways (it should work fine in most cases), you can do the
 following instead of `make install`:
 ```
-$ make source
+$ make install_unsupported
 ```
 
 Note: This process may break if [gx](https://github.com/whyrusleeping/gx) (used for

--- a/README.md
+++ b/README.md
@@ -104,14 +104,10 @@ $ make install
 
 If your operating system isn't officially supported, but you still want to try
 building ipfs anyways (it should work fine in most cases), you can do the
-following:
-
-- Install gx: `go get -u github.com/whyrusleeping/gx`
-- Install gx-go: `go get -u github.com/whyrusleeping/gx-go`
-- Fetch ipfs source: `go get -d github.com/ipfs/go-ipfs 2> /dev/null`
-- Enter source directory: `cd $GOPATH/src/github.com/ipfs/go-ipfs`
-- Install deps: `gx install`
-- Install ipfs: `go install ./cmd/ipfs`
+following instead of `make install`:
+```
+$ make source
+```
 
 Note: This process may break if [gx](https://github.com/whyrusleeping/gx) or any of its dependencies break as `go get`
 will always select the latest code for every dependency, often resulting in


### PR DESCRIPTION
Could be further streamlined if the os/dist is auto-detected.
Fixes #3579

License: MIT
Signed-off-by: rht <rhtbot@gmail.com>