### PR TITLE
update to fixed cbor ipld lib

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -9,7 +9,7 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 
 	node "gx/ipfs/QmRSU5EqqWVZSNdbU51yXmVoF1uNw3JgTNB6RaiL7DZM16/go-ipld-node"
-	ipldcbor "gx/ipfs/QmbuuwTd9x4NReZ7sxtiKk7wFcfDUo54MfWBdtF5MRCPGR/go-ipld-cbor"
+	ipldcbor "gx/ipfs/Qmb9fKmqrMn5n7WNpe2yWq3taRg2fC9wPWR4HLH54qi8fi/go-ipld-cbor"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -13,7 +13,7 @@ import (
 
 	node "gx/ipfs/QmRSU5EqqWVZSNdbU51yXmVoF1uNw3JgTNB6RaiL7DZM16/go-ipld-node"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
-	ipldcbor "gx/ipfs/QmbuuwTd9x4NReZ7sxtiKk7wFcfDUo54MfWBdtF5MRCPGR/go-ipld-cbor"
+	ipldcbor "gx/ipfs/Qmb9fKmqrMn5n7WNpe2yWq3taRg2fC9wPWR4HLH54qi8fi/go-ipld-cbor"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 )
 

--- a/package.json
+++ b/package.json
@@ -272,9 +272,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbuuwTd9x4NReZ7sxtiKk7wFcfDUo54MfWBdtF5MRCPGR",
+      "hash": "Qmb9fKmqrMn5n7WNpe2yWq3taRg2fC9wPWR4HLH54qi8fi",
       "name": "go-ipld-cbor",
-      "version": "0.4.2"
+      "version": "0.5.0"
     },
     {
       "author": "lgierth",


### PR DESCRIPTION
This fixes cbor parsing to follow the ipld spec in regards to storing links as a special cbor tag instead of mapping the `{"/":"QmFooBar"}` syntax into cbor. We've selected 258 as the ipld link tag value for now since it doesnt appear to actually be defined anywhere in the spec.

cc @diasdavid @jbenet @nicola

License: MIT
Signed-off-by: Jeromy <why@ipfs.io>