### PR TITLE
blockservice: avoid using unnecessary continue statement

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -112,10 +112,9 @@ func (s *blockService) AddBlocks(bs []blocks.Block) ([]*cid.Cid, error) {
 			if err != nil {
 				return nil, err
 			}
-			if has {
-				continue
+			if !has {
+				toput = append(toput, b)
 			}
-			toput = append(toput, b)
 		}
 	} else {
 		toput = bs


### PR DESCRIPTION
Fixes

> 1173c00, in AddBlocks, append to array 'if !has' to avoid using extra flow control structures

in #3534 
