### PR TITLE
quickstart images are unreachable

### DIFF
--- a/assets/init-doc/quick-start
+++ b/assets/init-doc/quick-start
@@ -104,10 +104,6 @@ Browse:
 
     http://localhost:8080/ipfs/QmVc6zuAneKJzicnJpfrqCH9gSy6bz54JhcypfJYhGUFQu/play#/ipfs/QmTKZgRNwDNZwHtJSjCp6r5FYefzpULfy37JvMt9DwvXse
 
-  images:
-
-    http://localhost:8080/ipfs/QmZpc3HvfjEXvLWGQPWbHk3AjD5j8NEN4gmFN8Jmrd5g83/cs
-
   markdown renderer app:
 
     http://localhost:8080/ipfs/QmX7M9CiYXjVeFnkfVGf3y5ixTZ2ACeSGyL1vBJY1HvQPp/mdown


### PR DESCRIPTION
The documentation for ipfs in the quickstart document references on images, that are not there anymore: http://localhost:8080/ipfs/QmZpc3HvfjEXvLWGQPWbHk3AjD5j8NEN4gmFN8Jmrd5g83/cs