### PR TITLE
Make pin rm not try to find pinned ancestors by default

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -184,6 +184,7 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 	},
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("recursive", "r", "Recursively unpin the object linked to by the specified object(s).").WithDefault(true),
+		cmdkit.BoolOption("explain", "e", "Check for other pinned objects which could cause specified object(s) to be indirectly pinned").WithDefault(false),
 	},
 	Type: PinOutput{},
 	Run: func(req cmds.Request, res cmds.Response) {
@@ -200,7 +201,13 @@ collected if needed. (By default, recursively. Use -r=false for direct pins.)
 			return
 		}
 
-		removed, err := corerepo.Unpin(n, req.Context(), req.Arguments(), recursive)
+		explain, _, err := req.Option("explain").Bool()
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
+		removed, err := corerepo.Unpin(n, req.Context(), req.Arguments(), recursive, explain)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -53,7 +53,7 @@ func (api *PinAPI) Ls(ctx context.Context, opts ...caopts.PinLsOption) ([]coreif
 }
 
 func (api *PinAPI) Rm(ctx context.Context, p coreiface.Path) error {
-	_, err := corerepo.Unpin(api.node, ctx, []string{p.String()}, true)
+	_, err := corerepo.Unpin(api.node, ctx, []string{p.String()}, true, true)
 	if err != nil {
 		return err
 	}

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -58,7 +58,7 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 	return out, nil
 }
 
-func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
+func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool, explain bool) ([]*cid.Cid, error) {
 	unpinned := make([]*cid.Cid, len(paths))
 
 	r := &resolver.Resolver{
@@ -77,7 +77,7 @@ func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool
 			return nil, err
 		}
 
-		err = n.Pinning.Unpin(ctx, k, recursive)
+		err = n.Pinning.Unpin(ctx, k, recursive, explain)
 		if err != nil {
 			return nil, err
 		}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -183,7 +183,7 @@ func (adder *Adder) PinRoot() error {
 	}
 
 	if adder.tempRoot != nil {
-		err := adder.pinning.Unpin(adder.ctx, adder.tempRoot, true)
+		err := adder.pinning.Unpin(adder.ctx, adder.tempRoot, true, false)
 		if err != nil {
 			return err
 		}

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -137,7 +137,7 @@ func TestPinnerBasic(t *testing.T) {
 	assertPinned(t, p, dk, "pinned node not found.")
 
 	// Test recursive unpin
-	err = p.Unpin(ctx, dk, true)
+	err = p.Unpin(ctx, dk, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestIsPinnedLookup(t *testing.T) {
 	assertPinned(t, p, bk, "B should be pinned")
 
 	// Unpin A5 recursively
-	if err := p.Unpin(ctx, aKeys[5], true); err != nil {
+	if err := p.Unpin(ctx, aKeys[5], true, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,7 +269,7 @@ func TestIsPinnedLookup(t *testing.T) {
 	assertUnpinned(t, p, aKeys[4], "A4 should be unpinned")
 
 	// Unpin B recursively
-	if err := p.Unpin(ctx, bk, true); err != nil {
+	if err := p.Unpin(ctx, bk, true, false); err != nil {
 		t.Fatal(err)
 	}
 	assertUnpinned(t, p, bk, "B should be unpinned")

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -86,9 +86,15 @@ test_expect_success "pinning directly should fail now" '
 '
 
 test_expect_success "'ipfs pin rm -r=false <hash>' should fail" '
-  echo "Error: $HASH is pinned recursively" >expected4 &&
+  echo "Error: $HASH is not pinned directly" >expected4 &&
   test_must_fail ipfs pin rm -r=false "$HASH" 2>actual4 &&
   test_cmp expected4 actual4
+'
+
+test_expect_success "'ipfs pin rm -e -r=false <hash>' should fail and explain why" '
+  echo "Error: $HASH is pinned recursively" >expected11 &&
+  test_must_fail ipfs pin rm -e -r=false "$HASH" 2>actual11 &&
+  test_cmp expected11 actual11
 '
 
 test_expect_success "remove recursive pin, add direct" '
@@ -100,6 +106,13 @@ test_expect_success "remove recursive pin, add direct" '
 
 test_expect_success "remove direct pin" '
   echo "unpinned $HASH" >expected6 &&
+  ipfs pin rm -r=false "$HASH" >actual6 &&
+  test_cmp expected6 actual6
+'
+
+test_expect_success "remove direct pin with pin rm -r" '
+  echo "unpinned $HASH" >expected6 &&
+  ipfs pin add -r=false "$HASH"
   ipfs pin rm "$HASH" >actual6 &&
   test_cmp expected6 actual6
 '

--- a/test/sharness/t0252-files-gc.sh
+++ b/test/sharness/t0252-files-gc.sh
@@ -34,7 +34,7 @@ test_expect_success "gc okay after adding incomplete node -- prep" '
   ipfs repo gc && # will remove /adir/file1 and /adir/file2 but not /adir
   test_must_fail ipfs cat $FILE1_HASH &&
   ipfs files cp /ipfs/$ADIR_HASH /adir &&
-  ipfs pin rm $ADIR_HASH
+  ipfs pin rm -r=false $ADIR_HASH
 '
 
 test_expect_success "gc okay after adding incomplete node" '


### PR DESCRIPTION
Also make a switch to pin rm to allow old behavior.
Trying to look up pins which interfere with requested unpin
can be an extremely costly operation and typically is not
required by user.