### PR TITLE
Remove 'FindProviders` from routing mocks

### DIFF
--- a/exchange/reprovide/reprovide_test.go
+++ b/exchange/reprovide/reprovide_test.go
@@ -10,6 +10,7 @@ import (
 	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
 	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
 	dssync "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore/sync"
+	pstore "gx/ipfs/QmeXj9VAjmYQZxpmVz7VzccbJrpmr8qkCDSjfVNsPTWTYU/go-libp2p-peerstore"
 
 	. "github.com/ipfs/go-ipfs/exchange/reprovide"
 )
@@ -37,16 +38,19 @@ func TestReprovide(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provs, err := clB.FindProviders(ctx, blk.Cid())
-	if err != nil {
-		t.Fatal(err)
+	var providers []pstore.PeerInfo
+	maxProvs := 100
+
+	provChan := clB.FindProvidersAsync(ctx, blk.Cid(), maxProvs)
+	for p := range provChan {
+		providers = append(providers, p)
 	}
 
-	if len(provs) == 0 {
+	if len(providers) == 0 {
 		t.Fatal("Should have gotten a provider")
 	}
 
-	if provs[0].ID != idA.ID() {
+	if providers[0].ID != idA.ID() {
 		t.Fatal("Somehow got the wrong peer back as a provider.")
 	}
 }

--- a/routing/mock/centralized_test.go
+++ b/routing/mock/centralized_test.go
@@ -7,7 +7,6 @@ import (
 
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
 	"github.com/ipfs/go-ipfs/thirdparty/testutil"
-
 	u "gx/ipfs/Qmb912gdngC1UWwTkhuW8knyRbcWeu5kqkxBpveLmW8bSr/go-ipfs-util"
 	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
 	pstore "gx/ipfs/QmeXj9VAjmYQZxpmVz7VzccbJrpmr8qkCDSjfVNsPTWTYU/go-libp2p-peerstore"
@@ -154,20 +153,21 @@ func TestValidAfter(t *testing.T) {
 	rs.Client(pi).Provide(ctx, key)
 
 	var providers []pstore.PeerInfo
-	providers, err := rs.Client(pi).FindProviders(ctx, key)
-	if err != nil {
-		t.Fatal(err)
+	max := 100
+	providersChan := rs.Client(pi).FindProvidersAsync(ctx, key, max)
+	for p := range providersChan {
+		providers = append(providers, p)
 	}
 	if len(providers) > 0 {
 		t.Fail()
 	}
 
 	conf.ValueVisibility.Set(0)
-	providers, err = rs.Client(pi).FindProviders(ctx, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	providersChan = rs.Client(pi).FindProvidersAsync(ctx, key, max)
 	t.Log("providers", providers)
+	for p := range providersChan {
+		providers = append(providers, p)
+	}
 	if len(providers) != 1 {
 		t.Fail()
 	}

--- a/routing/mock/interface.go
+++ b/routing/mock/interface.go
@@ -12,8 +12,6 @@ import (
 
 	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
 	routing "gx/ipfs/QmbkGVaN9W6RYJK4Ws5FvMKXKDqdRQ5snhtaa92qP6L8eU/go-libp2p-routing"
-	cid "gx/ipfs/QmcTcsTvfaeEBRFo1TkFgT8sRmgi1n1LTZpecfVP8fzpGD/go-cid"
-	pstore "gx/ipfs/QmeXj9VAjmYQZxpmVz7VzccbJrpmr8qkCDSjfVNsPTWTYU/go-libp2p-peerstore"
 	peer "gx/ipfs/QmfMmLGoKzCHDN7cGgk64PJr4iipzidDRME8HABSJqvmhC/go-libp2p-peer"
 )
 
@@ -25,7 +23,6 @@ type Server interface {
 
 // Client implements IpfsRouting
 type Client interface {
-	FindProviders(context.Context, *cid.Cid) ([]pstore.PeerInfo, error)
 	routing.IpfsRouting
 }
 

--- a/routing/offline/offline.go
+++ b/routing/offline/offline.go
@@ -91,10 +91,6 @@ func (c *offlineRouting) GetValues(ctx context.Context, key string, _ int) ([]ro
 	}, nil
 }
 
-func (c *offlineRouting) FindProviders(ctx context.Context, key *cid.Cid) ([]pstore.PeerInfo, error) {
-	return nil, ErrOffline
-}
-
 func (c *offlineRouting) FindPeer(ctx context.Context, pid peer.ID) (pstore.PeerInfo, error) {
 	return pstore.PeerInfo{}, ErrOffline
 }


### PR DESCRIPTION
PR to address issues I raised in https://github.com/ipfs/go-ipfs/issues/3510 (routing mock contains the deprecated `FindProviders` method).
Tests that use this mock now call `FindProvidersAsync` instead.