### PR TITLE
Tests for mfsr.go

### DIFF
--- a/repo/fsrepo/migrations/mfsr.go
+++ b/repo/fsrepo/migrations/mfsr.go
@@ -43,7 +43,7 @@ func (rp RepoPath) CheckVersion(version int) error {
 	}
 
 	if v != version {
-		return fmt.Errorf("versions differ (expected: %s, actual:%s)", version, v)
+		return fmt.Errorf("versions differ (expected: %d, actual:%d)", version, v)
 	}
 
 	return nil

--- a/repo/fsrepo/migrations/mfsr.go
+++ b/repo/fsrepo/migrations/mfsr.go
@@ -23,8 +23,8 @@ func (rp RepoPath) Version() (int, error) {
 	}
 
 	fn := rp.VersionFile()
-	if _, err := os.Stat(fn); os.IsNotExist(err) {
-		return 0, VersionFileNotFound(rp)
+	if _, err := os.Stat(fn); err != nil {
+		return 0, err
 	}
 
 	c, err := ioutil.ReadFile(fn)
@@ -52,10 +52,4 @@ func (rp RepoPath) CheckVersion(version int) error {
 func (rp RepoPath) WriteVersion(version int) error {
 	fn := rp.VersionFile()
 	return ioutil.WriteFile(fn, []byte(fmt.Sprintf("%d\n", version)), 0644)
-}
-
-type VersionFileNotFound string
-
-func (v VersionFileNotFound) Error() string {
-	return "no version file in repo at " + string(v)
 }

--- a/repo/fsrepo/migrations/mfsr_test.go
+++ b/repo/fsrepo/migrations/mfsr_test.go
@@ -1,0 +1,33 @@
+package mfsr
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/ipfs/go-ipfs/thirdparty/assert"
+)
+
+func testVersionFile(v string, t *testing.T) (rp RepoPath) {
+	name, err := ioutil.TempDir("", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rp = RepoPath(name)
+	return rp
+}
+
+func TestVersion(t *testing.T) {
+	rp := RepoPath("")
+	_, err := rp.Version()
+	assert.Err(err, t, "Should throw an error when path is bad,")
+
+	rp = testVersionFile("4", t)
+	_, err = rp.Version()
+	assert.Err(err, t, "Bad VersionFile")
+
+	assert.Nil(rp.WriteVersion(4), t, "Trouble writing version")
+
+	assert.Nil(rp.CheckVersion(4), t, "Trouble checking the verion")
+
+	assert.Err(rp.CheckVersion(1), t, "Should throw an error for the wrong version.")
+}

--- a/repo/fsrepo/migrations/mfsr_test.go
+++ b/repo/fsrepo/migrations/mfsr_test.go
@@ -2,6 +2,7 @@ package mfsr
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ipfs/go-ipfs/thirdparty/assert"
@@ -20,6 +21,12 @@ func TestVersion(t *testing.T) {
 	rp := RepoPath("")
 	_, err := rp.Version()
 	assert.Err(err, t, "Should throw an error when path is bad,")
+
+	rp = RepoPath("/path/to/nowhere")
+	_, err = rp.Version()
+	if !os.IsNotExist(err) {
+		t.Fatalf("Should throw an `IsNotExist` error when file doesn't exist: %v", err)
+	}
 
 	rp = testVersionFile("4", t)
 	_, err = rp.Version()

--- a/repo/fsrepo/migrations/mfsr_test.go
+++ b/repo/fsrepo/migrations/mfsr_test.go
@@ -3,6 +3,7 @@ package mfsr
 import (
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/ipfs/go-ipfs/thirdparty/assert"
@@ -28,13 +29,15 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("Should throw an `IsNotExist` error when file doesn't exist: %v", err)
 	}
 
-	rp = testVersionFile("4", t)
+	fsrepoV := 5
+
+	rp = testVersionFile(strconv.Itoa(fsrepoV), t)
 	_, err = rp.Version()
 	assert.Err(err, t, "Bad VersionFile")
 
-	assert.Nil(rp.WriteVersion(4), t, "Trouble writing version")
+	assert.Nil(rp.WriteVersion(fsrepoV), t, "Trouble writing version")
 
-	assert.Nil(rp.CheckVersion(4), t, "Trouble checking the verion")
+	assert.Nil(rp.CheckVersion(fsrepoV), t, "Trouble checking the verion")
 
 	assert.Err(rp.CheckVersion(1), t, "Should throw an error for the wrong version.")
 }


### PR DESCRIPTION
Adds tests for `msfr.go`. Does not hit coverage target of 80%.
Remove code that was transforming errs when the version file didn't exist, which may have confused callers of the `Version` method.