### PR TITLE
Fix/random repo test failure

### DIFF
--- a/test/sharness/t0086-repo-verify.sh
+++ b/test/sharness/t0086-repo-verify.sh
@@ -24,7 +24,7 @@ sort_rand() {
 }
 
 check_random_corruption() {
-	to_break=$(find "$IPFS_PATH/blocks" -type f | sort_rand | head -n 1)
+	to_break=$(find "$IPFS_PATH/blocks" -type f | grep -v README | grep -v SHARDING | sort_rand | head -n 1)
 
 	test_expect_success "back up file and overwrite it" '
 		cp "$to_break" backup_file &&


### PR DESCRIPTION
weird things were happening when this test selected the README or SHARDING file to delete (namely, deleting the sharding file makes it hard to know how to read  the datastore)