### PR TITLE
docker: expose port for /tcp/ws transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,16 @@ MAINTAINER Lars Gierth <lgierth@ipfs.io>
 # Please keep these two Dockerfiles in sync.
 
 
-# Ports for Swarm TCP, Swarm uTP, API, Gateway
+# /tcp transport
 EXPOSE 4001
+# /udp/utp transport
 EXPOSE 4002/udp
+# api
 EXPOSE 5001
+# gateway
 EXPOSE 8080
+# /tcp/ws transport
+EXPOSE 8081
 
 # Volume for mounting an IPFS fs-repo
 # This is moved to the bottom for technical reasons.


### PR DESCRIPTION
Picked :8081 here because the websockets transport's usage seemed more closely related to the gateway.