### PR TITLE
Link caching

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -218,9 +218,9 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 	}
 
 	n.Blocks = bserv.New(n.Blockstore, n.Exchange)
-	n.DAG = dag.NewDAGService(n.Blocks)
+	n.DAG = dag.NewDAGService(n.Blocks, n.Repo.Datastore())
 
-	internalDag := dag.NewDAGService(bserv.New(n.Blockstore, offline.Exchange(n.Blockstore)))
+	internalDag := dag.NewDAGService(bserv.New(n.Blockstore, offline.Exchange(n.Blockstore)), n.Repo.Datastore())
 	n.Pinning, err = pin.LoadPinner(n.Repo.Datastore(), n.DAG, internalDag)
 	if err != nil {
 		// TODO: we should move towards only running 'NewPinner' explicity on

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -251,13 +251,14 @@ You can now check what blocks have been created by:
 		}
 
 		exch := n.Exchange
+
 		local, _, _ := req.Option("local").Bool()
 		if local {
 			exch = offline.Exchange(addblockstore)
 		}
 
 		bserv := blockservice.New(addblockstore, exch)
-		dserv := dag.NewDAGService(bserv)
+		dserv := dag.NewDAGService(bserv, n.Repo.Datastore())
 
 		outChan := make(chan interface{}, adderOutChanSize)
 

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -377,8 +377,9 @@ func provideKeysRec(ctx context.Context, r routing.IpfsRouting, dserv dag.DAGSer
 	provided := cid.NewSet()
 	for _, c := range cids {
 		kset := cid.NewSet()
+		visitor := dag.FetchingVisitor(ctx, kset, dserv)
 
-		err := dag.EnumerateChildrenAsync(ctx, dag.GetLinksDirect(dserv), c, kset.Visit)
+		err := dag.EnumerateChildrenAsync(ctx, dserv.GetLinks, c, visitor)
 		if err != nil {
 			return err
 		}

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -79,7 +79,7 @@ The JSON output contains type information.
 		if !resolve {
 			offlineexch := offline.Exchange(nd.Blockstore)
 			bserv := blockservice.New(nd.Blockstore, offlineexch)
-			dserv = merkledag.NewDAGService(bserv)
+			dserv = merkledag.NewDAGService(bserv, nd.Repo.Datastore())
 		}
 
 		paths := req.Arguments()

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -554,8 +554,9 @@ func pinLsAll(typeStr string, ctx context.Context, n *core.IpfsNode) (map[string
 	}
 	if typeStr == "indirect" || typeStr == "all" {
 		set := cid.NewSet()
+		visitor := dag.FetchingVisitor(ctx, set, n.DAG)
 		for _, k := range n.Pinning.RecursiveKeys() {
-			err := dag.EnumerateChildren(n.Context(), n.DAG.GetLinks, k, set.Visit)
+			err := dag.EnumerateChildren(n.Context(), n.DAG.GetLinks, k, visitor)
 			if err != nil {
 				return nil, err
 			}

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -35,13 +35,14 @@ var RepoCmd = &cmds.Command{
 	},
 
 	Subcommands: map[string]*cmds.Command{
-		"stat": repoStatCmd,
+		"stat":    repoStatCmd,
 	},
 	OldSubcommands: map[string]*oldcmds.Command{
 		"gc":      repoGcCmd,
-		"fsck":    RepoFsckCmd,
-		"version": repoVersionCmd,
-		"verify":  repoVerifyCmd,
+		"fsck":           RepoFsckCmd,
+		"version":        repoVersionCmd,
+		"verify":         repoVerifyCmd,
+		"flushlinkcache": repoFlushLinkCacheCmd,
 	},
 }
 
@@ -215,6 +216,33 @@ Version         string The repo version.
 			return nil
 
 		}),
+	},
+}
+
+var repoFlushLinkCacheCmd = &oldcmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Flush link cache.",
+		ShortDescription: `
+'ipfs repo flushlinkcache' is a plumbing command that will flush link cache.
+`,
+	},
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
+		n, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
+		err = corerepo.FlushLinkCache(req.Context(), n)
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+		res.SetOutput(&MessageOutput{"Link cache flushed.\n"})
+	},
+	Type: MessageOutput{},
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Text: MessageTextMarshaler,
 	},
 }
 

--- a/core/corerepo/linkcache.go
+++ b/core/corerepo/linkcache.go
@@ -1,0 +1,25 @@
+package corerepo
+
+import (
+	context "context"
+	core "github.com/ipfs/go-ipfs/core"
+	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	dsq "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore/query"
+)
+
+// FlushLinkCache flushes link cache, deleting all keys in it
+func FlushLinkCache(ctx context.Context, n *core.IpfsNode) error {
+	d := n.Repo.Datastore()
+	q := dsq.Query{KeysOnly: true, Prefix: "/local/links/"}
+	qr, err := d.Query(q)
+	if err != nil {
+		return err
+	}
+	for result := range qr.Next() {
+		if result.Error != nil {
+			return result.Error
+		}
+		d.Delete(ds.NewKey(result.Entry.Key))
+	}
+	return nil
+}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -570,7 +570,7 @@ func NewMemoryDagService() dag.DAGService {
 	// build mem-datastore for editor's intermediary nodes
 	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
 	bsrv := bserv.New(bs, offline.Exchange(bs))
-	return dag.NewDAGService(bsrv)
+	return dag.NewDAGService(bsrv, syncds.MutexWrap(ds.NewMapDatastore()))
 }
 
 // from core/commands/object.go

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -26,7 +26,7 @@ func getDagserv(t *testing.T) merkledag.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))
-	return merkledag.NewDAGService(blockserv)
+	return merkledag.NewDAGService(blockserv, db)
 }
 
 func TestMetadata(t *testing.T) {

--- a/exchange/reprovide/providers.go
+++ b/exchange/reprovide/providers.go
@@ -55,8 +55,11 @@ func pinSet(ctx context.Context, pinning pin.Pinner, dag merkledag.DAGService, o
 		for _, key := range pinning.RecursiveKeys() {
 			set.add(key)
 
+			visitor := func(cid *cid.Cid) (bool, error) {
+				return set.add(key), nil
+			}
 			if !onlyRoots {
-				err := merkledag.EnumerateChildren(ctx, dag.GetLinks, key, set.add)
+				err := merkledag.EnumerateChildren(ctx, dag.GetLinks, key, visitor)
 				if err != nil {
 					log.Errorf("reprovide indirect pins: %s", err)
 					return

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -16,6 +16,28 @@ import (
 // for now, we use a PBNode intermediate thing.
 // because native go objects are nice.
 
+func intermediateMarshal(l *node.Link) *pb.PBLink {
+	pbl := &pb.PBLink{}
+	pbl.Name = &l.Name
+	pbl.Tsize = &l.Size
+	if l.Cid != nil {
+		pbl.Hash = l.Cid.Bytes()
+	}
+	return pbl
+}
+
+func intermediateUnmarshal(pbl *pb.PBLink) (*node.Link, error) {
+	l := new(node.Link)
+	l.Name = pbl.GetName()
+	l.Size = pbl.GetTsize()
+	c, err := cid.Cast(pbl.GetHash())
+	if err != nil {
+		return nil, fmt.Errorf("Link hash is not valid multihash. %v", err)
+	}
+	l.Cid = c
+	return l, nil
+}
+
 // unmarshal decodes raw data into a *Node instance.
 // The conversion uses an intermediate PBNode.
 func (n *ProtoNode) unmarshal(encoded []byte) error {

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -27,6 +27,8 @@ import (
 	node "gx/ipfs/QmNwUEK7QbwSqyKBu3mMtToo8SUc6wQJ7gdZq4gGGJqfnf/go-ipld-format"
 	u "gx/ipfs/QmPsAfmDBnZN3kZGSuNwvCNDZiHneERSKmRcFyG3UkvcT3/go-ipfs-util"
 	cid "gx/ipfs/QmeSrf6pzut73u6zLQkRFQ3ygt3k6XFT2kjdYP8Tnkwwyg/go-cid"
+	ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
+	syncds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore/sync"
 )
 
 func TestNode(t *testing.T) {
@@ -133,7 +135,7 @@ func runBatchFetchTest(t *testing.T, read io.Reader) {
 	ctx := context.Background()
 	var dagservs []DAGService
 	for _, bsi := range bstest.Mocks(5) {
-		dagservs = append(dagservs, NewDAGService(bsi))
+		dagservs = append(dagservs, NewDAGService(bsi, syncds.MutexWrap(ds.NewMapDatastore())))
 	}
 
 	spl := chunk.NewSizeSplitter(read, 512)
@@ -224,7 +226,7 @@ func TestFetchGraph(t *testing.T) {
 	var dservs []DAGService
 	bsis := bstest.Mocks(2)
 	for _, bsi := range bsis {
-		dservs = append(dservs, NewDAGService(bsi))
+		dservs = append(dservs, NewDAGService(bsi, syncds.MutexWrap(ds.NewMapDatastore())))
 	}
 
 	read := io.LimitReader(u.NewTimeSeededRand(), 1024*32)
@@ -241,9 +243,9 @@ func TestFetchGraph(t *testing.T) {
 	// create an offline dagstore and ensure all blocks were fetched
 	bs := bserv.New(bsis[1].Blockstore(), offline.Exchange(bsis[1].Blockstore()))
 
-	offline_ds := NewDAGService(bs)
+	offlineDs := NewDAGService(bs, syncds.MutexWrap(ds.NewMapDatastore()))
 
-	err = EnumerateChildren(context.Background(), offline_ds.GetLinks, root.Cid(), func(_ *cid.Cid) bool { return true })
+	err = EnumerateChildren(context.Background(), offlineDs.GetLinks, root.Cid(), OnceVisitor(cid.NewSet()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +253,7 @@ func TestFetchGraph(t *testing.T) {
 
 func TestEnumerateChildren(t *testing.T) {
 	bsi := bstest.Mocks(1)
-	ds := NewDAGService(bsi[0])
+	ds := NewDAGService(bsi[0], syncds.MutexWrap(ds.NewMapDatastore()))
 
 	read := io.LimitReader(u.NewTimeSeededRand(), 1024*1024)
 	root, err := imp.BuildDagFromReader(ds, chunk.NewSizeSplitter(read, 512))
@@ -260,7 +262,7 @@ func TestEnumerateChildren(t *testing.T) {
 	}
 
 	set := cid.NewSet()
-	err = EnumerateChildren(context.Background(), ds.GetLinks, root.Cid(), set.Visit)
+	err = EnumerateChildren(context.Background(), ds.GetLinks, root.Cid(), FetchingVisitor(context.Background(), set, ds))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +473,7 @@ func TestCidRetention(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ds := NewDAGService(bs)
+	ds := NewDAGService(bs, syncds.MutexWrap(ds.NewMapDatastore()))
 	out, err := ds.Get(context.Background(), c2)
 	if err != nil {
 		t.Fatal(err)
@@ -483,7 +485,7 @@ func TestCidRetention(t *testing.T) {
 }
 
 func TestCidRawDoesnNeedData(t *testing.T) {
-	srv := NewDAGService(dstest.Bserv())
+	srv := NewDAGService(dstest.Bserv(), syncds.MutexWrap(ds.NewMapDatastore()))
 	nd := NewRawNode([]byte("somedata"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -506,7 +508,7 @@ func TestEnumerateAsyncFailsNotFound(t *testing.T) {
 	c := NodeWithData([]byte("foo3"))
 	d := NodeWithData([]byte("foo4"))
 
-	ds := dstest.Mock()
+	ds := NewDAGService(dstest.Bserv(), syncds.MutexWrap(ds.NewMapDatastore()))
 	for _, n := range []node.Node{a, b, c} {
 		_, err := ds.Add(n)
 		if err != nil {
@@ -536,8 +538,7 @@ func TestEnumerateAsyncFailsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cset := cid.NewSet()
-	err = EnumerateChildrenAsync(context.Background(), GetLinksDirect(ds), pcid, cset.Visit)
+	err = EnumerateChildrenAsync(context.Background(), ds.GetLinks, pcid, FetchingVisitor(context.Background(), cid.NewSet(), ds))
 	if err == nil {
 		t.Fatal("this should have failed")
 	}

--- a/merkledag/test/utils.go
+++ b/merkledag/test/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Mock() dag.DAGService {
-	return dag.NewDAGService(Bserv())
+	return dag.NewDAGService(Bserv(), ds.NewMapDatastore())
 }
 
 func Bserv() bsrv.BlockService {

--- a/merkledag/utils/diffenum.go
+++ b/merkledag/utils/diffenum.go
@@ -13,7 +13,7 @@ import (
 // DiffEnumerate fetches every object in the graph pointed to by 'to' that is
 // not in 'from'. This can be used to more efficiently fetch a graph if you can
 // guarantee you already have the entirety of 'from'
-func DiffEnumerate(ctx context.Context, dserv node.NodeGetter, from, to *cid.Cid) error {
+func DiffEnumerate(ctx context.Context, dserv mdag.DAGService, from, to *cid.Cid) error {
 	fnd, err := dserv.Get(ctx, from)
 	if err != nil {
 		return fmt.Errorf("get %s: %s", from, err)
@@ -40,7 +40,7 @@ func DiffEnumerate(ctx context.Context, dserv node.NodeGetter, from, to *cid.Cid
 			if sset.Has(c.aft) {
 				continue
 			}
-			err := mdag.EnumerateChildrenAsync(ctx, mdag.GetLinksDirect(dserv), c.aft, sset.Visit)
+			err := mdag.EnumerateChildrenAsync(ctx, dserv.GetLinks, c.aft, mdag.FetchingVisitor(ctx, sset, dserv))
 			if err != nil {
 				return err
 			}

--- a/merkledag/utils/diffenum_test.go
+++ b/merkledag/utils/diffenum_test.go
@@ -154,17 +154,49 @@ func TestDiffEnumBasic(t *testing.T) {
 }
 
 type getLogger struct {
-	ds  node.NodeGetter
+	ds  dag.DAGService
 	log []*cid.Cid
 }
 
 func (gl *getLogger) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
-	nd, err := gl.ds.Get(ctx, c)
+	n, err := gl.ds.Get(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 	gl.log = append(gl.log, c)
-	return nd, nil
+	return n, nil
+}
+
+func (gl *getLogger) Add(n node.Node) (*cid.Cid, error) {
+	return gl.ds.Add(n)
+}
+
+func (gl *getLogger) Fetch(ctx context.Context, c *cid.Cid) error {
+	err := gl.ds.Fetch(ctx, c)
+	if err == nil {
+		gl.log = append(gl.log, c)
+	}
+	return err
+}
+
+func (gl *getLogger) Remove(n node.Node) error {
+	return gl.ds.Remove(n)
+}
+
+func (gl *getLogger) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *dag.NodeOption {
+	return gl.ds.GetMany(ctx, cids)
+}
+
+func (gl *getLogger) Batch() *dag.Batch {
+	return gl.ds.Batch()
+}
+
+func (gl *getLogger) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
+	return gl.ds.GetLinks(ctx, c)
+}
+
+func (gl *getLogger) GetOfflineLinkService() dag.LinkService {
+	return gl.ds.GetOfflineLinkService()
 }
 
 func assertCidList(a, b []*cid.Cid) error {

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -31,7 +31,7 @@ func NewMemoryDagService() dag.DAGService {
 	// build mem-datastore for editor's intermediary nodes
 	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
 	bsrv := bserv.New(bs, offline.Exchange(bs))
-	return dag.NewDAGService(bsrv)
+	return dag.NewDAGService(bsrv, syncds.MutexWrap(ds.NewMapDatastore()))
 }
 
 // root is the node to be modified, source is the dagstore to pull nodes from (optional)

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -39,7 +39,7 @@ func getDagserv(t *testing.T) dag.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))
-	return dag.NewDAGService(blockserv)
+	return dag.NewDAGService(blockserv, db)
 }
 
 func getRandFile(t *testing.T, ds dag.DAGService, size int64) node.Node {

--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -114,7 +114,7 @@ func Descendants(ctx context.Context, getLinks dag.GetLinks, set *cid.Set, roots
 		set.Add(c)
 
 		// EnumerateChildren recursively walks the dag and adds the keys to the given set
-		err := dag.EnumerateChildren(ctx, getLinks, c, set.Visit)
+		err := dag.EnumerateChildren(ctx, getLinks, c, dag.OnceVisitor(set))
 		if err != nil {
 			return err
 		}

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -53,7 +53,7 @@ func TestPinnerBasic(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 
 	// TODO does pinner need to share datastore with blockservice?
 	p := NewPinner(dstore, dserv, dserv)
@@ -178,7 +178,7 @@ func TestIsPinnedLookup(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 
 	// TODO does pinner need to share datastore with blockservice?
 	p := NewPinner(dstore, dserv, dserv)
@@ -278,7 +278,7 @@ func TestDuplicateSemantics(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 
 	// TODO does pinner need to share datastore with blockservice?
 	p := NewPinner(dstore, dserv, dserv)
@@ -313,7 +313,7 @@ func TestFlush(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 	p := NewPinner(dstore, dserv, dserv)
 	_, k := randNode()
 
@@ -329,7 +329,7 @@ func TestPinRecursiveFail(t *testing.T) {
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 
 	p := NewPinner(dstore, dserv, dserv)
 
@@ -373,7 +373,7 @@ func TestPinUpdate(t *testing.T) {
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
 
-	dserv := mdag.NewDAGService(bserv)
+	dserv := mdag.NewDAGService(bserv, dstore)
 	p := NewPinner(dstore, dserv, dserv)
 	n1, c1 := randNode()
 	n2, c2 := randNode()

--- a/pin/set_test.go
+++ b/pin/set_test.go
@@ -39,7 +39,7 @@ func objCount(d ds.Datastore) int {
 func TestSet(t *testing.T) {
 	dst := ds.NewMapDatastore()
 	bstore := blockstore.NewBlockstore(dst)
-	ds := dag.NewDAGService(bserv.New(bstore, offline.Exchange(bstore)))
+	ds := dag.NewDAGService(bserv.New(bstore, offline.Exchange(bstore)), dst)
 
 	// this value triggers the creation of a recursive shard.
 	// If the recursive sharding is done improperly, this will result in

--- a/test/sharness/t0087-repo-robust-gc.sh
+++ b/test/sharness/t0087-repo-robust-gc.sh
@@ -45,6 +45,7 @@ test_gc_robust_part1() {
   '
 
   test_expect_success "'ipfs repo gc' should abort without removing anything" '
+		ipfs repo flushlinkcache
     test_must_fail ipfs repo gc 2>&1 | tee gc_err &&
     grep -q "could not retrieve links for $HASH1" gc_err &&
     grep -q "aborted" gc_err
@@ -128,6 +129,7 @@ test_gc_robust_part2() {
   '
 
   test_expect_success "'ipfs repo gc' should abort with two errors" '
+		ipfs repo flushlinkcache
     test_must_fail ipfs repo gc 2>&1 | tee repo_gc_out &&
     grep -q "could not retrieve links for $LEAF1" repo_gc_out &&
     grep -q "could not retrieve links for $LEAF2" repo_gc_out &&


### PR DESCRIPTION
This PR introduces link caching in GetLinks, dramatically speeding up, among other things, pinning large sets of data already present in DB.

Performance on my machine:
Pinning 1.7GB without cache: 1.08m
Pinning the same with cache: ~1s

Includes #3598.
Fixes #3505.