### PR TITLE
migrations: make libc check more resilient

### DIFF
--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -128,7 +128,7 @@ func migrationsVersion(bin string) (int, error) {
 	vs := strings.Trim(string(out), " \n\t")
 	vn, err := strconv.Atoi(vs)
 	if err != nil {
-		return 0, fmt.Errorf("migrations binary version check did not return a number")
+		return 0, fmt.Errorf("migrations binary version check did not return a number: %s", err)
 	}
 
 	return vn, nil
@@ -253,17 +253,19 @@ func osWithVariant() (string, error) {
 		return "", fmt.Errorf("failed to resolve go-ipfs: %s", err)
 	}
 
-	cmd := exec.Command("ldd", bin)
+	// ldd outputs the system's kind of libc
+	// - on standard ubuntu: ldd (Ubuntu GLIBC 2.23-0ubuntu5) 2.23
+	// - on alpine: musl libc (x86_64)
+	cmd := exec.Command("ldd --version", bin)
 	buf := new(bytes.Buffer)
 	cmd.Stdout = buf
-	err = cmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("failed to run ldd: %s", err)
-	}
+	// we throw away the error, this code path must not fail because of
+	// a silly issue such as missing/broken ldd. we'll assume glibc in that case.
+	_ = cmd.Run()
 
 	scan := bufio.NewScanner(buf)
 	for scan.Scan() {
-		if strings.Contains(scan.Text(), "libc") && strings.Contains(scan.Text(), "musl") {
+		if strings.Contains(scan.Text(), "musl") {
 			return "linux-musl", nil
 		}
 	}


### PR DESCRIPTION
@hsanjuan you should be able to build go-ipfs from this branch and copy it into the container, and it should work then.

Fixes #3661.

There are a couple of cases in which ldd won't operate on an executable,
for example when the executable is statically linked.

This patch makes the call to ldd to ldd more resilient against errors,
and looks for the system libc, instead of the libc go-ipfs was linked against.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>