### PR TITLE
gx publish 0.4.5, cleaner

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.5: QmRAcFM1PvBDbad2KsDnbMX2vDZBQ6YNyAXb22RzWZaqwd
+0.4.5: QmTeScpc3XPbZkSjtxuMykH5wUew8hbV72N6jaCj4aRHPQ


### PR DESCRIPTION
The old hash had a bunch of test stuff that was hidden in it.