### PR TITLE
Dockerfile: Deprecate implicit daemon argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,6 @@ VOLUME $IPFS_PATH
 # 1. There's an fs-repo, and initializes one if there isn't.
 # 2. The API and Gateway are accessible from outside the container.
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
+
+# Execute the daemon subcommand by default
+CMD ["daemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ VOLUME $IPFS_PATH
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
 
 # Execute the daemon subcommand by default
-CMD ["daemon"]
+CMD ["daemon", "--migrate=true"]

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,3 +53,4 @@ RUN cd $SRC_PATH \
 USER ipfs
 VOLUME $IPFS_PATH
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
+CMD ["daemon"]

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,4 +53,4 @@ RUN cd $SRC_PATH \
 USER ipfs
 VOLUME $IPFS_PATH
 ENTRYPOINT ["/usr/local/bin/start_ipfs"]
-CMD ["daemon"]
+CMD ["daemon", "--migrate=true"]

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -32,7 +32,9 @@ else
   # when overwriting CMD, making this PR safe to merge
   echo "DEPRECATED: arguments have been set but the first argument isn't 'daemon'" >&2
   echo "DEPRECATED: run 'docker run ipfs/go-ipfs daemon $@' instead" >&2
-  echo "DEPRECATED: see https://github.com/ipfs/go-ipfs/pull/3573 for more information" >&2
+  echo "DEPRECATED: see the following PRs for more information:" >&2
+  echo "DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3573" >&2
+  echo "DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3685" >&2
 fi
 
 exec ipfs daemon "$@"

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -19,4 +19,20 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
+# if the first argument is daemon
+if [ "$1" = "daemon" ]; then
+  # filter the first argument until
+  # https://github.com/ipfs/go-ipfs/pull/3573
+  # has been resolved
+  shift
+else
+  # print deprecation warning
+  # go-ipfs used to hardcode "ipfs daemon" in it's entrypoint
+  # this workaround supports the new syntax so people start setting daemon explicitly
+  # when overwriting CMD, making this PR safe to merge
+  echo "DEPRECATED: arguments have been set but the first argument isn't 'daemon'" >&2
+  echo "DEPRECATED: run 'docker run ipfs/go-ipfs daemon $@' instead" >&2
+  echo "DEPRECATED: see https://github.com/ipfs/go-ipfs/pull/3573 for more information" >&2
+fi
+
 exec ipfs daemon "$@"


### PR DESCRIPTION
After the discussion in https://github.com/ipfs/go-ipfs/pull/3573 this patch prints a deprecation warning if:

1) the image has been executed with additional arguments
2) the first argument isn't daemon

This way people are able to migrate to the new syntax without any breaking changes.

License: MIT
Signed-off-by: kpcyrd <git@rxv.cc>