### PR TITLE
WIP: fsrepo: fix musl detection for migrations

### DIFF
--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -243,27 +243,30 @@ func GetBinaryForVersion(distname, binnom, root, vers, out string) error {
 	return unpackArchive(distname, binnom, arcpath, out, archive)
 }
 
+// osWithVariant returns the OS name with optional variant.
+// Currently returns either runtime.GOOS, or "linux-musl".
 func osWithVariant() (string, error) {
 	if runtime.GOOS != "linux" {
 		return runtime.GOOS, nil
 	}
 
-	bin, err := exec.LookPath(filepath.Base(os.Args[0]))
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve go-ipfs: %s", err)
-	}
-
-	// ldd outputs the system's kind of libc
+	// ldd outputs the system's kind of libc.
 	// - on standard ubuntu: ldd (Ubuntu GLIBC 2.23-0ubuntu5) 2.23
 	// - on alpine: musl libc (x86_64)
-	cmd := exec.Command("ldd --version", bin)
-	buf := new(bytes.Buffer)
-	cmd.Stdout = buf
-	// we throw away the error, this code path must not fail because of
-	// a silly issue such as missing/broken ldd. we'll assume glibc in that case.
-	_ = cmd.Run()
+	//
+	// we use the combined stdout+stderr,
+	// because ldd --version prints differently on different OSes.
+	// - on standard ubuntu: stdout
+	// - on alpine: stderr (it probably doesn't know the --version flag)
+	//
+	// we supress non-zero exit codes (see last point about alpine).
+	out, err := exec.Command("sh", "-c", "ldd --version || true").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
 
-	scan := bufio.NewScanner(buf)
+	// now just see if we can find "musl" somewhere in the output
+	scan := bufio.NewScanner(bytes.NewBuffer(out))
 	for scan.Scan() {
 		if strings.Contains(scan.Text(), "musl") {
 			return "linux-musl", nil

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -147,7 +147,7 @@ test_init_ipfs() {
 		test_config_set Mounts.IPFS "$(pwd)/ipfs" &&
 		test_config_set Mounts.IPNS "$(pwd)/ipns" &&
 		test_config_set Addresses.API "/ip4/127.0.0.1/tcp/0" &&
-		test_config_set Addresses.Gateway "/ip4/127.0.0.1/tcp/0" &&
+		test_config_set Addresses.Gateway "/ip4/0.0.0.0/tcp/0" &&
 		test_config_set --json Addresses.Swarm "[
   \"/ip4/0.0.0.0/tcp/0\"
 ]" &&

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -49,31 +49,4 @@ test_expect_success "output looks good" '
 	grep "Please get fs-repo-migrations from https://dist.ipfs.io" daemon_out > /dev/null
 '
 
-test_launch_ipfs_daemon
-
-test_expect_success "build fake dist.ipfs.io" '
-	mkdir -p fakedist/fs-repo-migrations/v1.0.0/
-	echo "v1.0.0" > fakedist/fs-repo-migrations/versions
-
-	echo "#!/bin/sh" >  fakedist/linux
-	echo "echo linux $@" >> fakedist/linux
-	tar -czf fakedist/fs-repo-migrations/fs-repo-migrations_v1.0.0_linux-amd64.tar.gz fakedist/linux
-
-	echo "#!/bin/sh" >  fakedist/linux-musl
-	echo "echo linux-musl $@" >> fakedist/linux-musl
-	tar -czf fakedist/fs-repo-migrations/fs-repo-migrations_v1.0.0_linux-musl-amd64.tar.gz fakedist/linux-musl
-
-	ipfs add -q -r fakedist/ > fakedisthash
-'
-
-test_expect_success "detect musl" '
-	IPFS_DIST_PATH="http://172.17.0.1:$GWAY_PORT" echo $IPFS_DIST_PATH
-'
-
-# make fakedist with executables that just echo "I'm $GOOS-$variant with $ARGV"
-# ipfs add -r fakedist
-# find out IPFS_DIST_PATH
-# run daemon --migrate end-to-end
-# check for correct output
-
 test_done

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -49,4 +49,31 @@ test_expect_success "output looks good" '
 	grep "Please get fs-repo-migrations from https://dist.ipfs.io" daemon_out > /dev/null
 '
 
+test_launch_ipfs_daemon
+
+test_expect_success "build fake dist.ipfs.io" '
+	mkdir -p fakedist/fs-repo-migrations/v1.0.0/
+	echo "v1.0.0" > fakedist/fs-repo-migrations/versions
+
+	echo "#!/bin/sh" >  fakedist/linux
+	echo "echo linux $@" >> fakedist/linux
+	tar -czf fakedist/fs-repo-migrations/fs-repo-migrations_v1.0.0_linux-amd64.tar.gz fakedist/linux
+
+	echo "#!/bin/sh" >  fakedist/linux-musl
+	echo "echo linux-musl $@" >> fakedist/linux-musl
+	tar -czf fakedist/fs-repo-migrations/fs-repo-migrations_v1.0.0_linux-musl-amd64.tar.gz fakedist/linux-musl
+
+	ipfs add -q -r fakedist/ > fakedisthash
+'
+
+test_expect_success "detect musl" '
+	IPFS_DIST_PATH="http://172.17.0.1:$GWAY_PORT" echo $IPFS_DIST_PATH
+'
+
+# make fakedist with executables that just echo "I'm $GOOS-$variant with $ARGV"
+# ipfs add -r fakedist
+# find out IPFS_DIST_PATH
+# run daemon --migrate end-to-end
+# check for correct output
+
 test_done

--- a/test/sharness/t0301-docker-migrate.sh
+++ b/test/sharness/t0301-docker-migrate.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# Copyright (c) 2017 Whyrusleeping
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test docker image migration"
+
+. lib/test-lib.sh
+
+# if in travis CI on OSX, docker is not available
+if ! test_have_prereq DOCKER; then
+	skip_all='skipping docker tests, docker not available'
+
+	test_done
+fi
+
+TEST_TRASH_DIR=$(pwd)
+TEST_SCRIPTS_DIR=$(dirname "$TEST_TRASH_DIR")
+TEST_TESTS_DIR=$(dirname "$TEST_SCRIPTS_DIR")
+APP_ROOT_DIR=$(dirname "$TEST_TESTS_DIR")
+
+test_expect_success "docker image build succeeds" '
+	docker_build "$TEST_TESTS_DIR/../Dockerfile.fast" "$APP_ROOT_DIR" >actual &&
+	IMAGE_ID=$(tail -n1 actual | cut -d " " -f 3)
+'
+
+test_init_ipfs
+
+test_expect_success "make repo be version 4" '
+	echo 4 > "$IPFS_PATH/version"
+'
+
+test_expect_success "setup http response" '
+	echo "HTTP/1.1 200 OK" > vers_resp &&
+	echo "Content-Length: 7" >> vers_resp &&
+	echo "" >> vers_resp &&
+	echo "v1.1.1" >> vers_resp
+'
+
+pretend_server() {
+	cat vers_resp | nc -l -i 1 -p 17233
+}
+
+test_expect_success "startup fake dists server" '
+	pretend_server > dist_serv_out &
+	echo $! > netcat_pid
+'
+
+test_expect_success "docker image runs" '
+	DOC_ID=$(docker run -d -v "$IPFS_PATH":/data/ipfs --net=host -e IPFS_DIST_PATH="http://localhost:17233" "$IMAGE_ID" --migrate)
+'
+
+test_expect_success "docker container tries to pull migrations from netcat" '
+	sleep 4 &&
+	cat dist_serv_out
+'
+
+test_expect_success "see logs" '
+	docker logs $DOC_ID
+'
+
+test_expect_success "stop docker container" '
+	docker_stop "$DOC_ID"
+'
+
+test_expect_success "kill the net cat" '
+	kill $(cat netcat_pid) || true
+'
+
+test_expect_success "correct version was requested" '
+	grep "/fs-repo-migrations/v1.1.1/fs-repo-migrations_v1.1.1_linux-musl-amd64.tar.gz" dist_serv_out > /dev/null
+'
+
+test_done
+


### PR DESCRIPTION
Note: the tests here are totally incomplete, I keep getting stuck :/

If someone else wants to take a look today, that'd be super helpful. The migrations code itself should be good.

------

The ldd command used for detection doesn't seem to have a
--version flag on Alpine Linux. It would print the expected
output, but instead of stdout, it would print it on stderr.

The musl detection code would only scan stdout for mentions
of "musl", and would thus *not* download the musl version
of the fs-repo-migrations executable.

This manifested in the well-known "fs-repo-migrations: not found"
error, which you get when executing something that was linked
against a different libc than the one present on the system.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>