### PR TITLE
Update gx to version 0.11

### DIFF
--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -1,8 +1,8 @@
 include mk/header.mk
 
-dist_root_$(d)=/ipfs/QmTazYLCem8B7pQGLsCj1Q4MxkqGMmD9XugvStLJSQ8uxA
+dist_root_$(d)=/ipfs/QmNjXP6N98fYT1i7abgeBHmdR5WoeBeik4DtGiX9iFWK31
 
-$(d)/gx: $(d)/gx-v0.10.0
+$(d)/gx: $(d)/gx-v0.11.0
 $(d)/gx-go: $(d)/gx-go-v1.4.0
 
 TGTS_$(d) := $(d)/gx $(d)/gx-go


### PR DESCRIPTION
Previous version 0.10 was built with faulty version of Go 1.7 which has
problems with TCP -> DNS -> UDP timeouts.

This results in many failed calls to `gx install`

This wasn't easy to find.

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>