### PR TITLE
make: use git clean in distclean target

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -83,6 +83,7 @@ coverage: $(COVERAGE)
 
 distclean: clean
 	rm -rf $(DISTCLEAN)
+	git clean -ffxd
 .PHONY: distclean
 
 test: $(TEST)


### PR DESCRIPTION
This is the cleanest the repo will get.
If you need to publish it, tar it or anything else like that use
`make distclean`.

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>