### PR TITLE
daemon: move gateway start to latter

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -372,17 +372,6 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 		return
 	}
 
-	// construct http gateway - if it is set in the config
-	var gwErrc <-chan error
-	if len(cfg.Addresses.Gateway) > 0 {
-		var err error
-		err, gwErrc = serveHTTPGateway(req)
-		if err != nil {
-			res.SetError(err, cmds.ErrNormal)
-			return
-		}
-	}
-
 	// construct fuse mountpoints - if the user provided the --mount flag
 	mount, _, err := req.Option(mountKwd).Bool()
 	if err != nil {
@@ -406,6 +395,17 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 	if err != nil {
 		res.SetError(err, cmds.ErrNormal)
 		return
+	}
+
+	// construct http gateway - if it is set in the config
+	var gwErrc <-chan error
+	if len(cfg.Addresses.Gateway) > 0 {
+		var err error
+		err, gwErrc = serveHTTPGateway(req)
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
 	}
 
 	// initialize metrics collector


### PR DESCRIPTION
To prevent panic when daemon closes early.

Resolves #3710

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>