### PR TITLE
feat: remove broken spdy multiplexer and enable multiplex by default as second option

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -161,8 +161,7 @@ Headers.
 		cmds.BoolOption(offlineKwd, "Run offline. Do not connect to the rest of the network but provide local API.").Default(false),
 		cmds.BoolOption(migrateKwd, "If true, assume yes at the migrate prompt. If false, assume no."),
 		cmds.BoolOption(enableFloodSubKwd, "Instantiate the ipfs daemon with the experimental pubsub feature enabled."),
-		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction."),
-
+		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").Default(true),
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
 		// cmds.StringOption(swarmAddrKwd, "Address for the swarm socket (overrides config)"),

--- a/core/core.go
+++ b/core/core.go
@@ -63,7 +63,6 @@ import (
 	ping "gx/ipfs/QmU3g3psEDiC4tQh1Qu2NYg5aYVQqxC3m74ZavLwPfJEtu/go-libp2p/p2p/protocol/ping"
 	dht "gx/ipfs/QmUpZqxzrUoyDsgWXDri9yYgi5r5EK7J5Tan1MbgnawYLx/go-libp2p-kad-dht"
 	cid "gx/ipfs/QmV5gPoRsjN1Gid3LMdNZTyfCtP2DsvqEbMAmz82RmmiGk/go-cid"
-	spdy "gx/ipfs/QmWUNsat6Jb19nC5CiJCDXepTkxjdxi3eZqeoB6mrmmaGu/go-smux-spdystream"
 	peer "gx/ipfs/QmZcUPvPhD1Xvk6mwijYF8AfR3mG31S1YsEfHG4khrFPRr/go-libp2p-peer"
 	routing "gx/ipfs/QmZghcVHwXQC3Zvnvn24LgTmSPkEn2o3PDyKb6nrtPRzRh/go-libp2p-routing"
 	u "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
@@ -276,8 +275,6 @@ func makeSmuxTransport(mplexExp bool) smux.Transport {
 	}
 
 	mstpt.AddTransport("/yamux/1.0.0", ymxtpt)
-
-	mstpt.AddTransport("/spdy/3.1.0", spdy.Transport)
 
 	if mplexExp {
 		mstpt.AddTransport("/mplex/6.7.0", mplex.DefaultTransport)

--- a/test/sharness/t0130-multinode.sh
+++ b/test/sharness/t0130-multinode.sh
@@ -90,7 +90,7 @@ test_expect_success "set up tcp testbed" '
 
 # test multiplex muxer
 export LIBP2P_MUX_PREFS="/mplex/6.7.0"
-run_advanced_test "--enable-mplex-experiment"
+run_advanced_test
 unset LIBP2P_MUX_PREFS
 
 # test default configuration


### PR DESCRIPTION
- spdystream is not fully spdy spec compatible, creating issues when
  doing interop with js, so it is removed
- muliplex is working well now in interop with js, so being enabled by
  default

This means the new default muxers are `yamux,mplex`