### PR TITLE
Add support for s3 backed ipfs repo

### DIFF
--- a/repo/config/datastore.go
+++ b/repo/config/datastore.go
@@ -35,6 +35,21 @@ type S3Datastore struct {
 	ACL    string `json:"acl"`
 }
 
+type FlatDS struct {
+	Path      string
+	PrefixLen int
+	Sync      bool
+}
+
+type LevelDB struct {
+	Path        string
+	Compression string
+}
+
+type MeasureDB struct {
+	Label string
+}
+
 // DataStorePath returns the default data store path given a configuration root
 // (set an empty string to have the default configuration root)
 func DataStorePath(configroot string) (string, error) {

--- a/repo/config/datastore.go
+++ b/repo/config/datastore.go
@@ -1,32 +1,20 @@
 package config
 
-import (
-	"encoding/json"
-)
-
 // DefaultDataStoreDirectory is the directory to store all the local IPFS data.
 const DefaultDataStoreDirectory = "datastore"
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
-	Type               string
-	Path               string
 	StorageMax         string // in B, kB, kiB, MB, ...
 	StorageGCWatermark int64  // in percentage to multiply on StorageMax
 	GCPeriod           string // in ns, us, ms, s, m, h
+	Path               string
+	NoSync             bool // deprecated
 
-	Params          *json.RawMessage
-	NoSync          bool
+	Spec map[string]interface{}
+
 	HashOnRead      bool
 	BloomFilterSize int
-}
-
-func (d *Datastore) ParamData() []byte {
-	if d.Params == nil {
-		return nil
-	}
-
-	return []byte(*d.Params)
 }
 
 type S3Datastore struct {
@@ -44,10 +32,6 @@ type FlatDS struct {
 type LevelDB struct {
 	Path        string
 	Compression string
-}
-
-type MeasureDB struct {
-	Label string
 }
 
 // DataStorePath returns the default data store path given a configuration root

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -40,7 +40,7 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 			Gateway: "/ip4/127.0.0.1/tcp/8080",
 		},
 
-		Datastore: datastore,
+		Datastore: *datastore,
 		Bootstrap: BootstrapPeerStrings(bootstrapPeers),
 		Identity:  identity,
 		Discovery: Discovery{MDNS{
@@ -76,19 +76,38 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 	return conf, nil
 }
 
-func datastoreConfig() (Datastore, error) {
-	dspath, err := DataStorePath("")
-	if err != nil {
-		return Datastore{}, err
-	}
-	return Datastore{
-		Path:               dspath,
-		Type:               "leveldb",
+func datastoreConfig() (*Datastore, error) {
+	return &Datastore{
 		StorageMax:         "10GB",
 		StorageGCWatermark: 90, // 90%
 		GCPeriod:           "1h",
-		HashOnRead:         false,
 		BloomFilterSize:    0,
+		Spec: map[string]interface{}{
+			"type": "mount",
+			"mounts": []interface{}{
+				map[string]interface{}{
+					"mountpoint": "/blocks",
+					"type":       "measure",
+					"prefix":     "flatfs.datastore",
+					"child": map[string]interface{}{
+						"type":      "flatfs",
+						"path":      "blocks",
+						"nosync":    false,
+						"prefixLen": 4,
+					},
+				},
+				map[string]interface{}{
+					"mountpoint": "/",
+					"type":       "measure",
+					"prefix":     "leveldb.datastore",
+					"child": map[string]interface{}{
+						"type":        "levelds",
+						"path":        "datastore",
+						"compression": "none",
+					},
+				},
+			},
+		},
 	}, nil
 }
 

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -3,7 +3,7 @@ package fsrepo
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
+	"path/filepath"
 
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
@@ -11,72 +11,132 @@ import (
 	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
 	mount "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore/syncmount"
 	levelds "gx/ipfs/QmaHHmfEozrrotyhyN44omJouyuEtx6ahddqV6W5yRaUSQ/go-ds-leveldb"
-	ldb "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
+	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
+	"gx/ipfs/QmbUSMTQtK9GRrUbD4ngqJwSzHsquUc8nyDubRWp4vPybH/go-ds-measure"
 	"gx/ipfs/Qmbx2KUs8mUbDUiiESzC1ms7mdmh4pRu8X1V1tffC46M4n/go-ds-flatfs"
 )
 
-func openDatastore(kind string, params []byte) (repo.Datastore, error) {
+func (r *FSRepo) constructDatastore(kind string, params []byte) (repo.Datastore, error) {
 	switch kind {
 	case "mount":
-		var mountmap map[string]*json.RawMessage
-		if err := json.Unmarshal(params, &mountmap); err != nil {
+		var mounts []*mountConfig
+		if err := json.Unmarshal(params, &mounts); err != nil {
 			return nil, fmt.Errorf("datastore mount: %v", err)
 		}
 
-		return openMountDatastore(mountmap)
+		return r.openMountDatastore(mounts)
 	case "flatfs":
 		var flatfsparams config.FlatDS
 		if err := json.Unmarshal(params, &flatfsparams); err != nil {
-			return nil, fmt.Errorf("datastore mount: %v", err)
+			return nil, fmt.Errorf("datastore flatfs: %v", err)
 		}
 
-		return openFlatfsDatastore(&flatfsparams)
+		return r.openFlatfsDatastore(&flatfsparams)
+	case "mem":
+		return ds.NewMapDatastore(), nil
+	case "log":
+		var cfg struct {
+			Name      string
+			ChildType string
+			Child     *json.RawMessage
+		}
+
+		if err := json.Unmarshal(params, &cfg); err != nil {
+			return nil, fmt.Errorf("datastore measure: %v", err)
+		}
+
+		child, err := r.constructDatastore(cfg.ChildType, []byte(*cfg.Child))
+		if err != nil {
+			return nil, err
+		}
+
+		return ds.NewLogDatastore(child, cfg.Name), nil
+
+	case "measure":
+		var measureOpts struct {
+			Prefix    string
+			ChildType string
+			Child     *json.RawMessage
+		}
+
+		if err := json.Unmarshal(params, &measureOpts); err != nil {
+			return nil, fmt.Errorf("datastore measure: %v", err)
+		}
+
+		child, err := r.constructDatastore(measureOpts.ChildType, []byte(*measureOpts.Child))
+		if err != nil {
+			return nil, err
+		}
+
+		return r.openMeasureDB(measureOpts.Prefix, child)
+
+	case "levelds":
+		var c config.LevelDB
+		if err := json.Unmarshal(params, &c); err != nil {
+			return nil, fmt.Errorf("datastore levelds: %v", err)
+		}
+
+		return r.openLeveldbDatastore(&c)
+
 	default:
 		return nil, fmt.Errorf("unknown datastore type: %s", kind)
 	}
 }
 
-func openMountDatastore(mountmap map[string]*json.RawMessage) (repo.Datastore, error) {
+type mountConfig struct {
+	Path      string
+	ChildType string
+	Child     *json.RawMessage
+}
+
+func (r *FSRepo) openMountDatastore(mountcfg []*mountConfig) (repo.Datastore, error) {
 	var mounts []mount.Mount
-	for k, v := range mountmap {
-		vals := strings.Split(k, "@")
-		if len(vals) != 2 {
-			return nil, fmt.Errorf("mount config must be 'type@path'")
-		}
+	for _, cfg := range mountcfg {
 
-		kind := vals[0]
-		path := vals[1]
-
-		child, err := openDatastore(kind, []byte(*v))
+		child, err := r.constructDatastore(cfg.ChildType, []byte(*cfg.Child))
 		if err != nil {
 			return nil, err
 		}
 
 		mounts = append(mounts, mount.Mount{
 			Datastore: child,
-			Prefix:    ds.NewKey(path),
+			Prefix:    ds.NewKey(cfg.Path),
 		})
 	}
 
 	return mount.New(mounts), nil
 }
 
-func openFlatfsDatastore(params *config.FlatDS) (repo.Datastore, error) {
-	return flatfs.New(params.Path, params.PrefixLen, params.Sync)
+func (r *FSRepo) openFlatfsDatastore(params *config.FlatDS) (repo.Datastore, error) {
+	p := params.Path
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(r.path, p)
+	}
+	return flatfs.New(p, params.PrefixLen, params.Sync)
 }
 
-func openLeveldbDatastore(params *config.LevelDB) (repo.Datastore, error) {
-	var compress ldb.Compression
-	switch params.Compression {
-	case "snappy":
-		compress = ldb.SnappyCompression
-	case "none":
-		compress = ldb.NoCompression
-	default:
-		compress = ldb.DefaultCompression
+func (r *FSRepo) openLeveldbDatastore(params *config.LevelDB) (repo.Datastore, error) {
+	p := params.Path
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(r.path, p)
 	}
 
-	return levelds.NewDatastore(params.Path, &levelds.Options{
-		Compression: compress,
+	var c ldbopts.Compression
+	switch params.Compression {
+	case "none":
+		c = ldbopts.NoCompression
+	case "snappy":
+		c = ldbopts.SnappyCompression
+	case "":
+		fallthrough
+	default:
+		c = ldbopts.DefaultCompression
+	}
+	return levelds.NewDatastore(p, &levelds.Options{
+		Compression: c,
 	})
+}
+
+func (r *FSRepo) openMeasureDB(prefix string, child repo.Datastore) (repo.Datastore, error) {
+	return measure.New(prefix, child), nil
 }

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -1,0 +1,82 @@
+package fsrepo
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	repo "github.com/ipfs/go-ipfs/repo"
+	config "github.com/ipfs/go-ipfs/repo/config"
+
+	ds "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore"
+	mount "gx/ipfs/QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364/go-datastore/syncmount"
+	levelds "gx/ipfs/QmaHHmfEozrrotyhyN44omJouyuEtx6ahddqV6W5yRaUSQ/go-ds-leveldb"
+	ldb "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
+	"gx/ipfs/Qmbx2KUs8mUbDUiiESzC1ms7mdmh4pRu8X1V1tffC46M4n/go-ds-flatfs"
+)
+
+func openDatastore(kind string, params []byte) (repo.Datastore, error) {
+	switch kind {
+	case "mount":
+		var mountmap map[string]*json.RawMessage
+		if err := json.Unmarshal(params, &mountmap); err != nil {
+			return nil, fmt.Errorf("datastore mount: %v", err)
+		}
+
+		return openMountDatastore(mountmap)
+	case "flatfs":
+		var flatfsparams config.FlatDS
+		if err := json.Unmarshal(params, &flatfsparams); err != nil {
+			return nil, fmt.Errorf("datastore mount: %v", err)
+		}
+
+		return openFlatfsDatastore(&flatfsparams)
+	default:
+		return nil, fmt.Errorf("unknown datastore type: %s", kind)
+	}
+}
+
+func openMountDatastore(mountmap map[string]*json.RawMessage) (repo.Datastore, error) {
+	var mounts []mount.Mount
+	for k, v := range mountmap {
+		vals := strings.Split(k, "@")
+		if len(vals) != 2 {
+			return nil, fmt.Errorf("mount config must be 'type@path'")
+		}
+
+		kind := vals[0]
+		path := vals[1]
+
+		child, err := openDatastore(kind, []byte(*v))
+		if err != nil {
+			return nil, err
+		}
+
+		mounts = append(mounts, mount.Mount{
+			Datastore: child,
+			Prefix:    ds.NewKey(path),
+		})
+	}
+
+	return mount.New(mounts), nil
+}
+
+func openFlatfsDatastore(params *config.FlatDS) (repo.Datastore, error) {
+	return flatfs.New(params.Path, params.PrefixLen, params.Sync)
+}
+
+func openLeveldbDatastore(params *config.LevelDB) (repo.Datastore, error) {
+	var compress ldb.Compression
+	switch params.Compression {
+	case "snappy":
+		compress = ldb.SnappyCompression
+	case "none":
+		compress = ldb.NoCompression
+	default:
+		compress = ldb.DefaultCompression
+	}
+
+	return levelds.NewDatastore(params.Path, &levelds.Options{
+		Compression: compress,
+	})
+}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -362,7 +362,7 @@ func (r *FSRepo) openDatastore() error {
 		}
 		r.ds = d
 	default:
-		d, err := openDatastore(r.config.Datastore.Type, r.config.Datastore.ParamData())
+		d, err := r.constructDatastore(r.config.Datastore.Type, r.config.Datastore.ParamData())
 		if err != nil {
 			return err
 		}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -353,20 +353,19 @@ func (r *FSRepo) openKeystore() error {
 
 // openDatastore returns an error if the config file is not present.
 func (r *FSRepo) openDatastore() error {
-	switch r.config.Datastore.Type {
-	case "default", "leveldb", "":
+	if r.config.Datastore.Spec != nil {
+		d, err := r.constructDatastore(r.config.Datastore.Spec)
+		if err != nil {
+			return err
+		}
+
+		r.ds = d
+	} else {
 		// TODO: This is for legacy configs, remove in the future
 		d, err := openDefaultDatastore(r)
 		if err != nil {
 			return err
 		}
-		r.ds = d
-	default:
-		d, err := r.constructDatastore(r.config.Datastore.Type, r.config.Datastore.ParamData())
-		if err != nil {
-			return err
-		}
-
 		r.ds = d
 	}
 

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 	keystore "github.com/ipfs/go-ipfs/keystore"
 	repo "github.com/ipfs/go-ipfs/repo"
 	"github.com/ipfs/go-ipfs/repo/common"
@@ -20,6 +19,7 @@ import (
 	serialize "github.com/ipfs/go-ipfs/repo/fsrepo/serialize"
 	dir "github.com/ipfs/go-ipfs/thirdparty/dir"
 
+	"github.com/ipfs/go-ipfs/Godeps/_workspace/src/github.com/mitchellh/go-homedir"
 	ma "gx/ipfs/QmSWLfmj5frN9xVLMMN846dMDriy5wN5jeghUm7aTW3DAG/go-multiaddr"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	util "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
@@ -355,13 +355,19 @@ func (r *FSRepo) openKeystore() error {
 func (r *FSRepo) openDatastore() error {
 	switch r.config.Datastore.Type {
 	case "default", "leveldb", "":
+		// TODO: This is for legacy configs, remove in the future
 		d, err := openDefaultDatastore(r)
 		if err != nil {
 			return err
 		}
 		r.ds = d
 	default:
-		return fmt.Errorf("unknown datastore type: %s", r.config.Datastore.Type)
+		d, err := openDatastore(r.config.Datastore.Type, r.config.Datastore.ParamData())
+		if err != nil {
+			return err
+		}
+
+		r.ds = d
 	}
 
 	// Wrap it with metrics gathering


### PR DESCRIPTION
This PR is a definite WIP and relies (At a minimum) on the configurable datastore PR: #3575 

Current usage requires creating a config on this branch (currently by running `ipfs init`, will be making a new command for this soon) then editing the config to have s3 configuration (TODO: documentation on this). Then running `ipfs init thatconfigfile` to initialize a new ipfs node with an s3 backed repo.

Initially, this will only be supported for new ipfs nodes, but we will add tools that allow migrations between different datastore formats.