### PR TITLE
fix: ipfs mount crashing if there was no name published before

### DIFF
--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -13,8 +13,10 @@ import (
 	core "github.com/ipfs/go-ipfs/core"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	mfs "github.com/ipfs/go-ipfs/mfs"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
+	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	ci "gx/ipfs/QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuUi/go-libp2p-crypto"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
@@ -95,7 +97,11 @@ func loadRoot(ctx context.Context, rt *keyRoot, ipfs *core.IpfsNode, name string
 	}
 
 	node, err := core.Resolve(ctx, ipfs.Namesys, ipfs.Resolver, p)
-	if err != nil {
+	switch err {
+	case nil:
+	case namesys.ErrResolveFailed:
+		node = uio.NewEmptyDirectory()
+	default:
 		log.Errorf("looking up %s: %s", p, err)
 		return nil, err
 	}


### PR DESCRIPTION
Bases of https://github.com/ipfs/go-ipfs/pull/3727

Resolves https://github.com/ipfs/go-ipfs/issues/3013