### PR TITLE
docker: Automatically fix permissions

### DIFF
--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -19,6 +19,8 @@ ENV GOPATH     /go
 ENV PATH       /go/bin:$PATH
 ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 
+VOLUME $IPFS_PATH
+
 # This is an optimization which avoids rebuilding
 # of the gx dependencies every time anything changes.
 # gx will only be invoked if the dependencies have changed.
@@ -28,10 +30,9 @@ ENV SRC_PATH   /go/src/github.com/ipfs/go-ipfs
 # and trigger a re-run of all following commands.
 COPY ./package.json $SRC_PATH/package.json
 
-RUN apk add --update musl-dev gcc go git bash wget ca-certificates \
-	&& mkdir -p $IPFS_PATH \
+RUN apk add --no-cache --virtual .build-deps-ipfs musl-dev gcc go git \
+	&& apk add --no-cache tini su-exec bash wget ca-certificates \
 	&& adduser -D -h $IPFS_PATH -u 1000 ipfs \
-	&& chown ipfs:ipfs $IPFS_PATH && chmod 755 $IPFS_PATH \
 	&& go get -u github.com/whyrusleeping/gx \
 	&& go get -u github.com/whyrusleeping/gx-go \
 	&& ([ -z "$GX_IPFS" ] || echo $GX_IPFS > $IPFS_PATH/api) \
@@ -48,9 +49,7 @@ RUN cd $SRC_PATH \
 	&& cp ipfs /usr/local/bin/ipfs \
 	&& cp $SRC_PATH/bin/container_daemon /usr/local/bin/start_ipfs \
 	&& chmod 755 /usr/local/bin/start_ipfs \
-	&& apk del --purge musl-dev gcc go git && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
+	&& apk del --purge .build-deps-ipfs && rm -rf $GOPATH && rm -vf $IPFS_PATH/api
 
-USER ipfs
-VOLUME $IPFS_PATH
-ENTRYPOINT ["/usr/local/bin/start_ipfs"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start_ipfs"]
 CMD ["daemon", "--migrate=true"]

--- a/README.md
+++ b/README.md
@@ -237,11 +237,6 @@ IPFS files that will persist when you restart the container.
     export ipfs_staging=</absolute/path/to/somewhere/>
     export ipfs_data=</absolute/path/to/somewhere_else/>
 
-Make sure docker can access these folders:
-
-    sudo chmod -R 777 /absolute/path/to/somewhere/
-    sudo chmod -R 777 /absolute/path/to/somewhere_else/
-
 Start a container running ipfs and expose ports 4001, 5001 and 8080:
 
     docker run -d --name ipfs_host -v $ipfs_staging:/export -v $ipfs_data:/data/ipfs -p 8080:8080 -p 4001:4001 -p 5001:5001 ipfs/go-ipfs:latest

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,14 +1,16 @@
 #!/bin/sh
-
-user=$(whoami)
+set -e
+user=ipfs
 repo="$IPFS_PATH"
 
-# Test whether the mounted directory is writable for us
-if [ ! -w "$repo" 2>/dev/null ]; then
-  echo "error: $repo is not writable for user $user (uid=$(id -u $user))"
-  exit 1
+if [ `id -u` -eq 0 ]; then
+  # ensure folder is writable
+  su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
+  # restart script with new privileges
+  exec su-exec "$user" "$0" "$@"
 fi
 
+# 2nd invocation with regular user
 ipfs version
 
 if [ -e "$repo/config" ]; then


### PR DESCRIPTION
This patch is delaying the point where permissions are dropped into the `start_ipfs` script. This way, instead of exiting on permission issues, we can fix them on our own inside the script, then drop privileges and continue doing ipfs specific stuff with the correct user.

I've removed the `chmod 0777` step from the readme since it's not needed anymore.

License: MIT
Signed-off-by: kpcyrd <git@rxv.cc>