### PR TITLE
fix: ipfs get panic with empty API call

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -51,6 +51,11 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		return err
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
+		if len(req.Arguments()) == 0 {
+			res.SetError(errors.New("not enough arugments provided"), cmds.ErrClient)
+			return
+		}
+
 		cmplvl, err := getCompressOptions(req)
 		if err != nil {
 			res.SetError(err, cmds.ErrClient)

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -141,7 +141,7 @@ test_get_fail() {
 	'
 
 	test_expect_success "ipfs get fails" '
-		test_expect_code 1 ipfs get QmaGidyrnX8FMbWJoxp8HVwZ1uRKwCyxBJzABnR1S2FVUr 
+		test_expect_code 1 ipfs get QmaGidyrnX8FMbWJoxp8HVwZ1uRKwCyxBJzABnR1S2FVUr
 	'
 }
 
@@ -154,6 +154,13 @@ test_get_fail
 # should work online
 test_launch_ipfs_daemon
 test_get_cmd
+
+test_expect_success "empty request to get doesn't panic and returns error" '
+	curl "http://$API_ADDR/api/v0/get" > curl_out || true &&
+		grep "not enough arugments provided" curl_out
+
+
+'
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
Resolves #3527
License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>