### PR TITLE
make: fix build when symlinked into GOPATH

### DIFF
--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -10,7 +10,7 @@ DEPS_GO :=
 TEST_GO :=
 CHECK_GO :=
 
-go-pkg-name=$(shell go list $(go-tags) ./$(1))
+go-pkg-name=$(shell go list $(go-tags) github.com/ipfs/go-ipfs/$(1))
 go-main-name=$(notdir $(call go-pkg-name,$(1)))$(?exe)
 go-curr-pkg-tgt=$(d)/$(call go-main-name,$(d))
 


### PR DESCRIPTION
In workspace setups that have the source tree symlinked into GOPATH,
the `go list `command wouldn't recognize that we're technically within GOPATH,
because `pwd` doesn't look like it.

For example

	/home/user/go/src/github.com/ipfs/go-ipfs
	=> /home/user/go/ipfs/go-ipfs

produces the import path

	_/home/user/ipfs/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-random/random

which is not within GOPATH.

We get around this by using fully-qualified import paths instead:
starting in github.com/ipfs/go-ipfs/ instead of ./

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>