### PR TITLE
Return 404 Not Found for failed path resolutions

### DIFF
--- a/commands/response.go
+++ b/commands/response.go
@@ -17,6 +17,7 @@ type ErrorType uint
 const (
 	ErrNormal         ErrorType = iota // general errors
 	ErrClient                          // error was caused by the client, (e.g. invalid CLI usage)
+	ErrNotFound                        // == HTTP 404 Not Found
 	ErrImplementation                  // programmer error in the server
 	// TODO: add more types of errors for better error-specific handling
 )

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -60,6 +60,10 @@ The resolver can recursively resolve:
 			depth = namesys.DefaultDepthLimit
 		}
 		output, err := resolver.ResolveN(req.Context(), name, depth)
+		if err == namesys.ErrResolveFailed {
+			res.SetError(err, cmds.ErrNotFound)
+			return
+		}
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -17,7 +17,6 @@ import (
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
-	"github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
@@ -162,26 +161,18 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	dir := false
 	switch err {
 	case nil:
-		// core.Resolve worked
+		// Cat() worked
 		defer dr.Close()
 	case coreiface.ErrIsDir:
 		dir = true
-	case namesys.ErrResolveFailed:
-		// Don't log that error as it is just noise
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Path Resolve error: %s", err.Error())
-		log.Info("Path Resolve error: %s", err.Error())
-		return
 	case coreiface.ErrOffline:
 		if !i.node.OnlineMode() {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprint(w, "Could not resolve path. Node is in offline mode.")
+			webError(w, "ipfs cat "+urlPath, err, http.StatusServiceUnavailable)
 			return
 		}
 		fallthrough
 	default:
-		// all other erros
-		webError(w, "Path Resolve error", err, http.StatusBadRequest)
+		webError(w, "ipfs cat "+urlPath, err, http.StatusNotFound)
 		return
 	}
 
@@ -532,7 +523,7 @@ func webErrorWithCode(w http.ResponseWriter, message string, err error, code int
 	w.WriteHeader(code)
 
 	log.Errorf("%s: %s", message, err) // TODO(cryptix): log until we have a better way to expose these (counter metrics maybe)
-	fmt.Fprintf(w, "%s: %s", message, err)
+	fmt.Fprintf(w, "%s: %s\n", message, err)
 }
 
 // return a 500 error and log

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -136,7 +136,7 @@ func TestGatewayGet(t *testing.T) {
 		{"localhost:5001", "/", http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/" + k, http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/ipfs/" + k, http.StatusOK, "fnord"},
-		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusInternalServerError, "Path Resolve error: " + namesys.ErrResolveFailed.Error()},
+		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusNotFound, "ipfs cat /ipns/nxdomain.example.com: " + namesys.ErrResolveFailed.Error() + "\n"},
 		{"localhost:5001", "/ipns/example.com", http.StatusOK, "fnord"},
 		{"example.com", "/", http.StatusOK, "fnord"},
 	} {


### PR DESCRIPTION
Fixes #2286 -- bonus: also kills gateway's namesys dependency

**But:** I just noticed that the CLI assumes "command not found" for 404 responses. Great.