### PR TITLE
test(commands): fix EOF failure with Multipart.Read

### DIFF
--- a/commands/files/file_test.go
+++ b/commands/files/file_test.go
@@ -127,7 +127,7 @@ anotherfile
 	if file, err := mpf.NextFile(); file != nil || err != ErrNotDirectory {
 		t.Fatal("Expected a nil file and ErrNotDirectory")
 	}
-	if n, err := mpf.Read(buf); n != 4 || err != nil {
+	if n, err := mpf.Read(buf); n != 4 || err != io.EOF && err != nil {
 		t.Fatal("Expected to be able to read 4 bytes: ", n, err)
 	}
 	if err := mpf.Close(); err != nil {
@@ -171,7 +171,7 @@ anotherfile
 	if mpf.FileName() != "dir/nested" {
 		t.Fatalf("Expected filename to be \"nested\", got %s", mpf.FileName())
 	}
-	if n, err := mpf.Read(buf); n != 12 || err != nil {
+	if n, err := mpf.Read(buf); n != 12 || err != io.EOF && err != nil {
 		t.Fatalf("expected to be able to read 12 bytes from file: %s (got %d)", err, n)
 	}
 	if err := mpf.Close(); err != nil {


### PR DESCRIPTION
The fix contains the changing nil with io.EOF
because acording to the Read interface implementation
An instance, (in our case Part.Read) of this general case
is that a Reader returning a non-zero number of bytes at
the end of the input stream may return either err == EOF or err == nil.
So this means that the Part.Reader chose to return
io.EOF instead of nil.
