### PR TITLE
daemon: use fsrepo.IsInitialized to test for initialization

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -26,7 +26,6 @@ import (
 	iconn "gx/ipfs/QmT6jBTqNKhhb8dbzCEMUNkGhm3RuRActcMhpShAHLpQtp/go-libp2p-interface-conn"
 	"gx/ipfs/QmVCNGTyD4EkvNYaAp253uMQ9Rjsjy2oGMvcdJJUoVRfja/go-multiaddr-net"
 	"gx/ipfs/QmX3QZ5jHEPidwUrymXV1iSCSUhdGxj15sm2gP4jKMef7B/client_golang/prometheus"
-	util "gx/ipfs/QmZuY8aV7zbNXVy6DyN9SmnuH3o9nG852F4aTiSBpts8d1/go-ipfs-util"
 	pstore "gx/ipfs/Qme1g4e3m2SmdiSGGU3vSWmUStwUjc5oECnEriaK9Xa1HU/go-libp2p-peerstore"
 )
 
@@ -227,12 +226,9 @@ func daemonFunc(req cmds.Request, res cmds.Response) {
 
 	if initialize {
 
-		// now, FileExists is our best method of detecting whether ipfs is
-		// configured. Consider moving this into a config helper method
-		// `IsInitialized` where the quality of the signal can be improved over
-		// time, and many call-sites can benefit.
-		if !util.FileExists(req.InvocContext().ConfigRoot) {
-			err := initWithDefaults(os.Stdout, req.InvocContext().ConfigRoot)
+		cfg := req.InvocContext().ConfigRoot
+		if !fsrepo.IsInitialized(cfg) {
+			err := initWithDefaults(os.Stdout, cfg)
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return

--- a/test/sharness/t0063-daemon-init.sh
+++ b/test/sharness/t0063-daemon-init.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Juan Batiz-Benet
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test daemon --init command"
+
+. lib/test-lib.sh
+
+# We don't want the normal test_init_ipfs but we need to make sure the
+# IPFS_PATH is set correctly.
+export IPFS_PATH="$(pwd)/.ipfs"
+
+# safety check since we will be removing the directory
+if [ -e "$IPFS_PATH" ]; then
+	echo "$IPFS_PATH exists"
+	exit 1
+fi
+
+test_ipfs_daemon_init() {
+	# Doing it manually since we want to launch the daemon with an
+	# empty or non-existent repo; the normal
+	# test_launch_ipfs_daemon does not work since it assumes the
+	# repo was created a particular way with regard to the API
+	# server.
+
+	test_expect_success "'ipfs daemon --init' succeeds" '
+		ipfs daemon --init >actual_daemon 2>daemon_err &
+		IPFS_PID=$!
+		sleep 2 &&
+		if ! kill -0 $IPFS_PID; then cat daemon_err; return 1; fi
+	'
+
+	test_expect_success "'ipfs daemon' can be killed" '
+		test_kill_repeat_10_sec $IPFS_PID
+	'
+}
+
+test_expect_success "remove \$IPFS_PATH dir" '
+	rm -rf "$IPFS_PATH"
+'
+test_ipfs_daemon_init
+
+test_expect_success "create empty \$IPFS_PATH dir" '
+	rm -rf "$IPFS_PATH" &&
+	mkdir "$IPFS_PATH"
+'
+
+test_ipfs_daemon_init
+
+test_done


### PR DESCRIPTION
Use fsrepo.IsInitialized to test for initialization instead of just testing if the directory exists.

Also add test cases for '--init' option, including one the creates an empty directory.

Closes #3773.
