### PR TITLE
Fix #3783: Improve IsPinned() lookups for indirect pins

### DIFF
--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -35,6 +35,17 @@ func assertPinned(t *testing.T, p Pinner, c *cid.Cid, failmsg string) {
 	}
 }
 
+func assertUnpinned(t *testing.T, p Pinner, c *cid.Cid, failmsg string) {
+	_, pinned, err := p.IsPinned(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pinned {
+		t.Fatal(failmsg)
+	}
+}
+
 func TestPinnerBasic(t *testing.T) {
 	ctx := context.Background()
 
@@ -143,6 +154,122 @@ func TestPinnerBasic(t *testing.T) {
 
 	// Test recursively pinned
 	assertPinned(t, np, bk, "could not find recursively pinned node")
+}
+
+func TestIsPinnedLookup(t *testing.T) {
+	// We are going to test that lookups work in pins which share
+	// the same branches. For that we will construct this tree:
+	//
+	// A5->A4->A3->A2->A1->A0
+	//         /           /
+	// B-------           /
+	//  \                /
+	//   C---------------
+	//
+	// We will ensure that IsPinned works for all objects both when they
+	// are pinned and once they have been unpinned.
+	aBranchLen := 6
+	if aBranchLen < 3 {
+		t.Fatal("set aBranchLen to at least 3")
+	}
+
+	ctx := context.Background()
+	dstore := dssync.MutexWrap(ds.NewMapDatastore())
+	bstore := blockstore.NewBlockstore(dstore)
+	bserv := bs.New(bstore, offline.Exchange(bstore))
+
+	dserv := mdag.NewDAGService(bserv)
+
+	// TODO does pinner need to share datastore with blockservice?
+	p := NewPinner(dstore, dserv, dserv)
+
+	aNodes := make([]*mdag.ProtoNode, aBranchLen, aBranchLen)
+	aKeys := make([]*cid.Cid, aBranchLen, aBranchLen)
+	for i := 0; i < aBranchLen; i++ {
+		a, _ := randNode()
+		if i >= 1 {
+			err := a.AddNodeLink("child", aNodes[i-1])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		ak, err := dserv.Add(a)
+		if err != nil {
+			t.Fatal(err)
+		}
+		//t.Logf("a[%d] is %s", i, ak)
+		aNodes[i] = a
+		aKeys[i] = ak
+	}
+
+	// Pin A5 recursively
+	if err := p.Pin(ctx, aNodes[aBranchLen-1], true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create node B and add A3 as child
+	b, _ := randNode()
+	if err := b.AddNodeLink("mychild", aNodes[3]); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create C node
+	c, _ := randNode()
+	// Add A0 as child of C
+	if err := c.AddNodeLink("child", aNodes[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add C
+	ck, err := dserv.Add(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//t.Logf("C is %s", ck)
+
+	// Add C to B and Add B
+	if err := b.AddNodeLink("myotherchild", c); err != nil {
+		t.Fatal(err)
+	}
+	bk, err := dserv.Add(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//t.Logf("B is %s", bk)
+
+	// Pin C recursively
+
+	if err := p.Pin(ctx, c, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pin B recursively
+
+	if err := p.Pin(ctx, b, true); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPinned(t, p, aKeys[0], "A0 should be pinned")
+	assertPinned(t, p, aKeys[1], "A1 should be pinned")
+	assertPinned(t, p, ck, "C should be pinned")
+	assertPinned(t, p, bk, "B should be pinned")
+
+	// Unpin A5 recursively
+	if err := p.Unpin(ctx, aKeys[5], true); err != nil {
+		t.Fatal(err)
+	}
+
+	assertPinned(t, p, aKeys[0], "A0 should still be pinned through B")
+	assertUnpinned(t, p, aKeys[4], "A4 should be unpinned")
+
+	// Unpin B recursively
+	if err := p.Unpin(ctx, bk, true); err != nil {
+		t.Fatal(err)
+	}
+	assertUnpinned(t, p, bk, "B should be unpinned")
+	assertUnpinned(t, p, aKeys[1], "A1 should be unpinned")
+	assertPinned(t, p, aKeys[0], "A0 should still be pinned through C")
 }
 
 func TestDuplicateSemantics(t *testing.T) {


### PR DESCRIPTION
This avoids revisiting already-searched branches and cut down
the IsPinned() check times considerably when recursive pins
share big underlying DAGs. Same mechanism as `merkledag.EnumerateChildren()`.

Here are some benchmarks with a randomly-selected list of 10 of my pins (and bad pins):

This runs `ipfs pin ls $pin` for each of the listed pins and measures how long it takes it.

With 0.4.7:

```
Time for good pin QmSUuF4bnRBRAmaRzJcXHAu7z7tdD8sx1c5hU5kuvdPuDV: 0:00.55elapsed   0
Time for bad pin QmSUuF4bnRBRAmaRzJcXHAu7z7tdD8sx1c5hU5kuvdPuD1: 0:07.84elapsed   1
Time for good pin QmPcd2ypbzvh5ew6DBw9yCR8HBPWDJrLXVEw5DFntKWemk: 0:01.82elapsed   0
Time for bad pin QmPcd2ypbzvh5ew6DBw9yCR8HBPWDJrLXVEw5DFntKWem1: 0:07.19elapsed   1
Time for good pin QmYihqmU45xvKGBW1cGHCSF1Qxe5DTXzYqwFNEuBCvsR4Y: 0:00.23elapsed   0
Time for bad pin QmYihqmU45xvKGBW1cGHCSF1Qxe5DTXzYqwFNEuBCvsR41: 0:07.38elapsed   1
Time for good pin QmSP2Ef89DKFSrJi9T3b8bEeUA4fQSfR9AosKD7QEoXn3q: 0:00.31elapsed   0
Time for bad pin QmSP2Ef89DKFSrJi9T3b8bEeUA4fQSfR9AosKD7QEoXn31: 0:08.11elapsed   1
Time for good pin QmfJ2jZD4ULrbpJyoqxXnetckcwwHrGZMZfwdwKmfdZ4VE: 0:00.55elapsed   0
Time for bad pin QmfJ2jZD4ULrbpJyoqxXnetckcwwHrGZMZfwdwKmfdZ4V1: 0:08.26elapsed   1
```

With this patch:

```
Time for good pin QmSUuF4bnRBRAmaRzJcXHAu7z7tdD8sx1c5hU5kuvdPuDV: 0:00.69elapsed   0
Time for bad pin QmSUuF4bnRBRAmaRzJcXHAu7z7tdD8sx1c5hU5kuvdPuD1: 0:01.59elapsed   1
Time for good pin QmPcd2ypbzvh5ew6DBw9yCR8HBPWDJrLXVEw5DFntKWemk: 0:01.59elapsed   0
Time for bad pin QmPcd2ypbzvh5ew6DBw9yCR8HBPWDJrLXVEw5DFntKWem1: 0:01.80elapsed   1
Time for good pin QmYihqmU45xvKGBW1cGHCSF1Qxe5DTXzYqwFNEuBCvsR4Y: 0:00.31elapsed   0
Time for bad pin QmYihqmU45xvKGBW1cGHCSF1Qxe5DTXzYqwFNEuBCvsR41: 0:01.82elapsed   1
Time for good pin QmSP2Ef89DKFSrJi9T3b8bEeUA4fQSfR9AosKD7QEoXn3q: 0:00.40elapsed   0
Time for bad pin QmSP2Ef89DKFSrJi9T3b8bEeUA4fQSfR9AosKD7QEoXn31: 0:01.80elapsed   1
Time for good pin QmfJ2jZD4ULrbpJyoqxXnetckcwwHrGZMZfwdwKmfdZ4VE: 0:00.61elapsed   0
Time for bad pin QmfJ2jZD4ULrbpJyoqxXnetckcwwHrGZMZfwdwKmfdZ4V1: 0:01.78elapsed   1
```