### PR TITLE
Bump default ulimit to 2048

### DIFF
--- a/cmd/ipfs/ulimit.go
+++ b/cmd/ipfs/ulimit.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 )
 
-var ipfsFileDescNum = uint64(1024)
+var ipfsFileDescNum = uint64(2048)
 
 func init() {
 	if val := os.Getenv("IPFS_FD_MAX"); val != "" {

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -208,7 +208,7 @@ test_launch_ipfs_daemon() {
 
 	args="$@"
 
-	test "$TEST_ULIMIT_PRESET" != 1 && ulimit -n 1024
+	test "$TEST_ULIMIT_PRESET" != 1 && ulimit -n 2048
 
 	test_expect_success "'ipfs daemon' succeeds" '
 		ipfs daemon $args >actual_daemon 2>daemon_err &

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -126,11 +126,11 @@ TEST_ULIMIT_PRESET=1
 test_launch_ipfs_daemon
 
 test_expect_success "daemon raised its fd limit" '
-	grep "raised file descriptor limit to 1024." actual_daemon > /dev/null
+	grep "raised file descriptor limit to 2048." actual_daemon > /dev/null
 '
 
-test_expect_success "daemon actually can handle 1024 file descriptors" '
-	hang-fds -hold=2s 1000 '$API_MADDR'
+test_expect_success "daemon actually can handle 2048 file descriptors" '
+	hang-fds -hold=2s 2000 '$API_MADDR' > /dev/null
 '
 
 test_expect_success "daemon didnt throw any errors" '


### PR DESCRIPTION
This should serve as a decent stopgap for the too many file descriptors problem until we come up with a better solution (connection closing, QUIC, relay, sbs)

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>