### PR TITLE
commands: restore original error order

### DIFF
--- a/commands/response.go
+++ b/commands/response.go
@@ -17,8 +17,8 @@ type ErrorType uint
 const (
 	ErrNormal         ErrorType = iota // general errors
 	ErrClient                          // error was caused by the client, (e.g. invalid CLI usage)
-	ErrNotFound                        // == HTTP 404 Not Found
 	ErrImplementation                  // programmer error in the server
+	ErrNotFound                        // == HTTP 404 Not Found
 	// TODO: add more types of errors for better error-specific handling
 )
 

--- a/commands/response_test.go
+++ b/commands/response_test.go
@@ -53,6 +53,12 @@ func TestMarshalling(t *testing.T) {
 	}
 }
 
+func TestErrTypeOrder(t *testing.T) {
+	if ErrNormal != 0 || ErrClient != 1 || ErrImplementation != 2 || ErrNotFound != 3 {
+		t.Fatal("ErrType order is wrong")
+	}
+}
+
 func removeWhitespace(input string) string {
 	input = strings.Replace(input, " ", "", -1)
 	input = strings.Replace(input, "\t", "", -1)


### PR DESCRIPTION
When `ErrNotFound` was added, it was not appended to the iota but inserted in the middle. This means that the numeric value of `ErrImplementation` changed, resulting in possible API breakage. This PR fixes the order. 