### PR TITLE
Bitswap sessions

### DIFF
--- a/blocks/blocksutil/block_generator.go
+++ b/blocks/blocksutil/block_generator.go
@@ -25,8 +25,8 @@ func (bg *BlockGenerator) Next() *blocks.BasicBlock {
 }
 
 // Blocks generates as many BasicBlocks as specified by n.
-func (bg *BlockGenerator) Blocks(n int) []*blocks.BasicBlock {
-	blocks := make([]*blocks.BasicBlock, 0)
+func (bg *BlockGenerator) Blocks(n int) []blocks.Block {
+	blocks := make([]blocks.Block, 0, n)
 	for i := 0; i < n; i++ {
 		b := bg.Next()
 		blocks = append(blocks, b)

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -32,7 +32,6 @@ type BlockService interface {
 	GetBlock(ctx context.Context, c *cid.Cid) (blocks.Block, error)
 	GetBlocks(ctx context.Context, ks []*cid.Cid) <-chan blocks.Block
 	DeleteBlock(o blocks.Block) error
-	NewSession(context.Context) *Session
 	Close() error
 }
 
@@ -79,18 +78,18 @@ func (bs *blockService) Exchange() exchange.Interface {
 	return bs.exchange
 }
 
-func (bs *blockService) NewSession(ctx context.Context) *Session {
-	bswap, ok := bs.Exchange().(*bitswap.Bitswap)
-	if ok {
+func NewSession(ctx context.Context, bs BlockService) *Session {
+	exchange := bs.Exchange()
+	if bswap, ok := exchange.(*bitswap.Bitswap); ok {
 		ses := bswap.NewSession(ctx)
 		return &Session{
 			ses: ses,
-			bs:  bs.blockstore,
+			bs:  bs.Blockstore(),
 		}
 	}
 	return &Session{
-		ses: bs.exchange,
-		bs:  bs.blockstore,
+		ses: exchange,
+		bs:  bs.Blockstore(),
 	}
 }
 

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -251,15 +251,18 @@ func (s *blockService) Close() error {
 	return s.exchange.Close()
 }
 
+// Session is a helper type to provide higher level access to bitswap sessions
 type Session struct {
 	bs  blockstore.Blockstore
 	ses exchange.Fetcher
 }
 
+// GetBlock gets a block in the context of a request session
 func (s *Session) GetBlock(ctx context.Context, c *cid.Cid) (blocks.Block, error) {
 	return getBlock(ctx, c, s.bs, s.ses)
 }
 
+// GetBlocks gets blocks in the context of a request session
 func (s *Session) GetBlocks(ctx context.Context, ks []*cid.Cid) <-chan blocks.Block {
 	return getBlocks(ctx, ks, s.bs, s.ses)
 }

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -78,6 +78,8 @@ func (bs *blockService) Exchange() exchange.Interface {
 	return bs.exchange
 }
 
+// NewSession creates a bitswap session that allows for controlled exchange of
+// wantlists to decrease the bandwidth overhead.
 func NewSession(ctx context.Context, bs BlockService) *Session {
 	exchange := bs.Exchange()
 	if bswap, ok := exchange.(*bitswap.Bitswap); ok {

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -64,7 +64,11 @@ var unwantCmd = &cmds.Command{
 			ks = append(ks, c)
 		}
 
-		bs.CancelWants(ks)
+		// TODO: This should maybe find *all* sessions for this request and cancel them?
+		// (why): in reality, i think this command should be removed. Its
+		// messing with the internal state of bitswap. You should cancel wants
+		// by killing the command that caused the want.
+		bs.CancelWants(ks, 0)
 	},
 }
 

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -111,6 +111,11 @@ Print out all blocks currently on the bitswap wantlist for the local peer.`,
 				res.SetError(err, cmds.ErrNormal)
 				return
 			}
+			if pid == nd.Identity {
+				res.SetOutput(&KeyList{bs.GetWantlist()})
+				return
+			}
+
 			res.SetOutput(&KeyList{bs.WantlistForPeer(pid)})
 		} else {
 			res.SetOutput(&KeyList{bs.GetWantlist()})

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -27,7 +27,7 @@ import (
 	node "gx/ipfs/QmPAKbSsgEX5B6fpmxa61jXYnoWzZr5sNafd3qgPiSH8Uv/go-ipld-format"
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
-	multibase "gx/ipfs/QmcxkxTVuURV2Ptse8TvkqH5BQDwV62X1x19JqqvbBzwUM/go-multibase"
+	multibase "gx/ipfs/Qme4T6BE4sQxg7ZouamF5M7Tx1ZFTqzcns7BkyQPXpoT99/go-multibase"
 )
 
 const (

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -285,6 +285,9 @@ func (bs *Bitswap) getNextSessionID() uint64 {
 
 // CancelWant removes a given key from the wantlist
 func (bs *Bitswap) CancelWants(cids []*cid.Cid, ses uint64) {
+	if len(cids) == 0 {
+		return
+	}
 	bs.wm.CancelWants(context.Background(), cids, nil, ses)
 }
 

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -323,6 +323,7 @@ func (bs *Bitswap) HasBlock(blk blocks.Block) error {
 	return nil
 }
 
+// SessionsForBlock returns a slice of all sessions that may be interested in the given cid
 func (bs *Bitswap) SessionsForBlock(c *cid.Cid) []*Session {
 	bs.sessLk.Lock()
 	defer bs.sessLk.Unlock()

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -23,7 +23,6 @@ import (
 	process "gx/ipfs/QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP/goprocess"
 	procctx "gx/ipfs/QmSF8fPo3jgVBAy8fpdjjYqgG87dkJgUprRBHRd2tmfgpP/goprocess/context"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
-	loggables "gx/ipfs/QmVesPmqbPp7xRGyY96tnBwzDtVV1nqv4SCVxo5zCqKyH8/go-libp2p-loggables"
 	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 	peer "gx/ipfs/QmdS9KpbDyPrieswibZhkod1oXqRwZJrUPzxCofAMWpFGq/go-libp2p-peer"

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -332,7 +332,7 @@ func TestBasicBitswap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(time.Millisecond * 20)
+	time.Sleep(time.Millisecond * 25)
 	wl := instances[2].Exchange.WantlistForPeer(instances[1].Peer)
 	if len(wl) != 0 {
 		t.Fatal("should have no items in other peers wantlist")

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -318,7 +318,7 @@ func TestBasicBitswap(t *testing.T) {
 
 	t.Log("Test a one node trying to get one block from another")
 
-	instances := sg.Instances(2)
+	instances := sg.Instances(3)
 	blocks := bg.Blocks(1)
 	err := instances[0].Exchange.HasBlock(blocks[0])
 	if err != nil {
@@ -333,6 +333,10 @@ func TestBasicBitswap(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 20)
+	wl := instances[2].Exchange.WantlistForPeer(instances[1].Peer)
+	if len(wl) != 0 {
+		t.Fatal("should have no items in other peers wantlist")
+	}
 	if len(instances[1].Exchange.GetWantlist()) != 0 {
 		t.Fatal("shouldnt have anything in wantlist")
 	}

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -291,7 +291,7 @@ func TestEmptyKey(t *testing.T) {
 	}
 }
 
-func assertStat(st *Stat, sblks, rblks int, sdata, rdata uint64) error {
+func assertStat(st *Stat, sblks, rblks, sdata, rdata uint64) error {
 	if sblks != st.BlocksSent {
 		return fmt.Errorf("mismatch in blocks sent: %d vs %d", sblks, st.BlocksSent)
 	}

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -332,6 +332,11 @@ func TestBasicBitswap(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	time.Sleep(time.Millisecond * 20)
+	if len(instances[1].Exchange.GetWantlist()) != 0 {
+		t.Fatal("shouldnt have anything in wantlist")
+	}
+
 	st0, err := instances[0].Exchange.Stat()
 	if err != nil {
 		t.Fatal(err)

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -105,13 +105,10 @@ func NewEngine(ctx context.Context, bs bstore.Blockstore) *Engine {
 }
 
 func (e *Engine) WantlistForPeer(p peer.ID) (out []*wl.Entry) {
-	e.lock.Lock()
-	partner, ok := e.ledgerMap[p]
-	if ok {
-		out = partner.wantList.SortedEntries()
-	}
-	e.lock.Unlock()
-	return out
+	partner := e.findOrCreate(p)
+	partner.lk.Lock()
+	defer partner.lk.Unlock()
+	return partner.wantList.SortedEntries()
 }
 
 func (e *Engine) LedgerForPeer(p peer.ID) *Receipt {

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -2,10 +2,10 @@
 package decision
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	context "context"
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	bsmsg "github.com/ipfs/go-ipfs/exchange/bitswap/message"
 	wl "github.com/ipfs/go-ipfs/exchange/bitswap/wantlist"

--- a/exchange/bitswap/get.go
+++ b/exchange/bitswap/get.go
@@ -1,0 +1,100 @@
+package bitswap
+
+import (
+	"context"
+	"errors"
+
+	blocks "github.com/ipfs/go-ipfs/blocks"
+	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
+	notifications "github.com/ipfs/go-ipfs/exchange/bitswap/notifications"
+
+	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
+)
+
+type getBlocksFunc func(context.Context, []*cid.Cid) (<-chan blocks.Block, error)
+
+func getBlock(p context.Context, k *cid.Cid, gb getBlocksFunc) (blocks.Block, error) {
+	if k == nil {
+		log.Error("nil cid in GetBlock")
+		return nil, blockstore.ErrNotFound
+	}
+
+	// Any async work initiated by this function must end when this function
+	// returns. To ensure this, derive a new context. Note that it is okay to
+	// listen on parent in this scope, but NOT okay to pass |parent| to
+	// functions called by this one. Otherwise those functions won't return
+	// when this context's cancel func is executed. This is difficult to
+	// enforce. May this comment keep you safe.
+	ctx, cancel := context.WithCancel(p)
+	defer cancel()
+
+	promise, err := gb(ctx, []*cid.Cid{k})
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case block, ok := <-promise:
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				return nil, errors.New("promise channel was closed")
+			}
+		}
+		return block, nil
+	case <-p.Done():
+		return nil, p.Err()
+	}
+}
+
+type wantFunc func(context.Context, []*cid.Cid)
+
+func getBlocksImpl(ctx context.Context, keys []*cid.Cid, notif notifications.PubSub, want wantFunc, cwants func([]*cid.Cid)) (<-chan blocks.Block, error) {
+	if len(keys) == 0 {
+		out := make(chan blocks.Block)
+		close(out)
+		return out, nil
+	}
+
+	remaining := cid.NewSet()
+	promise := notif.Subscribe(ctx, keys...)
+	for _, k := range keys {
+		log.Event(ctx, "Bitswap.GetBlockRequest.Start", k)
+		remaining.Add(k)
+	}
+
+	want(ctx, keys)
+
+	out := make(chan blocks.Block)
+	go handleIncoming(ctx, remaining, promise, out, cwants)
+	return out, nil
+}
+
+func handleIncoming(ctx context.Context, remaining *cid.Set, in <-chan blocks.Block, out chan blocks.Block, cfun func([]*cid.Cid)) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		close(out)
+		// can't just defer this call on its own, arguments are resolved *when* the defer is created
+		cfun(remaining.Keys())
+	}()
+	for {
+		select {
+		case blk, ok := <-in:
+			if !ok {
+				return
+			}
+
+			remaining.Remove(blk.Cid())
+			select {
+			case out <- blk:
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/exchange/bitswap/get.go
+++ b/exchange/bitswap/get.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 
-	blocks "github.com/ipfs/go-ipfs/blocks"
 	blockstore "github.com/ipfs/go-ipfs/blocks/blockstore"
 	notifications "github.com/ipfs/go-ipfs/exchange/bitswap/notifications"
+	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 )

--- a/exchange/bitswap/session.go
+++ b/exchange/bitswap/session.go
@@ -1,0 +1,221 @@
+package bitswap
+
+import (
+	"context"
+	"time"
+
+	blocks "github.com/ipfs/go-ipfs/blocks"
+	notifications "github.com/ipfs/go-ipfs/exchange/bitswap/notifications"
+
+	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	lru "gx/ipfs/QmVYxfoJQiZijTgPNHCHgHELvQpbsJNTg6Crmc3dQkj3yy/golang-lru"
+	loggables "gx/ipfs/QmVesPmqbPp7xRGyY96tnBwzDtVV1nqv4SCVxo5zCqKyH8/go-libp2p-loggables"
+	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
+	peer "gx/ipfs/QmdS9KpbDyPrieswibZhkod1oXqRwZJrUPzxCofAMWpFGq/go-libp2p-peer"
+)
+
+const activeWantsLimit = 16
+
+type Session struct {
+	ctx            context.Context
+	tofetch        []*cid.Cid
+	activePeers    map[peer.ID]struct{}
+	activePeersArr []peer.ID
+
+	bs         *Bitswap
+	incoming   chan blkRecv
+	newReqs    chan []*cid.Cid
+	cancelKeys chan []*cid.Cid
+
+	interest  *lru.Cache
+	liveWants map[string]time.Time
+	liveCnt   int
+
+	tick          *time.Timer
+	baseTickDelay time.Duration
+
+	latTotal time.Duration
+	fetchcnt int
+
+	notif notifications.PubSub
+
+	uuid logging.Loggable
+}
+
+func (bs *Bitswap) NewSession(ctx context.Context) *Session {
+	s := &Session{
+		activePeers:   make(map[peer.ID]struct{}),
+		liveWants:     make(map[string]time.Time),
+		newReqs:       make(chan []*cid.Cid),
+		cancelKeys:    make(chan []*cid.Cid),
+		ctx:           ctx,
+		bs:            bs,
+		incoming:      make(chan blkRecv),
+		notif:         notifications.New(),
+		uuid:          loggables.Uuid("GetBlockRequest"),
+		baseTickDelay: time.Millisecond * 500,
+	}
+
+	cache, _ := lru.New(2048)
+	s.interest = cache
+
+	bs.sessLk.Lock()
+	bs.sessions = append(bs.sessions, s)
+	bs.sessLk.Unlock()
+
+	go s.run(ctx)
+
+	return s
+}
+
+type blkRecv struct {
+	from peer.ID
+	blk  blocks.Block
+}
+
+func (s *Session) ReceiveBlock(from peer.ID, blk blocks.Block) {
+	s.incoming <- blkRecv{from: from, blk: blk}
+}
+
+func (s *Session) InterestedIn(c *cid.Cid) bool {
+	return s.interest.Contains(c.KeyString())
+}
+
+const provSearchDelay = time.Second * 10
+
+func (s *Session) addActivePeer(p peer.ID) {
+	if _, ok := s.activePeers[p]; !ok {
+		s.activePeers[p] = struct{}{}
+		s.activePeersArr = append(s.activePeersArr, p)
+	}
+}
+
+func (s *Session) resetTick() {
+	if s.latTotal == 0 {
+		s.tick.Reset(provSearchDelay)
+	} else {
+		avLat := s.latTotal / time.Duration(s.fetchcnt)
+		s.tick.Reset(s.baseTickDelay + (3 * avLat))
+	}
+}
+
+func (s *Session) run(ctx context.Context) {
+	s.tick = time.NewTimer(provSearchDelay)
+	newpeers := make(chan peer.ID, 16)
+	for {
+		select {
+		case blk := <-s.incoming:
+			s.tick.Stop()
+
+			s.addActivePeer(blk.from)
+
+			s.receiveBlock(ctx, blk.blk)
+
+			s.resetTick()
+		case keys := <-s.newReqs:
+			for _, k := range keys {
+				s.interest.Add(k.KeyString(), nil)
+			}
+			if s.liveCnt < activeWantsLimit {
+				toadd := activeWantsLimit - s.liveCnt
+				if toadd > len(keys) {
+					toadd = len(keys)
+				}
+				s.liveCnt += toadd
+
+				now := keys[:toadd]
+				keys = keys[toadd:]
+
+				s.wantBlocks(ctx, now)
+			}
+			s.tofetch = append(s.tofetch, keys...)
+		case keys := <-s.cancelKeys:
+			s.cancel(keys)
+
+		case <-s.tick.C:
+			var live []*cid.Cid
+			for c, _ := range s.liveWants {
+				cs, _ := cid.Cast([]byte(c))
+				live = append(live, cs)
+				s.liveWants[c] = time.Now()
+			}
+
+			// Broadcast these keys to everyone we're connected to
+			s.bs.wm.WantBlocks(ctx, live, nil)
+
+			if len(live) > 0 {
+				go func() {
+					for p := range s.bs.network.FindProvidersAsync(ctx, live[0], 10) {
+						newpeers <- p
+					}
+				}()
+			}
+			s.resetTick()
+		case p := <-newpeers:
+			s.addActivePeer(p)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Session) receiveBlock(ctx context.Context, blk blocks.Block) {
+	ks := blk.Cid().KeyString()
+	if _, ok := s.liveWants[ks]; ok {
+		s.liveCnt--
+		tval := s.liveWants[ks]
+		s.latTotal += time.Since(tval)
+		s.fetchcnt++
+		delete(s.liveWants, ks)
+		s.notif.Publish(blk)
+
+		if len(s.tofetch) > 0 {
+			next := s.tofetch[0:1]
+			s.tofetch = s.tofetch[1:]
+			s.wantBlocks(ctx, next)
+		}
+	}
+}
+
+func (s *Session) wantBlocks(ctx context.Context, ks []*cid.Cid) {
+	for _, c := range ks {
+		s.liveWants[c.KeyString()] = time.Now()
+	}
+	s.bs.wm.WantBlocks(ctx, ks, s.activePeersArr)
+}
+
+func (s *Session) cancel(keys []*cid.Cid) {
+	sset := cid.NewSet()
+	for _, c := range keys {
+		sset.Add(c)
+	}
+	var i, j int
+	for ; j < len(s.tofetch); j++ {
+		if sset.Has(s.tofetch[j]) {
+			continue
+		}
+		s.tofetch[i] = s.tofetch[j]
+		i++
+	}
+	s.tofetch = s.tofetch[:i]
+}
+
+func (s *Session) cancelWants(keys []*cid.Cid) {
+	s.cancelKeys <- keys
+}
+
+func (s *Session) fetch(ctx context.Context, keys []*cid.Cid) {
+	select {
+	case s.newReqs <- keys:
+	case <-ctx.Done():
+	}
+}
+
+func (s *Session) GetBlocks(ctx context.Context, keys []*cid.Cid) (<-chan blocks.Block, error) {
+	ctx = logging.ContextWithLoggable(ctx, s.uuid)
+	return getBlocksImpl(ctx, keys, s.notif, s.fetch, s.cancelWants)
+}
+
+func (s *Session) GetBlock(parent context.Context, k *cid.Cid) (blocks.Block, error) {
+	return getBlock(parent, k, s.GetBlocks)
+}

--- a/exchange/bitswap/session.go
+++ b/exchange/bitswap/session.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	blocks "github.com/ipfs/go-ipfs/blocks"
 	notifications "github.com/ipfs/go-ipfs/exchange/bitswap/notifications"
+	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	lru "gx/ipfs/QmVYxfoJQiZijTgPNHCHgHELvQpbsJNTg6Crmc3dQkj3yy/golang-lru"

--- a/exchange/bitswap/session.go
+++ b/exchange/bitswap/session.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	notifications "github.com/ipfs/go-ipfs/exchange/bitswap/notifications"
-	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	lru "gx/ipfs/QmVYxfoJQiZijTgPNHCHgHELvQpbsJNTg6Crmc3dQkj3yy/golang-lru"
 	loggables "gx/ipfs/QmVesPmqbPp7xRGyY96tnBwzDtVV1nqv4SCVxo5zCqKyH8/go-libp2p-loggables"
+	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 	peer "gx/ipfs/QmdS9KpbDyPrieswibZhkod1oXqRwZJrUPzxCofAMWpFGq/go-libp2p-peer"
 )
@@ -191,6 +191,7 @@ func (s *Session) run(ctx context.Context) {
 			_, ok := s.liveWants[lwchk.c.KeyString()]
 			lwchk.resp <- ok
 		case <-ctx.Done():
+			s.tick.Stop()
 			return
 		}
 	}

--- a/exchange/bitswap/session_test.go
+++ b/exchange/bitswap/session_test.go
@@ -103,8 +103,8 @@ func TestSessionBetweenPeers(t *testing.T) {
 		}
 	}
 	for _, is := range inst[2:] {
-		if is.Exchange.messagesRecvd > 2 {
-			t.Fatal("uninvolved nodes should only receive two messages", is.Exchange.messagesRecvd)
+		if is.Exchange.counters.messagesRecvd > 2 {
+			t.Fatal("uninvolved nodes should only receive two messages", is.Exchange.counters.messagesRecvd)
 		}
 	}
 }

--- a/exchange/bitswap/session_test.go
+++ b/exchange/bitswap/session_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	blocks "github.com/ipfs/go-ipfs/blocks"
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
+	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 )

--- a/exchange/bitswap/session_test.go
+++ b/exchange/bitswap/session_test.go
@@ -1,0 +1,152 @@
+package bitswap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	blocks "github.com/ipfs/go-ipfs/blocks"
+	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
+
+	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
+)
+
+func TestBasicSessions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vnet := getVirtualNetwork()
+	sesgen := NewTestSessionGenerator(vnet)
+	defer sesgen.Close()
+	bgen := blocksutil.NewBlockGenerator()
+
+	block := bgen.Next()
+	inst := sesgen.Instances(2)
+
+	a := inst[0]
+	b := inst[1]
+
+	if err := b.Blockstore().Put(block); err != nil {
+		t.Fatal(err)
+	}
+
+	sesa := a.Exchange.NewSession(ctx)
+
+	blkout, err := sesa.GetBlock(ctx, block.Cid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !blkout.Cid().Equals(block.Cid()) {
+		t.Fatal("got wrong block")
+	}
+}
+
+func assertBlockLists(got, exp []blocks.Block) error {
+	if len(got) != len(exp) {
+		return fmt.Errorf("got wrong number of blocks, %d != %d", len(got), len(exp))
+	}
+
+	h := cid.NewSet()
+	for _, b := range got {
+		h.Add(b.Cid())
+	}
+	for _, b := range exp {
+		if !h.Has(b.Cid()) {
+			return fmt.Errorf("didnt have: %s", b.Cid())
+		}
+	}
+	return nil
+}
+
+func TestSessionBetweenPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vnet := getVirtualNetwork()
+	sesgen := NewTestSessionGenerator(vnet)
+	defer sesgen.Close()
+	bgen := blocksutil.NewBlockGenerator()
+
+	inst := sesgen.Instances(10)
+
+	blks := bgen.Blocks(101)
+	if err := inst[0].Blockstore().PutMany(blks); err != nil {
+		t.Fatal(err)
+	}
+
+	var cids []*cid.Cid
+	for _, blk := range blks {
+		cids = append(cids, blk.Cid())
+	}
+
+	ses := inst[1].Exchange.NewSession(ctx)
+	if _, err := ses.GetBlock(ctx, cids[0]); err != nil {
+		t.Fatal(err)
+	}
+	blks = blks[1:]
+	cids = cids[1:]
+
+	for i := 0; i < 10; i++ {
+		ch, err := ses.GetBlocks(ctx, cids[i*10:(i+1)*10])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got []blocks.Block
+		for b := range ch {
+			got = append(got, b)
+		}
+		if err := assertBlockLists(got, blks[i*10:(i+1)*10]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, is := range inst[2:] {
+		if is.Exchange.messagesRecvd > 2 {
+			t.Fatal("uninvolved nodes should only receive two messages", is.Exchange.messagesRecvd)
+		}
+	}
+}
+
+func TestSessionSplitFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vnet := getVirtualNetwork()
+	sesgen := NewTestSessionGenerator(vnet)
+	defer sesgen.Close()
+	bgen := blocksutil.NewBlockGenerator()
+
+	inst := sesgen.Instances(11)
+
+	blks := bgen.Blocks(100)
+	for i := 0; i < 10; i++ {
+		if err := inst[i].Blockstore().PutMany(blks[i*10 : (i+1)*10]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var cids []*cid.Cid
+	for _, blk := range blks {
+		cids = append(cids, blk.Cid())
+	}
+
+	ses := inst[10].Exchange.NewSession(ctx)
+	ses.baseTickDelay = time.Millisecond * 10
+
+	for i := 0; i < 10; i++ {
+		ch, err := ses.GetBlocks(ctx, cids[i*10:(i+1)*10])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got []blocks.Block
+		for b := range ch {
+			got = append(got, b)
+		}
+		if err := assertBlockLists(got, blks[i*10:(i+1)*10]); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/exchange/bitswap/session_test.go
+++ b/exchange/bitswap/session_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	blocksutil "github.com/ipfs/go-ipfs/blocks/blocksutil"
-	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
+	blocks "gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 )
 

--- a/exchange/bitswap/stat.go
+++ b/exchange/bitswap/stat.go
@@ -10,11 +10,11 @@ type Stat struct {
 	ProvideBufLen   int
 	Wantlist        []*cid.Cid
 	Peers           []string
-	BlocksReceived  int
+	BlocksReceived  uint64
 	DataReceived    uint64
-	BlocksSent      int
+	BlocksSent      uint64
 	DataSent        uint64
-	DupBlksReceived int
+	DupBlksReceived uint64
 	DupDataReceived uint64
 }
 
@@ -23,12 +23,13 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	st.ProvideBufLen = len(bs.newBlocks)
 	st.Wantlist = bs.GetWantlist()
 	bs.counterLk.Lock()
-	st.BlocksReceived = bs.blocksRecvd
-	st.DupBlksReceived = bs.dupBlocksRecvd
-	st.DupDataReceived = bs.dupDataRecvd
-	st.BlocksSent = bs.blocksSent
-	st.DataSent = bs.dataSent
-	st.DataReceived = bs.dataRecvd
+	c := bs.counters
+	st.BlocksReceived = c.blocksRecvd
+	st.DupBlksReceived = c.dupBlocksRecvd
+	st.DupDataReceived = c.dupDataRecvd
+	st.BlocksSent = c.blocksSent
+	st.DataSent = c.dataSent
+	st.DataReceived = c.dataRecvd
 	bs.counterLk.Unlock()
 
 	for _, p := range bs.engine.Peers() {

--- a/exchange/bitswap/testutils.go
+++ b/exchange/bitswap/testutils.go
@@ -47,7 +47,7 @@ func (g *SessionGenerator) Next() Instance {
 	if err != nil {
 		panic("FIXME") // TODO change signature
 	}
-	return Session(g.ctx, g.net, p)
+	return MkSession(g.ctx, g.net, p)
 }
 
 func (g *SessionGenerator) Instances(n int) []Instance {
@@ -86,7 +86,7 @@ func (i *Instance) SetBlockstoreLatency(t time.Duration) time.Duration {
 // NB: It's easy make mistakes by providing the same peer ID to two different
 // sessions. To safeguard, use the SessionGenerator to generate sessions. It's
 // just a much better idea.
-func Session(ctx context.Context, net tn.Network, p testutil.Identity) Instance {
+func MkSession(ctx context.Context, net tn.Network, p testutil.Identity) Instance {
 	bsdelay := delay.Fixed(0)
 
 	adapter := net.Adapter(p)

--- a/exchange/bitswap/wantlist/wantlist.go
+++ b/exchange/bitswap/wantlist/wantlist.go
@@ -170,7 +170,7 @@ func (w *Wantlist) Remove(c *cid.Cid) bool {
 	}
 
 	delete(w.set, k)
-	return false
+	return true
 }
 
 func (w *Wantlist) Contains(k *cid.Cid) (*Entry, bool) {

--- a/exchange/bitswap/wantlist/wantlist.go
+++ b/exchange/bitswap/wantlist/wantlist.go
@@ -53,6 +53,14 @@ func New() *Wantlist {
 	}
 }
 
+// Add adds the given cid to the wantlist with the specified priority, governed
+// by the session ID 'ses'.  if a cid is added under multiple session IDs, then
+// it must be removed by each of those sessions before it is no longer 'in the
+// wantlist'. Calls to Add are idempotent given the same arguments. Subsequent
+// calls with different values for priority will not update the priority
+// TODO: think through priority changes here
+// Add returns true if the cid did not exist in the wantlist before this call
+// (even if it was under a different session)
 func (w *ThreadSafe) Add(c *cid.Cid, priority int, ses uint64) bool {
 	w.lk.Lock()
 	defer w.lk.Unlock()
@@ -84,6 +92,10 @@ func (w *ThreadSafe) AddEntry(e *Entry, ses uint64) bool {
 	return true
 }
 
+// Remove removes the given cid from being tracked by the given session.
+// 'true' is returned if this call to Remove removed the final session ID
+// tracking the cid. (meaning true will be returned iff this call caused the
+// value of 'Contains(c)' to change from true to false)
 func (w *ThreadSafe) Remove(c *cid.Cid, ses uint64) bool {
 	w.lk.Lock()
 	defer w.lk.Unlock()
@@ -101,6 +113,8 @@ func (w *ThreadSafe) Remove(c *cid.Cid, ses uint64) bool {
 	return false
 }
 
+// Contains returns true if the given cid is in the wantlist tracked by one or
+// more sessions
 func (w *ThreadSafe) Contains(k *cid.Cid) (*Entry, bool) {
 	w.lk.RLock()
 	defer w.lk.RUnlock()

--- a/exchange/bitswap/wantlist/wantlist.go
+++ b/exchange/bitswap/wantlist/wantlist.go
@@ -79,6 +79,7 @@ func (w *ThreadSafe) Add(c *cid.Cid, priority int, ses uint64) bool {
 	return true
 }
 
+// AddEntry adds given Entry to the wantlist. For more information see Add method.
 func (w *ThreadSafe) AddEntry(e *Entry, ses uint64) bool {
 	w.lk.Lock()
 	defer w.lk.Unlock()

--- a/exchange/bitswap/wantlist/wantlist_test.go
+++ b/exchange/bitswap/wantlist/wantlist_test.go
@@ -1,0 +1,87 @@
+package wantlist
+
+import (
+	"testing"
+
+	cid "gx/ipfs/QmYhQaCYEcaPPjxJX7YcPcVKkQfRy6sJ7B3XmGFk82XYdQ/go-cid"
+)
+
+var testcids []*cid.Cid
+
+func init() {
+	strs := []string{
+		"QmQL8LqkEgYXaDHdNYCG2mmpow7Sp8Z8Kt3QS688vyBeC7",
+		"QmcBDsdjgSXU7BP4A4V8LJCXENE5xVwnhrhRGVTJr9YCVj",
+		"QmQakgd2wDxc3uUF4orGdEm28zUT9Mmimp5pyPG2SFS9Gj",
+	}
+	for _, s := range strs {
+		c, err := cid.Decode(s)
+		if err != nil {
+			panic(err)
+		}
+		testcids = append(testcids, c)
+	}
+
+}
+
+type wli interface {
+	Contains(*cid.Cid) (*Entry, bool)
+}
+
+func assertHasCid(t *testing.T, w wli, c *cid.Cid) {
+	e, ok := w.Contains(c)
+	if !ok {
+		t.Fatal("expected to have ", c)
+	}
+	if !e.Cid.Equals(c) {
+		t.Fatal("returned entry had wrong cid value")
+	}
+}
+
+func assertNotHasCid(t *testing.T, w wli, c *cid.Cid) {
+	_, ok := w.Contains(c)
+	if ok {
+		t.Fatal("expected not to have ", c)
+	}
+}
+
+func TestBasicWantlist(t *testing.T) {
+	wl := New()
+
+	wl.Add(testcids[0], 5)
+	assertHasCid(t, wl, testcids[0])
+	wl.Add(testcids[1], 4)
+	assertHasCid(t, wl, testcids[0])
+	assertHasCid(t, wl, testcids[1])
+
+	if wl.Len() != 2 {
+		t.Fatal("should have had two items")
+	}
+
+	wl.Add(testcids[1], 4)
+	assertHasCid(t, wl, testcids[0])
+	assertHasCid(t, wl, testcids[1])
+
+	if wl.Len() != 2 {
+		t.Fatal("should have had two items")
+	}
+
+	wl.Remove(testcids[0])
+	assertHasCid(t, wl, testcids[1])
+	if _, has := wl.Contains(testcids[0]); has {
+		t.Fatal("shouldnt have this cid")
+	}
+}
+
+func TestSesRefWantlist(t *testing.T) {
+	wl := NewThreadSafe()
+
+	wl.Add(testcids[0], 5, 1)
+	assertHasCid(t, wl, testcids[0])
+	wl.Remove(testcids[0], 2)
+	assertHasCid(t, wl, testcids[0])
+	wl.Add(testcids[0], 5, 1)
+	assertHasCid(t, wl, testcids[0])
+	wl.Remove(testcids[0], 1)
+	assertNotHasCid(t, wl, testcids[0])
+}

--- a/exchange/bitswap/wantlist/wantlist_test.go
+++ b/exchange/bitswap/wantlist/wantlist_test.go
@@ -48,9 +48,13 @@ func assertNotHasCid(t *testing.T, w wli, c *cid.Cid) {
 func TestBasicWantlist(t *testing.T) {
 	wl := New()
 
-	wl.Add(testcids[0], 5)
+	if !wl.Add(testcids[0], 5) {
+		t.Fatal("expected true")
+	}
 	assertHasCid(t, wl, testcids[0])
-	wl.Add(testcids[1], 4)
+	if !wl.Add(testcids[1], 4) {
+		t.Fatal("expected true")
+	}
 	assertHasCid(t, wl, testcids[0])
 	assertHasCid(t, wl, testcids[1])
 
@@ -58,7 +62,9 @@ func TestBasicWantlist(t *testing.T) {
 		t.Fatal("should have had two items")
 	}
 
-	wl.Add(testcids[1], 4)
+	if wl.Add(testcids[1], 4) {
+		t.Fatal("add shouldnt report success on second add")
+	}
 	assertHasCid(t, wl, testcids[0])
 	assertHasCid(t, wl, testcids[1])
 
@@ -66,7 +72,10 @@ func TestBasicWantlist(t *testing.T) {
 		t.Fatal("should have had two items")
 	}
 
-	wl.Remove(testcids[0])
+	if !wl.Remove(testcids[0]) {
+		t.Fatal("should have gotten true")
+	}
+
 	assertHasCid(t, wl, testcids[1])
 	if _, has := wl.Contains(testcids[0]); has {
 		t.Fatal("shouldnt have this cid")
@@ -76,12 +85,20 @@ func TestBasicWantlist(t *testing.T) {
 func TestSesRefWantlist(t *testing.T) {
 	wl := NewThreadSafe()
 
-	wl.Add(testcids[0], 5, 1)
+	if !wl.Add(testcids[0], 5, 1) {
+		t.Fatal("should have added")
+	}
 	assertHasCid(t, wl, testcids[0])
-	wl.Remove(testcids[0], 2)
+	if wl.Remove(testcids[0], 2) {
+		t.Fatal("shouldnt have removed")
+	}
 	assertHasCid(t, wl, testcids[0])
-	wl.Add(testcids[0], 5, 1)
+	if wl.Add(testcids[0], 5, 1) {
+		t.Fatal("shouldnt have added")
+	}
 	assertHasCid(t, wl, testcids[0])
-	wl.Remove(testcids[0], 1)
+	if !wl.Remove(testcids[0], 1) {
+		t.Fatal("should have removed")
+	}
 	assertNotHasCid(t, wl, testcids[0])
 }

--- a/exchange/bitswap/wantlist/wantlist_test.go
+++ b/exchange/bitswap/wantlist/wantlist_test.go
@@ -3,7 +3,7 @@ package wantlist
 import (
 	"testing"
 
-	cid "gx/ipfs/QmYhQaCYEcaPPjxJX7YcPcVKkQfRy6sJ7B3XmGFk82XYdQ/go-cid"
+	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
 )
 
 var testcids []*cid.Cid

--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -71,13 +71,13 @@ type msgQueue struct {
 	done chan struct{}
 }
 
-func (pm *WantManager) WantBlocks(ctx context.Context, ks []*cid.Cid) {
+func (pm *WantManager) WantBlocks(ctx context.Context, ks []*cid.Cid, peers []peer.ID) {
 	log.Infof("want blocks: %s", ks)
-	pm.addEntries(ctx, ks, false)
+	pm.addEntries(ctx, ks, peers, false)
 }
 
-func (pm *WantManager) CancelWants(ks []*cid.Cid) {
-	pm.addEntries(context.Background(), ks, true)
+func (pm *WantManager) CancelWants(ctx context.Context, ks []*cid.Cid, peers []peer.ID) {
+	pm.addEntries(context.Background(), ks, peers, true)
 }
 
 type wantSet struct {
@@ -85,7 +85,7 @@ type wantSet struct {
 	targets []peer.ID
 }
 
-func (pm *WantManager) addEntries(ctx context.Context, ks []*cid.Cid, cancel bool) {
+func (pm *WantManager) addEntries(ctx context.Context, ks []*cid.Cid, targets []peer.ID, cancel bool) {
 	var entries []*bsmsg.Entry
 	for i, k := range ks {
 		entries = append(entries, &bsmsg.Entry{
@@ -98,7 +98,7 @@ func (pm *WantManager) addEntries(ctx context.Context, ks []*cid.Cid, cancel boo
 		})
 	}
 	select {
-	case pm.incoming <- &wantSet{entries: entries}:
+	case pm.incoming <- &wantSet{entries: entries, targets: targets}:
 	case <-pm.ctx.Done():
 	case <-ctx.Done():
 	}

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -49,7 +49,7 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 
 func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
 	idmap := logging.LoggableMap{"ID": id}
-	defer log.Info("bitswap task worker shutting down...")
+	defer log.Debug("bitswap task worker shutting down...")
 	for {
 		log.Event(ctx, "Bitswap.TaskWorker.Loop", idmap)
 		select {

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -73,8 +73,8 @@ func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
 
 				bs.wm.SendBlock(ctx, envelope)
 				bs.counterLk.Lock()
-				bs.blocksSent++
-				bs.dataSent += uint64(len(envelope.Block.RawData()))
+				bs.counters.blocksSent++
+				bs.counters.dataSent += uint64(len(envelope.Block.RawData()))
 				bs.counterLk.Unlock()
 			case <-ctx.Done():
 				return

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -13,10 +13,7 @@ import (
 // Any type that implements exchange.Interface may be used as an IPFS block
 // exchange protocol.
 type Interface interface { // type Exchanger interface
-	// GetBlock returns the block associated with a given key.
-	GetBlock(context.Context, *cid.Cid) (blocks.Block, error)
-
-	GetBlocks(context.Context, []*cid.Cid) (<-chan blocks.Block, error)
+	Fetcher
 
 	// TODO Should callers be concerned with whether the block was made
 	// available on the network?
@@ -25,4 +22,10 @@ type Interface interface { // type Exchanger interface
 	IsOnline() bool
 
 	io.Closer
+}
+
+type Fetcher interface {
+	// GetBlock returns the block associated with a given key.
+	GetBlock(context.Context, *cid.Cid) (blocks.Block, error)
+	GetBlocks(context.Context, []*cid.Cid) (<-chan blocks.Block, error)
 }

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -24,6 +24,7 @@ type Interface interface { // type Exchanger interface
 	io.Closer
 }
 
+// Fetcher is an object that can be used to retrieve blocks
 type Fetcher interface {
 	// GetBlock returns the block associated with a given key.
 	GetBlock(context.Context, *cid.Cid) (blocks.Block, error)

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -155,6 +155,9 @@ func GetLinksDirect(serv node.NodeGetter) GetLinks {
 	return func(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
 		node, err := serv.Get(ctx, c)
 		if err != nil {
+			if err == bserv.ErrNotFound {
+				err = ErrNotFound
+			}
 			return nil, err
 		}
 		return node.Links(), nil

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -182,7 +182,7 @@ func FetchGraph(ctx context.Context, root *cid.Cid, serv DAGService) error {
 	var ng node.NodeGetter = serv
 	ds, ok := serv.(*dagService)
 	if ok {
-		ng = &sesGetter{ds.Blocks.NewSession(ctx)}
+		ng = &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
 	}
 
 	v, _ := ctx.Value("progress").(*ProgressTracker)


### PR DESCRIPTION
This is an implementation of the bitswap sessions enhancement i proposed in https://github.com/ipfs/go-ipfs/issues/3786

Its still a work in progress, and has a few potential issues around tracking of wantlist refcounts in failure modes (if peers don't have any of the things we want and we re-broadcast, it increases the wantlist refcounts unnecessarily), but it generally works quite well and makes bitswap faster and have much less bandwidth overhead. In cases of transferring large files just between one or two peers, i've seen over a 2x speed improvement.