### PR TITLE
gateway: use CID as an ETag strong validator

### DIFF
--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -136,7 +136,7 @@ func TestGatewayGet(t *testing.T) {
 		{"localhost:5001", "/", http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/" + k, http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/ipfs/" + k, http.StatusOK, "fnord"},
-		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusNotFound, "ipfs cat /ipns/nxdomain.example.com: " + namesys.ErrResolveFailed.Error() + "\n"},
+		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusNotFound, "ipfs resolve -r /ipns/nxdomain.example.com: " + namesys.ErrResolveFailed.Error() + "\n"},
 		{"localhost:5001", "/ipns/example.com", http.StatusOK, "fnord"},
 		{"example.com", "/", http.StatusOK, "fnord"},
 	} {


### PR DESCRIPTION
* Always use the fully resolved CID from api.ResolveNode
  as the ETag (also for IPNS).

* Format the result as a valid "Strong Validator"
  (double quotes around the encoded CID).

Fixes #3868

License: MIT
Signed-off-by: Remco Bloemen <remco@2π.com>