### PR TITLE
gateway: fix erroneous Cache-Control: immutable on dir listings

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -202,7 +202,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	// and only if it's /ipfs!
 	// TODO: break this out when we split /ipfs /ipns routes.
 	modtime := time.Now()
-	if strings.HasPrefix(urlPath, ipfsPathPrefix) {
+	if strings.HasPrefix(urlPath, ipfsPathPrefix) && !dir {
 		w.Header().Set("Etag", etag)
 		w.Header().Set("Cache-Control", "public, max-age=29030400, immutable")
 


### PR DESCRIPTION
We set the [Cache-Control: immutable header](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/) on responses from the gateway's /ipfs route. That's fine, but we also set it on directory listings such as https://ipfs.io/ipfs/QmSwzyZ4zfHD9j4JZdXuzbWH4gXuDfZ7CdfMzpfqrMVcrz/go-libp2p-blankhost/ which effectively prevents us from changing e.g. the CSS on the listings, or really anything about the listing.

We should only ever set Cache-Control: immutable for responses that produce exactly the hash in the URL. This is only the case for unixfs files, not for the auto-generated directory listings.