### PR TITLE
deps: Update go-is-domain to contain new gTLD

### DIFF
--- a/core/corehttp/ipns_hostname.go
+++ b/core/corehttp/ipns_hostname.go
@@ -7,7 +7,7 @@ import (
 
 	"context"
 	"github.com/ipfs/go-ipfs/core"
-	isd "gx/ipfs/QmaeHSCBd9XjXxmgHEiKkHtLcMCb2eZsPLKT7bHgBfBkqw/go-is-domain"
+	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
 )
 
 // IPNSHostnameOption rewrites an incoming request if its Host: header contains

--- a/core/corehttp/ipns_hostname.go
+++ b/core/corehttp/ipns_hostname.go
@@ -1,12 +1,13 @@
 package corehttp
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
 
-	"context"
 	"github.com/ipfs/go-ipfs/core"
+
 	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
 )
 

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	context "context"
-	isd "gx/ipfs/QmaeHSCBd9XjXxmgHEiKkHtLcMCb2eZsPLKT7bHgBfBkqw/go-is-domain"
+	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
 
 	path "github.com/ipfs/go-ipfs/path"
 )

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -1,14 +1,14 @@
 package namesys
 
 import (
+	"context"
 	"errors"
 	"net"
 	"strings"
 
-	context "context"
-	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
-
 	path "github.com/ipfs/go-ipfs/path"
+
+	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
 )
 
 type LookupTXTFunc func(name string) (txt []string, err error)

--- a/package.json
+++ b/package.json
@@ -172,9 +172,9 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmaeHSCBd9XjXxmgHEiKkHtLcMCb2eZsPLKT7bHgBfBkqw",
+      "hash": "QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX",
       "name": "go-is-domain",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
It should resolve issues with newer gTLDs being not selected

License: MIT
Signed-off-by: Jakub Sztandera <kubuxu@protonmail.ch>