### PR TITLE
Fix gateway handling of sharded directories

### DIFF
--- a/test/sharness/t0260-sharding-flag.sh
+++ b/test/sharness/t0260-sharding-flag.sh
@@ -55,6 +55,12 @@ test_expect_success "sharded and unsharded output look the same" '
 	test_cmp sharded_out unsharded_out
 '
 
+test_expect_success "ipfs cat error output the same" '
+	test_expect_code 1 ipfs cat "$SHARDED" 2> sharded_err &&
+	test_expect_code 1 ipfs cat "$UNSHARDED" 2> unsharded_err &&
+	test_cmp sharded_err unsharded_err
+'
+
 test_add_large_dir_v1() {
 	exphash="$1"
 	test_expect_success "ipfs add (CIDv1) on very large directory succeeds" '

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -45,7 +45,7 @@ func NewDagReader(ctx context.Context, n node.Node, serv mdag.DAGService) (DagRe
 		}
 
 		switch pb.GetType() {
-		case ftpb.Data_Directory:
+		case ftpb.Data_Directory, ftpb.Data_HAMTShard:
 			// Dont allow reading directories
 			return nil, ErrIsDir
 		case ftpb.Data_File, ftpb.Data_Raw:


### PR DESCRIPTION
The gateway relies on the error output of the dagreader to tell if somethings a directory.

closes #3886 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>