### PR TITLE
Fix typo in message when file is not determined

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -111,7 +111,7 @@ You can now refer to the added file in a gateway, like so:
 		sizeFile, ok := req.Files().(files.SizeFile)
 		if !ok {
 			// we don't need to error, the progress bar just won't know how big the files are
-			log.Warning("cannnot determine size of input file")
+			log.Warning("cannot determine size of input file")
 			return nil
 		}
 


### PR DESCRIPTION
Fix for issue: https://github.com/ipfs/go-ipfs/issues/3894 

Typo in message.

License: MIT
Signed-off-by: Miguel Torres <migueltorreslopez@gmail.com>

