### PR TITLE
Adding documentation that PubSub Sub can be encoded.

### DIFF
--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -52,6 +52,18 @@ to be used in a production environment.
 
 To use, the daemon must be run with '--enable-pubsub-experiment'.
 `,
+		LongDescription: `
+ipfs pubsub sub subscribes to messages on a given topic.
+
+This is an experimental feature. It is not intended in its current state
+to be used in a production environment.
+
+To use, the daemon must be run with '--enable-pubsub-experiment'.
+
+This command outputs data in the following encodings:
+  * "json"
+(Specified by the "--encoding" or "--enc" flag)
+`,
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("topic", true, false, "String name of topic to subscribe to."),


### PR DESCRIPTION
Turns out, the Message will Marshal properly. I tested XML and Protobufs, but doesn't seem the "marshaller" is there. I'm still not familiar enough with the codebase to go poking around, so I'm just adding a bit of documentation that was missed, and is in my opinion pretty useful.