### PR TITLE
core: make announced swarm addresses configurable

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -497,15 +497,29 @@ func printSwarmAddrs(node *core.IpfsNode) {
 		fmt.Println("Swarm not listening, running in offline mode.")
 		return
 	}
+
+	var lisAddrs []string
+	ifaceAddrs, err := node.PeerHost.Network().InterfaceListenAddresses()
+	if err != nil {
+		log.Errorf("failed to read listening addresses: %s", err)
+	}
+	for _, addr := range ifaceAddrs {
+		lisAddrs = append(lisAddrs, addr.String())
+	}
+	sort.Sort(sort.StringSlice(lisAddrs))
+	for _, addr := range lisAddrs {
+		fmt.Printf("Swarm listening on %s\n", addr)
+	}
+
 	var addrs []string
 	for _, addr := range node.PeerHost.Addrs() {
 		addrs = append(addrs, addr.String())
 	}
 	sort.Sort(sort.StringSlice(addrs))
-
 	for _, addr := range addrs {
-		fmt.Printf("Swarm listening on %s\n", addr)
+		fmt.Printf("Swarm announcing %s\n", addr)
 	}
+
 }
 
 // serveHTTPGateway collects options, creates listener, prints status message and starts serving requests

--- a/package.json
+++ b/package.json
@@ -446,6 +446,11 @@
       "hash": "Qma7Kuwun7w8SZphjEPDVxvGfetBkqdNGmigDA13sJdLex",
       "name": "go-ipld-git",
       "version": "0.1.3"
+    },
+    {
+      "hash": "QmQBB2dQLmQHJgs2gqZ3iqL2XiuCtUCvXzWt5kMXDf5Zcr",
+      "name": "go-maddr-filter",
+      "version": "1.1.4"
     }
   ],
   "gxVersion": "0.10.0",

--- a/repo/config/addresses.go
+++ b/repo/config/addresses.go
@@ -2,7 +2,9 @@ package config
 
 // Addresses stores the (string) multiaddr addresses for the node.
 type Addresses struct {
-	Swarm   []string // addresses for the swarm network
-	API     string   // address for the local API (RPC)
-	Gateway string   // address to listen on for IPFS HTTP object gateway
+	Swarm      []string // addresses for the swarm to listen on
+	Announce   []string // swarm addresses to announce to the network
+	NoAnnounce []string // swarm addresses not to announce to the network
+	API        string   // address for the local API (RPC)
+	Gateway    string   // address to listen on for IPFS HTTP object gateway
 }

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -36,8 +36,10 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 				// "/ip4/0.0.0.0/udp/4002/utp", // disabled for now.
 				"/ip6/::/tcp/4001",
 			},
-			API:     "/ip4/127.0.0.1/tcp/5001",
-			Gateway: "/ip4/127.0.0.1/tcp/8080",
+			Announce:   []string{},
+			NoAnnounce: []string{},
+			API:        "/ip4/127.0.0.1/tcp/5001",
+			Gateway:    "/ip4/127.0.0.1/tcp/8080",
 		},
 
 		Datastore: datastore,

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -39,6 +39,7 @@ test_expect_success "ipfs daemon output looks good" '
   STARTFILE="ipfs cat /ipfs/$HASH_WELCOME_DOCS/readme" &&
   echo "Initializing daemon..." >expected_daemon &&
   sed "s/^/Swarm listening on /" local_addrs >>expected_daemon &&
+  sed "s/^/Swarm announcing /" local_addrs >>expected_daemon &&
   echo "API server listening on '$API_MADDR'" >>expected_daemon &&
   echo "Gateway (readonly) server listening on '$GWAY_MADDR'" >>expected_daemon &&
   echo "Daemon is ready" >>expected_daemon &&

--- a/test/sharness/t0140-swarm.sh
+++ b/test/sharness/t0140-swarm.sh
@@ -49,4 +49,52 @@ test_expect_success "cant trigger a dial backoff with swarm connect" '
 
 test_kill_ipfs_daemon
 
+announceCfg='["/ip4/127.0.0.1/tcp/4001", "/ip4/1.2.3.4/tcp/1234"]'
+test_expect_success "test_config_set succeeds" "
+  ipfs config --json Addresses.Announce '$announceCfg'
+"
+
+test_launch_ipfs_daemon
+
+test_expect_success 'Addresses.Announce affects addresses' '
+	ipfs swarm addrs local >actual &&
+	grep "/ip4/1.2.3.4/tcp/1234" actual &&
+	ipfs id -f"<addrs>" | xargs -n1 echo >actual &&
+	grep "/ip4/1.2.3.4/tcp/1234" actual
+'
+
+test_kill_ipfs_daemon
+
+noAnnounceCfg='["/ip4/1.2.3.4/tcp/1234"]'
+test_expect_success "test_config_set succeeds" "
+  ipfs config --json Addresses.NoAnnounce '$noAnnounceCfg'
+"
+
+test_launch_ipfs_daemon
+
+test_expect_success "Addresses.NoAnnounce affects addresses" '
+	ipfs swarm addrs local >actual &&
+  grep -v "/ip4/1.2.3.4/tcp/1234" actual &&
+	ipfs id -f"<addrs>" | xargs -n1 echo >actual &&
+  grep -v "/ip4/1.2.3.4/tcp/1234" actual
+'
+
+test_kill_ipfs_daemon
+
+noAnnounceCfg='["/ip4/1.2.3.4/ipcidr/16"]'
+test_expect_success "test_config_set succeeds" "
+  ipfs config --json Addresses.NoAnnounce '$noAnnounceCfg'
+"
+
+test_launch_ipfs_daemon
+
+test_expect_success "Addresses.NoAnnounce with /ipcidr affects addresses" '
+	ipfs swarm addrs local >actual &&
+  grep -v "/ip4/1.2.3.4/tcp/1234" actual &&
+	ipfs id -f"<addrs>" | xargs -n1 echo >actual &&
+  grep -v "/ip4/1.2.3.4/tcp/1234" actual
+'
+
+test_kill_ipfs_daemon
+
 test_done


### PR DESCRIPTION
Fixes #3613

- Tests failing because it depends on libp2p/go-libp2p#196 which I haven't bubbled up yet
- I need to update a bunch of docs regarding the Addresses config section
- A tiny code comment here and there might be good as well

Overall this is good for CR though.