### PR TITLE
docker: expose port 8081 for /ws listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ MAINTAINER Lars Gierth <lgierth@ipfs.io>
 # Please keep these two Dockerfiles in sync.
 
 
-# Ports for Swarm TCP, Swarm uTP, API, Gateway
+# Ports for Swarm TCP, Swarm uTP, API, Gateway, Swarm Websockets
 EXPOSE 4001
 EXPOSE 4002/udp
 EXPOSE 5001
 EXPOSE 8080
+EXPOSE 8081
 
 # IPFS API to use for fetching gx packages.
 # This can be a gateway too, since its read-only API provides all gx needs.


### PR DESCRIPTION
Opening this again because it's been a reality in ipfs/infrastructure for a while.

Yes, the `/ws` listener is soon gonna be part of the gateway and a dedicated port no longer neccessary, but until then the lack of this exposed port is a pain.