### PR TITLE
gateway: don't redirect to trailing slash if it's go get

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -280,7 +280,9 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	case err == nil:
 		log.Debugf("found index.html link for %s", urlPath)
 
-		if urlPath[len(urlPath)-1] != '/' {
+		dirwithoutslash := urlPath[len(urlPath)-1] != '/'
+		goget := r.URL.Query().Get("go-get") == "1"
+		if dirwithoutslash && !goget {
 			// See comment above where originalUrlPath is declared.
 			http.Redirect(w, r, originalUrlPath+"/", 302)
 			log.Debugf("redirect to %s", originalUrlPath+"/")

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -490,6 +490,27 @@ func TestCacheControlImmutable(t *testing.T) {
 	}
 }
 
+func TestGoGetSupport(t *testing.T) {
+	ts, _ := newTestServerAndNode(t, nil)
+	t.Logf("test server url: %s", ts.URL)
+	defer ts.Close()
+
+	// mimic go-get
+	req, err := http.NewRequest("GET", ts.URL+emptyDir+"?go-get=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := doWithoutRedirect(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Errorf("status is %d, expected 200", res.StatusCode)
+	}
+}
+
 func TestVersion(t *testing.T) {
 	config.CurrentCommit = "theshortcommithash"
 


### PR DESCRIPTION
This enables `go get` to parse go-import meta tags from index.html files stored in IPFS. One tiny step toward whyrusleeping/gx-go#2.

For an import like `ipfs.io/ipfs/QmFoo/mypkg`, the gateway would previously redirect to `/ipfs/QmFoo/mypkg/` (note the trailing slash), which the `go get` tool can't deal with. Thankfully, `go get` sets a URL query parameter (`?go-get=1`) which we can use to switch off the redirect in this case.