### PR TITLE
Filestore: more verbose error when adding a file from outside of the root

### DIFF
--- a/filestore/fsrefstore.go
+++ b/filestore/fsrefstore.go
@@ -211,7 +211,7 @@ func (f *FileManager) putTo(b *posinfo.FilestoreNode, to putter) error {
 	var dobj pb.DataObj
 
 	if !filepath.HasPrefix(b.PosInfo.FullPath, f.root) {
-		return fmt.Errorf("cannot add filestore references outside ipfs root")
+		return fmt.Errorf("cannot add filestore references outside ipfs root (%s)", f.root)
 	}
 
 	p, err := filepath.Rel(f.root, b.PosInfo.FullPath)


### PR DESCRIPTION
I got very confused by what 'ipfs root' is. Hopefully this will help the next person.

License: MIT
Signed-off-by: Michael Muré <batolettre@gmail.com>