### PR TITLE
Add 'ipfs dht findprovs --num-providers' to allow choosing number of providers to find

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -145,6 +145,7 @@ var findProvidersDhtCmd = &cmds.Command{
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("verbose", "v", "Print extra information.").Default(false),
+		cmds.IntOption("num-providers", "n", "The number of providers to find.").Default(20),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		n, err := req.InvocContext().GetNode()
@@ -159,7 +160,15 @@ var findProvidersDhtCmd = &cmds.Command{
 			return
 		}
 
-		numProviders := 20
+		numProviders, _, err := res.Request().Option("n").Int()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+		if numProviders < 1 {
+			res.SetError(fmt.Errorf("Number of providers must be greater than 0"), cmds.ErrNormal)
+			return
+		}
 
 		outChan := make(chan interface{})
 		res.SetOutput((<-chan interface{})(outChan))

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -160,7 +160,7 @@ var findProvidersDhtCmd = &cmds.Command{
 			return
 		}
 
-		numProviders, _, err := res.Request().Option("n").Int()
+		numProviders, _, err := res.Request().Option("num-providers").Int()
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return


### PR DESCRIPTION
Closes: #3839

I was looking for ways to add tests to findProviders command when new option --num-providers is given. But could not find a good example on existing commands to test options.

One possibility is to use a mocking library to mock the Node, but I didn't want to introduce new library dependencies for such a trivial change.

Please advice if new tests are needed.

License: MIT
Signed-off-by: Miguel Torres <migueltorreslopez@gmail.com>