### PR TITLE
Do not publish public keys extractable from ID

### DIFF
--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -150,12 +150,10 @@ func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqn
 		entry.Ttl = proto.Uint64(uint64(ttl.Nanoseconds()))
 	}
 
-	var errs chan error
+	errs := make(chan error, 2) // At most two errors (IPNS, and public key)
 
 	// Attempt to extract the public key from the ID
 	var extractedPublicKey = peer.ExtractPublicKey()
-
-	errs = make(chan error, 2) // At most two errors (IPNS and public key)
 
 	go func() {
 		errs <- PublishEntry(ctx, r, ipnskey, entry)


### PR DESCRIPTION
Initial implementation for https://github.com/ipfs/go-ipfs/issues/3896

The function `peer.ExtractPublicKey()` is part of PR https://github.com/libp2p/go-libp2p-peer/pull/14

cc @whyrusleeping

License: MIT
Signed-off-by: Justin Drake <justin@duo.money>