### PR TITLE
Implement --profile option in ipfs init

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -58,6 +58,13 @@ var initCmd = &cmds.Command{
 		ShortDescription: `
 Initializes ipfs configuration files and generates a new keypair.
 
+If you are going to run IPFS in server environment, you may want to
+initialize it using 'server' profile.
+
+Available profiles:
+    'server' - Disables local host discovery, recommended when
+        running IPFS on machines with public IPv4 addresses.
+
 ipfs uses a repository in the local file system. By default, the repo is
 located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
 environment variable:

--- a/repo/config/profile.go
+++ b/repo/config/profile.go
@@ -1,0 +1,31 @@
+package config
+
+// ConfigProfiles is a map holding configuration transformers
+var ConfigProfiles = map[string]func(*Config) error{
+	"server": func(c *Config) error {
+
+		// defaultServerFilters has a list of non-routable IPv4 prefixes
+		// according to http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+		defaultServerFilters := []string{
+			"/ip4/10.0.0.0/ipcidr/8",
+			"/ip4/100.64.0.0/ipcidr/10",
+			"/ip4/169.254.0.0/ipcidr/16",
+			"/ip4/172.16.0.0/ipcidr/12",
+			"/ip4/192.0.0.0/ipcidr/24",
+			"/ip4/192.0.0.0/ipcidr/29",
+			"/ip4/192.0.0.8/ipcidr/32",
+			"/ip4/192.0.0.170/ipcidr/32",
+			"/ip4/192.0.0.171/ipcidr/32",
+			"/ip4/192.0.2.0/ipcidr/24",
+			"/ip4/192.168.0.0/ipcidr/16",
+			"/ip4/198.18.0.0/ipcidr/15",
+			"/ip4/198.51.100.0/ipcidr/24",
+			"/ip4/203.0.113.0/ipcidr/24",
+			"/ip4/240.0.0.0/ipcidr/4",
+		}
+
+		c.Swarm.AddrFilters = append(c.Swarm.AddrFilters, defaultServerFilters...)
+		c.Discovery.MDNS.Enabled = false
+		return nil
+	},
+}

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -126,6 +126,21 @@ test_expect_success "clean up ipfs dir" '
 	rm -rf "$IPFS_PATH"
 '
 
+# test init profiles
+test_expect_success "'ipfs init --profile' succeeds" '
+	BITS="1024" &&
+	ipfs init --bits="$BITS" --profile=server
+'
+
+test_expect_success "'ipfs config Swarm.AddrFilters' looks good" '
+	ipfs config Swarm.AddrFilters > actual_config &&
+	test $(cat actual_config | wc -l) = 17
+'
+
+test_expect_success "clean up ipfs dir" '
+	rm -rf "$IPFS_PATH"
+'
+
 test_init_ipfs
 
 test_launch_ipfs_daemon

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -127,6 +127,13 @@ test_expect_success "clean up ipfs dir" '
 '
 
 # test init profiles
+test_expect_success "'ipfs init --profile' with invalid profile fails" '
+	BITS="1024" &&
+	test_must_fail ipfs init --bits="$BITS" --profile=nonexistent_profile 2> invalid_profile_out
+	EXPECT="Error: invalid configuration profile: nonexistent_profile" &&
+	grep "$EXPECT" invalid_profile_out
+'
+
 test_expect_success "'ipfs init --profile' succeeds" '
 	BITS="1024" &&
 	ipfs init --bits="$BITS" --profile=server


### PR DESCRIPTION
Closes #3987

This implements `ipfs init --profile ...` which allows to apply profiles to default config. The server profile does what was requested in #3987.

Profiles can be stacked, this may be very useful when the configurable datastore PR is merged and there are more datastores.