### PR TITLE
Do not publish public keys extractable from ID

### DIFF
--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -150,18 +150,24 @@ func PutRecordToRouting(ctx context.Context, k ci.PrivKey, value path.Path, seqn
 		entry.Ttl = proto.Uint64(uint64(ttl.Nanoseconds()))
 	}
 
-	errs := make(chan error, 2)
+	errs := make(chan error, 2) // At most two errors (IPNS, and public key)
+
+	// Attempt to extract the public key from the ID
+	var extractedPublicKey = peer.ExtractPublicKey()
 
 	go func() {
 		errs <- PublishEntry(ctx, r, ipnskey, entry)
 	}()
 
-	go func() {
-		errs <- PublishPublicKey(ctx, r, namekey, k.GetPublic())
-	}()
+	// Publish the public key if a public key cannot be extracted from the ID
+	if extractedPublicKey == nil {
+		go func() {
+			errs <- PublishPublicKey(ctx, r, namekey, k.GetPublic())
+		}()
 
-	if err := waitOnErrChan(ctx, errs); err != nil {
-		return err
+		if err := waitOnErrChan(ctx, errs); err != nil {
+			return err
+		}
 	}
 
 	return waitOnErrChan(ctx, errs)


### PR DESCRIPTION
See https://github.com/ipfs/go-ipfs/pull/3998

Initial implementation for https://github.com/ipfs/go-ipfs/issues/3896

The function `peer.ExtractPublicKey()` is part of PR https://github.com/libp2p/go-libp2p-peer/pull/14

cc @whyrusleeping

License: MIT
Signed-off-by: Justin Drake <drakefjustin@gmail.com>