### PR TITLE
Use block decoding framework

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -112,7 +112,8 @@ func DecodeProtobuf(encoded []byte) (*ProtoNode, error) {
 	return n, nil
 }
 
-// A block decoder conforming to node.DecodeBlockFunc
+// DecodeProtobufBlock is a block decoder for protobuf IPLD nodes conforming to
+// node.DecodeBlockFunc
 func DecodeProtobufBlock(b blocks.Block) (node.Node, error) {
 	c := b.Cid()
 	if c.Type() != cid.DagProtobuf {

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -3,6 +3,9 @@ package merkledag
 import (
 	"fmt"
 	"sort"
+	"strings"
+
+	"gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	pb "github.com/ipfs/go-ipfs/merkledag/pb"
 
@@ -108,3 +111,26 @@ func DecodeProtobuf(encoded []byte) (*ProtoNode, error) {
 	}
 	return n, nil
 }
+
+// A block decoder conforming to node.DecodeBlockFunc
+func DecodeProtobufBlock(b blocks.Block) (node.Node, error) {
+	c := b.Cid()
+	if c.Type() != cid.DagProtobuf {
+		return nil, fmt.Errorf("this function can only decode protobuf nodes")
+	}
+
+	decnd, err := DecodeProtobuf(b.RawData())
+	if err != nil {
+		if strings.Contains(err.Error(), "Unmarshal failed") {
+			return nil, fmt.Errorf("The block referred to by '%s' was not a valid merkledag node", c)
+		}
+		return nil, fmt.Errorf("Failed to decode Protocol Buffers: %v", err)
+	}
+
+	decnd.cached = c
+	decnd.Prefix = c.Prefix()
+	return decnd, nil
+}
+
+// Type assertion
+var _ node.DecodeBlockFunc = DecodeProtobufBlock

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -12,6 +12,8 @@ import (
 
 	node "gx/ipfs/QmPAKbSsgEX5B6fpmxa61jXYnoWzZr5sNafd3qgPiSH8Uv/go-ipld-format"
 	cid "gx/ipfs/Qma4RJSuh7mMeJQYCqMbKzekn6EwBo7HEs5AQYjVRMQATB/go-cid"
+
+	// Import these to automatically register block decoders.
 	_ "gx/ipfs/Qmcdid3XrCxcoNQUqZKiiKtM7JXxtyipU3izyRqwjFbVWw/go-ipld-cbor"
 )
 

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -24,7 +24,7 @@ func NewRawNode(data []byte) *RawNode {
 	return &RawNode{blk}
 }
 
-// A raw block decoder conforming to `node.DecodeBlockFunc`.
+// DecodeRawBlock is a block decoder for raw IPLD nodes conforming to `node.DecodeBlockFunc`.
 func DecodeRawBlock(block blocks.Block) (node.Node, error) {
 	if block.Cid().Type() != cid.Raw {
 		return nil, fmt.Errorf("raw nodes cannot be decoded from non-raw blocks: %d", block.Cid().Type())

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -1,6 +1,8 @@
 package merkledag
 
 import (
+	"fmt"
+
 	"gx/ipfs/QmXxGS5QsUxpR3iqL5DjmsYPHR1Yz74siRQ4ChJqWFosMh/go-block-format"
 
 	node "gx/ipfs/QmPAKbSsgEX5B6fpmxa61jXYnoWzZr5sNafd3qgPiSH8Uv/go-ipld-format"
@@ -21,6 +23,17 @@ func NewRawNode(data []byte) *RawNode {
 
 	return &RawNode{blk}
 }
+
+// A raw block decoder conforming to `node.DecodeBlockFunc`.
+func DecodeRawBlock(block blocks.Block) (node.Node, error) {
+	if block.Cid().Type() != cid.Raw {
+		return nil, fmt.Errorf("raw nodes cannot be decoded from non-raw blocks: %d", block.Cid().Type())
+	}
+	// Once you "share" a block, it should be immutable. Therefore, we can just use this block as-is.
+	return &RawNode{block}, nil
+}
+
+var _ node.DecodeBlockFunc = DecodeRawBlock
 
 // NewRawNodeWPrefix creates a RawNode with the hash function
 // specified in prefix.


### PR DESCRIPTION
Change IPFS to use the new pluggable Block to IPLD decoding framework.

Later, I'll pull the other node formats *out* of IPFS (at least the raw one).

Concern: As-is, it's non-obvious that importing go-ipld-cbor automagically makes
`node.Decode` decode CBOR nodes. Worse, it's non-obvious *where* we should be
importing this package (it really only needs to be imported once).