### PR TITLE
Add test init profile

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -34,6 +34,8 @@ initialize it using 'server' profile.
 Available profiles:
     'server' - Disables local host discovery, recommended when
         running IPFS on machines with public IPv4 addresses.
+    'test' - Reduces external interference of IPFS daemon, this
+        is useful when using the daemon in test environments.
 
 ipfs uses a repository in the local file system. By default, the repo is
 located at ~/.ipfs. To change the repo location, set the $IPFS_PATH

--- a/repo/config/profile.go
+++ b/repo/config/profile.go
@@ -28,4 +28,17 @@ var ConfigProfiles = map[string]func(*Config) error{
 		c.Discovery.MDNS.Enabled = false
 		return nil
 	},
+	"test": func(c *Config) error {
+		c.Addresses.API = "/ip4/127.0.0.1/tcp/0"
+		c.Addresses.Gateway = "/ip4/127.0.0.1/tcp/0"
+
+		c.Swarm.DisableNatPortMap = true
+		c.Addresses.Swarm = []string{
+			"/ip4/127.0.0.1/tcp/0",
+		}
+
+		c.Bootstrap = []string{}
+		c.Discovery.MDNS.Enabled = false
+		return nil
+	},
 }

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -148,6 +148,25 @@ test_expect_success "clean up ipfs dir" '
 	rm -rf "$IPFS_PATH"
 '
 
+test_expect_success "'ipfs init --profile=test' succeeds" '
+	BITS="1024" &&
+	ipfs init --bits="$BITS" --profile=test
+'
+
+test_expect_success "'ipfs config Bootstrap' looks good" '
+	ipfs config Bootstrap > actual_config &&
+	test $(cat actual_config) = "[]"
+'
+
+test_expect_success "'ipfs config Addresses.API' looks good" '
+	ipfs config Addresses.API > actual_config &&
+	test $(cat actual_config) = "/ip4/127.0.0.1/tcp/0"
+'
+
+test_expect_success "clean up ipfs dir" '
+	rm -rf "$IPFS_PATH"
+'
+
 test_init_ipfs
 
 test_launch_ipfs_daemon


### PR DESCRIPTION
This will be useful for sharness tests of external tools. Goal of this profile is to reduce external interference as much as possible.