### PR TITLE
Fixes #4003

### DIFF
--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -64,11 +64,6 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 
 	args := make([]string, valCount)
 
-	//skip further checks if we have fewer provided arguments than minimum required
-	if valCount < numRequired {
-		return nil, fmt.Errorf("Needed at least %v argument(s), got %v", numRequired, valCount)
-	}
-
 	valIndex := 0
 	requiredFile := ""
 	for _, argDef := range cmd.Arguments {

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -64,6 +64,11 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 
 	args := make([]string, valCount)
 
+	//skip further checks if we have fewer provided arguments than minimum required
+	if valCount < numRequired {
+		return nil, fmt.Errorf("Needed at least %v argument(s), got %v", numRequired, valCount)
+	}
+
 	valIndex := 0
 	requiredFile := ""
 	for _, argDef := range cmd.Arguments {
@@ -115,6 +120,10 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 			Mediatype: mediatype,
 			Reader:    reader,
 		}
+	}
+
+	if f.FullPath() == "" {
+		return nil, fmt.Errorf("Corrupted data passed as file argument")
 	}
 
 	// if there is a required filearg, error if no files were provided

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -122,13 +122,13 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		}
 	}
 
-	if f.FullPath() == "" {
-		return nil, fmt.Errorf("Corrupted data passed as file argument")
-	}
-
 	// if there is a required filearg, error if no files were provided
 	if len(requiredFile) > 0 && f == nil {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
+	}
+
+	if f != nil && f.FullPath() == "" {
+		return nil, fmt.Errorf("Corrupted data passed as file argument")
 	}
 
 	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs)

--- a/commands/http/parse.go
+++ b/commands/http/parse.go
@@ -122,10 +122,6 @@ func Parse(r *http.Request, root *cmds.Command) (cmds.Request, error) {
 		return nil, fmt.Errorf("File argument '%s' is required", requiredFile)
 	}
 
-	if f != nil && f.FullPath() == "" {
-		return nil, fmt.Errorf("Corrupted data passed as file argument")
-	}
-
 	req, err := cmds.NewRequest(pth, opts, args, f, cmd, optDefs)
 	if err != nil {
 		return nil, err

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -223,6 +223,11 @@ func (adder *Adder) Finalize() (node.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if len(children) == 0 {
+			return nil, fmt.Errorf("expected at least one child dir, got none")
+		}
+
 		name = children[0]
 
 		mr, err := adder.mfsRoot()

--- a/test/sharness/t0600-issues-and-regressions-online.sh
+++ b/test/sharness/t0600-issues-and-regressions-online.sh
@@ -46,6 +46,11 @@ test_expect_success "pin add api looks right - #3753" '
 	test_cmp pinrm_out pinrm_exp
 '
 
+test_expect_success "no daemon crash on improper file argument - #4003" '
+    FNC=$(echo $API_ADDR | awk -F: '\''{ printf "%s %s", $1, $2 }'\'') &&
+    echo -n "POST /api/v0/add?pin=true HTTP/1.1\r\nHost: $API_ADDR\r\nContent-Type: multipart/form-data; boundary=Pyw9xQLtiLPE6XcI\r\nContent-Length: 22\r\n\r\n\r\n--Pyw9xQLtiLPE6XcI\r\n" | nc -v $FNC | grep "200 OK"
+'
+
 test_kill_ipfs_daemon
 
 test_expect_success "ipfs daemon --offline --mount fails - #2995" '


### PR DESCRIPTION
Includes a general sanity check to skip further checks if user provided fewer arguments than minimum required and a specific check for corrupted data passed as file.

License: MIT
Signed-off-by: Mateja Milosevic <minima38123@gmail.com>