### PR TITLE
Change IPFS to use the new pluggable Block to IPLD decoding framework.

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -3,6 +3,9 @@ package merkledag
 import (
 	"fmt"
 	"sort"
+	"strings"
+
+	"gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
 
 	pb "github.com/ipfs/go-ipfs/merkledag/pb"
 
@@ -108,3 +111,27 @@ func DecodeProtobuf(encoded []byte) (*ProtoNode, error) {
 	}
 	return n, nil
 }
+
+// DecodeProtobufBlock is a block decoder for protobuf IPLD nodes conforming to
+// node.DecodeBlockFunc
+func DecodeProtobufBlock(b blocks.Block) (node.Node, error) {
+	c := b.Cid()
+	if c.Type() != cid.DagProtobuf {
+		return nil, fmt.Errorf("this function can only decode protobuf nodes")
+	}
+
+	decnd, err := DecodeProtobuf(b.RawData())
+	if err != nil {
+		if strings.Contains(err.Error(), "Unmarshal failed") {
+			return nil, fmt.Errorf("The block referred to by '%s' was not a valid merkledag node", c)
+		}
+		return nil, fmt.Errorf("Failed to decode Protocol Buffers: %v", err)
+	}
+
+	decnd.cached = c
+	decnd.Prefix = c.Prefix()
+	return decnd, nil
+}
+
+// Type assertion
+var _ node.DecodeBlockFunc = DecodeProtobufBlock

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -1,6 +1,7 @@
 package merkledag
 
 import (
+	"fmt"
 	"gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
@@ -21,6 +22,17 @@ func NewRawNode(data []byte) *RawNode {
 
 	return &RawNode{blk}
 }
+
+// DecodeRawBlock is a block decoder for raw IPLD nodes conforming to `node.DecodeBlockFunc`.
+func DecodeRawBlock(block blocks.Block) (node.Node, error) {
+	if block.Cid().Type() != cid.Raw {
+		return nil, fmt.Errorf("raw nodes cannot be decoded from non-raw blocks: %d", block.Cid().Type())
+	}
+	// Once you "share" a block, it should be immutable. Therefore, we can just use this block as-is.
+	return &RawNode{block}, nil
+}
+
+var _ node.DecodeBlockFunc = DecodeRawBlock
 
 // NewRawNodeWPrefix creates a RawNode with the hash function
 // specified in prefix.


### PR DESCRIPTION
Later, we should:

1. Pull the other node formats out of IPFS (at least the raw one).
2. Pull out the decoder registration/management into a `go-ipld` library.