### PR TITLE
[WIP] Extract DAGService and friends

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -258,6 +258,10 @@ type Session struct {
 	ses exchange.Fetcher
 }
 
+func (s *Session) Blockstore() blockstore.Blockstore {
+	return s.bs
+}
+
 // GetBlock gets a block in the context of a request session
 func (s *Session) GetBlock(ctx context.Context, c *cid.Cid) (blocks.Block, error) {
 	return getBlock(ctx, c, s.bs, s.ses)

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -10,9 +10,9 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	pin "github.com/ipfs/go-ipfs/pin"
 
+	ipldcbor "gx/ipfs/QmRsVKyuqssWQn4jtvH2PMA9Yc3AC9TYFFtvzCUbZG4kTT/go-ipld-cbor"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
-	ipldcbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var DagCmd = &cmds.Command{

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -19,6 +19,7 @@ import (
 	b58 "gx/ipfs/QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf/go-base58"
 	ipdht "gx/ipfs/QmTHyAbD9KzGrseLNzmEoNkVxA8F2h7LQG2iV6uhBqs6kX/go-libp2p-kad-dht"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 )
 
@@ -374,7 +375,7 @@ func provideKeys(ctx context.Context, r routing.IpfsRouting, cids []*cid.Cid) er
 	return nil
 }
 
-func provideKeysRec(ctx context.Context, r routing.IpfsRouting, dserv dag.DAGService, cids []*cid.Cid) error {
+func provideKeysRec(ctx context.Context, r routing.IpfsRouting, dserv node.DAGService, cids []*cid.Cid) error {
 	provided := cid.NewSet()
 	for _, c := range cids {
 		kset := cid.NewSet()

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -154,7 +154,7 @@ func statGetFormatOptions(req cmds.Request) (string, error) {
 	}
 }
 
-func statNode(ds dag.DAGService, fsn mfs.FSNode) (*Object, error) {
+func statNode(ds node.DAGService, fsn mfs.FSNode) (*Object, error) {
 	nd, err := fsn.GetNode()
 	if err != nil {
 		return nil, err

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -19,7 +19,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var log = logging.Logger("cmds/files")

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -16,7 +16,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type LsLink struct {

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -19,7 +19,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // ErrObjectTooLarge is returned when too much data was read from stdin. current limit 2m

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -14,7 +14,7 @@ import (
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // KeyList is a general type for outputting lists of keys

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -9,7 +9,6 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
@@ -220,7 +219,7 @@ type RefWrapper struct {
 
 type RefWriter struct {
 	out chan interface{}
-	DAG dag.DAGService
+	DAG node.DAGService
 	Ctx context.Context
 
 	Unique    bool
@@ -242,7 +241,7 @@ func (rw *RefWriter) writeRefsRecursive(n node.Node) (int, error) {
 	nc := n.Cid()
 
 	var count int
-	for i, ng := range dag.GetDAG(rw.Ctx, rw.DAG, n) {
+	for i, ng := range node.GetDAG(rw.Ctx, rw.DAG, n) {
 		lc := n.Links()[i].Cid
 		if rw.skip(lc) {
 			continue

--- a/core/core.go
+++ b/core/core.go
@@ -56,6 +56,7 @@ import (
 	b58 "gx/ipfs/QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf/go-base58"
 	dht "gx/ipfs/QmTHyAbD9KzGrseLNzmEoNkVxA8F2h7LQG2iV6uhBqs6kX/go-libp2p-kad-dht"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	metrics "gx/ipfs/QmVjRAPfRtResCMCE4eBqr4Beoa6A89P1YweG9wUS6RqUL/go-libp2p-metrics"
 	ma "gx/ipfs/QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji/go-multiaddr"
@@ -114,7 +115,7 @@ type IpfsNode struct {
 	BaseBlocks bstore.Blockstore    // the raw blockstore, no filestore wrapping
 	GCLocker   bstore.GCLocker      // the locker used to protect the blockstore during gc
 	Blocks     bserv.BlockService   // the block service, get/add blocks.
-	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
+	DAG        node.DAGService      // the merkle dag service, get/add objects.
 	Resolver   *path.Resolver       // the path resolution system
 	Reporter   metrics.Reporter
 	Discovery  discovery.Service

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	ipld "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	ipld "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type Path interface {

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -9,7 +9,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type UnixfsAPI CoreAPI

--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -16,7 +16,7 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
-	cbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
+	cbor "gx/ipfs/QmRsVKyuqssWQn4jtvH2PMA9Yc3AC9TYFFtvzCUbZG4kTT/go-ipld-cbor"
 )
 
 // `echo -n 'hello, world!' | ipfs add`

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -26,7 +26,7 @@ import (
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	routing "gx/ipfs/QmPjTrrSfE6TzLv6ya6VWhGcCgPrUAdcgrDcQyRDX2VyW1/go-libp2p-routing"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	multibase "gx/ipfs/Qme4T6BE4sQxg7ZouamF5M7Tx1ZFTqzcns7BkyQPXpoT99/go-multibase"
 )
 

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -22,7 +22,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -70,7 +70,7 @@ type AddedObject struct {
 	Bytes int64  `json:",omitempty"`
 }
 
-func NewAdder(ctx context.Context, p pin.Pinner, bs bstore.GCBlockstore, ds dag.DAGService) (*Adder, error) {
+func NewAdder(ctx context.Context, p pin.Pinner, bs bstore.GCBlockstore, ds node.DAGService) (*Adder, error) {
 	return &Adder{
 		ctx:        ctx,
 		pinning:    p,
@@ -90,7 +90,7 @@ type Adder struct {
 	ctx        context.Context
 	pinning    pin.Pinner
 	blockstore bstore.GCBlockstore
-	dagService dag.DAGService
+	dagService node.DAGService
 	Out        chan interface{}
 	Progress   bool
 	Hidden     bool
@@ -548,7 +548,7 @@ func outputDagnode(out chan interface{}, name string, dn node.Node) error {
 	return nil
 }
 
-func NewMemoryDagService() dag.DAGService {
+func NewMemoryDagService() node.DAGService {
 	// build mem-datastore for editor's intermediary nodes
 	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
 	bsrv := bserv.New(bs, offline.Exchange(bs))

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -26,9 +26,9 @@ import (
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	syncds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
 )
 
 var log = logging.Logger("coreunix")

--- a/core/coreunix/add_test.go
+++ b/core/coreunix/add_test.go
@@ -148,7 +148,7 @@ func TestAddGCLive(t *testing.T) {
 	defer cancel()
 
 	set := cid.NewSet()
-	err = dag.EnumerateChildren(ctx, node.DAG.GetLinks, last, set.Visit)
+	err = dag.EnumerateChildren(ctx, dag.GetLinksWithDAG(node.DAG), last, set.Visit)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -18,11 +18,12 @@ import (
 	context "context"
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	dssync "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
 )
 
-func getDagserv(t *testing.T) merkledag.DAGService {
+func getDagserv(t *testing.T) node.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -9,7 +9,7 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // ErrNoNamesys is an explicit error for when an IPFS node doesn't

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -23,7 +23,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	fstest "gx/ipfs/QmaFNtBAXX4nVMQWbUqNysXyhevUj1k4B1y5uS45LC7Vw9/fuse/fs/fstestutil"
 )
 

--- a/importer/balanced/balanced_test.go
+++ b/importer/balanced/balanced_test.go
@@ -16,11 +16,12 @@ import (
 
 	"context"
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // TODO: extract these tests and more as a generic layout test suite
 
-func buildTestDag(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error) {
+func buildTestDag(ds node.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
@@ -34,7 +35,7 @@ func buildTestDag(ds dag.DAGService, spl chunk.Splitter) (*dag.ProtoNode, error)
 	return nd.(*dag.ProtoNode), nil
 }
 
-func getTestDag(t *testing.T, ds dag.DAGService, size int64, blksize int64) (*dag.ProtoNode, []byte) {
+func getTestDag(t *testing.T, ds node.DAGService, size int64, blksize int64) (*dag.ProtoNode, []byte) {
 	data := make([]byte, size)
 	u.NewTimeSeededRand().Read(data)
 	r := bytes.NewReader(data)

--- a/importer/balanced/builder.go
+++ b/importer/balanced/builder.go
@@ -5,7 +5,7 @@ import (
 
 	h "github.com/ipfs/go-ipfs/importer/helpers"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func BalancedLayout(db *h.DagBuilderHelper) (node.Node, error) {

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -10,7 +10,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // DagBuilderHelper wraps together a bunch of objects needed to

--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -16,13 +16,13 @@ import (
 // DagBuilderHelper wraps together a bunch of objects needed to
 // efficiently create unixfs dag trees
 type DagBuilderHelper struct {
-	dserv     dag.DAGService
+	dserv     node.DAGService
 	spl       chunk.Splitter
 	recvdErr  error
 	rawLeaves bool
 	nextData  []byte // the next item to return.
 	maxlinks  int
-	batch     *dag.Batch
+	batch     *node.Batch
 	fullPath  string
 	stat      os.FileInfo
 	prefix    *cid.Prefix
@@ -40,7 +40,7 @@ type DagBuilderParams struct {
 	Prefix *cid.Prefix
 
 	// DAGService to write blocks to (required)
-	Dagserv dag.DAGService
+	Dagserv node.DAGService
 
 	// NoCopy signals to the chunker that it should track fileinfo for
 	// filestore adds
@@ -56,7 +56,7 @@ func (dbp *DagBuilderParams) New(spl chunk.Splitter) *DagBuilderHelper {
 		rawLeaves: dbp.RawLeaves,
 		prefix:    dbp.Prefix,
 		maxlinks:  dbp.Maxlinks,
-		batch:     dbp.Dagserv.Batch(),
+		batch:     node.Batching(dbp.Dagserv),
 	}
 	if fi, ok := spl.Reader().(files.FileInfo); dbp.NoCopy && ok {
 		db.fullPath = fi.AbsPath()
@@ -106,7 +106,7 @@ func (db *DagBuilderHelper) Next() ([]byte, error) {
 }
 
 // GetDagServ returns the dagservice object this Helper is using
-func (db *DagBuilderHelper) GetDagServ() dag.DAGService {
+func (db *DagBuilderHelper) GetDagServ() node.DAGService {
 	return db.dserv
 }
 

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -78,7 +78,7 @@ func (n *UnixfsNode) Set(other *UnixfsNode) {
 	}
 }
 
-func (n *UnixfsNode) GetChild(ctx context.Context, i int, ds dag.DAGService) (*UnixfsNode, error) {
+func (n *UnixfsNode) GetChild(ctx context.Context, i int, ds node.NodeGetter) (*UnixfsNode, error) {
 	nd, err := n.node.Links()[i].GetNode(ctx, ds)
 	if err != nil {
 		return nil, err

--- a/importer/helpers/helpers.go
+++ b/importer/helpers/helpers.go
@@ -10,7 +10,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // BlockSizeLimit specifies the maximum size an imported block can have.

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -11,14 +11,13 @@ import (
 	"github.com/ipfs/go-ipfs/importer/chunk"
 	h "github.com/ipfs/go-ipfs/importer/helpers"
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
-	dag "github.com/ipfs/go-ipfs/merkledag"
 
 	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // Builds a DAG from the given file, writing created blocks to disk as they are
 // created
-func BuildDagFromFile(fpath string, ds dag.DAGService) (node.Node, error) {
+func BuildDagFromFile(fpath string, ds node.DAGService) (node.Node, error) {
 	stat, err := os.Lstat(fpath)
 	if err != nil {
 		return nil, err
@@ -37,7 +36,7 @@ func BuildDagFromFile(fpath string, ds dag.DAGService) (node.Node, error) {
 	return BuildDagFromReader(ds, chunk.NewSizeSplitter(f, chunk.DefaultBlockSize))
 }
 
-func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error) {
+func BuildDagFromReader(ds node.DAGService, spl chunk.Splitter) (node.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,
@@ -46,7 +45,7 @@ func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error
 	return bal.BalancedLayout(dbp.New(spl))
 }
 
-func BuildTrickleDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error) {
+func BuildTrickleDagFromReader(ds node.DAGService, spl chunk.Splitter) (node.Node, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -13,7 +13,7 @@ import (
 	trickle "github.com/ipfs/go-ipfs/importer/trickle"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // Builds a DAG from the given file, writing created blocks to disk as they are

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -13,7 +13,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func getBalancedDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAGService) {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -16,7 +15,7 @@ import (
 	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
-func getBalancedDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAGService) {
+func getBalancedDag(t testing.TB, size int64, blksize int64) (node.Node, node.DAGService) {
 	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildDagFromReader(ds, chunk.NewSizeSplitter(r, blksize))
@@ -26,7 +25,7 @@ func getBalancedDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAG
 	return nd, ds
 }
 
-func getTrickleDag(t testing.TB, size int64, blksize int64) (node.Node, dag.DAGService) {
+func getTrickleDag(t testing.TB, size int64, blksize int64) (node.Node, node.DAGService) {
 	ds := mdtest.Mock()
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	nd, err := BuildTrickleDagFromReader(ds, chunk.NewSizeSplitter(r, blksize))
@@ -102,7 +101,7 @@ func BenchmarkTrickleReadFull(b *testing.B) {
 	runReadBench(b, nd, ds)
 }
 
-func runReadBench(b *testing.B, nd node.Node, ds dag.DAGService) {
+func runReadBench(b *testing.B, nd node.Node, ds node.DAGService) {
 	for i := 0; i < b.N; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
 		read, err := uio.NewDagReader(ctx, nd, ds)

--- a/importer/trickle/trickle_test.go
+++ b/importer/trickle/trickle_test.go
@@ -17,9 +17,10 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
-func buildTestDag(ds merkledag.DAGService, spl chunk.Splitter) (*merkledag.ProtoNode, error) {
+func buildTestDag(ds node.DAGService, spl chunk.Splitter) (*merkledag.ProtoNode, error) {
 	dbp := h.DagBuilderParams{
 		Dagserv:  ds,
 		Maxlinks: h.DefaultLinksPerBlock,

--- a/importer/trickle/trickledag.go
+++ b/importer/trickle/trickledag.go
@@ -236,7 +236,7 @@ func trickleDepthInfo(node *h.UnixfsNode, maxlinks int) (int, int) {
 
 // VerifyTrickleDagStructure checks that the given dag matches exactly the trickle dag datastructure
 // layout
-func VerifyTrickleDagStructure(nd node.Node, ds dag.DAGService, direct int, layerRepeat int) error {
+func VerifyTrickleDagStructure(nd node.Node, ds node.NodeGetter, direct int, layerRepeat int) error {
 	pbnd, ok := nd.(*dag.ProtoNode)
 	if !ok {
 		return dag.ErrNotProtobuf
@@ -246,7 +246,7 @@ func VerifyTrickleDagStructure(nd node.Node, ds dag.DAGService, direct int, laye
 }
 
 // Recursive call for verifying the structure of a trickledag
-func verifyTDagRec(nd *dag.ProtoNode, depth, direct, layerRepeat int, ds dag.DAGService) error {
+func verifyTDagRec(nd *dag.ProtoNode, depth, direct, layerRepeat int, ds node.NodeGetter) error {
 	if depth == 0 {
 		// zero depth dag is raw data block
 		if len(nd.Links()) > 0 {

--- a/importer/trickle/trickledag.go
+++ b/importer/trickle/trickledag.go
@@ -9,7 +9,7 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // layerRepeat specifies how many times to append a child tree of a

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -10,7 +10,7 @@ import (
 	pb "github.com/ipfs/go-ipfs/merkledag/pb"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // for now, we use a PBNode intermediate thing.

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -10,9 +10,9 @@ import (
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	blocks "gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
 
+	ipldcbor "gx/ipfs/QmRsVKyuqssWQn4jtvH2PMA9Yc3AC9TYFFtvzCUbZG4kTT/go-ipld-cbor"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
-	ipldcbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // TODO: We should move these registrations elsewhere. Really, most of the IPLD

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -26,31 +26,6 @@ func init() {
 
 var ErrNotFound = fmt.Errorf("merkledag: not found")
 
-// DAGService is an IPFS Merkle DAG service.
-type DAGService interface {
-	Add(node.Node) (*cid.Cid, error)
-	Get(context.Context, *cid.Cid) (node.Node, error)
-	Remove(node.Node) error
-
-	// GetDAG returns, in order, all the single leve child
-	// nodes of the passed in node.
-	GetMany(context.Context, []*cid.Cid) <-chan *NodeOption
-
-	Batch() *Batch
-
-	LinkService
-}
-
-type LinkService interface {
-	// GetLinks return all links for a node.  The complete node does not
-	// necessarily have to exist locally, or at all.  For example, raw
-	// leaves cannot possibly have links so there is no need to look
-	// at the node.
-	GetLinks(context.Context, *cid.Cid) ([]*node.Link, error)
-
-	GetOfflineLinkService() LinkService
-}
-
 func NewDAGService(bs bserv.BlockService) *dagService {
 	return &dagService{Blocks: bs}
 }
@@ -73,16 +48,12 @@ func (n *dagService) Add(nd node.Node) (*cid.Cid, error) {
 	return n.Blocks.AddBlock(nd)
 }
 
-func (n *dagService) Batch() *Batch {
-	return &Batch{
-		ds:      n,
-		MaxSize: 8 << 20,
-
-		// By default, only batch up to 128 nodes at a time.
-		// The current implementation of flatfs opens this many file
-		// descriptors at the same time for the optimized batch write.
-		MaxBlocks: 128,
+func (n *dagService) AddMany(nds []node.Node) ([]*cid.Cid, error) {
+	blks := make([]blocks.Block, len(nds))
+	for i, nd := range nds {
+		blks[i] = nd
 	}
+	return n.Blocks.AddBlocks(blks)
 }
 
 // Get retrieves a node from the dagService, fetching the block in the BlockService
@@ -118,7 +89,7 @@ func (n *dagService) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, er
 	return node.Links(), nil
 }
 
-func (n *dagService) GetOfflineLinkService() LinkService {
+func (n *dagService) OfflineNodeGetter() node.NodeGetter {
 	if n.Blocks.Exchange().IsOnline() {
 		bsrv := bserv.New(n.Blocks.Blockstore(), offline.Exchange(n.Blocks.Blockstore()))
 		return NewDAGService(bsrv)
@@ -160,8 +131,13 @@ func (sg *sesGetter) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
 	return node.Decode(blk)
 }
 
+func (sg *sesGetter) OfflineNodeGetter() node.NodeGetter {
+	bsrv := bserv.New(sg.bs.Blockstore(), offline.Exchange(sg.bs.Blockstore()))
+	return NewDAGService(bsrv)
+}
+
 // FetchGraph fetches all nodes that are children of the given node
-func FetchGraph(ctx context.Context, root *cid.Cid, serv DAGService) error {
+func FetchGraph(ctx context.Context, root *cid.Cid, serv node.DAGService) error {
 	var ng node.NodeGetter = serv
 	ds, ok := serv.(*dagService)
 	if ok {
@@ -196,13 +172,8 @@ func FindLinks(links []*cid.Cid, c *cid.Cid, start int) []int {
 	return out
 }
 
-type NodeOption struct {
-	Node node.Node
-	Err  error
-}
-
-func (ds *dagService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *NodeOption {
-	out := make(chan *NodeOption, len(keys))
+func (ds *dagService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *node.NodeOption {
+	out := make(chan *node.NodeOption, len(keys))
 	blocks := ds.Blocks.GetBlocks(ctx, keys)
 	var count int
 
@@ -213,22 +184,22 @@ func (ds *dagService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *Node
 			case b, ok := <-blocks:
 				if !ok {
 					if count != len(keys) {
-						out <- &NodeOption{Err: fmt.Errorf("failed to fetch all nodes")}
+						out <- &node.NodeOption{Err: fmt.Errorf("failed to fetch all nodes")}
 					}
 					return
 				}
 
 				nd, err := node.Decode(b)
 				if err != nil {
-					out <- &NodeOption{Err: err}
+					out <- &node.NodeOption{Err: err}
 					return
 				}
 
-				out <- &NodeOption{Node: nd}
+				out <- &node.NodeOption{Node: nd}
 				count++
 
 			case <-ctx.Done():
-				out <- &NodeOption{Err: ctx.Err()}
+				out <- &node.NodeOption{Err: ctx.Err()}
 				return
 			}
 		}
@@ -236,180 +207,13 @@ func (ds *dagService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *Node
 	return out
 }
 
-// GetDAG will fill out all of the links of the given Node.
-// It returns a channel of nodes, which the caller can receive
-// all the child nodes of 'root' on, in proper order.
-func GetDAG(ctx context.Context, ds DAGService, root node.Node) []NodeGetter {
-	var cids []*cid.Cid
-	for _, lnk := range root.Links() {
-		cids = append(cids, lnk.Cid)
-	}
-
-	return GetNodes(ctx, ds, cids)
-}
-
-// GetNodes returns an array of 'NodeGetter' promises, with each corresponding
-// to the key with the same index as the passed in keys
-func GetNodes(ctx context.Context, ds DAGService, keys []*cid.Cid) []NodeGetter {
-
-	// Early out if no work to do
-	if len(keys) == 0 {
-		return nil
-	}
-
-	promises := make([]NodeGetter, len(keys))
-	for i := range keys {
-		promises[i] = newNodePromise(ctx)
-	}
-
-	dedupedKeys := dedupeKeys(keys)
-	go func() {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		nodechan := ds.GetMany(ctx, dedupedKeys)
-
-		for count := 0; count < len(keys); {
-			select {
-			case opt, ok := <-nodechan:
-				if !ok {
-					for _, p := range promises {
-						p.Fail(ErrNotFound)
-					}
-					return
-				}
-
-				if opt.Err != nil {
-					for _, p := range promises {
-						p.Fail(opt.Err)
-					}
-					return
-				}
-
-				nd := opt.Node
-				is := FindLinks(keys, nd.Cid(), 0)
-				for _, i := range is {
-					count++
-					promises[i].Send(nd)
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-	return promises
-}
-
-// Remove duplicates from a list of keys
-func dedupeKeys(cids []*cid.Cid) []*cid.Cid {
-	set := cid.NewSet()
-	for _, c := range cids {
-		set.Add(c)
-	}
-	return set.Keys()
-}
-
-func newNodePromise(ctx context.Context) NodeGetter {
-	return &nodePromise{
-		recv: make(chan node.Node, 1),
-		ctx:  ctx,
-		err:  make(chan error, 1),
-	}
-}
-
-type nodePromise struct {
-	cache node.Node
-	clk   sync.Mutex
-	recv  chan node.Node
-	ctx   context.Context
-	err   chan error
-}
-
-// NodeGetter provides a promise like interface for a dag Node
-// the first call to Get will block until the Node is received
-// from its internal channels, subsequent calls will return the
-// cached node.
-type NodeGetter interface {
-	Get(context.Context) (node.Node, error)
-	Fail(err error)
-	Send(node.Node)
-}
-
-func (np *nodePromise) Fail(err error) {
-	np.clk.Lock()
-	v := np.cache
-	np.clk.Unlock()
-
-	// if promise has a value, don't fail it
-	if v != nil {
-		return
-	}
-
-	np.err <- err
-}
-
-func (np *nodePromise) Send(nd node.Node) {
-	var already bool
-	np.clk.Lock()
-	if np.cache != nil {
-		already = true
-	}
-	np.cache = nd
-	np.clk.Unlock()
-
-	if already {
-		panic("sending twice to the same promise is an error!")
-	}
-
-	np.recv <- nd
-}
-
-func (np *nodePromise) Get(ctx context.Context) (node.Node, error) {
-	np.clk.Lock()
-	c := np.cache
-	np.clk.Unlock()
-	if c != nil {
-		return c, nil
-	}
-
-	select {
-	case nd := <-np.recv:
-		return nd, nil
-	case <-np.ctx.Done():
-		return nil, np.ctx.Err()
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-np.err:
-		return nil, err
-	}
-}
-
-type Batch struct {
-	ds *dagService
-
-	blocks    []blocks.Block
-	size      int
-	MaxSize   int
-	MaxBlocks int
-}
-
-func (t *Batch) Add(nd node.Node) (*cid.Cid, error) {
-	t.blocks = append(t.blocks, nd)
-	t.size += len(nd.RawData())
-	if t.size > t.MaxSize || len(t.blocks) > t.MaxBlocks {
-		return nd.Cid(), t.Commit()
-	}
-	return nd.Cid(), nil
-}
-
-func (t *Batch) Commit() error {
-	_, err := t.ds.Blocks.AddBlocks(t.blocks)
-	t.blocks = nil
-	t.size = 0
-	return err
-}
-
 type GetLinks func(context.Context, *cid.Cid) ([]*node.Link, error)
+
+func GetLinksWithDAG(ng node.NodeGetter) GetLinks {
+	return func(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
+		return node.GetLinks(ctx, ng, c)
+	}
+}
 
 // EnumerateChildren will walk the dag below the given root node and add all
 // unseen children to the passed in set.
@@ -536,3 +340,8 @@ func EnumerateChildrenAsync(ctx context.Context, getLinks GetLinks, c *cid.Cid, 
 	}
 
 }
+
+var _ node.LinkGetter = &dagService{}
+var _ node.NodeGetter = &dagService{}
+var _ node.NodeGetter = &sesGetter{}
+var _ node.DAGService = &dagService{}

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -26,7 +26,7 @@ import (
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func TestNode(t *testing.T) {

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -131,7 +131,7 @@ func TestBatchFetchDupBlock(t *testing.T) {
 
 func runBatchFetchTest(t *testing.T, read io.Reader) {
 	ctx := context.Background()
-	var dagservs []DAGService
+	var dagservs []node.DAGService
 	for _, bsi := range bstest.Mocks(5) {
 		dagservs = append(dagservs, NewDAGService(bsi))
 	}
@@ -221,7 +221,7 @@ func TestCantGet(t *testing.T) {
 }
 
 func TestFetchGraph(t *testing.T) {
-	var dservs []DAGService
+	var dservs []node.DAGService
 	bsis := bstest.Mocks(2)
 	for _, bsi := range bsis {
 		dservs = append(dservs, NewDAGService(bsi))
@@ -243,7 +243,7 @@ func TestFetchGraph(t *testing.T) {
 
 	offline_ds := NewDAGService(bs)
 
-	err = EnumerateChildren(context.Background(), offline_ds.GetLinks, root.Cid(), func(_ *cid.Cid) bool { return true })
+	err = EnumerateChildren(context.Background(), GetLinksWithDAG(offline_ds), root.Cid(), func(_ *cid.Cid) bool { return true })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestEnumerateChildren(t *testing.T) {
 	}
 
 	set := cid.NewSet()
-	err = EnumerateChildren(context.Background(), ds.GetLinks, root.Cid(), set.Visit)
+	err = EnumerateChildren(context.Background(), GetLinksWithDAG(ds), root.Cid(), set.Visit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestFetchFailure(t *testing.T) {
 		}
 	}
 
-	getters := GetDAG(context.Background(), ds, top)
+	getters := node.GetDAG(context.Background(), ds, top)
 	for i, getter := range getters {
 		_, err := getter.Get(context.Background())
 		if err != nil && i < 10 {
@@ -491,7 +491,7 @@ func TestCidRawDoesnNeedData(t *testing.T) {
 
 	// there is no data for this node in the blockservice
 	// so dag service can't load it
-	links, err := srv.GetLinks(ctx, nd.Cid())
+	links, err := node.GetLinks(ctx, srv, nd.Cid())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +570,7 @@ func testProgressIndicator(t *testing.T, depth int) {
 	}
 }
 
-func mkDag(ds DAGService, depth int) (*cid.Cid, int) {
+func mkDag(ds node.DAGService, depth int) (*cid.Cid, int) {
 	totalChildren := 0
 	f := func() *ProtoNode {
 		p := new(ProtoNode)

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -154,7 +154,7 @@ func (n *ProtoNode) GetNodeLink(name string) (*node.Link, error) {
 	return nil, ErrLinkNotFound
 }
 
-func (n *ProtoNode) GetLinkedProtoNode(ctx context.Context, ds DAGService, name string) (*ProtoNode, error) {
+func (n *ProtoNode) GetLinkedProtoNode(ctx context.Context, ds node.NodeGetter, name string) (*ProtoNode, error) {
 	nd, err := n.GetLinkedNode(ctx, ds, name)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (n *ProtoNode) GetLinkedProtoNode(ctx context.Context, ds DAGService, name 
 	return pbnd, nil
 }
 
-func (n *ProtoNode) GetLinkedNode(ctx context.Context, ds DAGService, name string) (node.Node, error) {
+func (n *ProtoNode) GetLinkedNode(ctx context.Context, ds node.NodeGetter, name string) (node.Node, error) {
 	lnk, err := n.GetNodeLink(name)
 	if err != nil {
 		return nil, err

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -7,7 +7,7 @@ import (
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
 	mh "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var ErrNotProtobuf = fmt.Errorf("expected protobuf dag node")

--- a/merkledag/node_test.go
+++ b/merkledag/node_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func TestRemoveLink(t *testing.T) {

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -6,7 +6,7 @@ import (
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type RawNode struct {

--- a/merkledag/test/utils.go
+++ b/merkledag/test/utils.go
@@ -5,11 +5,12 @@ import (
 	bsrv "github.com/ipfs/go-ipfs/blockservice"
 	"github.com/ipfs/go-ipfs/exchange/offline"
 	dag "github.com/ipfs/go-ipfs/merkledag"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	dssync "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
 )
 
-func Mock() dag.DAGService {
+func Mock() node.DAGService {
 	return dag.NewDAGService(Bserv())
 }
 

--- a/merkledag/traverse/traverse.go
+++ b/merkledag/traverse/traverse.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // Order is an identifier for traversal algorithm orders

--- a/merkledag/traverse/traverse_test.go
+++ b/merkledag/traverse/traverse_test.go
@@ -350,7 +350,7 @@ func testWalkOutputs(t *testing.T, root node.Node, opts Options, expect []byte) 
 	}
 }
 
-func newFan(t *testing.T, ds mdag.DAGService) node.Node {
+func newFan(t *testing.T, ds node.DAGService) node.Node {
 	a := mdag.NodeWithData([]byte("/a"))
 	addLink(t, ds, a, child(t, ds, a, "aa"))
 	addLink(t, ds, a, child(t, ds, a, "ab"))
@@ -359,7 +359,7 @@ func newFan(t *testing.T, ds mdag.DAGService) node.Node {
 	return a
 }
 
-func newLinkedList(t *testing.T, ds mdag.DAGService) node.Node {
+func newLinkedList(t *testing.T, ds node.DAGService) node.Node {
 	a := mdag.NodeWithData([]byte("/a"))
 	aa := child(t, ds, a, "aa")
 	aaa := child(t, ds, aa, "aaa")
@@ -372,7 +372,7 @@ func newLinkedList(t *testing.T, ds mdag.DAGService) node.Node {
 	return a
 }
 
-func newBinaryTree(t *testing.T, ds mdag.DAGService) node.Node {
+func newBinaryTree(t *testing.T, ds node.DAGService) node.Node {
 	a := mdag.NodeWithData([]byte("/a"))
 	aa := child(t, ds, a, "aa")
 	ab := child(t, ds, a, "ab")
@@ -385,7 +385,7 @@ func newBinaryTree(t *testing.T, ds mdag.DAGService) node.Node {
 	return a
 }
 
-func newBinaryDAG(t *testing.T, ds mdag.DAGService) node.Node {
+func newBinaryDAG(t *testing.T, ds node.DAGService) node.Node {
 	a := mdag.NodeWithData([]byte("/a"))
 	aa := child(t, ds, a, "aa")
 	aaa := child(t, ds, aa, "aaa")
@@ -402,7 +402,7 @@ func newBinaryDAG(t *testing.T, ds mdag.DAGService) node.Node {
 	return a
 }
 
-func addLink(t *testing.T, ds mdag.DAGService, a, b node.Node) {
+func addLink(t *testing.T, ds node.DAGService, a, b node.Node) {
 	to := string(a.(*mdag.ProtoNode).Data()) + "2" + string(b.(*mdag.ProtoNode).Data())
 	if _, err := ds.Add(b); err != nil {
 		t.Error(err)
@@ -412,6 +412,6 @@ func addLink(t *testing.T, ds mdag.DAGService, a, b node.Node) {
 	}
 }
 
-func child(t *testing.T, ds mdag.DAGService, a node.Node, name string) node.Node {
+func child(t *testing.T, ds node.DAGService, a node.Node, name string) node.Node {
 	return mdag.NodeWithData([]byte(string(a.(*mdag.ProtoNode).Data()) + "/" + name))
 }

--- a/merkledag/traverse/traverse_test.go
+++ b/merkledag/traverse/traverse_test.go
@@ -8,7 +8,7 @@ import (
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 	mdagtest "github.com/ipfs/go-ipfs/merkledag/test"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func TestDFSPreNoSkip(t *testing.T) {

--- a/merkledag/utils/diff.go
+++ b/merkledag/utils/diff.go
@@ -37,7 +37,7 @@ func (c *Change) String() string {
 	}
 }
 
-func ApplyChange(ctx context.Context, ds dag.DAGService, nd *dag.ProtoNode, cs []*Change) (*dag.ProtoNode, error) {
+func ApplyChange(ctx context.Context, ds node.DAGService, nd *dag.ProtoNode, cs []*Change) (*dag.ProtoNode, error) {
 	e := NewDagEditor(nd, ds)
 	for _, c := range cs {
 		switch c.Type {
@@ -89,7 +89,7 @@ func ApplyChange(ctx context.Context, ds dag.DAGService, nd *dag.ProtoNode, cs [
 }
 
 // Diff returns a set of changes that transform node 'a' into node 'b'
-func Diff(ctx context.Context, ds dag.DAGService, a, b node.Node) ([]*Change, error) {
+func Diff(ctx context.Context, ds node.DAGService, a, b node.Node) ([]*Change, error) {
 	if len(a.Links()) == 0 && len(b.Links()) == 0 {
 		return []*Change{
 			&Change{

--- a/merkledag/utils/diff.go
+++ b/merkledag/utils/diff.go
@@ -8,7 +8,7 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 const (

--- a/merkledag/utils/diffenum.go
+++ b/merkledag/utils/diffenum.go
@@ -7,7 +7,7 @@ import (
 	mdag "github.com/ipfs/go-ipfs/merkledag"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // DiffEnumerate fetches every object in the graph pointed to by 'to' that is

--- a/merkledag/utils/diffenum_test.go
+++ b/merkledag/utils/diffenum_test.go
@@ -9,7 +9,7 @@ import (
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func buildNode(name string, desc map[string]ndesc, out map[string]node.Node) node.Node {

--- a/merkledag/utils/diffenum_test.go
+++ b/merkledag/utils/diffenum_test.go
@@ -90,7 +90,7 @@ func TestDiffEnumBasic(t *testing.T) {
 	nds := mkGraph(tg1)
 
 	ds := mdtest.Mock()
-	lgds := &getLogger{ds: ds}
+	lgds := &getLogger{ds: ds, log: &[]*cid.Cid{}}
 
 	for _, nd := range nds {
 		_, err := ds.Add(nd)
@@ -104,7 +104,7 @@ func TestDiffEnumBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = assertCidList(lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid()})
+	err = assertCidList(*lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestDiffEnumBasic(t *testing.T) {
 
 type getLogger struct {
 	ds  node.NodeGetter
-	log []*cid.Cid
+	log *[]*cid.Cid
 }
 
 func (gl *getLogger) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
@@ -120,8 +120,15 @@ func (gl *getLogger) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	gl.log = append(gl.log, c)
+	*gl.log = append(*gl.log, c)
 	return nd, nil
+}
+
+func (gl *getLogger) OfflineNodeGetter() node.NodeGetter {
+	return &getLogger{
+		ds:  gl.ds.OfflineNodeGetter(),
+		log: gl.log,
+	}
 }
 
 func assertCidList(a, b []*cid.Cid) error {
@@ -142,7 +149,7 @@ func TestDiffEnumFail(t *testing.T) {
 	nds := mkGraph(tg2)
 
 	ds := mdtest.Mock()
-	lgds := &getLogger{ds: ds}
+	lgds := &getLogger{ds: ds, log: &[]*cid.Cid{}}
 
 	for _, s := range []string{"a1", "a2", "b", "c"} {
 		_, err := ds.Add(nds[s])
@@ -156,7 +163,7 @@ func TestDiffEnumFail(t *testing.T) {
 		t.Fatal("expected err not found")
 	}
 
-	err = assertCidList(lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid()})
+	err = assertCidList(*lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +176,7 @@ func TestDiffEnumRecurse(t *testing.T) {
 	nds := mkGraph(tg3)
 
 	ds := mdtest.Mock()
-	lgds := &getLogger{ds: ds}
+	lgds := &getLogger{ds: ds, log: &[]*cid.Cid{}}
 
 	for _, s := range []string{"a1", "a2", "b", "c", "d"} {
 		_, err := ds.Add(nds[s])
@@ -183,7 +190,7 @@ func TestDiffEnumRecurse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = assertCidList(lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid(), nds["d"].Cid()})
+	err = assertCidList(*lgds.log, []*cid.Cid{nds["a1"].Cid(), nds["a2"].Cid(), nds["c"].Cid(), nds["d"].Cid()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -10,9 +10,9 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
 
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	syncds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
 )
 
 type Editor struct {

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -20,14 +20,14 @@ type Editor struct {
 
 	// tmp is a temporary in memory (for now) dagstore for all of the
 	// intermediary nodes to be stored in
-	tmp dag.DAGService
+	tmp node.DAGService
 
 	// src is the dagstore with *all* of the data on it, it is used to pull
 	// nodes from for modification (nil is a valid value)
-	src dag.DAGService
+	src node.DAGService
 }
 
-func NewMemoryDagService() dag.DAGService {
+func NewMemoryDagService() node.DAGService {
 	// build mem-datastore for editor's intermediary nodes
 	bs := bstore.NewBlockstore(syncds.MutexWrap(ds.NewMapDatastore()))
 	bsrv := bserv.New(bs, offline.Exchange(bs))
@@ -35,7 +35,7 @@ func NewMemoryDagService() dag.DAGService {
 }
 
 // root is the node to be modified, source is the dagstore to pull nodes from (optional)
-func NewDagEditor(root *dag.ProtoNode, source dag.DAGService) *Editor {
+func NewDagEditor(root *dag.ProtoNode, source node.DAGService) *Editor {
 	return &Editor{
 		root: root,
 		tmp:  NewMemoryDagService(),
@@ -47,11 +47,11 @@ func (e *Editor) GetNode() *dag.ProtoNode {
 	return e.root.Copy().(*dag.ProtoNode)
 }
 
-func (e *Editor) GetDagService() dag.DAGService {
+func (e *Editor) GetDagService() node.DAGService {
 	return e.tmp
 }
 
-func addLink(ctx context.Context, ds dag.DAGService, root *dag.ProtoNode, childname string, childnd node.Node) (*dag.ProtoNode, error) {
+func addLink(ctx context.Context, ds node.DAGService, root *dag.ProtoNode, childname string, childnd node.Node) (*dag.ProtoNode, error) {
 	if childname == "" {
 		return nil, errors.New("cannot create link with no name!")
 	}
@@ -188,13 +188,13 @@ func (e *Editor) rmLink(ctx context.Context, root *dag.ProtoNode, path []string)
 	return root, nil
 }
 
-func (e *Editor) Finalize(ds dag.DAGService) (*dag.ProtoNode, error) {
+func (e *Editor) Finalize(ds node.DAGService) (*dag.ProtoNode, error) {
 	nd := e.GetNode()
 	err := copyDag(nd, e.tmp, ds)
 	return nd, err
 }
 
-func copyDag(nd *dag.ProtoNode, from, to dag.DAGService) error {
+func copyDag(nd *dag.ProtoNode, from, to node.DAGService) error {
 	_, err := to.Add(nd)
 	if err != nil {
 		return err

--- a/merkledag/utils/utils_test.go
+++ b/merkledag/utils/utils_test.go
@@ -9,6 +9,7 @@ import (
 
 	context "context"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func TestAddLink(t *testing.T) {
@@ -37,7 +38,7 @@ func TestAddLink(t *testing.T) {
 	}
 }
 
-func assertNodeAtPath(t *testing.T, ds dag.DAGService, root *dag.ProtoNode, pth string, exp *cid.Cid) {
+func assertNodeAtPath(t *testing.T, ds node.DAGService, root *dag.ProtoNode, pth string, exp *cid.Cid) {
 	parts := path.SplitList(pth)
 	cur := root
 	for _, e := range parts {

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -16,7 +16,7 @@ import (
 	ufspb "github.com/ipfs/go-ipfs/unixfs/pb"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var ErrNotYetImplemented = errors.New("not yet implemented")

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -24,7 +24,7 @@ var ErrInvalidChild = errors.New("invalid child node")
 var ErrDirExists = errors.New("directory already has entry by that name")
 
 type Directory struct {
-	dserv  dag.DAGService
+	dserv  node.DAGService
 	parent childCloser
 
 	childDirs map[string]*Directory
@@ -40,7 +40,7 @@ type Directory struct {
 	name string
 }
 
-func NewDirectory(ctx context.Context, name string, node node.Node, parent childCloser, dserv dag.DAGService) (*Directory, error) {
+func NewDirectory(ctx context.Context, name string, node node.Node, parent childCloser, dserv node.DAGService) (*Directory, error) {
 	db, err := uio.NewDirectoryFromNode(dserv, node)
 	if err != nil {
 		return nil, err

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -10,7 +10,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	mod "github.com/ipfs/go-ipfs/unixfs/mod"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type File struct {

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -20,13 +20,13 @@ type File struct {
 
 	desclock sync.RWMutex
 
-	dserv  dag.DAGService
+	dserv  node.DAGService
 	node   node.Node
 	nodelk sync.Mutex
 }
 
 // NewFile returns a NewFile object with the given parameters
-func NewFile(name string, node node.Node, parent childCloser, dserv dag.DAGService) (*File, error) {
+func NewFile(name string, node node.Node, parent childCloser, dserv node.DAGService) (*File, error) {
 	return &File{
 		dserv:  dserv,
 		parent: parent,

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -35,19 +35,19 @@ func emptyDirNode() *dag.ProtoNode {
 	return dag.NodeWithData(ft.FolderPBData())
 }
 
-func getDagserv(t *testing.T) dag.DAGService {
+func getDagserv(t *testing.T) node.DAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))
 	return dag.NewDAGService(blockserv)
 }
 
-func getRandFile(t *testing.T, ds dag.DAGService, size int64) node.Node {
+func getRandFile(t *testing.T, ds node.DAGService, size int64) node.Node {
 	r := io.LimitReader(u.NewTimeSeededRand(), size)
 	return fileNodeFromReader(t, ds, r)
 }
 
-func fileNodeFromReader(t *testing.T, ds dag.DAGService, r io.Reader) node.Node {
+func fileNodeFromReader(t *testing.T, ds node.DAGService, r io.Reader) node.Node {
 	nd, err := importer.BuildDagFromReader(ds, chunk.DefaultSplitter(r))
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func compStrArrs(a, b []string) bool {
 	return true
 }
 
-func assertFileAtPath(ds dag.DAGService, root *Directory, expn node.Node, pth string) error {
+func assertFileAtPath(ds node.DAGService, root *Directory, expn node.Node, pth string) error {
 	exp, ok := expn.(*dag.ProtoNode)
 	if !ok {
 		return dag.ErrNotProtobuf
@@ -182,7 +182,7 @@ func assertFileAtPath(ds dag.DAGService, root *Directory, expn node.Node, pth st
 	return nil
 }
 
-func catNode(ds dag.DAGService, nd *dag.ProtoNode) ([]byte, error) {
+func catNode(ds node.DAGService, nd *dag.ProtoNode) ([]byte, error) {
 	r, err := uio.NewDagReader(context.TODO(), nd, ds)
 	if err != nil {
 		return nil, err
@@ -192,7 +192,7 @@ func catNode(ds dag.DAGService, nd *dag.ProtoNode) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-func setupRoot(ctx context.Context, t *testing.T) (dag.DAGService, *Root) {
+func setupRoot(ctx context.Context, t *testing.T) (node.DAGService, *Root) {
 	ds := getDagserv(t)
 
 	root := emptyDirNode()

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -26,9 +26,9 @@ import (
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	dssync "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
 )
 
 func emptyDirNode() *dag.ProtoNode {

--- a/mfs/ops.go
+++ b/mfs/ops.go
@@ -9,7 +9,7 @@ import (
 
 	path "github.com/ipfs/go-ipfs/path"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // Mv moves the file or directory at 'src' to 'dst'

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -21,7 +21,7 @@ import (
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var ErrNotExist = errors.New("no such rootfs")

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -58,7 +58,7 @@ type Root struct {
 
 	repub *Republisher
 
-	dserv dag.DAGService
+	dserv node.DAGService
 
 	Type string
 
@@ -69,7 +69,7 @@ type Root struct {
 type PubFunc func(context.Context, *cid.Cid) error
 
 // newRoot creates a new Root and starts up a republisher routine for it
-func NewRoot(parent context.Context, ds dag.DAGService, node *dag.ProtoNode, pf PubFunc) (*Root, error) {
+func NewRoot(parent context.Context, ds node.DAGService, node *dag.ProtoNode, pf PubFunc) (*Root, error) {
 
 	var repub *Republisher
 	if pf != nil {

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	pb "github.com/ipfs/go-ipfs/namesys/pb"
 	path "github.com/ipfs/go-ipfs/path"
 	pin "github.com/ipfs/go-ipfs/pin"
@@ -16,6 +15,7 @@ import (
 
 	routing "gx/ipfs/QmPjTrrSfE6TzLv6ya6VWhGcCgPrUAdcgrDcQyRDX2VyW1/go-libp2p-routing"
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
@@ -315,7 +315,7 @@ func ValidateIpnsRecord(k string, val []byte) error {
 // InitializeKeyspace sets the ipns record for the given key to
 // point to an empty directory.
 // TODO: this doesnt feel like it belongs here
-func InitializeKeyspace(ctx context.Context, ds dag.DAGService, pub Publisher, pins pin.Pinner, key ci.PrivKey) error {
+func InitializeKeyspace(ctx context.Context, ds node.DAGService, pub Publisher, pins pin.Pinner, key ci.PrivKey) error {
 	emptyDir := ft.EmptyDirNode()
 	nodek, err := ds.Add(emptyDir)
 	if err != nil {

--- a/package.json
+++ b/package.json
@@ -255,15 +255,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6",
+      "hash": "QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9",
       "name": "go-ipld-format",
-      "version": "0.5.0"
+      "version": "0.5.1"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR",
+      "hash": "QmRsVKyuqssWQn4jtvH2PMA9Yc3AC9TYFFtvzCUbZG4kTT",
       "name": "go-ipld-cbor",
-      "version": "1.2.6"
+      "version": "1.2.7"
     },
     {
       "author": "lgierth",

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -35,12 +35,12 @@ func (e ErrNoLink) Error() string {
 // TODO: now that this is more modular, try to unify this code with the
 //       the resolvers in namesys
 type Resolver struct {
-	DAG dag.DAGService
+	DAG node.DAGService
 
-	ResolveOnce func(ctx context.Context, ds dag.DAGService, nd node.Node, names []string) (*node.Link, []string, error)
+	ResolveOnce func(ctx context.Context, ds node.DAGService, nd node.Node, names []string) (*node.Link, []string, error)
 }
 
-func NewBasicResolver(ds dag.DAGService) *Resolver {
+func NewBasicResolver(ds node.DAGService) *Resolver {
 	return &Resolver{
 		DAG:         ds,
 		ResolveOnce: ResolveSingle,
@@ -123,7 +123,7 @@ func (s *Resolver) ResolvePath(ctx context.Context, fpath Path) (node.Node, erro
 
 // ResolveSingle simply resolves one hop of a path through a graph with no
 // extra context (does not opaquely resolve through sharded nodes)
-func ResolveSingle(ctx context.Context, ds dag.DAGService, nd node.Node, names []string) (*node.Link, []string, error) {
+func ResolveSingle(ctx context.Context, ds node.DAGService, nd node.Node, names []string) (*node.Link, []string, error) {
 	return nd.ResolveLink(names)
 }
 

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -11,7 +11,7 @@ import (
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var log = logging.Logger("path")

--- a/path/resolver_test.go
+++ b/path/resolver_test.go
@@ -10,7 +10,7 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 
 	util "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func randNode() *merkledag.ProtoNode {

--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -10,7 +10,7 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // Result represents an incremental output from a garbage collection

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -147,13 +147,13 @@ type pinner struct {
 	// Track the keys used for storing the pinning state, so gc does
 	// not delete them.
 	internalPin *cid.Set
-	dserv       mdag.DAGService
-	internal    mdag.DAGService // dagservice used to store internal objects
+	dserv       node.DAGService
+	internal    node.DAGService // dagservice used to store internal objects
 	dstore      ds.Datastore
 }
 
 // NewPinner creates a new pinner using the given datastore as a backend
-func NewPinner(dstore ds.Datastore, serv, internal mdag.DAGService) Pinner {
+func NewPinner(dstore ds.Datastore, serv, internal node.DAGService) Pinner {
 
 	rcset := cid.NewSet()
 	dirset := cid.NewSet()
@@ -318,7 +318,7 @@ func (p *pinner) CheckIfPinned(cids ...*cid.Cid) ([]Pinned, error) {
 	// Now walk all recursive pins to check for indirect pins
 	var checkChildren func(*cid.Cid, *cid.Cid) error
 	checkChildren = func(rk, parentKey *cid.Cid) error {
-		links, err := p.dserv.GetLinks(context.Background(), parentKey)
+		links, err := node.GetLinks(context.Background(), p.dserv, parentKey)
 		if err != nil {
 			return err
 		}
@@ -384,7 +384,7 @@ func cidSetWithValues(cids []*cid.Cid) *cid.Set {
 }
 
 // LoadPinner loads a pinner and its keysets from the given datastore
-func LoadPinner(d ds.Datastore, dserv, internal mdag.DAGService) (Pinner, error) {
+func LoadPinner(d ds.Datastore, dserv, internal node.DAGService) (Pinner, error) {
 	p := new(pinner)
 
 	rootKeyI, err := d.Get(pinDatastoreKey)
@@ -547,8 +547,8 @@ func (p *pinner) PinWithMode(c *cid.Cid, mode PinMode) {
 
 // hasChild recursively looks for a Cid among the children of a root Cid.
 // The visit function can be used to shortcut already-visited branches.
-func hasChild(ds mdag.LinkService, root *cid.Cid, child *cid.Cid, visit func(*cid.Cid) bool) (bool, error) {
-	links, err := ds.GetLinks(context.Background(), root)
+func hasChild(ds node.NodeGetter, root *cid.Cid, child *cid.Cid, visit func(*cid.Cid) bool) (bool, error) {
+	links, err := node.GetLinks(context.Background(), ds, root)
 	if err != nil {
 		return false, err
 	}

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -14,8 +14,8 @@ import (
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
 )
 
 var log = logging.Logger("pin")

--- a/pin/set.go
+++ b/pin/set.go
@@ -54,7 +54,7 @@ func (s sortByHash) Swap(a, b int) {
 	s.links[a], s.links[b] = s.links[b], s.links[a]
 }
 
-func storeItems(ctx context.Context, dag merkledag.DAGService, estimatedLen uint64, depth uint32, iter itemIterator, internalKeys keyObserver) (*merkledag.ProtoNode, error) {
+func storeItems(ctx context.Context, dag node.DAGService, estimatedLen uint64, depth uint32, iter itemIterator, internalKeys keyObserver) (*merkledag.ProtoNode, error) {
 	links := make([]*node.Link, 0, defaultFanout+maxItems)
 	for i := 0; i < defaultFanout; i++ {
 		links = append(links, &node.Link{Cid: emptyKey})
@@ -202,7 +202,7 @@ func writeHdr(n *merkledag.ProtoNode, hdr *pb.Set) error {
 
 type walkerFunc func(idx int, link *node.Link) error
 
-func walkItems(ctx context.Context, dag merkledag.DAGService, n *merkledag.ProtoNode, fn walkerFunc, children keyObserver) error {
+func walkItems(ctx context.Context, dag node.DAGService, n *merkledag.ProtoNode, fn walkerFunc, children keyObserver) error {
 	hdr, err := readHdr(n)
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func walkItems(ctx context.Context, dag merkledag.DAGService, n *merkledag.Proto
 	return nil
 }
 
-func loadSet(ctx context.Context, dag merkledag.DAGService, root *merkledag.ProtoNode, name string, internalKeys keyObserver) ([]*cid.Cid, error) {
+func loadSet(ctx context.Context, dag node.DAGService, root *merkledag.ProtoNode, name string, internalKeys keyObserver) ([]*cid.Cid, error) {
 	l, err := root.GetNodeLink(name)
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ func getCidListIterator(cids []*cid.Cid) itemIterator {
 	}
 }
 
-func storeSet(ctx context.Context, dag merkledag.DAGService, cids []*cid.Cid, internalKeys keyObserver) (*merkledag.ProtoNode, error) {
+func storeSet(ctx context.Context, dag node.DAGService, cids []*cid.Cid, internalKeys keyObserver) (*merkledag.ProtoNode, error) {
 	iter := getCidListIterator(cids)
 
 	n, err := storeItems(ctx, dag, uint64(len(cids)), 0, iter, internalKeys)

--- a/pin/set.go
+++ b/pin/set.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ipfs/go-ipfs/pin/internal/pb"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	"gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 )
 

--- a/tar/format.go
+++ b/tar/format.go
@@ -34,7 +34,7 @@ func marshalHeader(h *tar.Header) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func ImportTar(r io.Reader, ds dag.DAGService) (*dag.ProtoNode, error) {
+func ImportTar(r io.Reader, ds node.DAGService) (*dag.ProtoNode, error) {
 	tr := tar.NewReader(r)
 
 	root := new(dag.ProtoNode)
@@ -100,7 +100,7 @@ func escapePath(pth string) string {
 
 type tarReader struct {
 	links []*node.Link
-	ds    dag.DAGService
+	ds    node.DAGService
 
 	childRead *tarReader
 	hdrBuf    *bytes.Reader
@@ -194,7 +194,7 @@ func (tr *tarReader) Read(b []byte) (int, error) {
 	return tr.Read(b)
 }
 
-func ExportTar(ctx context.Context, root *dag.ProtoNode, ds dag.DAGService) (io.Reader, error) {
+func ExportTar(ctx context.Context, root *dag.ProtoNode, ds node.DAGService) (io.Reader, error) {
 	if string(root.Data()) != "ipfs/tar" {
 		return nil, errors.New("not an IPFS tarchive")
 	}

--- a/tar/format.go
+++ b/tar/format.go
@@ -16,7 +16,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 var log = logging.Logger("tarfmt")

--- a/thirdparty/posinfo/posinfo.go
+++ b/thirdparty/posinfo/posinfo.go
@@ -3,7 +3,7 @@ package posinfo
 import (
 	"os"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 type PosInfo struct {

--- a/unixfs/archive/archive.go
+++ b/unixfs/archive/archive.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"path"
 
-	mdag "github.com/ipfs/go-ipfs/merkledag"
 	tar "github.com/ipfs/go-ipfs/unixfs/archive/tar"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -31,7 +30,7 @@ func (i *identityWriteCloser) Close() error {
 }
 
 // DagArchive is equivalent to `ipfs getdag $hash | maybe_tar | maybe_gzip`
-func DagArchive(ctx context.Context, nd node.Node, name string, dag mdag.DAGService, archive bool, compression int) (io.Reader, error) {
+func DagArchive(ctx context.Context, nd node.Node, name string, dag node.DAGService, archive bool, compression int) (io.Reader, error) {
 
 	_, filename := path.Split(name)
 

--- a/unixfs/archive/archive.go
+++ b/unixfs/archive/archive.go
@@ -11,7 +11,7 @@ import (
 	tar "github.com/ipfs/go-ipfs/unixfs/archive/tar"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // DefaultBufSize is the buffer size for gets. for now, 1MB, which is ~4 blocks.

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -21,14 +21,14 @@ import (
 // unixfs merkledag nodes as a tar archive format.
 // It wraps any io.Writer.
 type Writer struct {
-	Dag  mdag.DAGService
+	Dag  node.DAGService
 	TarW *tar.Writer
 
 	ctx context.Context
 }
 
 // NewWriter wraps given io.Writer.
-func NewWriter(ctx context.Context, dag mdag.DAGService, archive bool, compression int, w io.Writer) (*Writer, error) {
+func NewWriter(ctx context.Context, dag node.DAGService, archive bool, compression int, w io.Writer) (*Writer, error) {
 	return &Writer{
 		Dag:  dag,
 		TarW: tar.NewWriter(w),
@@ -41,7 +41,7 @@ func (w *Writer) writeDir(nd *mdag.ProtoNode, fpath string) error {
 		return err
 	}
 
-	for i, ng := range mdag.GetDAG(w.ctx, w.Dag, nd) {
+	for i, ng := range node.GetDAG(w.ctx, w.Dag, nd) {
 		child, err := ng.Get(w.ctx)
 		if err != nil {
 			return err

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -13,7 +13,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	upb "github.com/ipfs/go-ipfs/unixfs/pb"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 )
 

--- a/unixfs/hamt/hamt.go
+++ b/unixfs/hamt/hamt.go
@@ -32,7 +32,7 @@ import (
 	upb "github.com/ipfs/go-ipfs/unixfs/pb"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 	"gx/ipfs/QmfJHywXQu98UeZtGJBQrPAR6AtmDjjbe3qjTo9piXHPnx/murmur3"
 )

--- a/unixfs/hamt/hamt.go
+++ b/unixfs/hamt/hamt.go
@@ -57,7 +57,7 @@ type HamtShard struct {
 	prefixPadStr string
 	maxpadlen    int
 
-	dserv dag.DAGService
+	dserv node.DAGService
 }
 
 // child can either be another shard, or a leaf node value
@@ -66,7 +66,7 @@ type child interface {
 	Label() string
 }
 
-func NewHamtShard(dserv dag.DAGService, size int) (*HamtShard, error) {
+func NewHamtShard(dserv node.DAGService, size int) (*HamtShard, error) {
 	ds, err := makeHamtShard(dserv, size)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func NewHamtShard(dserv dag.DAGService, size int) (*HamtShard, error) {
 	return ds, nil
 }
 
-func makeHamtShard(ds dag.DAGService, size int) (*HamtShard, error) {
+func makeHamtShard(ds node.DAGService, size int) (*HamtShard, error) {
 	lg2s := int(math.Log2(float64(size)))
 	if 1<<uint(lg2s) != size {
 		return nil, fmt.Errorf("hamt size should be a power of two")
@@ -93,7 +93,7 @@ func makeHamtShard(ds dag.DAGService, size int) (*HamtShard, error) {
 	}, nil
 }
 
-func NewHamtFromDag(dserv dag.DAGService, nd node.Node) (*HamtShard, error) {
+func NewHamtFromDag(dserv node.DAGService, nd node.Node) (*HamtShard, error) {
 	pbnd, ok := nd.(*dag.ProtoNode)
 	if !ok {
 		return nil, dag.ErrLinkNotFound

--- a/unixfs/hamt/hamt_stress_test.go
+++ b/unixfs/hamt/hamt_stress_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 	ft "github.com/ipfs/go-ipfs/unixfs"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func getNames(prefix string, count int) []string {
@@ -112,7 +112,7 @@ func validateOpSetCompletion(t *testing.T, s *HamtShard, keep, temp []string) er
 	return nil
 }
 
-func executeOpSet(t *testing.T, ds dag.DAGService, width int, ops []testOp) (*HamtShard, error) {
+func executeOpSet(t *testing.T, ds node.DAGService, width int, ops []testOp) (*HamtShard, error) {
 	ctx := context.TODO()
 	s, err := NewHamtShard(ds, width)
 	if err != nil {
@@ -188,7 +188,7 @@ func genOpSet(seed int64, keep, temp []string) []testOp {
 }
 
 // executes the given op set with a repl to allow easier debugging
-/*func debugExecuteOpSet(ds dag.DAGService, width int, ops []testOp) (*HamtShard, error) {
+/*func debugExecuteOpSet(ds node.DAGService, width int, ops []testOp) (*HamtShard, error) {
 
 	s, err := NewHamtShard(ds, width)
 	if err != nil {

--- a/unixfs/hamt/hamt_test.go
+++ b/unixfs/hamt/hamt_test.go
@@ -13,6 +13,7 @@ import (
 	mdtest "github.com/ipfs/go-ipfs/merkledag/test"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
 	ft "github.com/ipfs/go-ipfs/unixfs"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func shuffle(seed int64, arr []string) {
@@ -24,11 +25,11 @@ func shuffle(seed int64, arr []string) {
 	}
 }
 
-func makeDir(ds dag.DAGService, size int) ([]string, *HamtShard, error) {
+func makeDir(ds node.DAGService, size int) ([]string, *HamtShard, error) {
 	return makeDirWidth(ds, size, 256)
 }
 
-func makeDirWidth(ds dag.DAGService, size, width int) ([]string, *HamtShard, error) {
+func makeDirWidth(ds node.DAGService, size, width int) ([]string, *HamtShard, error) {
 	s, _ := NewHamtShard(ds, width)
 
 	var dirs []string
@@ -70,7 +71,7 @@ func assertLink(s *HamtShard, name string, found bool) error {
 	}
 }
 
-func assertSerializationWorks(ds dag.DAGService, s *HamtShard) error {
+func assertSerializationWorks(ds node.DAGService, s *HamtShard) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	nd, err := s.Node()
@@ -493,7 +494,7 @@ func TestSetHamtChild(t *testing.T) {
 	}
 }
 
-func printDiff(ds dag.DAGService, a, b *dag.ProtoNode) {
+func printDiff(ds node.DAGService, a, b *dag.ProtoNode) {
 	diff, err := dagutils.Diff(context.TODO(), ds, a, b)
 	if err != nil {
 		panic(err)

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -34,7 +34,7 @@ type ReadSeekCloser interface {
 
 // NewDagReader creates a new reader object that reads the data represented by
 // the given node, using the passed in DAGService for data retreival
-func NewDagReader(ctx context.Context, n node.Node, serv mdag.DAGService) (DagReader, error) {
+func NewDagReader(ctx context.Context, n node.Node, serv node.DAGService) (DagReader, error) {
 	switch n := n.(type) {
 	case *mdag.RawNode:
 		return NewBufDagReader(n.RawData()), nil

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -10,7 +10,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 )
 

--- a/unixfs/io/dirbuilder.go
+++ b/unixfs/io/dirbuilder.go
@@ -26,14 +26,14 @@ var UseHAMTSharding = false
 var DefaultShardWidth = 256
 
 type Directory struct {
-	dserv   mdag.DAGService
+	dserv   node.DAGService
 	dirnode *mdag.ProtoNode
 
 	shard *hamt.HamtShard
 }
 
 // NewDirectory returns a Directory. It needs a DAGService to add the Children
-func NewDirectory(dserv mdag.DAGService) *Directory {
+func NewDirectory(dserv node.DAGService) *Directory {
 	db := new(Directory)
 	db.dserv = dserv
 	if UseHAMTSharding {
@@ -51,7 +51,7 @@ func NewDirectory(dserv mdag.DAGService) *Directory {
 // ErrNotADir implies that the given node was not a unixfs directory
 var ErrNotADir = fmt.Errorf("merkledag node was not a directory or shard")
 
-func NewDirectoryFromNode(dserv mdag.DAGService, nd node.Node) (*Directory, error) {
+func NewDirectoryFromNode(dserv node.DAGService, nd node.Node) (*Directory, error) {
 	pbnd, ok := nd.(*mdag.ProtoNode)
 	if !ok {
 		return nil, ErrNotADir

--- a/unixfs/io/dirbuilder.go
+++ b/unixfs/io/dirbuilder.go
@@ -10,7 +10,7 @@ import (
 	hamt "github.com/ipfs/go-ipfs/unixfs/hamt"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // ShardSplitThreshold specifies how large of an unsharded directory

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -10,12 +10,13 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	ftpb "github.com/ipfs/go-ipfs/unixfs/pb"
 
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 )
 
 // DagReader provides a way to easily read the data contained in a dag.
 type pbDagReader struct {
-	serv mdag.DAGService
+	serv node.DAGService
 
 	// the node being read
 	node *mdag.ProtoNode
@@ -28,7 +29,7 @@ type pbDagReader struct {
 	buf ReadSeekCloser
 
 	// NodeGetters for each of 'nodes' child links
-	promises []mdag.NodeGetter
+	promises []*node.NodePromise
 
 	// the index of the child link currently being read from
 	linkPosition int
@@ -45,9 +46,9 @@ type pbDagReader struct {
 
 var _ DagReader = (*pbDagReader)(nil)
 
-func NewPBFileReader(ctx context.Context, n *mdag.ProtoNode, pb *ftpb.Data, serv mdag.DAGService) *pbDagReader {
+func NewPBFileReader(ctx context.Context, n *mdag.ProtoNode, pb *ftpb.Data, serv node.DAGService) *pbDagReader {
 	fctx, cancel := context.WithCancel(ctx)
-	promises := mdag.GetDAG(fctx, serv, n)
+	promises := node.GetDAG(fctx, serv, n)
 	return &pbDagReader{
 		node:     n,
 		serv:     serv,

--- a/unixfs/io/resolve.go
+++ b/unixfs/io/resolve.go
@@ -12,7 +12,7 @@ import (
 
 // ResolveUnixfsOnce resolves a single hop of a path through a graph in a
 // unixfs context. This includes handling traversing sharded directories.
-func ResolveUnixfsOnce(ctx context.Context, ds dag.DAGService, nd node.Node, names []string) (*node.Link, []string, error) {
+func ResolveUnixfsOnce(ctx context.Context, ds node.DAGService, nd node.Node, names []string) (*node.Link, []string, error) {
 	switch nd := nd.(type) {
 	case *dag.ProtoNode:
 		upb, err := ft.FromBytes(nd.Data())

--- a/unixfs/io/resolve.go
+++ b/unixfs/io/resolve.go
@@ -7,7 +7,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	hamt "github.com/ipfs/go-ipfs/unixfs/hamt"
 
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 // ResolveUnixfsOnce resolves a single hop of a path through a graph in a

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -15,7 +15,7 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 )
 

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -29,7 +29,7 @@ var writebufferSize = 1 << 21
 // perform surgery on a DAG 'file'
 // Dear god, please rename this to something more pleasant
 type DagModifier struct {
-	dagserv mdag.DAGService
+	dagserv node.DAGService
 	curNode node.Node
 
 	splitter   chunk.SplitterGen
@@ -45,7 +45,7 @@ type DagModifier struct {
 
 var ErrNotUnixfs = fmt.Errorf("dagmodifier only supports unixfs nodes (proto or raw)")
 
-func NewDagModifier(ctx context.Context, from node.Node, serv mdag.DAGService, spl chunk.SplitterGen) (*DagModifier, error) {
+func NewDagModifier(ctx context.Context, from node.Node, serv node.DAGService, spl chunk.SplitterGen) (*DagModifier, error) {
 	switch from.(type) {
 	case *mdag.ProtoNode, *mdag.RawNode:
 		// ok
@@ -478,7 +478,7 @@ func (dm *DagModifier) Truncate(size int64) error {
 }
 
 // dagTruncate truncates the given node to 'size' and returns the modified Node
-func dagTruncate(ctx context.Context, n node.Node, size uint64, ds mdag.DAGService) (*mdag.ProtoNode, error) {
+func dagTruncate(ctx context.Context, n node.Node, size uint64, ds node.DAGService) (*mdag.ProtoNode, error) {
 	nd, ok := n.(*mdag.ProtoNode)
 	if !ok {
 		return nil, ErrNoRawYet

--- a/unixfs/test/utils.go
+++ b/unixfs/test/utils.go
@@ -15,7 +15,7 @@ import (
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
-	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
+	node "gx/ipfs/QmVHxZ8ovAuHiHTbJa68budGYAqmMUzb1bqDW1SVb6y5M9/go-ipld-format"
 )
 
 func SizeSplitterGen(size int64) chunk.SplitterGen {

--- a/unixfs/test/utils.go
+++ b/unixfs/test/utils.go
@@ -24,11 +24,11 @@ func SizeSplitterGen(size int64) chunk.SplitterGen {
 	}
 }
 
-func GetDAGServ() mdag.DAGService {
+func GetDAGServ() node.DAGService {
 	return mdagmock.Mock()
 }
 
-func GetNode(t testing.TB, dserv mdag.DAGService, data []byte) node.Node {
+func GetNode(t testing.TB, dserv node.DAGService, data []byte) node.Node {
 	in := bytes.NewReader(data)
 	node, err := imp.BuildTrickleDagFromReader(dserv, SizeSplitterGen(500)(in))
 	if err != nil {
@@ -38,11 +38,11 @@ func GetNode(t testing.TB, dserv mdag.DAGService, data []byte) node.Node {
 	return node
 }
 
-func GetEmptyNode(t testing.TB, dserv mdag.DAGService) node.Node {
+func GetEmptyNode(t testing.TB, dserv node.DAGService) node.Node {
 	return GetNode(t, dserv, []byte{})
 }
 
-func GetRandomNode(t testing.TB, dserv mdag.DAGService, size int64) ([]byte, node.Node) {
+func GetRandomNode(t testing.TB, dserv node.DAGService, size int64) ([]byte, node.Node) {
 	in := io.LimitReader(u.NewTimeSeededRand(), size)
 	buf, err := ioutil.ReadAll(in)
 	if err != nil {
@@ -65,7 +65,7 @@ func ArrComp(a, b []byte) error {
 	return nil
 }
 
-func PrintDag(nd *mdag.ProtoNode, ds mdag.DAGService, indent int) {
+func PrintDag(nd *mdag.ProtoNode, ds node.DAGService, indent int) {
 	pbd, err := ft.FromBytes(nd.Data())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**DO NOT MERGE!**

Refactor IPFS to use: https://github.com/ipfs/go-ipld-format/pull/8

Context: IPLD isn't currently very usable from libp2p because interfaces like the DAGService are bundled into go-ipfs. This PR extracts these interfaces and some of the related helper functions.