### PR TITLE
gx: update ipldcbor

### DIFF
--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -16,7 +16,7 @@ import (
 	config "github.com/ipfs/go-ipfs/repo/config"
 	testutil "github.com/ipfs/go-ipfs/thirdparty/testutil"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
-	cbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
+	cbor "gx/ipfs/QmXgUVPAxjMLZSyxx818YstJJAoRg3nyPWENmBLVzLtoax/go-ipld-cbor"
 )
 
 // `echo -n 'hello, world!' | ipfs add`

--- a/core/coredag/dagtransl.go
+++ b/core/coredag/dagtransl.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	ipldcbor "gx/ipfs/QmXgUVPAxjMLZSyxx818YstJJAoRg3nyPWENmBLVzLtoax/go-ipld-cbor"
 	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
-	ipldcbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
 )
 
 // DagParser is function used for parsing stream into Node

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -11,8 +11,8 @@ import (
 	blocks "gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
 
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	ipldcbor "gx/ipfs/QmXgUVPAxjMLZSyxx818YstJJAoRg3nyPWENmBLVzLtoax/go-ipld-cbor"
 	node "gx/ipfs/QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6/go-ipld-format"
-	ipldcbor "gx/ipfs/QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR/go-ipld-cbor"
 )
 
 // TODO: We should move these registrations elsewhere. Really, most of the IPLD

--- a/package.json
+++ b/package.json
@@ -261,9 +261,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmemYymP73eVdTUUMZEiSpiHeZQKNJdT5dP2iuHssZh1sR",
+      "hash": "QmXgUVPAxjMLZSyxx818YstJJAoRg3nyPWENmBLVzLtoax",
       "name": "go-ipld-cbor",
-      "version": "1.2.6"
+      "version": "1.2.7"
     },
     {
       "author": "lgierth",


### PR DESCRIPTION
I previously optimized the IPLD cbor decoder to *not* encode and then re-decode
objects when constructing them with `WrapObject`. Unfortunately, we rely on this
to canonicalize the object before computing the tree/links.