### PR TITLE
remove `-f` flags from calls to init

### DIFF
--- a/test/bench/bench_cli_ipfs_add/main.go
+++ b/test/bench/bench_cli_ipfs_add/main.go
@@ -64,7 +64,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 				}
 			}
 
-			initCmd := exec.Command("ipfs", "init", "-f", "-b=1024")
+			initCmd := exec.Command("ipfs", "init", "-b=1024")
 			setupCmd(initCmd)
 			if err := initCmd.Run(); err != nil {
 				benchmarkError = err

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -48,7 +48,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 				cmd.Env = env
 			}
 
-			cmd := exec.Command("ipfs", "init", "-f", "-b=1024")
+			cmd := exec.Command("ipfs", "init", "-b=1024")
 			setupCmd(cmd)
 			if err := cmd.Run(); err != nil {
 				b.Fatal(err)


### PR DESCRIPTION
It doesn't mean anything anymore.