### PR TITLE
ipfs add: added size to response of `ipfs add` command

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	gopath "path"
+	"strconv"
 
 	bs "github.com/ipfs/go-ipfs/blocks/blockstore"
 	bstore "github.com/ipfs/go-ipfs/blocks/blockstore"
@@ -46,6 +47,7 @@ type Link struct {
 type Object struct {
 	Hash  string
 	Links []Link
+	Size  string
 }
 
 type hiddenFileError struct {
@@ -68,6 +70,7 @@ type AddedObject struct {
 	Name  string
 	Hash  string `json:",omitempty"`
 	Bytes int64  `json:",omitempty"`
+	Size  string `json:",omitempty"`
 }
 
 func NewAdder(ctx context.Context, p pin.Pinner, bs bstore.GCBlockstore, ds dag.DAGService) (*Adder, error) {
@@ -543,6 +546,7 @@ func outputDagnode(out chan interface{}, name string, dn node.Node) error {
 	out <- &AddedObject{
 		Hash: o.Hash,
 		Name: name,
+		Size: o.Size,
 	}
 
 	return nil
@@ -558,9 +562,14 @@ func NewMemoryDagService() dag.DAGService {
 // from core/commands/object.go
 func getOutput(dagnode node.Node) (*Object, error) {
 	c := dagnode.Cid()
+	s, err := dagnode.Size()
+	if err != nil {
+		return nil, err
+	}
 
 	output := &Object{
 		Hash:  c.String(),
+		Size:  strconv.FormatUint(s, 10),
 		Links: make([]Link, len(dagnode.Links())),
 	}
 

--- a/test/sharness/t0410-api-add.sh
+++ b/test/sharness/t0410-api-add.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (c) 2016 Tom O'Donnell
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test API add command"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+# Verify that that API add command returns size
+
+test_launch_ipfs_daemon
+test_expect_success "API Add response includes size field" '
+  echo "hi" | curl -s -F file=@- "http://localhost:$API_PORT/api/v0/add" | grep "\"Size\": *\"11\""
+'
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
The `ipfs add` command was modified to include the added
node's size as a string. The size is included in the
dagnode info sent over the output channel.

License: MIT
Signed-off-by: Tom O'Donnell todonnel91@gmail.com