### PR TITLE
object put --pin option

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -412,15 +412,15 @@ And then run:
 			}
 		}
 
-		res.SetOutput(objectCid)
+		res.SetOutput(&Object{Hash: objectCid.String()})
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
-			object := res.Output().(*cid.Cid)
-			return strings.NewReader("added " + object.String() + "\n"), nil
+			object := res.Output().(*Object)
+			return strings.NewReader("added " + object.Hash + "\n"), nil
 		},
 	},
-	Type: cid.Cid{},
+	Type: Object{},
 }
 
 var ObjectNewCmd = &cmds.Command{

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -168,7 +168,23 @@ test_object_cmd() {
 		test_cmp expected actual
 	'
 
-    test_expect_success "'ipfs object patch' should work (no unixfs-dir)" '
+	test_expect_success "'ipfs object put --pin' succeeds" '
+		HASH="QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V" &&
+		echo "added $HASH" >expected &&
+		echo "{ \"Data\": \"abc\" }" | ipfs object put --pin >actual
+	'
+
+	test_expect_success "'ipfs object put --pin' output looks good" '
+		echo "added $HASH" >expected &&
+		test_cmp expected actual
+	'
+
+	test_expect_success "after gc, objects still acessible" '
+		ipfs repo gc > /dev/null &&
+		ipfs refs -r --timeout=2s $HASH > /dev/null
+	'
+
+	test_expect_success "'ipfs object patch' should work (no unixfs-dir)" '
 		EMPTY_DIR=$(ipfs object new) &&
 		OUTPUT=$(ipfs object patch $EMPTY_DIR add-link foo $EMPTY_DIR) &&
 		ipfs object stat $OUTPUT


### PR DESCRIPTION
Closes #4092

Based off #4004. The question now is what to do about `object patch *` commands.