### PR TITLE
Reprovider strategies

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -231,5 +231,11 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 	}
 	n.Resolver = path.NewBasicResolver(n.DAG)
 
+	if cfg.Online {
+		if err := n.startLateOnlineServices(ctx); err != nil {
+			return err
+		}
+	}
+
 	return n.loadFilesRoot()
 }

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -21,10 +21,11 @@ var BitswapCmd = &cmds.Command{
 		ShortDescription: ``,
 	},
 	Subcommands: map[string]*cmds.Command{
-		"wantlist": showWantlistCmd,
-		"stat":     bitswapStatCmd,
-		"unwant":   unwantCmd,
-		"ledger":   ledgerCmd,
+		"wantlist":  showWantlistCmd,
+		"stat":      bitswapStatCmd,
+		"unwant":    unwantCmd,
+		"ledger":    ledgerCmd,
+		"reprovide": reprovideCmd,
 	},
 }
 
@@ -240,5 +241,32 @@ prints the ledger associated with a given peer.
 				out.Sent, out.Recv)
 			return buf, nil
 		},
+	},
+}
+
+var reprovideCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Trigger reprovider.",
+		ShortDescription: `
+Trigger reprovider to announce our data to network.
+`,
+	},
+	Run: func(req cmds.Request, res cmds.Response) {
+		nd, err := req.InvocContext().GetNode()
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
+
+		if !nd.OnlineMode() {
+			res.SetError(errNotOnline, cmds.ErrClient)
+			return
+		}
+
+		err = nd.Reprovider.Trigger(req.Context())
+		if err != nil {
+			res.SetError(err, cmds.ErrNormal)
+			return
+		}
 	},
 }

--- a/core/core.go
+++ b/core/core.go
@@ -277,7 +277,7 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	default:
 		return fmt.Errorf("unknown reprovider strtaegy '%s'", cfg.Reprovider.Strategy)
 	}
-	n.Reprovider = rp.NewReprovider(n.Routing, keyProvider)
+	n.Reprovider = rp.NewReprovider(ctx, n.Routing, keyProvider)
 
 	if cfg.Reprovider.Interval != "0" {
 		interval := kReprovideFrequency
@@ -290,7 +290,7 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 			interval = dur
 		}
 
-		go n.Reprovider.ProvideEvery(ctx, interval)
+		go n.Reprovider.ProvideEvery(interval)
 	}
 
 	return nil

--- a/core/core.go
+++ b/core/core.go
@@ -263,7 +263,7 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 		return err
 	}
 
-	var keyProvider func(context.Context) (<-chan *cid.Cid, error)
+	var keyProvider rp.KeyChanFunc
 
 	switch cfg.Reprovider.Strategy {
 	case "all":
@@ -275,7 +275,7 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	case "pinned":
 		keyProvider = rp.NewPinnedProvider(n.Pinning, n.DAG, false)
 	default:
-		return fmt.Errorf("unknown reprovider strtaegy '%s'", cfg.Reprovider.Strategy)
+		return fmt.Errorf("unknown reprovider strategy '%s'", cfg.Reprovider.Strategy)
 	}
 	n.Reprovider = rp.NewReprovider(ctx, n.Routing, keyProvider)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ a running daemon do not read the config file at runtime.
 - [`Identity`](#identity)
 - [`Ipns`](#ipns)
 - [`Mounts`](#mounts)
-- [`ReproviderInterval`](#reproviderinterval)
+- [`Reproviderl`](#reprovider)
 - [`SupernodeRouting`](#supernoderouting)
 - [`Swarm`](#swarm)
 - [`Tour`](#tour)
@@ -193,7 +193,9 @@ Mountpoint for `/ipns/`.
 - `FuseAllowOther`
 Sets the FUSE allow other option on the mountpoint.
 
-## `ReproviderInterval`
+## `Reprovider`
+
+- `Interval`
 Sets the time between rounds of reproviding local content to the routing
 system. If unset, it defaults to 12 hours. If set to the value `"0"` it will
 disable content reproviding.
@@ -202,6 +204,12 @@ Note: disabling content reproviding will result in other nodes on the network
 not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
 manually announce your content periodically.
+
+- `Strategy`
+Tells reprovider what should be announced. Valid strategies are:
+  - "all" (default) - announce all stored data
+  - "pinned" - only announce pinned data
+  - "roots" - only announce directly pinned keys and root keys of recursive pins
 
 ## `SupernodeRouting`
 Deprecated.

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ a running daemon do not read the config file at runtime.
 - [`Identity`](#identity)
 - [`Ipns`](#ipns)
 - [`Mounts`](#mounts)
-- [`Reproviderl`](#reprovider)
+- [`Reprovider`](#reprovider)
 - [`SupernodeRouting`](#supernoderouting)
 - [`Swarm`](#swarm)
 - [`Tour`](#tour)

--- a/exchange/reprovide/providers.go
+++ b/exchange/reprovide/providers.go
@@ -26,6 +26,7 @@ func NewPinnedProvider(pinning pin.Pinner, dag merkledag.DAGService, onlyRoots b
 
 		outCh := make(chan *cid.Cid)
 		go func() {
+			defer close(outCh)
 			set.ForEach(func(c *cid.Cid) error {
 				select {
 				case <-ctx.Done():

--- a/exchange/reprovide/providers.go
+++ b/exchange/reprovide/providers.go
@@ -3,7 +3,6 @@ package reprovide
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	blocks "github.com/ipfs/go-ipfs/blocks/blockstore"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"

--- a/exchange/reprovide/providers.go
+++ b/exchange/reprovide/providers.go
@@ -1,0 +1,62 @@
+package reprovide
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	blocks "github.com/ipfs/go-ipfs/blocks/blockstore"
+	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	pin "github.com/ipfs/go-ipfs/pin"
+
+	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+)
+
+func NewBlockstoreProvider(bstore blocks.Blockstore) KeyChanFunc {
+	return func(ctx context.Context) (<-chan *cid.Cid, error) {
+		return bstore.AllKeysChan(ctx)
+	}
+}
+
+func NewPinnedProvider(pinning pin.Pinner, dag merkledag.DAGService, onlyRoots bool) KeyChanFunc {
+	return func(ctx context.Context) (<-chan *cid.Cid, error) {
+		set, err := pinSet(ctx, pinning, dag, onlyRoots)
+		if err != nil {
+			return nil, err
+		}
+
+		outCh := make(chan *cid.Cid)
+		go func() {
+			set.ForEach(func(c *cid.Cid) error {
+				select {
+				case <-ctx.Done():
+					return errors.New("context cancelled")
+				case outCh <- c:
+				}
+				return nil
+			})
+		}()
+
+		return outCh, nil
+	}
+}
+
+func pinSet(ctx context.Context, pinning pin.Pinner, dag merkledag.DAGService, onlyRoots bool) (*cid.Set, error) {
+	set := cid.NewSet()
+	for _, key := range pinning.DirectKeys() {
+		set.Add(key)
+	}
+
+	for _, key := range pinning.RecursiveKeys() {
+		set.Add(key)
+
+		if !onlyRoots {
+			err := merkledag.EnumerateChildren(ctx, dag.GetLinks, key, set.Visit)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return set, nil
+}

--- a/exchange/reprovide/providers.go
+++ b/exchange/reprovide/providers.go
@@ -11,13 +11,15 @@ import (
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
 )
 
-func NewBlockstoreProvider(bstore blocks.Blockstore) KeyChanFunc {
+// NewBlockstoreProvider returns key provider using bstore.AllKeysChan
+func NewBlockstoreProvider(bstore blocks.Blockstore) keyChanFunc {
 	return func(ctx context.Context) (<-chan *cid.Cid, error) {
 		return bstore.AllKeysChan(ctx)
 	}
 }
 
-func NewPinnedProvider(pinning pin.Pinner, dag merkledag.DAGService, onlyRoots bool) KeyChanFunc {
+// NewPinnedProvider returns provider supplying pinned keys
+func NewPinnedProvider(pinning pin.Pinner, dag merkledag.DAGService, onlyRoots bool) keyChanFunc {
 	return func(ctx context.Context) (<-chan *cid.Cid, error) {
 		set, err := pinSet(ctx, pinning, dag, onlyRoots)
 		if err != nil {

--- a/exchange/reprovide/reprovide_test.go
+++ b/exchange/reprovide/reprovide_test.go
@@ -33,8 +33,8 @@ func TestReprovide(t *testing.T) {
 	bstore.Put(blk)
 
 	keyProvider := NewBlockstoreProvider(bstore)
-	reprov := NewReprovider(clA, keyProvider)
-	err := reprov.Reprovide(ctx)
+	reprov := NewReprovider(ctx, clA, keyProvider)
+	err := reprov.Reprovide()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exchange/reprovide/reprovide_test.go
+++ b/exchange/reprovide/reprovide_test.go
@@ -32,7 +32,8 @@ func TestReprovide(t *testing.T) {
 	blk := blocks.NewBlock([]byte("this is a test"))
 	bstore.Put(blk)
 
-	reprov := NewReprovider(clA, bstore)
+	keyProvider := NewBlockstoreProvider(bstore)
+	reprov := NewReprovider(clA, keyProvider)
 	err := reprov.Reprovide(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -72,6 +72,7 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		},
 		Reprovider: Reprovider{
 			Interval: "12h",
+			Strategy: "all",
 		},
 	}
 

--- a/repo/config/reprovider.go
+++ b/repo/config/reprovider.go
@@ -2,4 +2,5 @@ package config
 
 type Reprovider struct {
 	Interval string // Time period to reprovide locally stored objects to the network
+	Strategy string // Which keys to announce
 }

--- a/test/sharness/t0175-reprovider.sh
+++ b/test/sharness/t0175-reprovider.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+test_description="Test reprovider"
+
+. lib/test-lib.sh
+
+init_strategy() {
+  NUM_NODES=2
+  test_expect_success 'init iptb' '
+    iptb init -f -n $NUM_NODES --bootstrap=none --port=0
+  '
+
+  test_expect_success 'peer ids' '
+    PEERID_0=$(iptb get id 0) &&
+    PEERID_1=$(iptb get id 1)
+  '
+
+  test_expect_success 'use pinning startegy for reprovider' '
+    ipfsi 0 config Reprovider.Strategy '$1'
+  '
+
+  test_expect_success 'start peers' '
+    iptb start 0 &&
+    iptb start 1 &&
+    iptb connect 0 1
+  '
+}
+
+findprovs_empty() {
+  test_expect_success 'findprovs succeeds' '
+    ipfsi 1 dht findprovs -n 1 '$1' > findprovsOut
+  '
+
+  test_expect_success "findprovs output is empty" '
+    test_must_be_empty findprovsOut
+  '
+}
+
+findprovs_expect() {
+  test_expect_success 'findprovs succeeds' '
+    ipfsi 1 dht findprovs -n 1 '$1' > findprovsOut &&
+    echo '$2' > expected
+  '
+
+  test_expect_success "findprovs output looks good" '
+    test_cmp findprovsOut expected
+  '
+}
+
+reprovide() {
+  test_expect_success 'reprovide' '
+    # TODO: this hangs, though only after reprovision was done
+    ipfsi 0 bitswap reprovide
+  '
+}
+
+test_expect_success 'stop peer 1' '
+  iptb stop 1
+'
+
+# Test 'all' strategy
+init_strategy 'all'
+
+test_expect_success 'add test object' '
+  HASH_0=$(echo "foo" | ipfsi 0 add -q --local)
+'
+
+findprovs_empty '$HASH_0'
+reprovide
+findprovs_expect '$HASH_0' '$PEERID_0'
+
+# Test 'pinned' strategy
+init_strategy 'pinned'
+
+test_expect_success 'prepare test files' '
+  echo foo > f1 &&
+  echo bar > f2
+'
+
+test_expect_success 'add test objects' '
+  HASH_FOO=$(ipfsi 0 add -q --local --pin=false f1) &&
+  HASH_BAR=$(ipfsi 0 add -q --local --pin=false f2) &&
+  HASH_BAR_DIR=$(ipfsi 0 add -q --local -w f2)
+'
+
+findprovs_empty '$HASH_FOO'
+findprovs_empty '$HASH_BAR'
+findprovs_empty '$HASH_BAR_DIR'
+
+reprovide
+
+findprovs_empty '$HASH_FOO'
+findprovs_expect '$HASH_BAR' '$PEERID_0'
+findprovs_expect '$HASH_BAR_DIR' '$PEERID_0'
+
+test_expect_success 'stop peer 1' '
+  iptb stop 1
+'
+
+# Test 'roots' strategy
+init_strategy 'roots'
+
+test_expect_success 'prepare test files' '
+  echo foo > f1 &&
+  echo bar > f2
+'
+
+test_expect_success 'add test objects' '
+  HASH_FOO=$(ipfsi 0 add -q --local --pin=false f1) &&
+  HASH_BAR=$(ipfsi 0 add -q --local --pin=false f2) &&
+  HASH_BAR_DIR=$(ipfsi 0 add -q --local -w f2)
+'
+
+findprovs_empty '$HASH_FOO'
+findprovs_empty '$HASH_BAR'
+findprovs_empty '$HASH_BAR_DIR'
+
+reprovide
+
+findprovs_empty '$HASH_FOO'
+findprovs_empty '$HASH_BAR'
+findprovs_expect '$HASH_BAR_DIR' '$PEERID_0'
+
+test_expect_success 'stop peer 1' '
+  iptb stop 1
+'
+
+test_done


### PR DESCRIPTION
Reprovider strategies allow to specify which keys to provide to the content routing.
Supported strategies are:  `all` - all blocks,  `pinned` - all pinned blocks, `roots` - root/directly pined blocks.
Current reprovider is slow(~0.2keys/s with my setup), so constraining key set should speed the process up, announcing only pin roots should still work quite well in most cases.

TODO: 
* [x] Tests
* [x] Docs (experimental?)
* [x] Reduce 'pinned' strategy i/o overhead (it's really bad with larger repos now)
* [ ] Speed up reprovider (probably out of scope of this PR)