### PR TITLE
sharness: fix the 'useful error message when adding a named pipe' test

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -364,7 +364,7 @@ generic_stat() {
             _STAT="stat -f %Sp"
             ;;
     esac
-    $_STAT "$1"
+    $_STAT "$1" || echo "failed" # Avoid returning nothing.
 }
 
 test_check_peerid() {

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -192,8 +192,9 @@ test_add_named_pipe() {
     test_expect_success "useful error message when adding a named pipe" '
         mkfifo named-pipe &&
 	    test_expect_code 1 ipfs add named-pipe 2>actual &&
+        STAT=$(generic_stat named-pipe) &&
         rm named-pipe &&
-        grep "Error: Unrecognized file type for named-pipe: $(generic_stat named-pipe)" actual &&
+        grep "Error: Unrecognized file type for named-pipe: $STAT" actual &&
         grep USAGE actual &&
         grep "ipfs add" actual
     '
@@ -201,8 +202,9 @@ test_add_named_pipe() {
     test_expect_success "useful error message when recursively adding a named pipe" '
     	mkdir -p named-pipe-dir &&
     	mkfifo named-pipe-dir/named-pipe &&
+    	STAT=$(generic_stat named-pipe-dir/named-pipe) &&
     	test_expect_code 1 ipfs add -r named-pipe-dir 2>actual &&
-        printf "Error:$err_prefix Unrecognized file type for named-pipe-dir/named-pipe: $(generic_stat named-pipe-dir/named-pipe)\n" >expected &&
+        printf "Error:$err_prefix Unrecognized file type for named-pipe-dir/named-pipe: $STAT\n" >expected &&
         rm named-pipe-dir/named-pipe &&
         rmdir named-pipe-dir &&
     	test_cmp expected actual


### PR DESCRIPTION
We were removing the file before testing, ignoring the error from stat, and then grepping for `Error: Unrecognized file type for named-pipe: ` (because nothing was sent to stdout).

This fix:

1. Changes our stat command to output failed to stdout on failure to ensure that bugs like this *can't* happen.
2. Checks to make sure stat actually succeeds.