### PR TITLE
wrap-desc: Wrap help descriptions under 80 chars

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -67,18 +67,18 @@ The daemon will start listening on ports on the network, which are
 documented in (and can be modified through) 'ipfs config Addresses'.
 For example, to change the 'Gateway' port:
 
-    ipfs config Addresses.Gateway /ip4/127.0.0.1/tcp/8082
+  ipfs config Addresses.Gateway /ip4/127.0.0.1/tcp/8082
 
 The API address can be changed the same way:
 
-   ipfs config Addresses.API /ip4/127.0.0.1/tcp/5002
+  ipfs config Addresses.API /ip4/127.0.0.1/tcp/5002
 
 Make sure to restart the daemon after changing addresses.
 
 By default, the gateway is only accessible locally. To expose it to
 other computers in the network, use 0.0.0.0 as the ip address:
 
-   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+  ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 
 Be careful if you expose the API. It is a security risk, as anyone could
 control your node remotely. If you need to control the node remotely,
@@ -91,8 +91,8 @@ ipfs supports passing arbitrary headers to the API and Gateway. You can
 do this by setting headers on the API.HTTPHeaders and Gateway.HTTPHeaders
 keys:
 
-	ipfs config --json API.HTTPHeaders.X-Special-Header '["so special :)"]'
-	ipfs config --json Gateway.HTTPHeaders.X-Special-Header '["so special :)"]'
+  ipfs config --json API.HTTPHeaders.X-Special-Header '["so special :)"]'
+  ipfs config --json Gateway.HTTPHeaders.X-Special-Header '["so special :)"]'
 
 Note that the value of the keys is an _array_ of strings. This is because
 headers can have more than one value, and it is convenient to pass through
@@ -102,9 +102,9 @@ CORS Headers (for API)
 
 You can setup CORS headers the same way:
 
-	ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["example.com"]'
-	ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-	ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["example.com"]'
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials '["true"]'
 
 Shutdown
 
@@ -119,15 +119,15 @@ ipfs uses a repository in the local file system. By default, the repo is
 located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
 environment variable:
 
-    export IPFS_PATH=/path/to/ipfsrepo
+  export IPFS_PATH=/path/to/ipfsrepo
 
 Routing
 
 IPFS by default will use a DHT for content routing. There is a highly
-experimental alternative that operates the DHT in a 'client only' mode that can
-be enabled by running the daemon as:
+experimental alternative that operates the DHT in a 'client only' mode that
+can be enabled by running the daemon as:
 
-    ipfs daemon --routing=dhtclient
+  ipfs daemon --routing=dhtclient
 
 This will later be transitioned into a config option once it gets out of the
 'experimental' stage.
@@ -136,7 +136,7 @@ DEPRECATION NOTICE
 
 Previously, ipfs used an environment variable as seen below:
 
-   export API_ORIGIN="http://localhost:8888/"
+  export API_ORIGIN="http://localhost:8888/"
 
 This is deprecated. It is still honored in this version, but will be removed
 in a future version, along with this notice. Please move to setting the HTTP

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -128,7 +128,8 @@ var DagGetCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Get a dag node from ipfs.",
 		ShortDescription: `
-'ipfs dag get' fetches a dag node from ipfs and prints it out in the specifed format.
+'ipfs dag get' fetches a dag node from ipfs and prints it out in the specifed
+format.
 `,
 	},
 	Arguments: []cmds.Argument{

--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -557,7 +557,8 @@ var FilesWriteCmd = &cmds.Command{
 		Tagline: "Write to a mutable file in a given filesystem.",
 		ShortDescription: `
 Write data to a file in a given filesystem. This command allows you to specify
-a beginning offset to write to. The entire length of the input will be written.
+a beginning offset to write to. The entire length of the input will be
+written.
 
 If the '--create' option is specified, the file will be created if it does not
 exist. Nonexistant intermediate directories will not be created.

--- a/core/commands/ipns.go
+++ b/core/commands/ipns.go
@@ -26,7 +26,8 @@ the private key enables publishing new (signed) values. In both publish
 and resolve, the default name used is the node's own PeerID,
 which is the hash of its public key.
 
-You can use the 'ipfs key' commands to list and generate more names and their respective keys.
+You can use the 'ipfs key' commands to list and generate more names and their
+respective keys.
 
 Examples:
 

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -20,7 +20,8 @@ var KeyCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Create and list IPNS name keypairs",
 		ShortDescription: `
-'ipfs key gen' generates a new keypair for usage with IPNS and 'ipfs name publish'.
+'ipfs key gen' generates a new keypair for usage with IPNS and 'ipfs name
+publish'.
 
   > ipfs key gen --type=rsa --size=2048 mykey
   > ipfs name publish --key=mykey QmSomeHash

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -35,7 +35,8 @@ var logLevelCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Change the logging level.",
 		ShortDescription: `
-Change the verbosity of one or all subsystems log output. This does not affect the event log.
+Change the verbosity of one or all subsystems log output. This does not affect
+the event log.
 `,
 	},
 

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -22,7 +22,8 @@ the private key enables publishing new (signed) values. In both publish
 and resolve, the default name used is the node's own PeerID,
 which is the hash of its public key.
 
-You can use the 'ipfs key' commands to list and generate more names and their respective keys.
+You can use the 'ipfs key' commands to list and generate more names and their
+respective keys.
 
 Examples:
 

--- a/core/commands/p2p.go
+++ b/core/commands/p2p.go
@@ -47,7 +47,8 @@ var P2PCmd = &cmds.Command{
 		ShortDescription: `
 Create and use tunnels to remote peers over libp2p
 
-Note: this command is experimental and subject to change as usecases and APIs are refined`,
+Note: this command is experimental and subject to change as usecases and APIs
+are refined`,
 	},
 
 	Subcommands: map[string]*cmds.Command{
@@ -188,7 +189,8 @@ var p2pListenerListenCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Forward p2p connections to a network multiaddr.",
 		ShortDescription: `
-Register a p2p connection handler and forward the connections to a specified address.
+Register a p2p connection handler and forward the connections to a specified
+address.
 
 Note that the connections originate from the ipfs daemon process.
 		`,
@@ -237,9 +239,9 @@ var p2pStreamDialCmd = &cmds.Command{
 		ShortDescription: `
 Establish a new connection to a peer service.
 
-When a connection is made to a peer service the ipfs daemon will setup one time
-TCP listener and return it's bind port, this way a dialing application can
-transparently connect to a p2p service.
+When a connection is made to a peer service the ipfs daemon will setup one
+time TCP listener and return it's bind port, this way a dialing application
+can transparently connect to a p2p service.
 		`,
 	},
 	Arguments: []cmds.Argument{

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -34,7 +34,8 @@ the private key enables publishing new (signed) values. In both publish
 and resolve, the default name used is the node's own PeerID,
 which is the hash of its public key.
 
-You can use the 'ipfs key' commands to list and generate more names and their respective keys.
+You can use the 'ipfs key' commands to list and generate more names and their
+respective keys.
 
 Examples:
 
@@ -49,7 +50,8 @@ Publish an <ipfs-path> with another name, added by an 'ipfs key' command:
   > ipfs name publish --key=mykey /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
   Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
-Alternatively, publish an <ipfs-path> using a valid PeerID(as listed by 'ipfs key list -l'):
+Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by 
+'ipfs key list -l'):
 
  > ipfs name publish --key=QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
   Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -66,8 +66,9 @@ TOOL COMMANDS
 
 Use 'ipfs <command> --help' to learn more about each command.
 
-ipfs uses a repository in the local file system. By default, the repo is located
-at ~/.ipfs. To change the repo location, set the $IPFS_PATH environment variable:
+ipfs uses a repository in the local file system. By default, the repo is
+located at ~/.ipfs. To change the repo location, set the $IPFS_PATH
+environment variable:
 
   export IPFS_PATH=/path/to/ipfsrepo
 


### PR DESCRIPTION
Make all help command descriptions wrap under 80 characters, as per issue #2783

License: MIT
Signed-off-by: Richard Pajerski <devedge@outlook.com>