### PR TITLE
Add event system to blockstore

### DIFF
--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -49,6 +49,8 @@ type Blockstore interface {
 	// HashOnRead specifies if every read block should be
 	// rehashed to make sure it matches its CID.
 	HashOnRead(enabled bool)
+	// RegisterEventHandler registers an event handler
+	RegisterEventHandler(EventID, EventFunc)
 }
 
 // GCLocker abstract functionality to lock a blockstore when performing
@@ -105,6 +107,10 @@ type blockstore struct {
 	events    *eventSystem
 
 	rehash bool
+}
+
+func (bs *blockstore) RegisterEventHandler(t EventID, eh EventFunc) {
+	bs.events.addHandler(t, eh)
 }
 
 func (bs *blockstore) HashOnRead(enabled bool) {

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -98,7 +98,7 @@ func NewBlockstore(d ds.Batching) Blockstore {
 	dsb = dd
 	return &blockstore{
 		datastore: dsb,
-		events:    &eventSystem{},
+		events:    newEventSystem(),
 	}
 }
 

--- a/blocks/blockstore/events.go
+++ b/blocks/blockstore/events.go
@@ -32,6 +32,10 @@ type eventSystem struct {
 	handlers map[EventID][]EventFunc
 }
 
+func newEventSystem() *eventSystem {
+	return &eventSystem{handlers: make(map[EventID][]EventFunc)}
+}
+
 func (es *eventSystem) addHandler(t EventID, ef EventFunc) {
 	es.lock.Lock()
 	defer es.lock.Unlock()

--- a/blocks/blockstore/events.go
+++ b/blocks/blockstore/events.go
@@ -63,15 +63,15 @@ func (es *eventSystem) fireEvent(t EventID, e *Event) error {
 	return nil
 }
 
-func (e *eventSystem) fireMany(t EventID, es []*Event) error {
-	e.lock.RLock()
-	hs, ok := e.handlers[t]
-	e.lock.RUnlock()
+func (es *eventSystem) fireMany(t EventID, evs []*Event) error {
+	es.lock.RLock()
+	hs, ok := es.handlers[t]
+	es.lock.RUnlock()
 	if !ok {
 		return nil
 	}
 
-	for _, e := range es {
+	for _, e := range evs {
 		for _, h := range hs {
 			handled, err := h(e)
 			if err != nil {

--- a/blocks/blockstore/events.go
+++ b/blocks/blockstore/events.go
@@ -1,0 +1,86 @@
+package blockstore
+
+import (
+	"sync"
+
+	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	blocks "gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
+)
+
+// Event is a type that contains information used to fire the event
+type Event struct {
+	cid   *cid.Cid
+	block blocks.Block
+}
+
+// EventID is describes type of event fired
+type EventID int32
+
+const (
+	// EventPostPut is fired after block was added to the blockstore
+	EventPostPut EventID = iota
+)
+
+// EventFunc is type of function that can be registered into event system
+// if return value of the function is true, the event will be marked as handled
+// and there is no need to process further handlers
+type EventFunc func(*Event) (bool, error)
+
+type eventSystem struct {
+	lock sync.RWMutex
+	// in future this can be replaced buy concurrent map
+	handlers map[EventID][]EventFunc
+}
+
+func (es *eventSystem) addHandler(t EventID, ef EventFunc) {
+	es.lock.Lock()
+	defer es.lock.Unlock()
+	hs, ok := es.handlers[t]
+	if !ok {
+		hs = []EventFunc{ef}
+	} else {
+		hs = append(hs, ef)
+	}
+	es.handlers[t] = hs
+}
+
+func (es *eventSystem) fireEvent(t EventID, e *Event) error {
+	es.lock.RLock()
+	hs, ok := es.handlers[t]
+	es.lock.RUnlock()
+	if !ok {
+		return nil
+	}
+	for _, h := range hs {
+		handled, err := h(e)
+		if err != nil {
+			return err
+		}
+		if handled {
+			break
+		}
+	}
+	return nil
+}
+
+func (e *eventSystem) fireMany(t EventID, es []*Event) error {
+	e.lock.RLock()
+	hs, ok := e.handlers[t]
+	e.lock.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	for _, e := range es {
+		for _, h := range hs {
+			handled, err := h(e)
+			if err != nil {
+				return err
+			}
+			if handled {
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/blocks/blockstore/events_test.go
+++ b/blocks/blockstore/events_test.go
@@ -1,0 +1,174 @@
+package blockstore
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-ipfs/blocks/blocksutil"
+)
+
+func TestBasicEventHandling(t *testing.T) {
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	b := blkgen.Next()
+	e := &Event{
+		cid:   b.Cid(),
+		block: b,
+	}
+
+	ok := false
+	handler := func(ei *Event) (bool, error) {
+		if e != ei {
+			t.Fatal("event is different")
+		}
+		ok = true
+		return false, nil
+	}
+
+	es.addHandler(EventPostPut, handler)
+	es.fireEvent(EventPostPut, e)
+	if !ok {
+		t.Fatal("event was not fired")
+	}
+}
+
+func TestEventMarkedDone(t *testing.T) {
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	b := blkgen.Next()
+	e := &Event{
+		cid:   b.Cid(),
+		block: b,
+	}
+
+	count := 0
+	handler := func(ei *Event) (bool, error) {
+		if e != ei {
+			t.Fatal("event is different")
+		}
+		count++
+		return true, nil
+	}
+
+	es.addHandler(EventPostPut, handler)
+	es.addHandler(EventPostPut, handler)
+	es.addHandler(EventPostPut, handler)
+	es.fireEvent(EventPostPut, e)
+	if count != 1 {
+		t.Fatalf("expected to fire the handler 1 time, it was fired %d times", count)
+	}
+}
+
+func TestEventFireMultiple(t *testing.T) {
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	N := 10
+	evs := make([]*Event, N)
+	for i, _ := range evs {
+		b := blkgen.Next()
+		evs[i] = &Event{
+			cid:   b.Cid(),
+			block: b,
+		}
+	}
+
+	count := 0
+	handler := func(ei *Event) (bool, error) {
+		if evs[count] != ei {
+			t.Fatal("event is different")
+		}
+		count++
+		return false, nil
+	}
+
+	es.addHandler(EventPostPut, handler)
+	es.fireMany(EventPostPut, evs)
+	if count != N {
+		t.Fatalf("events were not fired, count should be %d, is %d", N, count)
+	}
+}
+
+func TestEventFireMultipleMarkDone(t *testing.T) {
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	N := 10
+	evs := make([]*Event, N)
+	for i, _ := range evs {
+		b := blkgen.Next()
+		evs[i] = &Event{
+			cid:   b.Cid(),
+			block: b,
+		}
+	}
+
+	count := 0
+	handler := func(ei *Event) (bool, error) {
+		if evs[count] != ei {
+			t.Fatal("event is different")
+		}
+		count++
+		return true, nil
+	}
+	failHandler := func(ei *Event) (bool, error) {
+		t.Fatal("this should not fire")
+		return false, nil
+	}
+
+	es.addHandler(EventPostPut, handler)
+	es.addHandler(EventPostPut, failHandler)
+	es.fireMany(EventPostPut, evs)
+	if count != N {
+		t.Fatalf("expected to fire the handler 1 time, it was fired %d times", count)
+	}
+}
+
+func BenchmarkEventFireSingle(b *testing.B) {
+	b.N = 1000000
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	evs := make([]*Event, b.N)
+	for i, _ := range evs {
+		b := blkgen.Next()
+		evs[i] = &Event{
+			cid:   b.Cid(),
+			block: b,
+		}
+	}
+	count := 0
+	h := func(ei *Event) (bool, error) {
+		count++
+		return false, nil
+	}
+	es.addHandler(EventPostPut, h)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		es.fireEvent(EventPostPut, evs[i])
+	}
+}
+
+func BenchmarkEventFireMultiple(b *testing.B) {
+	b.N = 1000000
+	es := newEventSystem()
+	blkgen := blocksutil.NewBlockGenerator()
+	evs := make([]*Event, b.N)
+	for i, _ := range evs {
+		b := blkgen.Next()
+		evs[i] = &Event{
+			cid:   b.Cid(),
+			block: b,
+		}
+	}
+	count := 0
+	h := func(ei *Event) (bool, error) {
+		count++
+		return false, nil
+	}
+	es.addHandler(EventPostPut, h)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	es.fireMany(EventPostPut, evs)
+}

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -10,13 +10,12 @@ package filestore
 import (
 	"context"
 
-	"gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
-
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
 	posinfo "github.com/ipfs/go-ipfs/thirdparty/posinfo"
 
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cid "gx/ipfs/QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS/go-cid"
+	"gx/ipfs/QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg/go-block-format"
 	dsq "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/query"
 )
 


### PR DESCRIPTION
This is a small stub of something I hope we shift our blockstore in future.
With additional events like EventGet, EventHas we would be able to:
1. have add-on functionality in blockstore (imagine Ethereum blockstore plugin)
2. be much more flexible than what we do now (blockstore wrapping)
3. it will be easier to expand in future

This stub is to allow me to start working on tri-colour GC for go-ipfs which would replace the stop world GC we currently have.

Later I would also like to swich the current Has caches to base onto the event system.
It is quite possible that in future we will have to implement priority to the events but this can be solved.