### PR TITLE
Eliminate GetOfflineLinkService method from LinkService interface

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -29,7 +29,7 @@ import (
 	rp "github.com/ipfs/go-ipfs/exchange/reprovide"
 	filestore "github.com/ipfs/go-ipfs/filestore"
 	mount "github.com/ipfs/go-ipfs/fuse/mount"
-	merkledag "github.com/ipfs/go-ipfs/merkledag"
+	mdag "github.com/ipfs/go-ipfs/merkledag"
 	mfs "github.com/ipfs/go-ipfs/mfs"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	ipnsrp "github.com/ipfs/go-ipfs/namesys/republisher"
@@ -110,14 +110,14 @@ type IpfsNode struct {
 	PNetFingerpint []byte     // fingerprint of private network
 
 	// Services
-	Peerstore  pstore.Peerstore     // storage for other Peer instances
-	Blockstore bstore.GCBlockstore  // the block store (lower level)
-	Filestore  *filestore.Filestore // the filestore blockstore
-	BaseBlocks bstore.Blockstore    // the raw blockstore, no filestore wrapping
-	GCLocker   bstore.GCLocker      // the locker used to protect the blockstore during gc
-	Blocks     bserv.BlockService   // the block service, get/add blocks.
-	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
-	Resolver   *path.Resolver       // the path resolution system
+	Peerstore  pstore.Peerstore       // storage for other Peer instances
+	Blockstore bstore.GCBlockstore    // the block store (lower level)
+	Filestore  *filestore.Filestore   // the filestore blockstore
+	BaseBlocks bstore.Blockstore      // the raw blockstore, no filestore wrapping
+	GCLocker   bstore.GCLocker        // the locker used to protect the blockstore during gc
+	Blocks     bserv.BlockService     // the block service, get/add blocks.
+	DAG        *mdag.MerkleDAGService // the merkle dag service, get/add objects.
+	Resolver   *path.Resolver         // the path resolution system
 	Reporter   metrics.Reporter
 	Discovery  discovery.Service
 	FilesRoot  *mfs.Root
@@ -690,7 +690,7 @@ func (n *IpfsNode) loadFilesRoot() error {
 		return n.Repo.Datastore().Put(dsk, c.Bytes())
 	}
 
-	var nd *merkledag.ProtoNode
+	var nd *mdag.ProtoNode
 	val, err := n.Repo.Datastore().Get(dsk)
 
 	switch {
@@ -711,9 +711,9 @@ func (n *IpfsNode) loadFilesRoot() error {
 			return fmt.Errorf("error loading filesroot from DAG: %s", err)
 		}
 
-		pbnd, ok := rnd.(*merkledag.ProtoNode)
+		pbnd, ok := rnd.(*mdag.ProtoNode)
 		if !ok {
-			return merkledag.ErrNotProtobuf
+			return mdag.ErrNotProtobuf
 		}
 
 		nd = pbnd

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -86,7 +86,8 @@ func GarbageCollect(n *core.IpfsNode, ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	rmed := gc.GC(ctx, n.Blockstore, n.DAG, n.Pinning, roots)
+
+	rmed := gc.GC(ctx, n.Blockstore, n.DAG.GetOfflineLinkService(), n.Pinning, roots)
 
 	return CollectResult(ctx, rmed, nil)
 }
@@ -154,7 +155,7 @@ func GarbageCollectAsync(n *core.IpfsNode, ctx context.Context) <-chan gc.Result
 		return out
 	}
 
-	return gc.GC(ctx, n.Blockstore, n.DAG, n.Pinning, roots)
+	return gc.GC(ctx, n.Blockstore, n.DAG.GetOfflineLinkService(), n.Pinning, roots)
 }
 
 func PeriodicGC(ctx context.Context, node *core.IpfsNode) error {

--- a/core/coreunix/add_test.go
+++ b/core/coreunix/add_test.go
@@ -102,7 +102,7 @@ func TestAddGCLive(t *testing.T) {
 	gcstarted := make(chan struct{})
 	go func() {
 		defer close(gcstarted)
-		gcout = gc.GC(context.Background(), node.Blockstore, node.DAG, node.Pinning, nil)
+		gcout = gc.GC(context.Background(), node.Blockstore, node.DAG.GetOfflineLinkService(), node.Pinning, nil)
 	}()
 
 	// gc shouldnt start until we let the add finish its current file.

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -22,7 +22,7 @@ import (
 	dssync "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/sync"
 )
 
-func getDagserv(t *testing.T) merkledag.DAGService {
+func getDagserv(t *testing.T) *merkledag.MerkleDAGService {
 	db := dssync.MutexWrap(ds.NewMapDatastore())
 	bs := bstore.NewBlockstore(db)
 	blockserv := bserv.New(bs, offline.Exchange(bs))

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -47,33 +47,31 @@ type LinkService interface {
 	// leaves cannot possibly have links so there is no need to look
 	// at the node.
 	GetLinks(context.Context, *cid.Cid) ([]*node.Link, error)
-
-	GetOfflineLinkService() LinkService
 }
 
-func NewDAGService(bs bserv.BlockService) *dagService {
-	return &dagService{Blocks: bs}
+func NewDAGService(bs bserv.BlockService) *MerkleDAGService {
+	return &MerkleDAGService{Blocks: bs}
 }
 
-// dagService is an IPFS Merkle DAG service.
+// MerkleDAGService is an IPFS Merkle DAG service.
 // - the root is virtual (like a forest)
 // - stores nodes' data in a BlockService
 // TODO: should cache Nodes that are in memory, and be
 //       able to free some of them when vm pressure is high
-type dagService struct {
+type MerkleDAGService struct {
 	Blocks bserv.BlockService
 }
 
-// Add adds a node to the dagService, storing the block in the BlockService
-func (n *dagService) Add(nd node.Node) (*cid.Cid, error) {
+// Add adds a node to the MerkleDAGService, storing the block in the BlockService
+func (n *MerkleDAGService) Add(nd node.Node) (*cid.Cid, error) {
 	if n == nil { // FIXME remove this assertion. protect with constructor invariant
-		return nil, fmt.Errorf("dagService is nil")
+		return nil, fmt.Errorf("MerkleDAGService is nil")
 	}
 
 	return n.Blocks.AddBlock(nd)
 }
 
-func (n *dagService) Batch() *Batch {
+func (n *MerkleDAGService) Batch() *Batch {
 	return &Batch{
 		ds:      n,
 		MaxSize: 8 << 20,
@@ -85,10 +83,10 @@ func (n *dagService) Batch() *Batch {
 	}
 }
 
-// Get retrieves a node from the dagService, fetching the block in the BlockService
-func (n *dagService) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
+// Get retrieves a node from the MerkleDAGService, fetching the block in the BlockService
+func (n *MerkleDAGService) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
 	if n == nil {
-		return nil, fmt.Errorf("dagService is nil")
+		return nil, fmt.Errorf("MerkleDAGService is nil")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -107,7 +105,7 @@ func (n *dagService) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
 
 // GetLinks return the links for the node, the node doesn't necessarily have
 // to exist locally.
-func (n *dagService) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
+func (n *MerkleDAGService) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, error) {
 	if c.Type() == cid.Raw {
 		return nil, nil
 	}
@@ -118,16 +116,22 @@ func (n *dagService) GetLinks(ctx context.Context, c *cid.Cid) ([]*node.Link, er
 	return node.Links(), nil
 }
 
-func (n *dagService) GetOfflineLinkService() LinkService {
+// OfflineLinkService is just a wrapper around LinkService that is
+// assumed to be offline.
+type OfflineLinkService struct {
+	LinkService
+}
+
+func (n *MerkleDAGService) GetOfflineLinkService() OfflineLinkService {
 	if n.Blocks.Exchange().IsOnline() {
 		bsrv := bserv.New(n.Blocks.Blockstore(), offline.Exchange(n.Blocks.Blockstore()))
-		return NewDAGService(bsrv)
+		return OfflineLinkService{NewDAGService(bsrv)}
 	} else {
-		return n
+		return OfflineLinkService{n}
 	}
 }
 
-func (n *dagService) Remove(nd node.Node) error {
+func (n *MerkleDAGService) Remove(nd node.Node) error {
 	return n.Blocks.DeleteBlock(nd)
 }
 
@@ -163,7 +167,7 @@ func (sg *sesGetter) Get(ctx context.Context, c *cid.Cid) (node.Node, error) {
 // FetchGraph fetches all nodes that are children of the given node
 func FetchGraph(ctx context.Context, root *cid.Cid, serv DAGService) error {
 	var ng node.NodeGetter = serv
-	ds, ok := serv.(*dagService)
+	ds, ok := serv.(*MerkleDAGService)
 	if ok {
 		ng = &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
 	}
@@ -201,7 +205,7 @@ type NodeOption struct {
 	Err  error
 }
 
-func (ds *dagService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *NodeOption {
+func (ds *MerkleDAGService) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *NodeOption {
 	out := make(chan *NodeOption, len(keys))
 	blocks := ds.Blocks.GetBlocks(ctx, keys)
 	var count int
@@ -385,7 +389,7 @@ func (np *nodePromise) Get(ctx context.Context) (node.Node, error) {
 }
 
 type Batch struct {
-	ds *dagService
+	ds *MerkleDAGService
 
 	blocks    []blocks.Block
 	size      int

--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -33,15 +33,13 @@ type Result struct {
 // The routine then iterates over every block in the blockstore and
 // deletes any block that is not found in the marked set.
 //
-func GC(ctx context.Context, bs bstore.GCBlockstore, ls dag.LinkService, pn pin.Pinner, bestEffortRoots []*cid.Cid) <-chan Result {
+func GC(ctx context.Context, bs bstore.GCBlockstore, ls dag.OfflineLinkService, pn pin.Pinner, bestEffortRoots []*cid.Cid) <-chan Result {
 
 	elock := log.EventBegin(ctx, "GC.lockWait")
 	unlocker := bs.GCLock()
 	elock.Done()
 	elock = log.EventBegin(ctx, "GC.locked")
 	emark := log.EventBegin(ctx, "GC.mark")
-
-	ls = ls.GetOfflineLinkService()
 
 	output := make(chan Result, 128)
 


### PR DESCRIPTION
This eliminates the GetOfflineLinkService method to make https://github.com/ipfs/go-ipld-format/pull/8 easier and also avoid the need for #4009, at least for now.

It does it by keeping the method but instead exposing the type create by `NewDAGService` so that implementation specific methods can be called, with one of them being `GetOfflineLinkService`.  The GC function now expects an offline LinkService.  To help reinforce this notion a trivial type `OfflineLinkService` is used.