### PR TITLE
reprovide: fix ipfs bitswap reprovide when interval set to 0

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -283,19 +283,17 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	}
 	n.Reprovider = rp.NewReprovider(ctx, n.Routing, keyProvider)
 
-	if cfg.Reprovider.Interval != "0" {
-		interval := kReprovideFrequency
-		if cfg.Reprovider.Interval != "" {
-			dur, err := time.ParseDuration(cfg.Reprovider.Interval)
-			if err != nil {
-				return err
-			}
-
-			interval = dur
+	reproviderInterval := kReprovideFrequency
+	if cfg.Reprovider.Interval != "" {
+		dur, err := time.ParseDuration(cfg.Reprovider.Interval)
+		if err != nil {
+			return err
 		}
 
-		go n.Reprovider.ProvideEvery(interval)
+		reproviderInterval = dur
 	}
+
+	go n.Reprovider.Run(reproviderInterval)
 
 	return nil
 }

--- a/exchange/reprovide/reprovide.go
+++ b/exchange/reprovide/reprovide.go
@@ -38,14 +38,18 @@ func NewReprovider(ctx context.Context, rsys routing.ContentRouting, keyProvider
 	}
 }
 
-// ProvideEvery re-provides keys with 'tick' interval
-func (rp *Reprovider) ProvideEvery(tick time.Duration) {
+// Run re-provides keys with 'tick' interval or when triggered
+func (rp *Reprovider) Run(tick time.Duration) {
 	// dont reprovide immediately.
 	// may have just started the daemon and shutting it down immediately.
 	// probability( up another minute | uptime ) increases with uptime.
 	after := time.After(time.Minute)
 	var done doneFunc
 	for {
+		if tick == 0 {
+			after = make(chan time.Time)
+		}
+
 		select {
 		case <-rp.ctx.Done():
 			return
@@ -98,7 +102,7 @@ func (rp *Reprovider) Reprovide() error {
 	return nil
 }
 
-// Trigger starts reprovision process in rp.ProvideEvery and waits for it
+// Trigger starts reprovision process in rp.Run and waits for it
 func (rp *Reprovider) Trigger(ctx context.Context) error {
 	progressCtx, done := context.WithCancel(ctx)
 


### PR DESCRIPTION
`ipfs bitswap reprovide` would hang if `Reprovider.Interval` was set to 0