### PR TITLE
Fix Go 1.9 issues

### DIFF
--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -23,7 +23,7 @@ $(IPFS_BIN_$(d)): $(d) $$(DEPS_GO) ALWAYS #| $(DEPS_OO_$(d))
 
 $(d)-install: GOFLAGS += $(cmd/ipfs_flags)
 $(d)-install: $(d) $$(DEPS_GO) ALWAYS 
-	go install $(go-flags-with-tags) ./cmd/ipfs
+	$(GOCC) install $(go-flags-with-tags) ./cmd/ipfs
 .PHONY: $(d)-install
 
 COVER_BIN_$(d) := $(d)/ipfs-test-cover
@@ -31,9 +31,9 @@ CLEAN += $(COVER_BIN_$(d))
 
 $(COVER_BIN_$(d)): GOTAGS += testrunmain
 $(COVER_BIN_$(d)): $(d) $$(DEPS_GO) ALWAYS
-	$(eval TMP_PKGS := $(shell go list -f '{{range .Deps}}{{.}} {{end}}' $(go-flags-with-tags) ./cmd/ipfs | sed 's/ /\n/g' | grep ipfs/go-ipfs | grep -v ipfs/go-ipfs/Godeps) $(call go-pkg-name,$<))
+	$(eval TMP_PKGS := $(shell $(GOCC) list -f '{{range .Deps}}{{.}} {{end}}' $(go-flags-with-tags) ./cmd/ipfs | sed 's/ /\n/g' | grep ipfs/go-ipfs | grep -v ipfs/go-ipfs/Godeps) $(call go-pkg-name,$<))
 	$(eval TMP_LIST := $(call join-with,$(comma),$(TMP_PKGS)))
-	@echo go test $@ -c -covermode atomic -coverpkg ... $(go-flags-with-tags) ./$(@D) # for info
-	@go test -o $@ -c -covermode atomic -coverpkg $(TMP_LIST) $(go-flags-with-tags) ./$(@D) 2>&1 | (grep -v 'warning: no packages being tested' || true)
+	@echo $(GOCC) test $@ -c -covermode atomic -coverpkg ... $(go-flags-with-tags) ./$(@D) # for info
+	@$(GOCC) test -o $@ -c -covermode atomic -coverpkg $(TMP_LIST) $(go-flags-with-tags) ./$(@D) 2>&1 | (grep -v 'warning: no packages being tested' || true)
 
 include mk/footer.mk

--- a/commands/files/serialfile.go
+++ b/commands/files/serialfile.go
@@ -60,7 +60,14 @@ func (f *serialFile) NextFile() (File, error) {
 	// if a file was opened previously, close it
 	err := f.Close()
 	if err != nil {
-		return nil, err
+		switch err2 := err.(type) {
+		case *os.PathError:
+			if err2.Err != os.ErrClosed {
+				return nil, err
+			}
+		default:
+			return nil, err
+		}
 	}
 
 	// if there aren't any files left in the root directory, we're done

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -20,7 +20,7 @@ go-tags=$(if $(GOTAGS), -tags="$(call join-with,$(space),$(GOTAGS))")
 go-flags-with-tags=$(GOFLAGS)$(go-tags)
 
 define go-build
-$(GOCC) build -gcflags "-N -l" -i $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
+$(GOCC) build -i $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
 endef
 
 test_go_short: GOTFLAGS += -test.short

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -2,6 +2,7 @@
 GO_MIN_VERSION = 1.8
 
 # pre-definitions
+GOCC ?= go
 GOTAGS ?=
 GOFLAGS ?=
 GOTFLAGS ?=
@@ -10,16 +11,16 @@ DEPS_GO :=
 TEST_GO :=
 CHECK_GO :=
 
-go-pkg-name=$(shell go list $(go-tags) github.com/ipfs/go-ipfs/$(1))
+go-pkg-name=$(shell $(GOCC) list $(go-tags) github.com/ipfs/go-ipfs/$(1))
 go-main-name=$(notdir $(call go-pkg-name,$(1)))$(?exe)
 go-curr-pkg-tgt=$(d)/$(call go-main-name,$(d))
-go-pkgs-novendor=$(shell go list github.com/ipfs/go-ipfs/... | grep -v /Godeps/)
+go-pkgs-novendor=$(shell $(GOCC) list github.com/ipfs/go-ipfs/... | grep -v /Godeps/)
 
 go-tags=$(if $(GOTAGS), -tags="$(call join-with,$(space),$(GOTAGS))")
 go-flags-with-tags=$(GOFLAGS)$(go-tags)
 
 define go-build
-go build -i $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
+$(GOCC) build -gcflags "-N -l" -i $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
 endef
 
 test_go_short: GOTFLAGS += -test.short
@@ -31,7 +32,7 @@ test_go_race: test_go_expensive
 .PHONY: test_go_race
 
 test_go_expensive: $$(DEPS_GO)
-	go test $(go-flags-with-tags) $(GOTFLAGS) ./...
+	$(GOCC) test $(go-flags-with-tags) $(GOTFLAGS) ./...
 .PHONY: test_go_expensive
 TEST_GO += test_go_expensive
 
@@ -41,7 +42,7 @@ test_go_fmt:
 TEST_GO += test_go_fmt
 
 test_go_megacheck:
-	@go get honnef.co/go/tools/cmd/megacheck
+	@$(GOCC) get honnef.co/go/tools/cmd/megacheck
 	@for pkg in $(go-pkgs-novendor); do megacheck "$$pkg"; done
 .PHONY: megacheck
 

--- a/plugin/plugins/Rules.mk
+++ b/plugin/plugins/Rules.mk
@@ -8,11 +8,11 @@ $(d)_plugins_main:=$(addsuffix /main/main.go,$($(d)_plugins))
 $($(d)_plugins_main): d:=$(d)
 $($(d)_plugins_main):
 	$(d)/gen_main.sh "$(dir $@).." "$(call go-pkg-name,$(dir $@)/..)"
-	go fmt $@ >/dev/null
+	$(GOCC) fmt $@ >/dev/null
 
 $($(d)_plugins_so): %.so : %/main/main.go
 $($(d)_plugins_so): $$(DEPS_GO) ALWAYS
-	go build -buildmode=plugin -i -pkgdir "$(GOPATH)/pkg/linux_amd64_dynlink" $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$(basename $@))/main"
+	$(GOCC) build -buildmode=plugin -i -pkgdir "$(GOPATH)/pkg/linux_amd64_dynlink" $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$(basename $@))/main"
 	chmod +x "$@"
 
 CLEAN += $($(d)_plugins_so)


### PR DESCRIPTION
* Fixes #4097
  * Was caused by https://github.com/golang/go/commit/e3d7ec006f25385972c89f771d5d577adce3f024
* Will need to be propagated back to https://github.com/ipfs/go-ipfs/pull/3856 (Extract and rework commands package)
* There is 1 more issue I noticed when running sharness tests on that: when running `ipfs daemon --init` there is an error spam:
```
21:54:33.692 ERROR metrics-pr: Registering prometheus collector, name: ipfs_fsrepo_datastore_blocks_put_total, error: duplicate metrics collector registration attempted binding.go:74
```
* Might be related to https://github.com/ipfs/go-ipfs/issues/4132
  * Probably isn't