### PR TITLE
Update badgerds to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,9 +460,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmRh9Udeo8qCe4XKCSA2NUunTZbFvbc5d44E5wTZPFf3Fg",
+      "hash": "QmUPQpMxu9BFE2MhmBkiMUBn4VTSuAAZZkX9LT699tQeiw",
       "name": "go-ds-badger",
-      "version": "0.2.1"
+      "version": "0.3.1"
     }
   ],
   "gxVersion": "0.10.0",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -17,7 +17,7 @@ import (
 	mount "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/syncmount"
 
 	levelds "gx/ipfs/QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz/go-ds-leveldb"
-	badgerds "gx/ipfs/QmRh9Udeo8qCe4XKCSA2NUunTZbFvbc5d44E5wTZPFf3Fg/go-ds-badger"
+	badgerds "gx/ipfs/QmUPQpMxu9BFE2MhmBkiMUBn4VTSuAAZZkX9LT699tQeiw/go-ds-badger"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 )
 


### PR DESCRIPTION
Update badger to current master, fix `ipfs gc` bug.

NOTE: This breaks previous badger ds-es as badger bumped their manifest version. I'm not sure if there is a migration for that, if someone wants to rescue their data, convert using ds-convert to flatfs (you prorably will need to remove `QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n` using `block rm`)

