### PR TITLE
Discussion Point: Using Multihash not CID in blockstore and bitswap

### DIFF
--- a/blocks/blockstore/util/remove.go
+++ b/blocks/blockstore/util/remove.go
@@ -47,7 +47,7 @@ func RmBlocks(blocks bs.GCBlockstore, pins pin.Pinner, cids []*cid.Cid, opts RmB
 		stillOkay := FilterPinned(pins, out, cids)
 
 		for _, c := range stillOkay {
-			err := blocks.DeleteBlock(c)
+			err := blocks.DeleteBlock(c.Hash())
 			if err != nil && opts.Force && (err == bs.ErrNotFound || err == ds.ErrNotFound) {
 				// ignore non-existent blocks
 			} else if err != nil {

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -100,7 +100,7 @@ func NewSession(ctx context.Context, bs BlockService) *Session {
 func (s *blockService) AddBlock(o blocks.Block) (*cid.Cid, error) {
 	c := o.Cid()
 	if s.checkFirst {
-		has, err := s.blockstore.Has(c)
+		has, err := s.blockstore.Has(c.Hash())
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +126,7 @@ func (s *blockService) AddBlocks(bs []blocks.Block) ([]*cid.Cid, error) {
 	var toput []blocks.Block
 	if s.checkFirst {
 		for _, b := range bs {
-			has, err := s.blockstore.Has(b.Cid())
+			has, err := s.blockstore.Has(b.Cid().Hash())
 			if err != nil {
 				return nil, err
 			}
@@ -244,7 +244,7 @@ func getBlocks(ctx context.Context, ks []*cid.Cid, bs blockstore.Blockstore, f e
 
 // DeleteBlock deletes a block in the blockservice from the datastore
 func (s *blockService) DeleteBlock(o blocks.Block) error {
-	return s.blockstore.DeleteBlock(o.Cid())
+	return s.blockstore.DeleteBlock(o.Cid().Hash())
 }
 
 func (s *blockService) Close() error {

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -284,7 +284,7 @@ var provideRefDhtCmd = &cmds.Command{
 				return
 			}
 
-			has, err := n.Blockstore.Has(c)
+			has, err := n.Blockstore.Has(c.Hash())
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -18,6 +18,7 @@ import (
 
 	cid "gx/ipfs/QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ/go-cid"
 	u "gx/ipfs/QmSU6eubNdhXjFBJBSksTp8kv8YRub8mGAPv8tVJHmL2EU/go-ipfs-util"
+	mh "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
 )
 
 type RepoVersion struct {
@@ -43,7 +44,7 @@ var RepoCmd = &cmds.Command{
 
 // GcResult is the result returned by "repo gc" command.
 type GcResult struct {
-	Key   *cid.Cid
+	Key   mh.Multihash
 	Error string `json:",omitempty"`
 }
 
@@ -90,7 +91,7 @@ order to reclaim hard disk space.
 					res.SetError(fmt.Errorf("encountered errors during gc run"), cmds.ErrNormal)
 				}
 			} else {
-				err := corerepo.CollectResult(req.Context(), gcOutChan, func(k *cid.Cid) {
+				err := corerepo.CollectResult(req.Context(), gcOutChan, func(k mh.Multihash) {
 					outChan <- &GcResult{Key: k}
 				})
 				if err != nil {
@@ -290,7 +291,7 @@ var repoVerifyCmd = &cmds.Command{
 			var fails int
 			var i int
 			for k := range keys {
-				_, err := bs.Get(k)
+				_, err := bs.Get(cid.NewCidV1(cid.Raw, k))
 				if err != nil {
 					out <- &VerifyProgress{
 						Message: fmt.Sprintf("block %s was corrupt (%s)", k, err),

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -14,6 +14,7 @@ import (
 	cid "gx/ipfs/QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ/go-cid"
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
+	mh "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
 )
 
 var log = logging.Logger("corerepo")
@@ -94,7 +95,7 @@ func GarbageCollect(n *core.IpfsNode, ctx context.Context) error {
 // CollectResult collects the output of a garbage collection run and calls the
 // given callback for each object removed.  It also collects all errors into a
 // MultiError which is returned after the gc is completed.
-func CollectResult(ctx context.Context, gcOut <-chan gc.Result, cb func(*cid.Cid)) error {
+func CollectResult(ctx context.Context, gcOut <-chan gc.Result, cb func(mh.Multihash)) error {
 	var errors []error
 loop:
 	for {

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -405,7 +405,7 @@ var ErrAlreadyHaveBlock = errors.New("already have block")
 
 func (bs *Bitswap) updateReceiveCounters(b blocks.Block) {
 	blkLen := len(b.RawData())
-	has, err := bs.blockstore.Has(b.Cid())
+	has, err := bs.blockstore.Has(b.Cid().Hash())
 	if err != nil {
 		log.Infof("blockstore.Has error: %s", err)
 		return

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -237,7 +237,7 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) error {
 		} else {
 			log.Debugf("wants %s - %d", entry.Cid, entry.Priority)
 			l.Wants(entry.Cid, entry.Priority)
-			if exists, err := e.bs.Has(entry.Cid); err == nil && exists {
+			if exists, err := e.bs.Has(entry.Cid.Hash()); err == nil && exists {
 				e.peerRequestQueue.Push(entry.Entry, p)
 				newWorkExists = true
 			}

--- a/thirdparty/ds-help/key.go
+++ b/thirdparty/ds-help/key.go
@@ -2,6 +2,7 @@ package dshelp
 
 import (
 	cid "gx/ipfs/QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ/go-cid"
+	mh "gx/ipfs/QmU9a9NV9RdPNwZQDYd5uKsm6N6LJLSvLbywDDYFbaaC6P/go-multihash"
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	base32 "gx/ipfs/QmfVj3x4D6Jkq9SEoi5n2NmoUomLwoeiwnYz2KQa15wRw6/base32"
 )
@@ -20,13 +21,17 @@ func BinaryFromDsKey(k ds.Key) ([]byte, error) {
 }
 
 func CidToDsKey(k *cid.Cid) ds.Key {
-	return NewKeyFromBinary(k.Bytes())
+	return NewKeyFromBinary(k.Hash())
 }
 
-func DsKeyToCid(dsKey ds.Key) (*cid.Cid, error) {
+func MultihashToDsKey(mh mh.Multihash) ds.Key {
+	return NewKeyFromBinary(mh)
+}
+
+func DsKeyToMultihash(dsKey ds.Key) (mh.Multihash, error) {
 	kb, err := BinaryFromDsKey(dsKey)
 	if err != nil {
 		return nil, err
 	}
-	return cid.Cast(kb)
+	return mh.Cast(kb)
 }


### PR DESCRIPTION
This code is broken, that is known.  I did it as an exercise to see exactly what was involved to implement what @diasdavid had in mind in https://github.com/ipfs/go-cid/issues/34#issuecomment-326243777.  I implement enough of the idea to be confident so I know what is involved. Here is what is involved, most of this is likely known but I thought it would be good to spell it out:

(1) Blocks will need to indexed by MultiHash and not the CID.  With our currently infrastructure this means that that additional information provided by the CID will be lost, yet that information is still needed to construct a block given the current interface.  Thus most of the blockstore interface was converted to use Multihash instead of Cid's except for the `Get` method which needs the full Cid in order to correctly reconstruct the block.

(2) It would be temping to make all blocks raw and without any semantic information provided by the CID.  However, that will likely cause problems with the the filestore as it needs to know what type of block it is dealing with.  It may also cause problems elsewhere.

(3) As there is no Semantic information stored in the blockstore/datastore AllKeysChan will return a Multihash instead of CID.

(4) This means that in some cases all that we can return to the user is a Multihash, two noticeable places are "ipfs refs local" and the results of the keys deleted in the GC.  The question is how do we represent these keys to the user, I can think of several ideas: (a) present just the raw multihash but prefix it with a multibase prefix, since this is technically not allowed for CidV0 this could work well, (b) present the keys as Raw CidV1s, this could be confusing to the user (c) add a new Cid type for "unknown" and use that new code to convert the raw multihash to CidV1, this has the advantage of making it clear to the user that the actual Cid type is not known.  (a) could present a problem when we switch to Base32 and we have a need a way to embed a CidV0 into an existing dag, (b) is ambiguous, so I like (c) the best.

(4) AllKeysChan is used is used by the GC, but this is should not be a problem as the full CID is still stored in the pin.

(5) AllKeyChan is used by the republisher.  __This is where the change in the bitswap protocol is needed.__  In particular the proder list (if that is the correct term) would need to consist of multihashes not CID's as we no longer have the semantic information that the CID provides.

(6) As a consequence of storing just a multihash a repo migration will be needed, however since the datastore only cares about raw keys and not what they represent no change in any of the datastore code is needed.

(7) The on-wire protocol will need to be changed due to (5) and likely also changing the wantlist to use Multihashes.

CC @diasdavid @Stebalien @whyrusleeping @lgierth @jbenet (others)