### PR TITLE
Check for Peers before `dht provide`

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -274,6 +274,11 @@ var provideRefDhtCmd = &cmds.Command{
 			return
 		}
 
+		if len(n.PeerHost.Network().Conns()) == 0 {
+			res.SetError(errors.New("no peers in the swarm are connected to, cannot provide"), cmds.ErrNormal)
+			return
+		}
+
 		rec, _, _ := req.Option("recursive").Bool()
 
 		var cids []*cid.Cid


### PR DESCRIPTION
Check if there are any peers before running logic for `dht provide`. In response to https://github.com/ipfs/go-ipfs/issues/4258

License: MIT
Signed-off-by: Koushik Roy <meff@meff.me>