### PR TITLE
datastore: update badgerds to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,9 +460,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmYQYQ3FiVskUmMB2eLLvrhHhAfAPNZ3StZP5Ni7LTJgnX",
+      "hash": "QmUamAGkvPp1w84dfc2YMy9ic6iyBvaRoaTiaat8Crtawq",
       "name": "go-ds-badger",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -17,7 +17,7 @@ import (
 	mount "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/syncmount"
 
 	levelds "gx/ipfs/QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz/go-ds-leveldb"
-	badgerds "gx/ipfs/QmYQYQ3FiVskUmMB2eLLvrhHhAfAPNZ3StZP5Ni7LTJgnX/go-ds-badger"
+	badgerds "gx/ipfs/QmUamAGkvPp1w84dfc2YMy9ic6iyBvaRoaTiaat8Crtawq/go-ds-badger"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 )
 


### PR DESCRIPTION
This updates badger to 0.8 tag, including Windows mmap fix, should help with https://github.com/ipfs/go-ipfs/issues/3971#issuecomment-334913609