### PR TITLE
filter out "" from active peers in bitswap sessions

### DIFF
--- a/exchange/bitswap/session.go
+++ b/exchange/bitswap/session.go
@@ -159,7 +159,9 @@ func (s *Session) run(ctx context.Context) {
 		case blk := <-s.incoming:
 			s.tick.Stop()
 
-			s.addActivePeer(blk.from)
+			if blk.from != "" {
+				s.addActivePeer(blk.from)
+			}
 
 			s.receiveBlock(ctx, blk.blk)
 


### PR DESCRIPTION
We use "" to indicate that the block came from the local node. There's no reason to record "" as an active peer (doesn't really *hurt* but still...).