### PR TITLE
lower yamux accept buffer size

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -372,7 +372,7 @@ func makeSmuxTransport(mplexExp bool) smux.Transport {
 	mstpt := mssmux.NewBlankTransport()
 
 	ymxtpt := &yamux.Transport{
-		AcceptBacklog:          8192,
+		AcceptBacklog:          512,
 		ConnectionWriteTimeout: time.Second * 10,
 		KeepAliveInterval:      time.Second * 30,
 		EnableKeepAlive:        true,


### PR DESCRIPTION
Should *massively* reduce the amount of memory used by each peer (by 60KiB).

License: MIT
Signed-off-by: Steven Allen <steven@stebalien.com>