### PR TITLE
gx: Update badgerds to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,9 +460,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmUamAGkvPp1w84dfc2YMy9ic6iyBvaRoaTiaat8Crtawq",
+      "hash": "QmNm2bfBCtEzmpxVzaW2FZGzWx2KWHprfd27aWoXptrAGa",
       "name": "go-ds-badger",
-      "version": "0.4.1"
+      "version": "1.0.4"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -16,8 +16,8 @@ import (
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	mount "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/syncmount"
 
+	badgerds "gx/ipfs/QmNm2bfBCtEzmpxVzaW2FZGzWx2KWHprfd27aWoXptrAGa/go-ds-badger"
 	levelds "gx/ipfs/QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz/go-ds-leveldb"
-	badgerds "gx/ipfs/QmUamAGkvPp1w84dfc2YMy9ic6iyBvaRoaTiaat8Crtawq/go-ds-badger"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 )
 


### PR DESCRIPTION
This PR updates badgerds to use new transaction API. On-disk format hasn't changed (at least this is what I observed)

Fixes #4322