### PR TITLE
Dockerfiles: do not set gecos field on user add. Set group.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x \
   && chmod +x tini
 
 # Get the TLS CA certificates, they're not provided by busybox.
-RUN apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Now comes the actual target image, which aims to be as small as possible.
 FROM busybox:1-glibc
@@ -62,8 +62,8 @@ EXPOSE 8081
 # Create the fs-repo directory and switch to a non-privileged user.
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
-  && adduser -D -h $IPFS_PATH -u 1000 -g 100 ipfs \
-  && chown 1000:100 $IPFS_PATH
+  && adduser -D -h $IPFS_PATH -u 1000 -G users ipfs \
+  && chown ipfs:users $IPFS_PATH
 
 # Expose the fs-repo as a volume.
 # start_ipfs initializes an fs-repo if none is mounted.

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -58,8 +58,8 @@ EXPOSE 8081
 # Create the fs-repo directory and switch to a non-privileged user.
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
-  && useradd -s /usr/sbin/nologin -d $IPFS_PATH -u 1000 -g 100 ipfs \
-  && chown 1000:100 $IPFS_PATH
+  && useradd -s /usr/sbin/nologin -d $IPFS_PATH -u 1000 -G users ipfs \
+  && chown ipfs:users $IPFS_PATH
 
 # Expose the fs-repo as a volume.
 # start_ipfs initializes an fs-repo if none is mounted.


### PR DESCRIPTION
I think this was unintended: useradd -g sets the gecos field to "100".
Probably we meant to use -G to set the ipfs user group.

-G does not take gids, so it needs to be set by name.
The group with gid 100 is "users".

Additionally, since we install the ca-certificates package
(which is already installed), at least we should attempt to update it
to get the latest version of certs.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>