### PR TITLE
gx: update go-ds-badger to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,9 +460,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmNm2bfBCtEzmpxVzaW2FZGzWx2KWHprfd27aWoXptrAGa",
+      "hash": "QmNyEjsu9TxPRC1PqaL3JQRwAsSAGA1mu6ZtuHonvh5rju",
       "name": "go-ds-badger",
-      "version": "1.0.4"
+      "version": "1.1.1"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -16,7 +16,7 @@ import (
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	mount "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/syncmount"
 
-	badgerds "gx/ipfs/QmNm2bfBCtEzmpxVzaW2FZGzWx2KWHprfd27aWoXptrAGa/go-ds-badger"
+	badgerds "gx/ipfs/QmNyEjsu9TxPRC1PqaL3JQRwAsSAGA1mu6ZtuHonvh5rju/go-ds-badger"
 	levelds "gx/ipfs/QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz/go-ds-leveldb"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 )


### PR DESCRIPTION
This once again breaks the on-disk format, uses badger v1.0.0.

@whyrusleeping Should I write an upgrade script for the version in 0.4.12-rc1 too, or is just supporting the one in 0.4.11 fine?