### PR TITLE
core: get cmd outPath remove trailing slash - fixes #3729

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -120,11 +120,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 					return
 				}
 
-				outPath, _, _ := req.Option("output").String()
-				if len(outPath) == 0 {
-					_, outPath = gopath.Split(req.Arguments()[0])
-					outPath = gopath.Clean(outPath)
-				}
+				outPath := getOutPath(req)
 
 				cmplvl, err := getCompressOptions(req)
 				if err != nil {
@@ -186,6 +182,16 @@ func makeProgressBar(out io.Writer, l int64) *pb.ProgressBar {
 		log.Infof("terminal width: %v\n", terminalWidth)
 	}
 	return bar
+}
+
+func getOutPath(req cmds.Request) string {
+	outPath, _, _ := req.Option("output").String()
+	if outPath == "" {
+		trimmed := strings.TrimRight(req.Arguments()[0], "/")
+		_, outPath = gopath.Split(trimmed)
+		outPath = gopath.Clean(outPath)
+	}
+	return outPath
 }
 
 type getWriter struct {

--- a/core/commands/get_test.go
+++ b/core/commands/get_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"testing"
+
+	"gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit"
+	"gx/ipfs/QmUgr8HrEkQqXfBPtj1A2UEg1V7cvhUhDsmL44wFPCJk5k/go-ipfs-cmds"
+)
+
+func TestGetOutputPath(t *testing.T) {
+	cases := []struct {
+		args    []string
+		opts    cmdkit.OptMap
+		outPath string
+	}{
+		{
+			args: []string{"/ipns/multiformats.io/"},
+			opts: map[string]interface{}{
+				"output": "takes-precedence",
+			},
+			outPath: "takes-precedence",
+		},
+		{
+			args: []string{"/ipns/multiformats.io/", "some-other-arg-to-be-ignored"},
+			opts: cmdkit.OptMap{
+				"output": "takes-precedence",
+			},
+			outPath: "takes-precedence",
+		},
+		{
+			args:    []string{"/ipns/multiformats.io/"},
+			outPath: "multiformats.io",
+			opts:    cmdkit.OptMap{},
+		},
+		{
+			args:    []string{"/ipns/multiformats.io/logo.svg/"},
+			outPath: "logo.svg",
+			opts:    cmdkit.OptMap{},
+		},
+		{
+			args:    []string{"/ipns/multiformats.io", "some-other-arg-to-be-ignored"},
+			outPath: "multiformats.io",
+			opts:    cmdkit.OptMap{},
+		},
+	}
+
+	defOpts, err := GetCmd.GetOptions([]string{})
+	if err != nil {
+		t.Fatalf("error getting default command options: %v", err)
+	}
+
+	for _, tc := range cases {
+		req, err := cmds.NewRequest([]string{}, tc.opts, tc.args, nil, GetCmd, defOpts)
+		if err != nil {
+			t.Fatalf("error creating a command request: %v", err)
+		}
+		if outPath := getOutPath(req); outPath != tc.outPath {
+			t.Errorf("expected outPath %s to be %s", outPath, tc.outPath)
+		}
+	}
+}


### PR DESCRIPTION
This change fixes issue https://github.com/ipfs/go-ipfs/issues/3729.

When using path with trailing slashes, ipfs get command had issues with trying to store content into '.' folder (as the file part of the path was empty). Now, it correctly stores the file into desired path,
thanks to the removal of trailing slash by introducing a getOutPath function in get command, which does proper parsing of the output path.

BEFORE:
```
 $  ./ipfs get /ipns/multiformats.io/
Saving file(s) to  .
```

NOW:
```
$ ./ipfs get /ipns/multiformats.io/
Saving file(s) to multiformats.io
```