### PR TITLE
switch from syscall to golang.org/x/sys

### DIFF
--- a/cmd/ipfs/ulimit_freebsd.go
+++ b/cmd/ipfs/ulimit_freebsd.go
@@ -4,7 +4,8 @@ package main
 
 import (
 	"fmt"
-	"syscall"
+
+	unix "gx/ipfs/QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT/sys/unix"
 )
 
 func init() {
@@ -12,8 +13,8 @@ func init() {
 }
 
 func checkAndSetUlimit() error {
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	var rLimit unix.Rlimit
+	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error getting rlimit: %s", err)
 	}
@@ -31,7 +32,7 @@ func checkAndSetUlimit() error {
 		setting = true
 	}
 
-	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	err = unix.Setrlimit(unix.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error setting ulimit: %s", err)
 	}

--- a/cmd/ipfs/ulimit_unix.go
+++ b/cmd/ipfs/ulimit_unix.go
@@ -4,7 +4,8 @@ package main
 
 import (
 	"fmt"
-	"syscall"
+
+	unix "gx/ipfs/QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT/sys/unix"
 )
 
 func init() {
@@ -12,8 +13,8 @@ func init() {
 }
 
 func checkAndSetUlimit() error {
-	var rLimit syscall.Rlimit
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	var rLimit unix.Rlimit
+	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error getting rlimit: %s", err)
 	}
@@ -29,7 +30,7 @@ func checkAndSetUlimit() error {
 		setting = true
 	}
 
-	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	err = unix.Setrlimit(unix.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
 		return fmt.Errorf("error setting ulimit: %s", err)
 	}

--- a/fuse/node/mount_darwin.go
+++ b/fuse/node/mount_darwin.go
@@ -8,10 +8,10 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"syscall"
 
 	core "github.com/ipfs/go-ipfs/core"
 
+	unix "gx/ipfs/QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT/sys/unix"
 	"gx/ipfs/QmYRGECuvQnRX73fcvPnGbYijBcGN2HbKZQ7jh26qmLiHG/semver"
 )
 
@@ -165,7 +165,7 @@ func tryGFV() (string, error) {
 }
 
 func trySysctl() (string, error) {
-	v, err := syscall.Sysctl("osxfuse.version.number")
+	v, err := unix.Sysctl("osxfuse.version.number")
 	if err != nil {
 		log.Debug("mount: sysctl osxfuse.version.number:", "failed")
 		return "", err

--- a/package.json
+++ b/package.json
@@ -497,6 +497,12 @@
       "hash": "QmeS8cCKawUwejVrsBtmC1toTXmwVWZGiRJqzgTURVWeF9",
       "name": "go-ipfs-addr",
       "version": "0.1.1"
+    },
+    {
+      "author": "The Go Authors",
+      "hash": "QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT",
+      "name": "sys",
+      "version": "0.1.0"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
(mostly)

syscall has been frozen and mostly deprecated. We can't *entirely* switch but
this brings us closer.

progress on #3267

(we still need to pull through some go-reuseport changes)