### PR TITLE
Update badgerds to 1.1.2

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -301,6 +301,9 @@ Peers can see their (unspecific) relay address in the output of
 ### In Version
 0.4.11
 
+### State
+Experimental
+
 Plugins allow to add functionality without the need to recompile the daemon.
 
 ### Basic Usage:
@@ -312,3 +315,30 @@ See [Plugin docs](./plugins.md)
 - [ ] Better support for platforms other than Linux
 - [ ] More plugins and plugin types
 - [ ] Feedback on stability
+
+ ## Badger datastore
+
+ ### In Version
+ 0.4.11
+
+ Badger-ds is new datastore implementation based on
+ https://github.com/dgraph-io/badger
+
+ ### Basic Usage
+
+ ```
+ $ ipfs init --profile=badgerds
+ ```
+ or
+ ```
+ [BACKUP ~/.ipfs]
+ $ ipfs config profile apply badgerds
+ $ ipfs-ds-convert convert
+ ```
+
+###
+
+### Road to being a real feature
+
+- [ ] Needs more testing
+- [ ] Make sure there are no unknown major problems

--- a/package.json
+++ b/package.json
@@ -460,9 +460,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmNyEjsu9TxPRC1PqaL3JQRwAsSAGA1mu6ZtuHonvh5rju",
+      "hash": "QmaZp8XCS3su4Mzd8DL95npF9dqkEC9rTxmSiV3YX9qQy4",
       "name": "go-ds-badger",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -16,8 +16,8 @@ import (
 	ds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	mount "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore/syncmount"
 
-	badgerds "gx/ipfs/QmNyEjsu9TxPRC1PqaL3JQRwAsSAGA1mu6ZtuHonvh5rju/go-ds-badger"
 	levelds "gx/ipfs/QmPdvXuXWAR6gtxxqZw42RtSADMwz4ijVmYHGS542b6cMz/go-ds-leveldb"
+	badgerds "gx/ipfs/QmaZp8XCS3su4Mzd8DL95npF9dqkEC9rTxmSiV3YX9qQy4/go-ds-badger"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 )
 


### PR DESCRIPTION
With this when opening unsupported datastore version the error will point to https://github.com/ipfs/badgerds-upgrade