### PR TITLE
Remove reference to "this PR" in code

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -32,7 +32,7 @@ else
   # print deprecation warning
   # go-ipfs used to hardcode "ipfs daemon" in it's entrypoint
   # this workaround supports the new syntax so people start setting daemon explicitly
-  # when overwriting CMD, making this PR safe to merge
+  # when overwriting CMD
   echo "DEPRECATED: arguments have been set but the first argument isn't 'daemon'" >&2
   echo "DEPRECATED: run 'docker run ipfs/go-ipfs daemon $@' instead" >&2
   echo "DEPRECATED: see the following PRs for more information:" >&2


### PR DESCRIPTION
This is perhaps the most insignificant contribution ever...

I was reading through `bin/container_daemon` and saw a reference to "this PR" which no longer made sense now that the code is in master. Thought I would offer the correction while I'm at it.

I apologize if this is too small to be worth the reviewer's time.