### PR TITLE
Fix orphaned gx dependency

### DIFF
--- a/core/commands/mount_windows.go
+++ b/core/commands/mount_windows.go
@@ -3,9 +3,9 @@ package commands
 import (
 	"errors"
 
-	"gx/ipfs/QmadYQbq2fJpaRE3XhpMLH68NNxmWMwfMQy1ntr1cKf7eo/go-ipfs-cmdkit"
-
 	cmds "github.com/ipfs/go-ipfs/commands"
+
+	cmdkit "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit"
 )
 
 var MountCmd = &cmds.Command{


### PR DESCRIPTION
After https://github.com/ipfs/go-ipfs/pull/3856 I had build issues.
```
go install -ldflags="-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=225159bc"  ./cmd/ipfs
core\commands\mount_windows.go:6:2: cannot find package "gx/ipfs/QmadYQbq2fJpaRE3XhpMLH68NNxmWMwfMQy1ntr1cKf7eo/go-ipfs-cmdkit" in any of:
        C:\Go\src\gx\ipfs\QmadYQbq2fJpaRE3XhpMLH68NNxmWMwfMQy1ntr1cKf7eo\go-ipfs-cmdkit (from $GOROOT)
        C:\tmp\src\gx\ipfs\QmadYQbq2fJpaRE3XhpMLH68NNxmWMwfMQy1ntr1cKf7eo\go-ipfs-cmdkit (from $GOPATH)
make: *** [cmd/ipfs/Rules.mk:26: cmd/ipfs-install] Error 1
```
It seems like the hash in that file differs from the one in `package.json` for that dependency. I couldn't resolve the hash in this file (no peers seem to provide it) so I'm assuming it was an older version that was being tested and just wasn't updated. 