### PR TITLE
core/commands/pubsub.go: flush output before iterating over received messages

### DIFF
--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"time"
 
@@ -107,6 +108,10 @@ This command outputs data in the following encodings:
 
 				connectToPubSubPeers(req.Context(), n, cid)
 			}()
+		}
+
+		if f, ok := res.(http.Flusher); ok {
+			f.Flush()
 		}
 
 		for {


### PR DESCRIPTION
Fixes go-ipfs-api hanging on pubsub tests (currently all tests fail over there because of this)