### PR TITLE
Refactoring towards gateway extraction

### DIFF
--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -26,17 +26,17 @@ func (api *CoreAPI) Unixfs() coreiface.UnixfsAPI {
 }
 
 // TODO: also return path here
-func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (coreiface.Node, error) {
+func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (coreiface.Path, coreiface.Node, error) {
 	p, err := api.ResolvePath(ctx, p)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	node, err := api.node.DAG.Get(ctx, p.Cid())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return node, nil
+	return p, node, nil
 }
 
 // TODO: store all of ipfspath.Resolver.ResolvePathComponents() in Path

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -2,6 +2,7 @@ package coreapi
 
 import (
 	"context"
+	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
@@ -24,6 +25,7 @@ func (api *CoreAPI) Unixfs() coreiface.UnixfsAPI {
 	return (*UnixfsAPI)(api)
 }
 
+// TODO: also return path here
 func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (coreiface.Node, error) {
 	p, err := api.ResolvePath(ctx, p)
 	if err != nil {
@@ -52,6 +54,8 @@ func (api *CoreAPI) ResolvePath(ctx context.Context, p coreiface.Path) (coreifac
 	node, err := core.Resolve(ctx, api.node.Namesys, r, p2)
 	if err == core.ErrNoNamesys {
 		return nil, coreiface.ErrOffline
+	} else if _, ok := err.(ipfspath.ErrNoLink); ok {
+		return nil, coreiface.ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -76,7 +80,12 @@ func ParsePath(p string) (coreiface.Path, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &path{path: pp}, nil
+	var root *cid.Cid
+	r, _, err := ipfspath.SplitAbsPath(pp)
+	if err == nil {
+		root = r
+	}
+	return &path{path: pp, root: root}, nil
 }
 
 func ParseCid(c *cid.Cid) coreiface.Path {
@@ -87,7 +96,16 @@ func ResolvedPath(p string, c *cid.Cid, r *cid.Cid) coreiface.Path {
 	return &path{path: ipfspath.FromString(p), cid: c, root: r}
 }
 
-func (p *path) String() string { return p.path.String() }
-func (p *path) Cid() *cid.Cid  { return p.cid }
-func (p *path) Root() *cid.Cid { return p.root }
-func (p *path) Resolved() bool { return p.cid != nil }
+func (p *path) String() string       { return p.path.String() }
+func (p *path) Components() []string { return p.path.Segments() }
+func (p *path) Cid() *cid.Cid        { return p.cid }
+func (p *path) RootCid() *cid.Cid    { return p.root }
+func (p *path) Resolved() bool       { return p.cid != nil }
+
+func JoinComponents(comps []string) string {
+	return strings.Join(comps, "/")
+}
+
+func SplitPath(p string) []string {
+	return strings.Split(p, "/")
+}

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -30,13 +30,13 @@ type Reader interface {
 type CoreAPI interface {
 	Unixfs() UnixfsAPI
 	ResolvePath(context.Context, Path) (Path, error)
-	ResolveNode(context.Context, Path) (Node, error)
+	ResolveNode(context.Context, Path) (Path, Node, error)
 }
 
 type UnixfsAPI interface {
 	Add(context.Context, io.Reader) (Path, error)
-	Cat(context.Context, Path) (Reader, error)
-	Ls(context.Context, Path) ([]*Link, error)
+	Cat(context.Context, Path) (Path, Reader, error)
+	Ls(context.Context, Path) (Path, []*Link, error)
 }
 
 // type ObjectAPI interface {

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -11,8 +11,9 @@ import (
 
 type Path interface {
 	String() string
+	Components() []string
 	Cid() *cid.Cid
-	Root() *cid.Cid
+	RootCid() *cid.Cid
 	Resolved() bool
 }
 
@@ -61,4 +62,5 @@ type UnixfsAPI interface {
 // }
 
 var ErrIsDir = errors.New("object is a directory")
-var ErrOffline = errors.New("can't resolve, ipfs node is offline")
+var ErrOffline = errors.New("can't resolve, ipfs is offline")
+var ErrNotFound = errors.New("can't find requested node")

--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -64,7 +64,7 @@ func TestAdd(t *testing.T) {
 		t.Fatalf("expected path %s, got: %s", hello, p)
 	}
 
-	r, err := api.Cat(ctx, hello)
+	_, r, err := api.Cat(ctx, hello)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,12 +112,16 @@ func TestCatBasic(t *testing.T) {
 	p = "/ipfs/" + p
 
 	if p != hello.String() {
-		t.Fatalf("expected CID %s, got: %s", hello, p)
+		t.Fatalf("expected path %s, got: %s", hello, p)
 	}
 
-	r, err := api.Cat(ctx, hello)
+	rp, r, err := api.Cat(ctx, hello)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if rp.String() != hello.String() {
+		t.Fatalf("exptected path %s, got: %s", hello, rp)
 	}
 
 	buf := make([]byte, len(helloStr))
@@ -142,7 +146,7 @@ func TestCatEmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := api.Cat(ctx, emptyFile)
+	_, r, err := api.Cat(ctx, emptyFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +178,7 @@ func TestCatDir(t *testing.T) {
 		t.Fatalf("expected path %s, got: %s", emptyDir, p)
 	}
 
-	_, err = api.Cat(ctx, emptyDir)
+	_, _, err = api.Cat(ctx, emptyDir)
 	if err != coreiface.ErrIsDir {
 		t.Fatalf("expected ErrIsDir, got: %s", err)
 	}
@@ -192,7 +196,7 @@ func TestCatNonUnixfs(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = api.Cat(ctx, coreapi.ParseCid(c))
+	_, _, err = api.Cat(ctx, coreapi.ParseCid(c))
 	if !strings.Contains(err.Error(), "proto: required field") {
 		t.Fatalf("expected protobuf error, got: %s", err)
 	}
@@ -205,7 +209,7 @@ func TestCatOffline(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = api.Cat(ctx, coreapi.ResolvedPath("/ipns/Qmfoobar", nil, nil))
+	_, _, err = api.Cat(ctx, coreapi.ResolvedPath("/ipns/Qmfoobar", nil, nil))
 	if err != coreiface.ErrOffline {
 		t.Fatalf("expected ErrOffline, got: %s", err)
 	}
@@ -229,9 +233,13 @@ func TestLs(t *testing.T) {
 	}
 	p := coreapi.ResolvedPath("/ipfs/"+parts[0], nil, nil)
 
-	links, err := api.Ls(ctx, p)
+	rp, links, err := api.Ls(ctx, p)
 	if err != nil {
 		t.Error(err)
+	}
+
+	if rp.String() != p.String() {
+		t.Fatalf("exptected path %s, got: %s", p, rp)
 	}
 
 	if len(links) != 1 {
@@ -260,7 +268,7 @@ func TestLsEmptyDir(t *testing.T) {
 		t.Error(err)
 	}
 
-	links, err := api.Ls(ctx, emptyDir)
+	_, links, err := api.Ls(ctx, emptyDir)
 	if err != nil {
 		t.Error(err)
 	}
@@ -288,7 +296,7 @@ func TestLsNonUnixfs(t *testing.T) {
 		t.Error(err)
 	}
 
-	links, err := api.Ls(ctx, coreapi.ParseCid(c))
+	_, links, err := api.Ls(ctx, coreapi.ParseCid(c))
 	if err != nil {
 		t.Error(err)
 	}

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -182,7 +182,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		return
 	}
 
-	dr, err := i.api.Unixfs().Cat(ctx, resolvedPath)
+	_, dr, err := i.api.Unixfs().Cat(ctx, resolvedPath)
 	dir := false
 	switch err {
 	case nil:
@@ -271,7 +271,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		return
 	}
 
-	nd, err := i.api.ResolveNode(ctx, resolvedPath)
+	_, nd, err := i.api.ResolveNode(ctx, resolvedPath)
 	if err != nil {
 		internalWebError(w, err)
 		return
@@ -297,7 +297,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 			return
 		}
 
-		dr, err := i.api.Unixfs().Cat(ctx, coreapi.ParseCid(ixnd.Cid()))
+		_, dr, err := i.api.Unixfs().Cat(ctx, coreapi.ParseCid(ixnd.Cid()))
 		if err != nil {
 			internalWebError(w, err)
 			return
@@ -449,7 +449,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var newcid *cid.Cid
-	rnode, err := i.api.ResolveNode(ctx, rootPath)
+	_, rnode, err := i.api.ResolveNode(ctx, rootPath)
 	if err == coreiface.ErrNotFound {
 		// ev.Node < node where resolve failed
 		// ev.Name < new link

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -19,7 +19,6 @@ import (
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
-	path "github.com/ipfs/go-ipfs/path"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -332,7 +331,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 	var backLink string = prefix + urlPath
 
 	// don't go further up than /ipfs/$hash/
-	pathSplit := path.SplitList(backLink)
+	pathSplit := coreapi.SplitPath(backLink)
 	switch {
 	// keep backlink
 	case len(pathSplit) == 3: // url: /ipfs/$hash
@@ -355,7 +354,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		if len(pathSplit) > 5 {
 			// also strip the trailing segment, because it's a backlink
 			backLinkParts := pathSplit[3 : len(pathSplit)-2]
-			backLink += path.Join(backLinkParts) + "/"
+			backLink += coreapi.JoinComponents(backLinkParts) + "/"
 		}
 	}
 
@@ -417,13 +416,13 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(i.node.Context())
 	defer cancel()
 
-	rootPath, err := path.ParsePath(r.URL.Path)
+	rootPath, err := coreapi.ParsePath(r.URL.Path)
 	if err != nil {
 		webError(w, "putHandler: IPFS path not valid", err, http.StatusBadRequest)
 		return
 	}
 
-	rsegs := rootPath.Segments()
+	rsegs := rootPath.Components()
 	if rsegs[0] == ipnsPathPrefix {
 		webError(w, "putHandler: updating named entries not supported", errors.New("WritableGateway: ipns put not supported"), http.StatusBadRequest)
 		return
@@ -431,6 +430,9 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	var newnode node.Node
 	if rsegs[len(rsegs)-1] == "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn" {
+		// TODO(lgierth): this seems to mean that PUT /ipfs/QmUNLL/foo/bar
+		//                results in bar being an empty directory,
+		//                no matter what
 		newnode = ft.EmptyDirNode()
 	} else {
 		putNode, err := i.newDagFromReader(r.Body)
@@ -443,13 +445,12 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 
 	var newPath string
 	if len(rsegs) > 1 {
-		newPath = path.Join(rsegs[2:])
+		newPath = coreapi.JoinComponents(rsegs[2:])
 	}
 
 	var newcid *cid.Cid
-	rnode, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, rootPath)
-	switch ev := err.(type) {
-	case path.ErrNoLink:
+	rnode, err := i.api.ResolveNode(ctx, rootPath)
+	if err == coreiface.ErrNotFound {
 		// ev.Node < node where resolve failed
 		// ev.Name < new link
 		// but we need to patch from the root
@@ -485,8 +486,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		newcid = nnode.Cid()
-
-	case nil:
+	} else if err == nil {
 		pbnd, ok := rnode.(*dag.ProtoNode)
 		if !ok {
 			webError(w, "Cannot read non protobuf nodes through gateway", dag.ErrNotProtobuf, http.StatusBadRequest)
@@ -509,9 +509,9 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 			webError(w, fmt.Sprintf("putHandler: Could not add newnode(%q) to root(%q)", nnk.String(), rk.String()), err, http.StatusInternalServerError)
 			return
 		}
-	default:
-		log.Warningf("putHandler: unhandled resolve error %T", ev)
-		webError(w, "could not resolve root DAG", ev, http.StatusInternalServerError)
+	} else {
+		log.Warningf("putHandler: unhandled resolve error %T", err)
+		webError(w, "could not resolve root DAG", err, http.StatusInternalServerError)
 		return
 	}
 
@@ -525,21 +525,16 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(i.node.Context())
 	defer cancel()
 
-	p, err := path.ParsePath(urlPath)
+	p, err := coreapi.ParsePath(urlPath)
 	if err != nil {
 		webError(w, "failed to parse path", err, http.StatusBadRequest)
 		return
 	}
-
-	c, components, err := path.SplitAbsPath(p)
-	if err != nil {
-		webError(w, "Could not split path", err, http.StatusInternalServerError)
-		return
-	}
+	components := p.Components()[2:]
 
 	tctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
-	rootnd, err := i.node.Resolver.DAG.Get(tctx, c)
+	rootnd, err := i.node.Resolver.DAG.Get(tctx, p.RootCid())
 	if err != nil {
 		webError(w, "Could not resolve root object", err, http.StatusBadRequest)
 		return
@@ -589,12 +584,13 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Redirect to new path
-	ncid := newnode.Cid()
+	ncid := newnode.Cid().String()
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
-	w.Header().Set("IPFS-Hash", ncid.String())
-	http.Redirect(w, r, gopath.Join(ipfsPathPrefix+ncid.String(), path.Join(components[:len(components)-1])), http.StatusCreated)
+	w.Header().Set("IPFS-Hash", ncid)
+
+	npath := gopath.Join(ipfsPathPrefix+ncid, gopath.Join(components...))
+	http.Redirect(w, r, npath, http.StatusCreated)
 }
 
 func (i *gatewayHandler) addUserHeaders(w http.ResponseWriter) {
@@ -604,7 +600,7 @@ func (i *gatewayHandler) addUserHeaders(w http.ResponseWriter) {
 }
 
 func webError(w http.ResponseWriter, message string, err error, defaultCode int) {
-	if _, ok := err.(path.ErrNoLink); ok {
+	if err == coreiface.ErrNotFound {
 		webErrorWithCode(w, message, err, http.StatusNotFound)
 	} else if err == routing.ErrNotFound {
 		webErrorWithCode(w, message, err, http.StatusNotFound)


### PR DESCRIPTION
This replaces the gateway's usage of the `path` package with the Core API. The usages of `importer`, `merkledag`, and `unixfs` packages will land in another PR in the next couple of days.

Note that gateway_handler.go is a huuuuge mess. For now the priority is to extract it into its own package (ipfs/go-ipfs-gateway) and then refactor and cleanup there.