### PR TITLE
Fix orphaned gx dependency: 2

### DIFF
--- a/core/commands/mount_windows.go
+++ b/core/commands/mount_windows.go
@@ -5,7 +5,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 
-	cmdkit "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit"
+	cmdkit "gx/ipfs/QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ/go-ipfs-cmdkit"
 )
 
 var MountCmd = &cmds.Command{


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/pull/4403 caused the same issue as in https://github.com/ipfs/go-ipfs/pull/4400
gx dependency hash was not updated in `mount_windows.go` and causes builds to break on Windows. 🦃 

76e1da02a89bdea225dbe2b33cb52993bf486c27:
```
go install -ldflags="-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=76e1da02a"  ./cmd/ipfs
# github.com/ipfs/go-ipfs/commands
commands\request.go:124:35: option.DefaultVal undefined (type cmdkit.Option has no field or method DefaultVal)
make: *** [cmd/ipfs/Rules.mk:26: cmd/ipfs-install] Error 2
```

bcd25416d9a981d89d2ffa535da3604a6c4834e8:
```
go install -ldflags="-X "github.com/ipfs/go-ipfs/repo/config".CurrentCommit=bcd25416d"  ./cmd/ipfs
# github.com/ipfs/go-ipfs/core/commands
core\commands\mount_windows.go:12:10: cannot use "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit".HelpText literal (type "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit".HelpText) as type "gx/ipfs/QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ/go-ipfs-cmdkit".HelpText in field value
core\commands\mount_windows.go:18:26: cannot use "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit".ErrNormal (type "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit".ErrorType) as type "gx/ipfs/QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ/go-ipfs-cmdkit".ErrorType in argument to res.SetError
make: *** [cmd/ipfs/Rules.mk:26: cmd/ipfs-install] Error 2
```