### PR TITLE
fix builds on windows

### DIFF
--- a/core/commands/mount_windows.go
+++ b/core/commands/mount_windows.go
@@ -5,7 +5,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 
-	cmdkit "gx/ipfs/QmSNbH2A1evCCbJSDC6u3RV3GGDhgu6pRGbXHvrN89tMKf/go-ipfs-cmdkit"
+	cmdkit "gx/ipfs/QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ/go-ipfs-cmdkit"
 )
 
 var MountCmd = &cmds.Command{


### PR DESCRIPTION
cc @keks @Stebalien somehow we missed updating this hash. I'm pretty sure that gx doesnt skip any files because due to build constraints.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>