### PR TITLE
Refine gateway and namesys logging

### DIFF
--- a/namesys/base.go
+++ b/namesys/base.go
@@ -18,10 +18,9 @@ func resolve(ctx context.Context, r resolver, name string, depth int, prefixes .
 	for {
 		p, err := r.resolveOnce(ctx, name)
 		if err != nil {
-			log.Warningf("Could not resolve %s", name)
 			return "", err
 		}
-		log.Debugf("Resolved %s to %s", name, p.String())
+		log.Debugf("resolved %s to %s", name, p.String())
 
 		if strings.HasPrefix(p.String(), "/ipfs/") {
 			// we've bottomed out with an IPFS path

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -55,7 +55,7 @@ func (r *DNSResolver) resolveOnce(ctx context.Context, name string) (path.Path, 
 	if !isd.IsDomain(domain) {
 		return "", errors.New("not a valid domain name")
 	}
-	log.Infof("DNSResolver resolving %s", domain)
+	log.Debugf("DNSResolver resolving %s", domain)
 
 	rootChan := make(chan lookupRes, 1)
 	go workDomain(r, domain, rootChan)

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -91,7 +91,7 @@ func (ns *mpns) resolveOnce(ctx context.Context, name string) (path.Path, error)
 	}
 	segments := strings.SplitN(name, "/", 4)
 	if len(segments) < 3 || segments[0] != "" {
-		log.Warningf("Invalid name syntax for %s", name)
+		log.Debugf("invalid name syntax for %s", name)
 		return "", ErrResolveFailed
 	}
 
@@ -153,7 +153,7 @@ func (ns *mpns) resolveOnce(ctx context.Context, name string) (path.Path, error)
 		return "", ErrResolveFailed
 	}
 
-	log.Warningf("No resolver found for %s", name)
+	log.Debugf("no resolver found for %s", name)
 	return "", ErrResolveFailed
 }
 


### PR DESCRIPTION
The signal/noise ratio on the ipfs.io gateways is incredibly bad nowadays - this is a step to improving that.

All the logs here are based on user input, and they're neither WARN nor INFO worthy, so I'm degrading them all to DEBUG. Also removed a few useless log lines.

I'm already testing this on scrappy, where the logs are now actually readable.