### PR TITLE
AddWithContext wraps custom context

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -307,7 +307,7 @@ func Add(n *core.IpfsNode, r io.Reader) (string, error) {
 func AddWithContext(ctx context.Context, n *core.IpfsNode, r io.Reader) (string, error) {
 	defer n.Blockstore.PinLock().Unlock()
 
-	fileAdder, err := NewAdder(n.Context(), n.Pinning, n.Blockstore, n.DAG)
+	fileAdder, err := NewAdder(ctx, n.Pinning, n.Blockstore, n.DAG)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
AddWithContext should use the custom context when calling
NewAdder

License: MIT
Signed-off-by: ForrestWeston <forrest@protocol.ai>