### PR TITLE
Fix various IPNS issues

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -208,7 +208,7 @@ The base64 encoded protobuf describing (and containing) the nodes private key.
 
 - `RepublishPeriod`
 A time duration specifying how frequently to republish ipns records to ensure
-they stay fresh on the network. If unset, we default to 12 hours.
+they stay fresh on the network. If unset, we default to 4 hours.
 
 - `RecordLifetime`
 A time duration specifying the value to set on ipns records for their validity

--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -26,10 +26,16 @@ var errNoEntry = errors.New("no previous entry")
 
 var log = logging.Logger("ipns-repub")
 
+// DefaultRebroadcastInterval is the default interval at which we rebroadcast IPNS records
 var DefaultRebroadcastInterval = time.Hour * 4
+
+// InitialRebroadcastDelay is the delay before first broadcasting IPNS records on start
 var InitialRebroadcastDelay = time.Minute * 1
+
+// FailureRetryInterval is the interval at which we retry IPNS records broadcasts (when they fail)
 var FailureRetryInterval = time.Minute * 5
 
+// DefaultRecordLifetime is the default lifetime for IPNS records
 const DefaultRecordLifetime = time.Hour * 24
 
 type Republisher struct {

--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -65,6 +65,9 @@ func NewRepublisher(r routing.ValueStore, ds ds.Datastore, self ic.PrivKey, ks k
 func (rp *Republisher) Run(proc goprocess.Process) {
 	timer := time.NewTimer(InitialRebroadcastDelay)
 	defer timer.Stop()
+	if rp.Interval < InitialRebroadcastDelay {
+		timer.Reset(rp.Interval)
+	}
 
 	for {
 		select {
@@ -73,7 +76,9 @@ func (rp *Republisher) Run(proc goprocess.Process) {
 			err := rp.republishEntries(proc)
 			if err != nil {
 				log.Error("Republisher failed to republish: ", err)
-				timer.Reset(FailureRetryInterval)
+				if FailureRetryInterval < rp.Interval {
+					timer.Reset(FailureRetryInterval)
+				}
 			}
 		case <-proc.Closing():
 			return


### PR DESCRIPTION
Found while looking into: https://discuss.ipfs.io/t/ipfs-name-failing-to-resolve/1524

1. Fix the republish docs. We republish every 4 hours by default.
2. Republish after 1min on start. The 1min delay gives us time to start up everything else but ensures that the IPNS record becomes resolvable quickly if we've been offline for a while.
3. Republish every 5min when republishing fails. I doubt this will cost us *that* much bandwidth/CPU usage and will ensure that IPNS will continue working properly even if the node is intermittently offline.