### PR TITLE
don't warn when trying to send wantlist to disconnected peers

### DIFF
--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -326,7 +326,7 @@ func (pm *WantManager) Run() {
 				for _, t := range ws.targets {
 					p, ok := pm.peers[t]
 					if !ok {
-						log.Warning("tried sending wantlist change to non-partner peer")
+						// No longer connected.
 						continue
 					}
 					p.addMessage(ws.entries, ws.from)


### PR DESCRIPTION
fixes #4439

@whyrusleeping while I believe this is the correct fix for this bug, it may indicate that we're not giving enough weight to bitswap peers in the connection manager.