### PR TITLE
make repo size test pass deterministically

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -363,8 +363,29 @@ generic_stat() {
     FreeBSD | Darwin | DragonFly)
       _STAT="stat -f %Sp"
       ;;
+    *)
+        echo "unsupported OS" >&2
+        exit 1
+        ;;
   esac
   $_STAT "$1" || echo "failed" # Avoid returning nothing.
+}
+
+# output a file's permission in human readable format
+file_size() {
+    case $(uname -s) in
+        Linux)
+            _STAT="stat --format=%s"
+            ;;
+        FreeBSD | Darwin | DragonFly)
+            _STAT="stat -f%z"
+            ;;
+        *)
+            echo "unsupported OS" >&2
+            exit 1
+            ;;
+    esac
+    $_STAT "$1"
 }
 
 test_check_peerid() {

--- a/test/sharness/t0088-repo-stat-symlink.sh
+++ b/test/sharness/t0088-repo-stat-symlink.sh
@@ -15,14 +15,11 @@ test_expect_success "create symbolic link for IPFS_PATH" '
 
 test_init_ipfs
 
-# compare RepoSize when getting it directly vs via symbolic link
+# ensure that the RepoSize is reasonable when checked via a symlink.
 test_expect_success "'ipfs repo stat' RepoSize is correct with sym link" '
-  export IPFS_PATH="sym_link_target" &&
-  reposize_direct=$(ipfs repo stat | grep RepoSize | awk '\''{ print $2 }'\'') &&
-  export IPFS_PATH=".ipfs" &&
   reposize_symlink=$(ipfs repo stat | grep RepoSize | awk '\''{ print $2 }'\'') &&
-  echo "reposize_symlink: $reposize_symlink;  reposize_direct: $reposize_direct" &&
-  test $reposize_symlink -ge $reposize_direct
+  symlink_size=$(file_size .ipfs) &&
+  test "${reposize_symlink}" -gt "${symlink_size}"
 '
 
 test_done


### PR DESCRIPTION
This test assumed that the repo could only grow in size when it can also shrink. This commit makes the test actually test for the specific bug it was meant to detect.

fixes #4408