### PR TITLE
Implement "repo rm-root" command to unlike the files API root.

### DIFF
--- a/cmd/ipfs/ipfs.go
+++ b/cmd/ipfs/ipfs.go
@@ -97,12 +97,13 @@ func (d *cmdDetails) usesRepo() bool          { return !d.doesNotUseRepo }
 // properties so that other code can make decisions about whether to invoke a
 // command or return an error to the user.
 var cmdDetailsMap = map[string]cmdDetails{
-	"init":        {doesNotUseConfigAsInput: true, cannotRunOnDaemon: true, doesNotUseRepo: true},
-	"daemon":      {doesNotUseConfigAsInput: true, cannotRunOnDaemon: true},
-	"commands":    {doesNotUseRepo: true},
-	"version":     {doesNotUseConfigAsInput: true, doesNotUseRepo: true}, // must be permitted to run before init
-	"log":         {cannotRunOnClient: true},
-	"diag/cmds":   {cannotRunOnClient: true},
-	"repo/fsck":   {cannotRunOnDaemon: true},
-	"config/edit": {cannotRunOnDaemon: true, doesNotUseRepo: true},
+	"init":         {doesNotUseConfigAsInput: true, cannotRunOnDaemon: true, doesNotUseRepo: true},
+	"daemon":       {doesNotUseConfigAsInput: true, cannotRunOnDaemon: true},
+	"commands":     {doesNotUseRepo: true},
+	"version":      {doesNotUseConfigAsInput: true, doesNotUseRepo: true}, // must be permitted to run before init
+	"log":          {cannotRunOnClient: true},
+	"diag/cmds":    {cannotRunOnClient: true},
+	"repo/fsck":    {cannotRunOnDaemon: true},
+	"repo/rm-root": {cannotRunOnDaemon: true},
+	"config/edit":  {cannotRunOnDaemon: true, doesNotUseRepo: true},
 }

--- a/core/core.go
+++ b/core/core.go
@@ -716,8 +716,10 @@ func (n *IpfsNode) loadBootstrapPeers() ([]pstore.PeerInfo, error) {
 	return toPeerInfos(parsed), nil
 }
 
+func FilesRootKey() ds.Key { return ds.NewKey("/local/filesroot") }
+
 func (n *IpfsNode) loadFilesRoot() error {
-	dsk := ds.NewKey("/local/filesroot")
+	dsk := FilesRootKey()
 	pf := func(ctx context.Context, c *cid.Cid) error {
 		return n.Repo.Datastore().Put(dsk, c.Bytes())
 	}


### PR DESCRIPTION
Closes #3934.

Note I used the new API because the old API seams to initialize an `IpfsNode` even if `cmds.Context.ConstructNode()` is not called.  (Setting `doesNotUseRepo` and/or `doesNotUseConfigAsInput` did not seam to prevent the node initialization.)
