### PR TITLE
Pinning fixes

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -80,11 +80,6 @@ func addAssetList(nd *core.IpfsNode, l []string) (*cid.Cid, error) {
 		return nil, err
 	}
 
-	dcid, err := nd.DAG.Add(dir)
-	if err != nil {
-		return nil, fmt.Errorf("assets: DAG.Add(dir) failed: %s", err)
-	}
-
 	if err := nd.Pinning.Pin(nd.Context(), dir, true); err != nil {
 		return nil, fmt.Errorf("assets: Pinning on init-docu failed: %s", err)
 	}
@@ -93,5 +88,5 @@ func addAssetList(nd *core.IpfsNode, l []string) (*cid.Cid, error) {
 		return nil, fmt.Errorf("assets: Pinning flush failed: %s", err)
 	}
 
-	return dcid, nil
+	return dir.Cid(), nil
 }

--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -260,5 +260,5 @@ func initializeIpnsKeyspace(repoRoot string) error {
 		return err
 	}
 
-	return namesys.InitializeKeyspace(ctx, nd.DAG, nd.Namesys, nd.Pinning, nd.PrivateKey)
+	return namesys.InitializeKeyspace(ctx, nd.Namesys, nd.Pinning, nd.PrivateKey)
 }

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -50,8 +50,6 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 	for _, dagnode := range dagnodes {
 		c := dagnode.Cid()
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
 		err := n.Pinning.Pin(ctx, dagnode, recursive)
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
@@ -86,8 +84,6 @@ func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool
 			return nil, err
 		}
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
 		err = n.Pinning.Unpin(ctx, k, recursive)
 		if err != nil {
 			return nil, err

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -58,14 +58,14 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 }
 
 func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
-	var unpinned []*cid.Cid
+	unpinned := make([]*cid.Cid, len(paths))
 
 	r := &path.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}
 
-	for _, p := range paths {
+	for i, p := range paths {
 		p, err := path.ParsePath(p)
 		if err != nil {
 			return nil, err
@@ -80,7 +80,7 @@ func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool
 		if err != nil {
 			return nil, err
 		}
-		unpinned = append(unpinned, k)
+		unpinned[i] = k
 	}
 
 	err := n.Pinning.Flush()

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -22,18 +22,17 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ/go-cid"
-	node "gx/ipfs/QmPN7cwmpcc4DWXb4KTB9dNAJgjuPY69h3npsMfhRrQL9c/go-ipld-format"
 )
 
 func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
-	dagnodes := make([]node.Node, 0)
+	out := make([]*cid.Cid, len(paths))
 
 	r := &path.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}
 
-	for _, fpath := range paths {
+	for i, fpath := range paths {
 		p, err := path.ParsePath(fpath)
 		if err != nil {
 			return nil, err
@@ -43,18 +42,11 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}
-		dagnodes = append(dagnodes, dagnode)
-	}
-
-	var out []*cid.Cid
-	for _, dagnode := range dagnodes {
-		c := dagnode.Cid()
-
-		err := n.Pinning.Pin(ctx, dagnode, recursive)
+		err = n.Pinning.Pin(ctx, dagnode, recursive)
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}
-		out = append(out, c)
+		out[i] = dagnode.Cid()
 	}
 
 	err := n.Pinning.Flush()

--- a/fuse/ipns/common.go
+++ b/fuse/ipns/common.go
@@ -13,16 +13,12 @@ import (
 // InitializeKeyspace sets the ipns record for the given key to
 // point to an empty directory.
 func InitializeKeyspace(n *core.IpfsNode, key ci.PrivKey) error {
-	emptyDir := ft.EmptyDirNode()
-	nodek, err := n.DAG.Add(emptyDir)
-	if err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithCancel(n.Context())
 	defer cancel()
 
-	err = n.Pinning.Pin(ctx, emptyDir, false)
+	emptyDir := ft.EmptyDirNode()
+
+	err := n.Pinning.Pin(ctx, emptyDir, false)
 	if err != nil {
 		return err
 	}
@@ -34,5 +30,5 @@ func InitializeKeyspace(n *core.IpfsNode, key ci.PrivKey) error {
 
 	pub := nsys.NewRoutingPublisher(n.Routing, n.Repo.Datastore())
 
-	return pub.Publish(ctx, key, path.FromCid(nodek))
+	return pub.Publish(ctx, key, path.FromCid(emptyDir.Cid()))
 }

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	dag "github.com/ipfs/go-ipfs/merkledag"
 	pb "github.com/ipfs/go-ipfs/namesys/pb"
 	path "github.com/ipfs/go-ipfs/path"
 	pin "github.com/ipfs/go-ipfs/pin"
@@ -321,16 +320,12 @@ func ValidateIpnsRecord(k string, val []byte) error {
 // InitializeKeyspace sets the ipns record for the given key to
 // point to an empty directory.
 // TODO: this doesnt feel like it belongs here
-func InitializeKeyspace(ctx context.Context, ds dag.DAGService, pub Publisher, pins pin.Pinner, key ci.PrivKey) error {
+func InitializeKeyspace(ctx context.Context, pub Publisher, pins pin.Pinner, key ci.PrivKey) error {
 	emptyDir := ft.EmptyDirNode()
-	nodek, err := ds.Add(emptyDir)
-	if err != nil {
-		return err
-	}
 
 	// pin recursively because this might already be pinned
 	// and doing a direct pin would throw an error in that case
-	err = pins.Pin(ctx, emptyDir, true)
+	err := pins.Pin(ctx, emptyDir, true)
 	if err != nil {
 		return err
 	}
@@ -340,7 +335,7 @@ func InitializeKeyspace(ctx context.Context, ds dag.DAGService, pub Publisher, p
 		return err
 	}
 
-	return pub.Publish(ctx, key, path.FromCid(nodek))
+	return pub.Publish(ctx, key, path.FromCid(emptyDir.Cid()))
 }
 
 func IpnsKeysForID(id peer.ID) (name, ipns string) {

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -172,7 +172,10 @@ func NewPinner(dstore ds.Datastore, serv, internal mdag.DAGService) Pinner {
 func (p *pinner) Pin(ctx context.Context, node node.Node, recurse bool) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	c := node.Cid()
+	c, err := p.dserv.Add(node)
+	if err != nil {
+		return err
+	}
 
 	if recurse {
 		if p.recursePin.Has(c) {


### PR DESCRIPTION
* Better allocation patterns
* Fix a very small race condition between GC and pinning.
* Fix #4122 by resolving nodes as needed instead of up-front.
* Avoid creating many unnecessary contexts (also related to #4122).