### PR TITLE
Fix error handling in commands add and get

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -453,19 +453,8 @@ You can now check what blocks have been created by:
 
 				for {
 					v, err := res.Next()
-					if err != nil {
-						// replace error by actual error - will be looked at by next if-statement
-						if err == cmds.ErrRcvdError {
-							err = res.Error()
-						}
-
-						if e, ok := err.(*cmdkit.Error); ok {
-							re.Emit(e)
-						} else if err != io.EOF {
-							re.SetError(err, cmdkit.ErrNormal)
-						}
-
-						return
+					if !cmds.HandleError(err, res, re) {
+						break
 					}
 
 					select {

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -109,8 +109,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 				defer re.Close()
 
 				v, err := res.Next()
-				if err != nil {
-					log.Error(e.New(err))
+				if !cmds.HandleError(err, res, re) {
 					return
 				}
 


### PR DESCRIPTION
Closes #4452.

When `SetError` is called in a command, `res.Next()` returns the error "received command error" makes the error set by the command available by calling `res.Error()`. To make handling these errors easier, the functions `cmds.HandleError` was added. Unfortunately we forgot to use it in the get command.

The add command did the right thing, but manually instead of calling HandleError. I made it call that function instead.