### PR TITLE
core: get cmd outPath removes trailing slash from args - fixes #3729

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -62,10 +62,6 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		return err
 	},
 	Run: func(req cmds.Request, res cmds.ResponseEmitter) {
-		if len(req.Arguments()) == 0 {
-			res.SetError(errors.New("not enough arugments provided"), cmdkit.ErrClient)
-			return
-		}
 		cmplvl, err := getCompressOptions(req)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -191,7 +191,8 @@ func makeProgressBar(out io.Writer, l int64) *pb.ProgressBar {
 func getOutPath(req cmds.Request) string {
 	outPath, _, _ := req.Option("output").String()
 	if outPath == "" {
-		_, outPath = gopath.Split(req.Arguments()[0])
+		trimmed := strings.TrimRight(req.Arguments()[0], "/")
+		_, outPath = gopath.Split(trimmed)
 		outPath = gopath.Clean(outPath)
 	}
 	return outPath

--- a/core/commands/get_test.go
+++ b/core/commands/get_test.go
@@ -1,13 +1,14 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"gx/ipfs/QmUyfy4QSr3NXym4etEiRyxBLqqAeKHJuRdi8AACxg63fZ/go-ipfs-cmdkit"
 	"gx/ipfs/QmamUWYjFeYYzFDFPTvnmGkozJigsoDWUA4zoifTRFTnwK/go-ipfs-cmds"
 )
 
-func TestGetOutputPath(t *testing.T) {
+func TestGetCmdOutputPath(t *testing.T) {
 	cases := []struct {
 		args    []string
 		opts    cmdkit.OptMap
@@ -21,7 +22,7 @@ func TestGetOutputPath(t *testing.T) {
 			outPath: "takes-precedence",
 		},
 		{
-			args: []string{"/ipns/multiformats.io/", "some-other-arg-to-be-ignored"},
+			args: []string{"/ipns/multiformats.io/"},
 			opts: cmdkit.OptMap{
 				"output": "takes-precedence",
 			},
@@ -38,7 +39,7 @@ func TestGetOutputPath(t *testing.T) {
 			opts:    cmdkit.OptMap{},
 		},
 		{
-			args:    []string{"/ipns/multiformats.io", "some-other-arg-to-be-ignored"},
+			args:    []string{"/ipns/multiformats.io"},
 			outPath: "multiformats.io",
 			opts:    cmdkit.OptMap{},
 		},
@@ -54,6 +55,15 @@ func TestGetOutputPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error creating a command request: %v", err)
 		}
+
+		err = GetCmd.PreRun(req)
+		if err != nil {
+			t.Fatalf("get command PreRun failed with error: %v", err)
+		}
+		if pathArg := req.Arguments()[0]; strings.HasSuffix(pathArg, "/") {
+			t.Errorf("trailing suffix should have been removed, got %s", pathArg)
+		}
+
 		if outPath := getOutPath(req); outPath != tc.outPath {
 			t.Errorf("expected outPath %s to be %s", outPath, tc.outPath)
 		}


### PR DESCRIPTION
Commit a09d97465270ef441791b65bca98d37c25eb0564 was a poor fix, which only
modified the path printed to the StdOut. The arguments of command are
passed to the request's reader, which is turned into a tar Extractor.
The headers of that the tar Extractor were incorrectly populating the
write path, missing the root directory, causing files nested in root
folder to be written into the root output path.

fix visible at: https://asciinema.org/a/mDili4YFnOacgt3dbjHuXTzcT

We are making the assumption, that get Command will have always only 1 argument and it's safe to remove the trailing fix of all the paths. Happy to hear feedback on this from maintainers.
