### PR TITLE
Always set IPFS_PATH in test-lib.sh

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -40,6 +40,10 @@ SHARNESS_LIB="lib/sharness/sharness.sh"
 
 # Please put go-ipfs specific shell functions below
 
+# Make sure the ipfs path is set, also set in test_init_ipfs but that
+# is not always used.
+export IPFS_PATH="$(pwd)/.ipfs"
+
 TEST_OS="$(uname -s | tr '[a-z]' '[A-Z]')"
 
 # grab + output options


### PR DESCRIPTION
Before it was only set when "test_init_ipfs" is called but that is not always used, for example in t0025-datastores.sh.

Fixes #4467.
