### PR TITLE
Demote bitswap error to an info

### DIFF
--- a/exchange/bitswap/wantmanager.go
+++ b/exchange/bitswap/wantmanager.go
@@ -234,7 +234,7 @@ func (mq *msgQueue) doWork(ctx context.Context) {
 
 		err = mq.openSender(ctx)
 		if err != nil {
-			log.Errorf("couldnt open sender again after SendMsg(%s) failed: %s", mq.p, err)
+			log.Infof("couldnt open sender again after SendMsg(%s) failed: %s", mq.p, err)
 			// TODO(why): what do we do now?
 			// I think the *right* answer is to probably put the message we're
 			// trying to send back, and then return to waiting for new work or


### PR DESCRIPTION
Not being able to dial a peer we used to be connected to is interesting but definitely not an error.

fixes #4472