### PR TITLE
Fix sharness docker

### DIFF
--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -44,8 +44,7 @@ RUN set -x \
   && cd /tmp \
   && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
   && chmod +x tini \
-  # Install them
-  && mv su-exec/su-exec tini /sbin/
+  && mv su-exec/su-exec tini /sbin/ # Install them
 
 # Ports for Swarm TCP, Swarm uTP, API, Gateway, Swarm Websockets
 EXPOSE 4001

--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -1,5 +1,9 @@
 # Generic test functions for go-ipfs
 
+ansi_strip() {
+    sed 's/\x1b\[[0-9;]*m//g'
+}
+
 # Quote arguments for sh eval
 shellquote() {
 	_space=''
@@ -48,7 +52,7 @@ test_path_cmp() {
 
 # This takes a Dockerfile, and a build context directory
 docker_build() {
-    docker build --rm -f "$1" "$2"
+    docker build --rm -f "$1" "$2" | ansi_strip
 }
 
 # This takes an image as argument and writes a docker ID on stdout

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -43,6 +43,8 @@ SHARNESS_LIB="lib/sharness/sharness.sh"
 # Make sure the ipfs path is set, also set in test_init_ipfs but that
 # is not always used.
 export IPFS_PATH="$(pwd)/.ipfs"
+# Ask programs to please not print ANSI codes
+export TERM=dumb
 
 TEST_OS="$(uname -s | tr '[a-z]' '[A-Z]')"
 


### PR DESCRIPTION
1. Set TERM to dumb.
2. Strip any ANSI codes that make it into the docker output anyways.
3. Don't use empty continuation lines.


(probably overkill but...)