### PR TITLE
buffer bitswap messages

### DIFF
--- a/exchange/bitswap/message/message_test.go
+++ b/exchange/bitswap/message/message_test.go
@@ -109,7 +109,7 @@ func TestToNetFromNetPreservesWantList(t *testing.T) {
 	original.AddEntry(mkFakeCid("F"), 1)
 
 	buf := new(bytes.Buffer)
-	if err := original.ToNetV1(buf); err != nil {
+	if err := original.ToNet(ProtocolBitswap, buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +143,7 @@ func TestToAndFromNetMessage(t *testing.T) {
 	original.AddBlock(blocks.NewBlock([]byte("M")))
 
 	buf := new(bytes.Buffer)
-	if err := original.ToNetV1(buf); err != nil {
+	if err := original.ToNet(ProtocolBitswap, buf); err != nil {
 		t.Fatal(err)
 	}
 

--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -7,16 +7,7 @@ import (
 
 	ifconnmgr "gx/ipfs/QmSAJm4QdTJ3EGF2cvgNcQyXTEbxqWSW1x4kCVV1aJQUQr/go-libp2p-interface-connmgr"
 	peer "gx/ipfs/QmWNY7dV54ZDYmTA1ykVdwNCqC11mpU4zSUp6XDpLTH9eG/go-libp2p-peer"
-	protocol "gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
 	cid "gx/ipfs/QmeSrf6pzut73u6zLQkRFQ3ygt3k6XFT2kjdYP8Tnkwwyg/go-cid"
-)
-
-var (
-	// These two are equivalent, legacy
-	ProtocolBitswapOne    protocol.ID = "/ipfs/bitswap/1.0.0"
-	ProtocolBitswapNoVers protocol.ID = "/ipfs/bitswap"
-
-	ProtocolBitswap protocol.ID = "/ipfs/bitswap/1.1.0"
 )
 
 // BitSwapNetwork provides network connectivity for BitSwap sessions


### PR DESCRIPTION
Otherwise, we write the length and the message as two separate values.

Yes, we'll end up allocating a bit more than we would otherwise but that's
strictly better than sending two secio messages (with two separate MACs).

part of #4280