### PR TITLE
Don't lock up 256KiB buffers when adding small files

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -131,7 +131,7 @@ func (adder *Adder) SetMfsRoot(r *mfs.Root) {
 }
 
 // Constructs a node from reader's data, and adds it. Doesn't pin.
-func (adder Adder) add(reader io.Reader) (node.Node, error) {
+func (adder *Adder) add(reader io.Reader) (node.Node, error) {
 	chnk, err := chunk.FromString(reader, adder.Chunker)
 	if err != nil {
 		return nil, err

--- a/importer/chunk/parse.go
+++ b/importer/chunk/parse.go
@@ -11,7 +11,7 @@ import (
 func FromString(r io.Reader, chunker string) (Splitter, error) {
 	switch {
 	case chunker == "" || chunker == "default":
-		return NewSizeSplitter(r, DefaultBlockSize), nil
+		return DefaultSplitter(r), nil
 
 	case strings.HasPrefix(chunker, "size-"):
 		sizeStr := strings.Split(chunker, "-")[1]

--- a/importer/chunk/splitting_test.go
+++ b/importer/chunk/splitting_test.go
@@ -22,6 +22,20 @@ func copyBuf(buf []byte) []byte {
 	return cpy
 }
 
+func TestSizeSplitterOverAllocate(t *testing.T) {
+	max := 1000
+	r := bytes.NewReader(randBuf(t, max))
+	chunksize := int64(1024 * 256)
+	splitter := NewSizeSplitter(r, chunksize)
+	chunk, err := splitter.NextBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cap(chunk) > len(chunk) {
+		t.Fatal("chunk capacity too large")
+	}
+}
+
 func TestSizeSplitterIsDeterministic(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -34,7 +34,7 @@ func BuildDagFromFile(fpath string, ds dag.DAGService) (node.Node, error) {
 	}
 	defer f.Close()
 
-	return BuildDagFromReader(ds, chunk.NewSizeSplitter(f, chunk.DefaultBlockSize))
+	return BuildDagFromReader(ds, chunk.DefaultSplitter(f))
 }
 
 func BuildDagFromReader(ds dag.DAGService, spl chunk.Splitter) (node.Node, error) {

--- a/package.json
+++ b/package.json
@@ -509,6 +509,12 @@
       "hash": "QmYmhgAcvmDGXct1qBvc1kz9BxQSit1XBrTeiGZp2FvRyn",
       "name": "go-libp2p-blankhost",
       "version": "0.2.3"
+    },
+    {
+      "author": "jbenet",
+      "hash": "QmWBug6eBS7AxRdCDVuSY5CnSit7cS2XnPFYJWqWDumhCG",
+      "name": "go-msgio",
+      "version": "0.0.3"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
This is part of #4505.

~It's WIP because we still need to use some form of buffer pool. As is, allocating and throwing away 256KiB buffers is killing GC.~