### PR TITLE
Ensure that flush on the mfs root flushes its directory

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -443,9 +443,10 @@ func (adder *Adder) addFile(file files.File) error {
 		if err != nil {
 			return err
 		}
-		if err := mr.Flush(); err != nil {
+		if err := mr.FlushMemFree(adder.ctx); err != nil {
 			return err
 		}
+
 		adder.liveNodes = 0
 	}
 	adder.liveNodes++


### PR DESCRIPTION
During `ipfs add`, we periodically call flush on the mfs root to free up unused memory. Apparently `Flush` on the mfs root object wasnt actually calling `Flush` on its directory, which led to memory not actually being freed. I'm trying to think of the best way to test this.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>