### PR TITLE
[WIP] MFS improvements

### DIFF
--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -134,9 +134,9 @@ func (fi *fileDescriptor) flushUp(fullsync bool) error {
 			return nil
 		}
 		if nd == nil {
-			fi.inode.nodelk.Lock()
+			fi.inode.nodelk.RLock()
 			nd = fi.inode.node
-			fi.inode.nodelk.Unlock()
+			fi.inode.nodelk.RUnlock()
 		}
 
 		if err := fi.inode.parent.closeChild(fi.inode.name, nd, fullsync); err != nil {

--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -99,10 +99,16 @@ func (fi *fileDescriptor) Close() error {
 }
 
 func (fi *fileDescriptor) Sync() error {
+	if fi.mode == Closed {
+		return ErrClosed
+	}
 	return fi.flushUp(false)
 }
 
 func (fi *fileDescriptor) Flush() error {
+	if fi.mode == Closed {
+		return ErrClosed
+	}
 	return fi.flushUp(true)
 }
 

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -22,7 +22,7 @@ type File struct {
 
 	dserv  dag.DAGService
 	node   node.Node
-	nodelk sync.Mutex
+	nodelk sync.RWMutex
 
 	RawLeaves bool
 }
@@ -98,9 +98,9 @@ func (fi *File) Open(mode mode, sync bool) (_ FileDescriptor, _retErr error) {
 		return nil, fmt.Errorf("mode not supported")
 	}
 
-	fi.nodelk.Lock()
+	fi.nodelk.RLock()
 	node := fi.node
-	fi.nodelk.Unlock()
+	fi.nodelk.RUnlock()
 
 	switch node := node.(type) {
 	case *dag.ProtoNode:
@@ -137,8 +137,8 @@ func (fi *File) Open(mode mode, sync bool) (_ FileDescriptor, _retErr error) {
 
 // Size returns the size of this file
 func (fi *File) Size() (int64, error) {
-	fi.nodelk.Lock()
-	defer fi.nodelk.Unlock()
+	fi.nodelk.RLock()
+	defer fi.nodelk.RUnlock()
 	switch nd := fi.node.(type) {
 	case *dag.ProtoNode:
 		pbd, err := ft.FromBytes(nd.Data())
@@ -155,8 +155,8 @@ func (fi *File) Size() (int64, error) {
 
 // GetNode returns the dag node associated with this file
 func (fi *File) GetNode() (node.Node, error) {
-	fi.nodelk.Lock()
-	defer fi.nodelk.Unlock()
+	fi.nodelk.RLock()
+	defer fi.nodelk.RUnlock()
 	return fi.node, nil
 }
 

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -161,7 +161,7 @@ func assertFileAtPath(ds dag.DAGService, root *Directory, expn node.Node, pth st
 		return fmt.Errorf("%s was not a file!", pth)
 	}
 
-	rfd, err := file.Open(OpenReadOnly, false)
+	rfd, err := file.Open(ModeRead, false)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func TestMfsFile(t *testing.T) {
 		t.Fatal("some is seriously wrong here")
 	}
 
-	wfd, err := fi.Open(OpenReadWrite, true)
+	wfd, err := fi.Open(ModeReadWrite, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -555,7 +555,7 @@ func actorMakeFile(d *Directory) error {
 		return err
 	}
 
-	wfd, err := f.Open(OpenWriteOnly, true)
+	wfd, err := f.Open(ModeWrite, true)
 	if err != nil {
 		return err
 	}
@@ -635,7 +635,7 @@ func actorWriteFile(d *Directory) error {
 		return err
 	}
 
-	wfd, err := fi.Open(OpenWriteOnly, true)
+	wfd, err := fi.Open(ModeWrite, true)
 	if err != nil {
 		return err
 	}
@@ -667,7 +667,7 @@ func actorReadFile(d *Directory) error {
 		return err
 	}
 
-	rfd, err := fi.Open(OpenReadOnly, false)
+	rfd, err := fi.Open(ModeRead, false)
 	if err != nil {
 		return err
 	}
@@ -869,7 +869,7 @@ func readFile(rt *Root, path string, offset int64, buf []byte) error {
 		return fmt.Errorf("%s was not a file", path)
 	}
 
-	fd, err := fi.Open(OpenReadOnly, false)
+	fd, err := fi.Open(ModeRead, false)
 	if err != nil {
 		return err
 	}
@@ -947,7 +947,7 @@ func writeFile(rt *Root, path string, data []byte) error {
 		return fmt.Errorf("expected to receive a file, but didnt get one")
 	}
 
-	fd, err := fi.Open(OpenWriteOnly, true)
+	fd, err := fi.Open(ModeWrite, true)
 	if err != nil {
 		return err
 	}
@@ -1015,7 +1015,7 @@ func TestFileDescriptors(t *testing.T) {
 	}
 
 	// test read only
-	rfd1, err := fi.Open(OpenReadOnly, false)
+	rfd1, err := fi.Open(ModeRead, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1039,7 +1039,7 @@ func TestFileDescriptors(t *testing.T) {
 	go func() {
 		defer close(done)
 		// can open second readonly file descriptor
-		rfd2, err := fi.Open(OpenReadOnly, false)
+		rfd2, err := fi.Open(ModeRead, false)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1062,7 +1062,7 @@ func TestFileDescriptors(t *testing.T) {
 	done = make(chan struct{})
 	go func() {
 		defer close(done)
-		wfd1, err := fi.Open(OpenWriteOnly, true)
+		wfd1, err := fi.Open(ModeWrite, true)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1091,7 +1091,7 @@ func TestFileDescriptors(t *testing.T) {
 	case <-done:
 	}
 
-	wfd, err := fi.Open(OpenWriteOnly, true)
+	wfd, err := fi.Open(ModeWrite, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -25,6 +25,7 @@ import (
 )
 
 var ErrNotExist = errors.New("no such rootfs")
+var ErrClosed = errors.New("file closed")
 
 var log = logging.Logger("mfs")
 


### PR DESCRIPTION
* Avoid syncing/flushing after closing an fd.
* Avoid reading/writing after closing an fd.
* Use a rw lock to guard the file's node (allows concurrent size checks).
* Simpler mode/access checks.
* Fix #4514 (take the read/write lock before reading the file's node).
* Syncing/flushing when we don't need to.