### PR TITLE
cmd, core: fix Permament -> Permanent typo

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -289,7 +289,7 @@ func daemonFunc(req cmds.Request, re cmds.ResponseEmitter) {
 	// Start assembling node config
 	ncfg := &core.BuildCfg{
 		Repo:      repo,
-		Permament: true, // It is temporary way to signify that node is permament
+		Permanent: true, // It is temporary way to signify that node is permanent
 		Online:    !offline,
 		ExtraOpts: map[string]bool{
 			"pubsub": pubsub,

--- a/core/builder.go
+++ b/core/builder.go
@@ -37,9 +37,9 @@ type BuildCfg struct {
 	// ExtraOpts is a map of extra options used to configure the ipfs nodes creation
 	ExtraOpts map[string]bool
 
-	// If permament then node should run more expensive processes
+	// If permanent then node should run more expensive processes
 	// that will improve performance in long run
-	Permament bool
+	Permanent bool
 
 	// If NilRepo is set, a repo backed by a nil datastore will be constructed
 	NilRepo bool
@@ -181,7 +181,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 	uio.UseHAMTSharding = conf.Experimental.ShardingEnabled
 
 	opts.HasBloomFilterSize = conf.Datastore.BloomFilterSize
-	if !cfg.Permament {
+	if !cfg.Permanent {
 		opts.HasBloomFilterSize = 0
 	}
 


### PR DESCRIPTION
The `core.BuildCfg` struct had a typo (IMHO) in one of the field names: `permaMent`. This PR fixes that to `permaNent`. I hope there won't be any API breakage from this (thinking about config files, no idea how ipfs works with this regard).