### PR TITLE
sharness: Generate JUnit test reports

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,5 +1,7 @@
 import groovy.transform.Field
 
+/* SETTINGS */
+
 def test = 'go test -v ./...'
 
 def fast_build_platforms = [
@@ -19,6 +21,8 @@ def build_platforms = [
 
   ['freebsd', 'amd64']
 ]
+
+/* PIPELINE UTILS */
 
 def setupStep(nodeLabel, f) {
   node(label: nodeLabel) {
@@ -58,12 +62,19 @@ def gobuild_step(list) {
   }
 }
 
+/* PIPELINE */
+
 ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MINUTES') {
   stage('Checks') {
     parallel(
       'go fmt': {
         setupStep('linux') { run ->
           run 'make test_go_fmt'
+        }
+      },
+      'go vet': {
+        setupStep('linux') { run ->
+          run 'go vet ./...'
         }
       },
       'go build': {
@@ -113,7 +124,7 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MI
           run "make gx-deps"
 
           try {
-            run "make -j12 -Otarget test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1"
+            run "make -j12 -Otarget test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1 TEST_NO_DOCKER=1"
           } catch (err) {
             throw err
           } finally {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,153 @@
+import groovy.transform.Field
+
+def test = 'go test -v ./...'
+
+def fast_build_platforms = [
+  ['linux', 'amd64'],
+]
+
+def build_platforms = [
+  ['windows', '386'],
+  ['windows', 'amd64'],
+
+  ['linux', 'arm'],
+  ['linux', 'arm64'],
+  ['linux', '386'],
+
+  ['darwin', '386'],
+  ['darwin', 'amd64'],
+
+  ['freebsd', 'amd64']
+]
+
+def setupStep(nodeLabel, f) {
+  node(label: nodeLabel) {
+    def ps = nodeLabel != 'windows' ? '/' : '\\'
+    def psep = nodeLabel != 'windows' ? ':' : ';'
+
+    def root = tool name: '1.9.2', type: 'go'
+    def jobNameArr = "${JOB_NAME}"
+    def jobName = jobNameArr.split("/")[0..1].join(nodeLabel != 'windows' ? '/' : '\\\\').toLowerCase()
+    def subName = jobNameArr.split("/")[2].toLowerCase()
+    def originalWs = "${WORKSPACE}"
+
+    ws("${originalWs}${ps}src${ps}github.com${ps}${jobName}") {
+      def goEnv = ["GOROOT=${root}", "GOPATH=${originalWs}", "SUBNAME=${subName}", "PATH=$PATH${psep}${root}${ps}bin${psep}${originalWs}${ps}bin"]
+      withEnv(goEnv) {
+        checkout scm
+
+        def run = nodeLabel != 'windows' ? this.&sh : this.&bat
+
+        f(run)
+      }
+    }
+  }
+}
+
+def gobuild_step(list) {
+  setupStep('linux') {
+    list.each { platform ->
+      withEnv(["GOOS=${platform[0]}", "GOARCH=${platform[1]}"]) {
+        sh "go build -i -ldflags=\"-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=${env.SUBNAME}-${env.BUILD_NUMBER}\"  -o cmd/ipfs/ipfs github.com/ipfs/go-ipfs/cmd/ipfs"
+        sh "cp cmd/ipfs/ipfs cmd/ipfs/dist; cd cmd/ipfs/dist; tar -czvf ../go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz ."
+        archiveArtifacts artifacts: "cmd/ipfs/go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz", fingerprint: true
+      }
+    }
+  }
+}
+
+ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MINUTES') {
+  stage('Checks') {
+    parallel(
+      'go fmt': {
+        setupStep('linux') { run ->
+          run 'make test_go_fmt'
+        }
+      },
+      'go build': {
+        gobuild_step(fast_build_platforms)
+      }
+    )
+  }
+
+  stage('Tests') {
+    parallel(
+      'go build (other platforms)': {
+        gobuild_step(build_platforms)
+      },
+      windows: {
+        setupStep('windows') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report github.com/whyrusleeping/gx github.com/whyrusleeping/gx-go'
+          run "gx install --global"
+
+          try {
+            run test + ' -tags="nofuse" > output & type output'
+            run 'type output | go-junit-report > junit-report-windows.xml'
+          } catch (err) {
+            throw err
+          } finally {
+            junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+          }
+        }
+      },
+      linux: {
+        setupStep('linux') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          run "make gx-deps"
+
+          try {
+            run test + ' -tags="nofuse" 2>&1 | tee output'
+            run 'cat output | go-junit-report > junit-report-linux.xml'
+          } catch (err) {
+            throw err
+          } finally {
+            junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+          }
+        }
+      },
+      linuxSharness: {
+       setupStep('linux') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          run "make gx-deps"
+
+          try {
+            run "make -j12 -Otarget test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1"
+          } catch (err) {
+            throw err
+          } finally {
+            junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml'
+          }
+        }
+      },
+      macOS: {
+        setupStep('macos') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          run "make gx-deps"
+
+          try {
+            run test + ' -tags="nofuse" 2>&1 | tee output'
+            run 'cat output | go-junit-report > junit-report-macos.xml'
+          } catch (err) {
+            throw err
+          } finally {
+            junit 'junit-report-*.xml'
+          }
+        }
+      },
+      macSharness: {
+        setupStep('macos') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          run "make gx-deps"
+
+          try {
+            run "make -j12 test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1"
+          } catch (err) {
+            throw err
+          } finally {
+            junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml'
+          }
+        }
+      },
+    )
+  }
+}}}

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -45,11 +45,13 @@ def setupStep(nodeLabel, f) {
 }
 
 def gobuild_step(list) {
-  setupStep('linux') {
+  setupStep('linux') { run ->
+    run "make gx-deps"
+
     list.each { platform ->
       withEnv(["GOOS=${platform[0]}", "GOARCH=${platform[1]}"]) {
-        sh "go build -i -ldflags=\"-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=${env.SUBNAME}-${env.BUILD_NUMBER}\"  -o cmd/ipfs/ipfs github.com/ipfs/go-ipfs/cmd/ipfs"
-        sh "cp cmd/ipfs/ipfs cmd/ipfs/dist; cd cmd/ipfs/dist; tar -czvf ../go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz ."
+        run "go build -i -ldflags=\"-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=${env.SUBNAME}-${env.BUILD_NUMBER}\"  -o cmd/ipfs/ipfs github.com/ipfs/go-ipfs/cmd/ipfs"
+        run "cp cmd/ipfs/ipfs cmd/ipfs/dist; cd cmd/ipfs/dist; tar -czvf ../go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz ."
         archiveArtifacts artifacts: "cmd/ipfs/go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz", fingerprint: true
       }
     }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -99,7 +99,8 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MI
           } catch (err) {
             throw err
           } finally {
-            junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+            /* IGNORE TEST FAILS */
+            /* junit allowEmptyResults: true, testResults: 'junit-report-*.xml' */
           }
         }
       },
@@ -143,7 +144,8 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MI
           } catch (err) {
             throw err
           } finally {
-            junit 'junit-report-*.xml'
+            /* IGNORE TEST FAILS */
+            /* junit 'junit-report-*.xml' */
           }
         }
       },
@@ -157,7 +159,8 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) { timeout(time: 30, unit: 'MI
           } catch (err) {
             throw err
           } finally {
-            junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml'
+            /* IGNORE TEST FAILS */
+            /* junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml' */
           }
         }
       },

--- a/ci/jenkins
+++ b/ci/jenkins
@@ -1,1 +1,0 @@
-go-ipfs-jenkinsfile

--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -39,8 +39,12 @@ endif
 $(d)/aggregate: $(T_$(d))
 	@echo "*** $@ ***"
 	@(cd $(@D) && ./lib/test-aggregate-results.sh)
-	@(cd $(@D) && ./lib/gen-junit-report.sh)
 .PHONY: $(d)/aggregate
+
+$(d)/test-results/sharness.xml: export TEST_GENERATE_JUNIT=1
+$(d)/test-results/sharness.xml: test_sharness_expensive
+	@echo "*** $@ ***"
+	@(cd $(@D) && ./lib/gen-junit-report.sh)
 
 $(d)/clean-test-results:
 	rm -rf $(@D)/test-results

--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -44,7 +44,7 @@ $(d)/aggregate: $(T_$(d))
 $(d)/test-results/sharness.xml: export TEST_GENERATE_JUNIT=1
 $(d)/test-results/sharness.xml: test_sharness_expensive
 	@echo "*** $@ ***"
-	@(cd $(@D) && ./lib/gen-junit-report.sh)
+	@(cd $(@D)/.. && ./lib/gen-junit-report.sh)
 
 $(d)/clean-test-results:
 	rm -rf $(@D)/test-results

--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -29,12 +29,17 @@ export MAKE_SKIP_PATH=1
 
 $(T_$(d)): $$(DEPS_$(d)) # use second expansion so coverage can inject dependency
 	@echo "*** $@ ***"
+ifeq ($(CONTINUE_ON_S_FAILURE),1)
+	-@(cd $(@D) && ./$(@F)) 2>&1
+else
 	@(cd $(@D) && ./$(@F)) 2>&1
+endif
 .PHONY: $(T_$(d))
 
 $(d)/aggregate: $(T_$(d))
 	@echo "*** $@ ***"
 	@(cd $(@D) && ./lib/test-aggregate-results.sh)
+	@(cd $(@D) && ./lib/gen-junit-report.sh)
 .PHONY: $(d)/aggregate
 
 $(d)/clean-test-results:

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -46,7 +46,7 @@ index 6750ff7..7d9915a 100644
 +esc=$(printf '\033')
 +
 +esc_xml() {
-+	sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"$esc"'/\&#39;/g; s///g;'
++	sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s///g;'
 +}
 +
  test -n "$test_description" || error "Test script did not set test_description."

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -1,14 +1,14 @@
-From 8b4a5cd6ebf9dfa462d869559b85b17d2b277d06 Mon Sep 17 00:00:00 2001
+From 76b34f25b2bacdd30138b25ccbe0672d76a1632a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C5=81ukasz=20Magiera?= <magik6k@gmail.com>
-Date: Wed, 14 Mar 2018 21:26:35 +0100
+Date: Thu, 22 Mar 2018 06:11:01 +0100
 Subject: [PATCH] Generate partial JUnit reports
 
 ---
- sharness.sh | 99 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++----
- 1 file changed, 93 insertions(+), 6 deletions(-)
+ sharness.sh | 102 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 96 insertions(+), 6 deletions(-)
 
 diff --git a/sharness.sh b/sharness.sh
-index 6750ff7..dc99ef9 100644
+index 6750ff7..7d9915a 100644
 --- a/sharness.sh
 +++ b/sharness.sh
 @@ -1,4 +1,4 @@
@@ -68,7 +68,7 @@ index 6750ff7..dc99ef9 100644
 +
 +	shift
 +	cat > "$tc_file" <<-EOF
-+	<testcase name="$test_count - $(echo $test_name | esc_xml) ">
++	<testcase name="$test_count - $(echo $test_name | esc_xml)" classname="sharness$(uname -s).${SHARNESS_TEST_NAME}">
 +	$@
 +	EOF
 +
@@ -152,7 +152,7 @@ index 6750ff7..dc99ef9 100644
 +
 +		if test -n "$TEST_GENERATE_JUNIT"; then
 +			cat > ".junit/case-$(printf "%04d" $test_count)" <<-EOF
-+			<testcase name="$test_count - $(echo $2 | esc_xml)">
++			<testcase name="$test_count - $(echo $2 | esc_xml)" classname="sharness$(uname -s).${SHARNESS_TEST_NAME}">
 +				<skipped>
 +					skip $(echo $1 | esc_xml) (missing $missing_prereq${of_prereq})
 +				</skipped>
@@ -195,7 +195,7 @@ index 6750ff7..dc99ef9 100644
 +
 +		if test -n "$TEST_GENERATE_JUNIT"; then
 +			cat >>"$junit_results_path" <<-EOF
-+			<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" name="$SHARNESS_TEST_FILE">
++			<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" package="sharness$(uname -s).${SHARNESS_TEST_NAME}">
 +				$(find .junit -name 'case-*' | sort | xargs cat)
 +			</testsuite>
 +			EOF
@@ -203,7 +203,17 @@ index 6750ff7..dc99ef9 100644
  	fi
  
  	if test "$test_fixed" != 0; then
-@@ -771,6 +853,11 @@ mkdir -p "$test_dir" || exit 1
+@@ -745,6 +827,9 @@ export PATH SHARNESS_BUILD_DIRECTORY
+ SHARNESS_TEST_FILE="$0"
+ export SHARNESS_TEST_FILE
+ 
++SHARNESS_TEST_NAME=$(basename ${SHARNESS_TEST_FILE} ".sh")
++export SHARNESS_TEST_NAME
++
+ # Prepare test area.
+ test_dir="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
+ test -n "$root" && test_dir="$root/$test_dir"
+@@ -771,6 +856,11 @@ mkdir -p "$test_dir" || exit 1
  # in subprocesses like git equals our $PWD (for pathname comparisons).
  cd -P "$test_dir" || exit 1
  

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -196,7 +196,7 @@ index 6750ff7..dc99ef9 100644
 +		if test -n "$TEST_GENERATE_JUNIT"; then
 +			cat >>"$junit_results_path" <<-EOF
 +			<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" name="$SHARNESS_TEST_FILE">
-+				$(find .junit -name 'case-*' | sort | xargs -i cat "{}")
++				$(find .junit -name 'case-*' | sort | xargs cat)
 +			</testsuite>
 +			EOF
 +		fi

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -46,7 +46,7 @@ index 6750ff7..7d9915a 100644
 +esc=$(printf '\033')
 +
 +esc_xml() {
-+	sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s///g;'
++	sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"$esc"'/\&#27;/g; s///g;'
 +}
 +
  test -n "$test_description" || error "Test script did not set test_description."

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -1,0 +1,200 @@
+From 0e2a489651e8e2b1aa4abf1cb2587fc3d0f78ce6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C5=81ukasz=20Magiera?= <magik6k@gmail.com>
+Date: Thu, 28 Dec 2017 19:24:55 +0100
+Subject: [PATCH] Generate partial JUnit reports
+
+---
+ sharness.sh | 79 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 73 insertions(+), 6 deletions(-)
+
+diff --git a/sharness.sh b/sharness.sh
+index 6750ff7..55e10ac 100644
+--- a/sharness.sh
++++ b/sharness.sh
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/usr/bin/env bash
+ #
+ # Copyright (c) 2011-2012 Mathias Lafeldt
+ # Copyright (c) 2005-2012 Git project
+@@ -106,6 +106,8 @@ if test -n "$color"; then
+ 			test -n "$quiet" && return;;
+ 		esac
+ 		shift
++
++		echo "$*" >> .junit/tout
+ 		printf "%s" "$*"
+ 		tput sgr0
+ 		echo
+@@ -115,6 +117,8 @@ else
+ 	say_color() {
+ 		test -z "$1" && test -n "$quiet" && return
+ 		shift
++
++		echo "$*" >> .junit/tout
+ 		printf "%s\n" "$*"
+ 	}
+ fi
+@@ -129,6 +133,12 @@ say() {
+ 	say_color info "$*"
+ }
+ 
++esc=$(printf '\033')
++
++esc_xml() {
++	sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"$esc"'/\&#39;/g; s///g;'
++}
++
+ test -n "$test_description" || error "Test script did not set test_description."
+ 
+ if test "$help" = "t"; then
+@@ -251,30 +261,69 @@ test_have_prereq() {
+ 	test $total_prereq = $ok_prereq
+ }
+ 
++junit_testcase() {
++	test_name=$1
++	tc_file=".junit/case-$(printf "%04d" $test_count)"
++
++	shift
++	cat > "$tc_file" <<-EOF
++	<testcase name="$test_count - $(echo $test_name | esc_xml) ">
++	$@
++	EOF
++
++	if test -f .junit/tout; then
++		cat >> "$tc_file" <<-EOF
++		<system-out>
++			$(cat .junit/tout | esc_xml)
++		</system-out>
++		EOF
++	fi
++
++	if test -f .junit/terr; then
++		cat >> "$tc_file" <<-EOF
++		<system-err>
++			$(cat .junit/terr | esc_xml)
++		</system-err>
++		EOF
++	fi
++
++	echo "</testcase>" >> "$tc_file"
++	rm -f .junit/tout .junit/terr
++}
++
+ # You are not expected to call test_ok_ and test_failure_ directly, use
+ # the text_expect_* functions instead.
+ 
+ test_ok_() {
+ 	test_success=$(($test_success + 1))
+ 	say_color "" "ok $test_count - $@"
++
++	junit_testcase "$@"
+ }
+ 
+ test_failure_() {
+ 	test_failure=$(($test_failure + 1))
+ 	say_color error "not ok $test_count - $1"
++	test_name=$1
+ 	shift
+ 	echo "$@" | sed -e 's/^/#	/'
++	junit_testcase "$test_name" '<failure type="">'$(echo $@ | esc_xml)'</failure>'
++
+ 	test "$immediate" = "" || { EXIT_OK=t; exit 1; }
+ }
+ 
+ test_known_broken_ok_() {
+ 	test_fixed=$(($test_fixed + 1))
+ 	say_color error "ok $test_count - $@ # TODO known breakage vanished"
++
++	junit_testcase "$@" '<failure type="known breakage vanished"/>'
+ }
+ 
+ test_known_broken_failure_() {
+ 	test_broken=$(($test_broken + 1))
+ 	say_color warn "not ok $test_count - $@ # TODO known breakage"
++
++	junit_testcase "$@"
+ }
+ 
+ # Public: Execute commands in debug mode.
+@@ -310,7 +359,7 @@ test_pause() {
+ test_eval_() {
+ 	# This is a separate function because some tests use
+ 	# "return" to end a test_expect_success block early.
+-	eval </dev/null >&3 2>&4 "$*"
++	eval </dev/null > >(tee -a .junit/tout >&3) 2> >(tee -a .junit/terr >&4) "$*"
+ }
+ 
+ test_run_() {
+@@ -355,8 +404,16 @@ test_skip_() {
+ 			of_prereq=" of $test_prereq"
+ 		fi
+ 
+-		say_color skip >&3 "skipping test: $@"
+-		say_color skip "ok $test_count # skip $1 (missing $missing_prereq${of_prereq})"
++		say_color skip >&3 "skipping test: $1"
++		say_color skip "ok $test_count # skip $1 (missing $missing_prereqm${of_prereq})"
++
++		cat > ".junit/case-$(printf "%04d" $test_count)" <<-EOF
++		<testcase name="$test_count - $(echo $2 | esc_xml)">
++			<skipped>
++				skip $(echo $1 | esc_xml) (missing $missing_prereq${of_prereq})
++			</skipped>
++		</testcase>
++		EOF
+ 		: true
+ 		;;
+ 	*)
+@@ -403,7 +460,7 @@ test_expect_success() {
+ 	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+ 	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_success"
+ 	export test_prereq
+-	if ! test_skip_ "$@"; then
++	if ! test_skip_ "$@" "$1"; then
+ 		say >&3 "expecting success: $2"
+ 		if test_run_ "$2"; then
+ 			test_ok_ "$1"
+@@ -442,7 +499,7 @@ test_expect_failure() {
+ 	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
+ 	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_failure"
+ 	export test_prereq
+-	if ! test_skip_ "$@"; then
++	if ! test_skip_ "$@" "$1"; then
+ 		say >&3 "checking known breakage: $2"
+ 		if test_run_ "$2" expecting_failure; then
+ 			test_known_broken_ok_ "$1"
+@@ -675,6 +732,7 @@ test_done() {
+ 		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
+ 		mkdir -p "$test_results_dir"
+ 		test_results_path="$test_results_dir/${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}.$$.counts"
++		junit_results_path="$test_results_dir/${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}.$$.xml.part"
+ 
+ 		cat >>"$test_results_path" <<-EOF
+ 		total $test_count
+@@ -684,6 +742,12 @@ test_done() {
+ 		failed $test_failure
+ 
+ 		EOF
++
++		cat >>"$junit_results_path" <<-EOF
++		<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" name="$SHARNESS_TEST_FILE">
++			$(find .junit -name 'case-*' | sort | xargs -i cat "{}")
++		</testsuite>
++		EOF
+ 	fi
+ 
+ 	if test "$test_fixed" != 0; then
+@@ -771,6 +835,9 @@ mkdir -p "$test_dir" || exit 1
+ # in subprocesses like git equals our $PWD (for pathname comparisons).
+ cd -P "$test_dir" || exit 1
+ 
++# Prepare JUnit report dir
++mkdir -p .junit
++
+ this_test=${SHARNESS_TEST_FILE##*/}
+ this_test=${this_test%.$SHARNESS_TEST_EXTENSION}
+ for skp in $SKIP_TESTS; do
+-- 
+2.15.1
+

--- a/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
+++ b/test/sharness/lib/0001-Generate-partial-JUnit-reports.patch
@@ -1,14 +1,14 @@
-From 0e2a489651e8e2b1aa4abf1cb2587fc3d0f78ce6 Mon Sep 17 00:00:00 2001
+From 8b4a5cd6ebf9dfa462d869559b85b17d2b277d06 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C5=81ukasz=20Magiera?= <magik6k@gmail.com>
-Date: Thu, 28 Dec 2017 19:24:55 +0100
+Date: Wed, 14 Mar 2018 21:26:35 +0100
 Subject: [PATCH] Generate partial JUnit reports
 
 ---
- sharness.sh | 79 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
- 1 file changed, 73 insertions(+), 6 deletions(-)
+ sharness.sh | 99 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 93 insertions(+), 6 deletions(-)
 
 diff --git a/sharness.sh b/sharness.sh
-index 6750ff7..55e10ac 100644
+index 6750ff7..dc99ef9 100644
 --- a/sharness.sh
 +++ b/sharness.sh
 @@ -1,4 +1,4 @@
@@ -17,25 +17,29 @@ index 6750ff7..55e10ac 100644
  #
  # Copyright (c) 2011-2012 Mathias Lafeldt
  # Copyright (c) 2005-2012 Git project
-@@ -106,6 +106,8 @@ if test -n "$color"; then
+@@ -106,6 +106,10 @@ if test -n "$color"; then
  			test -n "$quiet" && return;;
  		esac
  		shift
 +
-+		echo "$*" >> .junit/tout
++		if test -n "$TEST_GENERATE_JUNIT"; then
++			echo "$*" >> .junit/tout
++		fi
  		printf "%s" "$*"
  		tput sgr0
  		echo
-@@ -115,6 +117,8 @@ else
+@@ -115,6 +119,10 @@ else
  	say_color() {
  		test -z "$1" && test -n "$quiet" && return
  		shift
 +
-+		echo "$*" >> .junit/tout
++		if test -n "$TEST_GENERATE_JUNIT"; then
++			echo "$*" >> .junit/tout
++		fi
  		printf "%s\n" "$*"
  	}
  fi
-@@ -129,6 +133,12 @@ say() {
+@@ -129,6 +137,12 @@ say() {
  	say_color info "$*"
  }
  
@@ -48,11 +52,17 @@ index 6750ff7..55e10ac 100644
  test -n "$test_description" || error "Test script did not set test_description."
  
  if test "$help" = "t"; then
-@@ -251,30 +261,69 @@ test_have_prereq() {
+@@ -251,30 +265,75 @@ test_have_prereq() {
  	test $total_prereq = $ok_prereq
  }
  
++# junit_testcase generates a testcase xml file after each test
++
 +junit_testcase() {
++	if test -z "$TEST_GENERATE_JUNIT"; then
++		return
++	fi
++
 +	test_name=$1
 +	tc_file=".junit/case-$(printf "%04d" $test_count)"
 +
@@ -118,16 +128,20 @@ index 6750ff7..55e10ac 100644
  }
  
  # Public: Execute commands in debug mode.
-@@ -310,7 +359,7 @@ test_pause() {
+@@ -310,7 +369,11 @@ test_pause() {
  test_eval_() {
  	# This is a separate function because some tests use
  	# "return" to end a test_expect_success block early.
 -	eval </dev/null >&3 2>&4 "$*"
-+	eval </dev/null > >(tee -a .junit/tout >&3) 2> >(tee -a .junit/terr >&4) "$*"
++	if test -n "$TEST_GENERATE_JUNIT"; then
++		eval </dev/null > >(tee -a .junit/tout >&3) 2> >(tee -a .junit/terr >&4) "$*"
++	else
++		eval </dev/null >&3 2>&4 "$*"
++	fi
  }
  
  test_run_() {
-@@ -355,8 +404,16 @@ test_skip_() {
+@@ -355,8 +418,18 @@ test_skip_() {
  			of_prereq=" of $test_prereq"
  		fi
  
@@ -136,17 +150,19 @@ index 6750ff7..55e10ac 100644
 +		say_color skip >&3 "skipping test: $1"
 +		say_color skip "ok $test_count # skip $1 (missing $missing_prereqm${of_prereq})"
 +
-+		cat > ".junit/case-$(printf "%04d" $test_count)" <<-EOF
-+		<testcase name="$test_count - $(echo $2 | esc_xml)">
-+			<skipped>
-+				skip $(echo $1 | esc_xml) (missing $missing_prereq${of_prereq})
-+			</skipped>
-+		</testcase>
-+		EOF
++		if test -n "$TEST_GENERATE_JUNIT"; then
++			cat > ".junit/case-$(printf "%04d" $test_count)" <<-EOF
++			<testcase name="$test_count - $(echo $2 | esc_xml)">
++				<skipped>
++					skip $(echo $1 | esc_xml) (missing $missing_prereq${of_prereq})
++				</skipped>
++			</testcase>
++			EOF
++		fi
  		: true
  		;;
  	*)
-@@ -403,7 +460,7 @@ test_expect_success() {
+@@ -403,7 +476,7 @@ test_expect_success() {
  	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
  	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_success"
  	export test_prereq
@@ -155,7 +171,7 @@ index 6750ff7..55e10ac 100644
  		say >&3 "expecting success: $2"
  		if test_run_ "$2"; then
  			test_ok_ "$1"
-@@ -442,7 +499,7 @@ test_expect_failure() {
+@@ -442,7 +515,7 @@ test_expect_failure() {
  	test "$#" = 3 && { test_prereq=$1; shift; } || test_prereq=
  	test "$#" = 2 || error "bug in the test script: not 2 or 3 parameters to test_expect_failure"
  	export test_prereq
@@ -164,7 +180,7 @@ index 6750ff7..55e10ac 100644
  		say >&3 "checking known breakage: $2"
  		if test_run_ "$2" expecting_failure; then
  			test_known_broken_ok_ "$1"
-@@ -675,6 +732,7 @@ test_done() {
+@@ -675,6 +748,7 @@ test_done() {
  		test_results_dir="$SHARNESS_TEST_DIRECTORY/test-results"
  		mkdir -p "$test_results_dir"
  		test_results_path="$test_results_dir/${SHARNESS_TEST_FILE%.$SHARNESS_TEST_EXTENSION}.$$.counts"
@@ -172,29 +188,33 @@ index 6750ff7..55e10ac 100644
  
  		cat >>"$test_results_path" <<-EOF
  		total $test_count
-@@ -684,6 +742,12 @@ test_done() {
+@@ -684,6 +758,14 @@ test_done() {
  		failed $test_failure
  
  		EOF
 +
-+		cat >>"$junit_results_path" <<-EOF
-+		<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" name="$SHARNESS_TEST_FILE">
-+			$(find .junit -name 'case-*' | sort | xargs -i cat "{}")
-+		</testsuite>
-+		EOF
++		if test -n "$TEST_GENERATE_JUNIT"; then
++			cat >>"$junit_results_path" <<-EOF
++			<testsuite errors="$test_broken" failures="$((test_failure+test_fixed))" tests="$test_count" name="$SHARNESS_TEST_FILE">
++				$(find .junit -name 'case-*' | sort | xargs -i cat "{}")
++			</testsuite>
++			EOF
++		fi
  	fi
  
  	if test "$test_fixed" != 0; then
-@@ -771,6 +835,9 @@ mkdir -p "$test_dir" || exit 1
+@@ -771,6 +853,11 @@ mkdir -p "$test_dir" || exit 1
  # in subprocesses like git equals our $PWD (for pathname comparisons).
  cd -P "$test_dir" || exit 1
  
 +# Prepare JUnit report dir
-+mkdir -p .junit
++if test -n "$TEST_GENERATE_JUNIT"; then
++	mkdir -p .junit
++fi
 +
  this_test=${SHARNESS_TEST_FILE##*/}
  this_test=${this_test%.$SHARNESS_TEST_EXTENSION}
  for skp in $SKIP_TESTS; do
 -- 
-2.15.1
+2.16.2
 

--- a/test/sharness/lib/gen-junit-report.sh
+++ b/test/sharness/lib/gen-junit-report.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cat > test-results/sharness.xml <<-EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="sharness">
+  $(find test-results -name '*.xml.part' | sort | xargs -i cat "{}")
+</testsuites>
+EOF

--- a/test/sharness/lib/gen-junit-report.sh
+++ b/test/sharness/lib/gen-junit-report.sh
@@ -3,6 +3,6 @@
 cat > test-results/sharness.xml <<-EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="sharness">
-  $(find test-results -name '*.xml.part' | sort | xargs -i cat "{}")
+  $(find test-results -name '*.xml.part' | sort | xargs cat)
 </testsuites>
 EOF

--- a/test/sharness/lib/gen-junit-report.sh
+++ b/test/sharness/lib/gen-junit-report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 cat > test-results/sharness.xml <<-EOF
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 <testsuites name="sharness">
   $(find test-results -name '*.xml.part' | sort | xargs cat)
 </testsuites>

--- a/test/sharness/lib/install-sharness.sh
+++ b/test/sharness/lib/install-sharness.sh
@@ -7,7 +7,7 @@
 
 # settings
 version=5eee9b51b5621cec95a64018f0cc779963b230d2
-patch_version=1
+patch_version=6
 
 urlprefix=https://github.com/mlafeldt/sharness.git
 if test ! -n "$clonedir" ; then

--- a/test/sharness/lib/install-sharness.sh
+++ b/test/sharness/lib/install-sharness.sh
@@ -7,13 +7,15 @@
 
 # settings
 version=5eee9b51b5621cec95a64018f0cc779963b230d2
+patch_version=1
+
 urlprefix=https://github.com/mlafeldt/sharness.git
 if test ! -n "$clonedir" ; then
   clonedir=lib
 fi
 sharnessdir=sharness
 
-if test -f "$clonedir/$sharnessdir/SHARNESS_VERSION_$version"
+if test -f "$clonedir/$sharnessdir/SHARNESS_VERSION_${version}_p${patch_version}"
 then
   # There is the right version file. Great, we are done!
   exit 0
@@ -24,11 +26,20 @@ die() {
   exit 1
 }
 
+apply_patches() {
+  git config --local user.email "noone@nowhere"
+  git config --local user.name "No One"
+  git am ../0001-Generate-partial-JUnit-reports.patch
+
+  touch "SHARNESS_VERSION_${version}_p${patch_version}" || die "Could not create 'SHARNESS_VERSION_${version}_p${patch_version}'"
+}
+
 checkout_version() {
   git checkout "$version" || die "Could not checkout '$version'"
   rm -f SHARNESS_VERSION_* || die "Could not remove 'SHARNESS_VERSION_*'"
-  touch "SHARNESS_VERSION_$version" || die "Could not create 'SHARNESS_VERSION_$version'"
   echo "Sharness version $version is checked out!"
+
+  apply_patches
 }
 
 if test -d "$clonedir/$sharnessdir/.git"

--- a/test/sharness/lib/install-sharness.sh
+++ b/test/sharness/lib/install-sharness.sh
@@ -7,7 +7,7 @@
 
 # settings
 version=5eee9b51b5621cec95a64018f0cc779963b230d2
-patch_version=7
+patch_version=8
 
 urlprefix=https://github.com/mlafeldt/sharness.git
 if test ! -n "$clonedir" ; then

--- a/test/sharness/lib/install-sharness.sh
+++ b/test/sharness/lib/install-sharness.sh
@@ -7,7 +7,7 @@
 
 # settings
 version=5eee9b51b5621cec95a64018f0cc779963b230d2
-patch_version=6
+patch_version=7
 
 urlprefix=https://github.com/mlafeldt/sharness.git
 if test ! -n "$clonedir" ; then

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -214,6 +214,7 @@ test_launch_ipfs_daemon() {
 
   test_expect_success "'ipfs daemon' succeeds" '
     ipfs daemon $args >actual_daemon 2>daemon_err &
+    IPFS_PID=$!
   '
 
   # wait for api file to show up
@@ -225,7 +226,6 @@ test_launch_ipfs_daemon() {
 
   # we say the daemon is ready when the API server is ready.
   test_expect_success "'ipfs daemon' is ready" '
-    IPFS_PID=$! &&
     pollEndpoint -ep=/version -host=$API_MADDR -v -tout=1s -tries=60 2>poll_apierr > poll_apiout ||
     test_fsh cat actual_daemon || test_fsh cat daemon_err || test_fsh cat poll_apierr || test_fsh cat poll_apiout
   '

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0015-basic-sh-functions.sh
+++ b/test/sharness/t0015-basic-sh-functions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0018-indent.sh
+++ b/test/sharness/t0018-indent.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test sharness test indent"
 

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.
@@ -46,7 +46,7 @@ test_expect_success "ipfs cat fails" '
 
 test_expect_success "ipfs cat no repo message looks good" '
   echo "Error: no IPFS repo found in $IPFS_PATH." > cat_fail_exp &&
-  echo "please run: 'ipfs init'" >> cat_fail_exp &&
+  echo "please run: '"'"'ipfs init'"'"'" >> cat_fail_exp &&
   test_path_cmp cat_fail_exp cat_fail_out
 '
 

--- a/test/sharness/t0021-config.sh
+++ b/test/sharness/t0021-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test config command"
 

--- a/test/sharness/t0022-init-default.sh
+++ b/test/sharness/t0022-init-default.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0023-shutdown.sh
+++ b/test/sharness/t0023-shutdown.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0024-datastore-config.sh
+++ b/test/sharness/t0024-datastore-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test datastore config"
 

--- a/test/sharness/t0025-datastores.sh
+++ b/test/sharness/t0025-datastores.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test non-standard datastores"
 

--- a/test/sharness/t0030-mount.sh
+++ b/test/sharness/t0030-mount.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0031-mount-publish.sh
+++ b/test/sharness/t0031-mount-publish.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test mount command in conjunction with publishing"
 

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0041-ping.sh
+++ b/test/sharness/t0041-ping.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test ping command"
 

--- a/test/sharness/t0042-add-skip.sh
+++ b/test/sharness/t0042-add-skip.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0043-add-w.sh
+++ b/test/sharness/t0043-add-w.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0044-add-symlink.sh
+++ b/test/sharness/t0044-add-symlink.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Henry Bubert
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0052-object-diff.sh
+++ b/test/sharness/t0052-object-diff.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0053-dag.sh
+++ b/test/sharness/t0053-dag.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Juan Batiz-Benet
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0061-daemon-opts.sh
+++ b/test/sharness/t0061-daemon-opts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Juan Batiz-Benet
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0062-daemon-api.sh
+++ b/test/sharness/t0062-daemon-api.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # MIT Licensed; see the LICENSE file in this repository.
 #

--- a/test/sharness/t0063-daemon-init.sh
+++ b/test/sharness/t0063-daemon-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Juan Batiz-Benet
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0063-external.sh
+++ b/test/sharness/t0063-external.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0065-active-requests.sh
+++ b/test/sharness/t0065-active-requests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0070-user-config.sh
+++ b/test/sharness/t0070-user-config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Brian Holder-Chow Lin On
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -169,14 +169,13 @@ test_expect_success "'ipfs pin ls --type=all --quiet' is correct" '
 
 test_expect_success "'ipfs refs --unique' is correct" '
   mkdir -p uniques &&
-  cd uniques &&
-  echo "content1" > file1 &&
-  echo "content1" > file2 &&
-  ipfs add -r -q . > ../add_output &&
-  ROOT=$(tail -n1 ../add_output) &&
+  echo "content1" > uniques/file1 &&
+  echo "content1" > uniques/file2 &&
+  ipfs add -r -q uniques > add_output &&
+  ROOT=$(tail -n1 add_output) &&
   ipfs refs --unique $ROOT >expected &&
-  ipfs add -q file1 >unique_hash &&
-  test_cmp expected unique_hash || test_fsh cat ../add_output
+  ipfs add -q uniques/file1 >unique_hash &&
+  test_cmp expected unique_hash || test_fsh cat add_output
 '
 
 test_expect_success "'ipfs refs --unique --recursive' is correct" '

--- a/test/sharness/t0081-repo-pinning.sh
+++ b/test/sharness/t0081-repo-pinning.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0082-repo-gc-auto.sh
+++ b/test/sharness/t0082-repo-gc-auto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # MIT Licensed; see the LICENSE file in this repository.
 #

--- a/test/sharness/t0083-repo-fsck.sh
+++ b/test/sharness/t0083-repo-fsck.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Mike Pfister 
 # MIT Licensed; see the LICENSE file in this repository.
@@ -23,7 +23,7 @@ repo.lock" '
   mkdir -p $IPFS_PATH/datastore &&
   touch $IPFS_PATH/datastore/LOCK &&
   touch $IPFS_PATH/repo.lock &&
-  printf "/ip4/127.0.0.1/tcp/5001" > $IPFS_PATH/api &&
+  printf "/ip4/127.0.0.1/tcp/5001" > "$IPFS_PATH/api" &&
   ipfs repo fsck > fsck_out_actual1
 '
 test_expect_success "'ipfs repo fsck' output looks good with no daemon" '
@@ -42,9 +42,9 @@ test_expect_success "'ipfs repo fsck' confirm file deletion" '
 # non-zero repo.lock issue
 test_expect_success "'ipfs repo fsck' succeeds with no daemon running non-zero
 repo.lock" '
-  mkdir -p $IPFS_PATH &&
-  printf ":D" > $IPFS_PATH/repo.lock &&
-  touch $IPFS_PATH/datastore/LOCK &&
+  mkdir -p "$IPFS_PATH" &&
+  printf ":D" > "$IPFS_PATH/repo.lock" &&
+  touch "$IPFS_PATH/datastore/LOCK" &&
   ipfs repo fsck > fsck_out_actual1b
 '
 test_expect_success "'ipfs repo fsck' output looks good with no daemon" '
@@ -64,7 +64,7 @@ test_expect_success "'ipfs repo fsck' confirm file deletion" '
 
 # Try with locks api and datastore/LOCK
 test_expect_success "'ipfs repo fsck' succeeds partial lock" '
-  printf  "/ip4/127.0.0.1/tcp/5001" > $IPFS_PATH/api &&
+  printf  "/ip4/127.0.0.1/tcp/5001" > "$IPFS_PATH/api" &&
   touch $IPFS_PATH/datastore/LOCK &&
   ipfs repo fsck > fsck_out_actual2
 '
@@ -82,7 +82,7 @@ test_expect_success "'ipfs repo fsck' confirm file deletion" '
 
 # Try with locks api and repo.lock
 test_expect_success "'ipfs repo fsck' succeeds partial lock" '
-  printf  "/ip4/127.0.0.1/tcp/5001" > $IPFS_PATH/api &&
+  printf  "/ip4/127.0.0.1/tcp/5001" > "$IPFS_PATH/api" &&
   touch $IPFS_PATH/repo.lock &&
   ipfs repo fsck > fsck_out_actual3
 '
@@ -154,7 +154,7 @@ test_expect_success "'ipfs repo fsck' confirm file deletion" '
 
 # Try with single lock api
 test_expect_success "'ipfs repo fsck' succeeds partial lock" '
-  printf "/ip4/127.0.0.1/tcp/5001" > $IPFS_PATH/api &&
+  printf "/ip4/127.0.0.1/tcp/5001" > "$IPFS_PATH/api" &&
   ipfs repo fsck > fsck_out_actual7
 '
 

--- a/test/sharness/t0084-repo-read-rehash.sh
+++ b/test/sharness/t0084-repo-read-rehash.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) Jakub Sztandera
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0085-pins.sh
+++ b/test/sharness/t0085-pins.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0086-repo-verify.sh
+++ b/test/sharness/t0086-repo-verify.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0087-repo-robust-gc.sh
+++ b/test/sharness/t0087-repo-robust-gc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0088-repo-stat-symlink.sh
+++ b/test/sharness/t0088-repo-stat-symlink.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 John Reed
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Matt Bell
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0101-iptb-name.sh
+++ b/test/sharness/t0101-iptb-name.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Matt Bell
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0112-gateway-cors.sh
+++ b/test/sharness/t0112-gateway-cors.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Marcin Rataj
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0120-bootstrap.sh
+++ b/test/sharness/t0120-bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0121-bootstrap-iptb.sh
+++ b/test/sharness/t0121-bootstrap-iptb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0125-twonode.sh
+++ b/test/sharness/t0125-twonode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0130-multinode.sh
+++ b/test/sharness/t0130-multinode.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0131-multinode-client-routing.sh
+++ b/test/sharness/t0131-multinode-client-routing.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0140-swarm.sh
+++ b/test/sharness/t0140-swarm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0141-addfilter.sh
+++ b/test/sharness/t0141-addfilter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0150-clisuggest.sh
+++ b/test/sharness/t0150-clisuggest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test ipfs cli cmd suggest"
 

--- a/test/sharness/t0151-sysdiag.sh
+++ b/test/sharness/t0151-sysdiag.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0160-resolve.sh
+++ b/test/sharness/t0160-resolve.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test resolve command"
 

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0170-dht.sh
+++ b/test/sharness/t0170-dht.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test dht command"
 

--- a/test/sharness/t0175-reprovider.sh
+++ b/test/sharness/t0175-reprovider.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test reprovider"
 

--- a/test/sharness/t0180-p2p.sh
+++ b/test/sharness/t0180-p2p.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test experimental p2p commands"
 

--- a/test/sharness/t0180-pubsub.sh
+++ b/test/sharness/t0180-pubsub.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test dht command"
 

--- a/test/sharness/t0181-private-network.sh
+++ b/test/sharness/t0181-private-network.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0181-private-network.sh
+++ b/test/sharness/t0181-private-network.sh
@@ -29,7 +29,7 @@ pnet_key() {
   random 16
 }
 
-pnet_key > $IPFS_PATH/swarm.key
+pnet_key > "${IPFS_PATH}/swarm.key"
 
 LIBP2P_FORCE_PNET=1 test_launch_ipfs_daemon
 
@@ -42,7 +42,7 @@ set_key() {
   node="$1"
   keyfile="$2"
 
-  cp "$keyfile" "$IPTB_ROOT/$node/swarm.key"
+  cp "$keyfile" "${IPTB_ROOT}/${node}/swarm.key"
 }
 
 pnet_key > key1

--- a/test/sharness/t0182-circuit-relay.sh
+++ b/test/sharness/t0182-circuit-relay.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test circuit relay"
 

--- a/test/sharness/t0183-namesys-pubsub.sh
+++ b/test/sharness/t0183-namesys-pubsub.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Test IPNS pubsub"
 

--- a/test/sharness/t0200-unixfs-ls.sh
+++ b/test/sharness/t0200-unixfs-ls.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0210-tar.sh
+++ b/test/sharness/t0210-tar.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0220-bitswap.sh
+++ b/test/sharness/t0220-bitswap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0230-channel-streaming-http-content-type.sh
+++ b/test/sharness/t0230-channel-streaming-http-content-type.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Cayman Nava
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0231-channel-streaming.sh
+++ b/test/sharness/t0231-channel-streaming.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0235-cli-request.sh
+++ b/test/sharness/t0235-cli-request.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0240-republisher.sh
+++ b/test/sharness/t0240-republisher.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0251-files-flushing.sh
+++ b/test/sharness/t0251-files-flushing.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0252-files-gc.sh
+++ b/test/sharness/t0252-files-gc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Kevin Atkinson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0260-sharding.sh
+++ b/test/sharness/t0260-sharding.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2014 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0270-filestore.sh
+++ b/test/sharness/t0270-filestore.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0271-filestore-utils.sh
+++ b/test/sharness/t0271-filestore-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0275-cid-security.sh
+++ b/test/sharness/t0275-cid-security.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jakub Sztandera
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0280-plugin-git.sh
+++ b/test/sharness/t0280-plugin-git.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Jakub Sztandera
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2015 Christian Couder
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0301-docker-migrate.sh
+++ b/test/sharness/t0301-docker-migrate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 Whyrusleeping
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0400-api-security.sh
+++ b/test/sharness/t0400-api-security.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Lars Gierth
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0410-api-add.sh
+++ b/test/sharness/t0410-api-add.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Tom O'Donnell
 # MIT Licensed; see the LICENSE file in this repository.

--- a/test/sharness/t0500-issues-and-regressions-offline.sh
+++ b/test/sharness/t0500-issues-and-regressions-offline.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Tests for various fixed issues and regressions."
 

--- a/test/sharness/t0600-issues-and-regressions-online.sh
+++ b/test/sharness/t0600-issues-and-regressions-online.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 test_description="Tests for various fixed issues and regressions."
 

--- a/test/sharness/x0601-pin-fail-test.sh
+++ b/test/sharness/x0601-pin-fail-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2016 Jeromy Johnson
 # MIT Licensed; see the LICENSE file in this repository.


### PR DESCRIPTION
This makes sharness generate a JUnit XML report that can be used by Jenkins to view test results in a bit nicer form than a huge txt file (removing the fun of wasting few minutes to find the failure each time one happens). The report is saved as `test/sharness/test-results/sharness.xml`.

Example report: https://ipfs.io/ipfs/QmZVCjX2L9DrbqYaVeVzTXZZUbyQvTM3mTUmzeMCoN8Pqc/sharness.xml - [HTML from junit2html](https://ipfs.io/ipfs/QmZVCjX2L9DrbqYaVeVzTXZZUbyQvTM3mTUmzeMCoN8Pqc/sharness.xml.html) - Jenkins should show failures at the top ([like here](https://ci.ipfs.team/blue/organizations/jenkins/IPFS%2Fjs-ipfs-unixfs-engine/detail/PR-200/2/tests))

Somewhat depends on https://github.com/ipfs/jenkins/pull/85