### PR TITLE
only construct bitswap event loggable if necessary

### DIFF
--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -59,11 +59,13 @@ func (bs *Bitswap) taskWorker(ctx context.Context, id int) {
 				if !ok {
 					continue
 				}
-				log.Event(ctx, "Bitswap.TaskWorker.Work", logging.LoggableMap{
-					"ID":     id,
-					"Target": envelope.Peer.Pretty(),
-					"Block":  envelope.Block.Cid().String(),
-				})
+				log.Event(ctx, "Bitswap.TaskWorker.Work", logging.LoggableF(func() map[string]interface{} {
+					return logging.LoggableMap{
+						"ID":     id,
+						"Target": envelope.Peer.Pretty(),
+						"Block":  envelope.Block.Cid().String(),
+					}
+				}))
 
 				// update the BS ledger to reflect sent message
 				// TODO: Should only track *useful* messages in ledger


### PR DESCRIPTION
Base58 encoding cids/peerIDs isn't exactly fast.