### PR TITLE
Implement the command "ipfs repo has"

### DIFF
--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -414,7 +414,7 @@ var repoVersionCmd = &oldcmds.Command{
 	},
 }
 
-type LocalityOutput struct {
+type localityOutput struct {
 	Hash      string
 	Local     bool
 	SizeLocal int `json:",omitempty"`
@@ -476,7 +476,7 @@ var repoHasCmd = &cmds.Command{
 
 			if !hasRoot || !recursive {
 				// we don't have precise size information
-				res.Emit(&LocalityOutput{Hash: k.String(), Local: hasRoot})
+				res.Emit(&localityOutput{Hash: k.String(), Local: hasRoot})
 				continue
 			}
 
@@ -486,7 +486,7 @@ var repoHasCmd = &cmds.Command{
 				return
 			}
 
-			res.Emit(&LocalityOutput{
+			res.Emit(&localityOutput{
 				Hash:      k.String(),
 				Local:     local,
 				SizeLocal: sizeLocal,
@@ -496,7 +496,7 @@ var repoHasCmd = &cmds.Command{
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeEncoder(func(req cmds.Request, w io.Writer, v interface{}) error {
-			lo, ok := v.(*LocalityOutput)
+			lo, ok := v.(*localityOutput)
 			if !ok {
 				return e.TypeErr(lo, v)
 			}
@@ -538,7 +538,7 @@ var repoHasCmd = &cmds.Command{
 			return nil
 		}),
 	},
-	Type: LocalityOutput{},
+	Type: localityOutput{},
 }
 
 func walkBlock(ctx context.Context, dagserv dag.DAGService, merkleNode node.Node) (bool, int, int, error) {

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -536,7 +536,7 @@ Example:
 					state = "incomplete"
 				}
 				if lo.SizeTotal <= 0 {
-					state = "unknow"
+					state = "unknown"
 				}
 			} else {
 				if lo.Local {
@@ -564,8 +564,8 @@ Example:
 	Type: localityOutput{},
 }
 
-func walkBlock(ctx context.Context, dagserv dag.DAGService, merkleNode node.Node) (bool, int, int, error) {
-	stat, err := merkleNode.Stat()
+func walkBlock(ctx context.Context, dagserv dag.DAGService, nd node.Node) (bool, int, int, error) {
+	stat, err := nd.Stat()
 	if err != nil {
 		return false, 0, 0, err
 	}
@@ -575,7 +575,7 @@ func walkBlock(ctx context.Context, dagserv dag.DAGService, merkleNode node.Node
 
 	local := true
 
-	for _, link := range merkleNode.Links() {
+	for _, link := range nd.Links() {
 		child, err := dagserv.Get(ctx, link.Cid)
 
 		if err == dag.ErrNotFound {

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -423,8 +423,31 @@ type localityOutput struct {
 
 var repoHasCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline:          "Show if an object is available locally",
-		ShortDescription: ``,
+		Tagline: "Show if an object is available locally",
+		ShortDescription: `
+'ipfs repo has' tell if an object is available locally. It will not do any network request.`,
+		LongDescription: `
+'ipfs repo has' tell if an object is available locally. It will not do any network request.
+
+When using the recursive option, the graph of objects will be traversed to compute precisely
+how much data is available locally.
+
+Example:
+
+	non-recursive
+	> ipfs repo has QmYGVhjTfVvBAAf2SAWMJsTDheo7UuyjQigGahmB8YU3ZH
+	QmYGVhjTfVvBAAf2SAWMJsTDheo7UuyjQigGahmB8YU3ZH	local
+	> ipfs repo has QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT
+	QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT	non local
+
+	recursive
+	> ipfs repo has -r QmQFnam7qMXfF8R1D3qrETCgESnVP8gt6iEnAbyG73gyqm
+	QmQFnam7qMXfF8R1D3qrETCgESnVP8gt6iEnAbyG73gyqm	unknow
+	> ipfs repo has -r QmQLXHs7K98JNQdWrBB2cQLJahPhmupbDjRuH1b9ibmwVa
+	QmQLXHs7K98JNQdWrBB2cQLJahPhmupbDjRuH1b9ibmwVa	incomplete	4.1 MB of 6.9 MB (60.31%)
+	> ipfs repo has -r QmeUKqHMr5r6wJzt3AVScnUAyC4TkdZGjYJNaFBCL1BmAv
+	QmeUKqHMr5r6wJzt3AVScnUAyC4TkdZGjYJNaFBCL1BmAv	complete	3.2 MB of 3.2 MB (100.00%)
+`,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("key", true, true, "Key(s) to check for locality.").EnableStdin(),


### PR DESCRIPTION
Following https://github.com/ipfs/go-ipfs/issues/4028, I implemented a `ipfs repo has` command that tell if something is available locally or not.
```
USAGE
  ipfs repo has <key>... - Show if an object is available locally

SYNOPSIS
  ipfs repo has [--recursive | -r] [--] <key>...

ARGUMENTS

  <key>... - Key(s) to check for locality.

OPTIONS

  -r, --recursive bool - Check recursively the graph of objects to build more precise stats.
```

Results look like this:
```
non-recursive
$ ipfs repo has QmYGVhjTfVvBAAf2SAWMJsTDheo7UuyjQigGahmB8YU3ZH
QmYGVhjTfVvBAAf2SAWMJsTDheo7UuyjQigGahmB8YU3ZH	local
$ ipfs repo has QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT
QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT	non local

recursive
$ ipfs repo has -r QmQFnam7qMXfF8R1D3qrETCgESnVP8gt6iEnAbyG73gyqm
QmQFnam7qMXfF8R1D3qrETCgESnVP8gt6iEnAbyG73gyqm	unknow
$ ipfs repo has -r QmQLXHs7K98JNQdWrBB2cQLJahPhmupbDjRuH1b9ibmwVa
QmQLXHs7K98JNQdWrBB2cQLJahPhmupbDjRuH1b9ibmwVa	incomplete	4.1 MB of 6.9 MB (60.31%)
$ ipfs repo has -r QmeUKqHMr5r6wJzt3AVScnUAyC4TkdZGjYJNaFBCL1BmAv
QmeUKqHMr5r6wJzt3AVScnUAyC4TkdZGjYJNaFBCL1BmAv	complete	3.2 MB of 3.2 MB (100.00%)
```

License: MIT
Signed-off-by: Michael Muré <batolettre@gmail.com>