### PR TITLE
[RFC] don't sniff the filename to determine the content type

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -261,14 +261,10 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 
 	if !dir {
 		urlFilename := r.URL.Query().Get("filename")
-		var name string
 		if urlFilename != "" {
 			w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename*=UTF-8''%s", url.PathEscape(urlFilename)))
-			name = urlFilename
-		} else {
-			name = gopath.Base(urlPath)
 		}
-		i.serveFile(w, r, name, modtime, dr)
+		i.serveFile(w, r, modtime, dr)
 		return
 	}
 
@@ -387,14 +383,14 @@ func (s *sizeSeeker) Seek(offset int64, whence int) (int64, error) {
 	return s.sizeReadSeeker.Seek(offset, whence)
 }
 
-func (i *gatewayHandler) serveFile(w http.ResponseWriter, req *http.Request, name string, modtime time.Time, content io.ReadSeeker) {
+func (i *gatewayHandler) serveFile(w http.ResponseWriter, req *http.Request, modtime time.Time, content io.ReadSeeker) {
 	if sp, ok := content.(sizeReadSeeker); ok {
 		content = &sizeSeeker{
 			sizeReadSeeker: sp,
 		}
 	}
 
-	http.ServeContent(w, req, name, modtime, content)
+	http.ServeContent(w, req, "", modtime, content)
 }
 
 func (i *gatewayHandler) postHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
fixes #4543, may break other things

IMO, this is the best way to do this (for now, until we start manually storing the content type along with the files). I'd rather not guess at all but we can at least avoid guessing by filename.