### PR TITLE
Allow install.sh to be run without being the script dir

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -5,7 +5,7 @@
 
 INSTALL_DIR=$(dirname $0)
 
-bin=$INSTALL_DIR/ipfs
+bin="$INSTALL_DIR/ipfs"
 binpaths="/usr/local/bin /usr/bin"
 
 # This variable contains a nonzero length string in case the script fails

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -3,7 +3,7 @@
 # Installation script for ipfs. It tries to move $bin in one of the
 # directories stored in $binpaths.
 
-INSTALL_DIR=`dirname $0`
+INSTALL_DIR=$(dirname $0)
 
 bin=$INSTALL_DIR/ipfs
 binpaths="/usr/local/bin /usr/bin"

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -3,7 +3,9 @@
 # Installation script for ipfs. It tries to move $bin in one of the
 # directories stored in $binpaths.
 
-bin=ipfs
+INSTALL_DIR=`dirname $0`
+
+bin=$INSTALL_DIR/ipfs
 binpaths="/usr/local/bin /usr/bin"
 
 # This variable contains a nonzero length string in case the script fails


### PR DESCRIPTION
This is a very simple change, but took me a few minutes to resolve, since the documentation is specifically broken related to this.

https://ipfs.io/docs/install/#installing-from-a-prebuilt-package

```
...
After downloading, untar the archive, and move the ipfs binary somewhere in your executables $PATH using the install.sh script:

tar xvfz go-ipfs.tar.gz

./go-ipfs/install.sh # <-- install.sh cannot currently be run when not inside the go-ipfs directory

Test it out:
...
```
  