### PR TITLE
Fix typos and inconsistencies in commands documentation

### DIFF
--- a/core/commands/files/files.go
+++ b/core/commands/files/files.go
@@ -749,8 +749,8 @@ NOTE: All paths must be absolute.
 
 Examples:
 
-    $ ipfs mfs mkdir /test/newdir
-    $ ipfs mfs mkdir -p /test/does/not/exist/yet
+    $ ipfs files mkdir /test/newdir
+    $ ipfs files mkdir -p /test/does/not/exist/yet
 `,
 	},
 

--- a/core/commands/name.go
+++ b/core/commands/name.go
@@ -40,7 +40,7 @@ Publish an <ipfs-path> with another name, added by an 'ipfs key' command:
 
   > ipfs key gen --type=rsa --size=2048 mykey
   > ipfs name publish --key=mykey /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  Published to QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Resolve the value of your name:
 

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -50,7 +50,7 @@ Publish an <ipfs-path> with another name, added by an 'ipfs key' command:
 
   > ipfs key gen --type=rsa --size=2048 mykey
   > ipfs name publish --key=mykey /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
-  Published to QmbCMUZw6JFeZ7Wp9jkzbye3Fzp2GGcPgC3nmeUjfVF87n: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
+  Published to QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd: /ipfs/QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy
 
 Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by 
 'ipfs key list -l'):


### PR DESCRIPTION
A few minor corrections I noticed when reading through https://ipfs.io/docs/commands/.

In the case of name and publish, the example is currently confusing because the output shows the ipfs path being published to the same ipns as earlier despite the fact it was published with a new key. 

Also, the generated public page on ipfs.io is a bit out of date (April 2017), so some old commands are still there despite being removed from the latest versions, e.g. "ipfs tour"