### PR TITLE
update link to filestore experimental status

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -195,7 +195,7 @@ You can now check what blocks have been created by:
 		hashFunStr, hfset, _ := req.Option(hashOptionName).String()
 
 		if nocopy && !cfg.Experimental.FilestoreEnabled {
-			res.SetError(errors.New("filestore is not enabled, see https://git.io/vy4XN"),
+			res.SetError(errors.New("filestore is not enabled, see https://git.io/vNItf"),
 				cmdkit.ErrClient)
 			return
 		}


### PR DESCRIPTION
According to https://github.com/ipfs/go-ipfs/issues/3397#issuecomment-317256365, the status of experimental features is now tracked in a file in the repo, not in an issue.