### PR TITLE
fix circleci cache directory list

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ dependencies:
 
   cache_directories:
     - ~/go1.9.2.linux-amd64.tar.gz
-    - "$HOME/.go_workspace/src/gx/ipfs"
+    - ~/.go_workspace/src/gx/ipfs
 
 test:
   override:


### PR DESCRIPTION
environment variable expansion doesn't work in the cache_directories section.