### PR TITLE
Avoid closing channels in commands if the context has errored (e.g timed out).

### DIFF
--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -6,6 +6,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -151,4 +152,15 @@ func unwrapOutput(i interface{}) (interface{}, error) {
 	}
 
 	return <-ch, nil
+}
+
+// closeUnlessErr closes `c`, unless `req` encountered an error (e.g. a timeout
+// or a cancellation). `defer closeUnlessErr(ctx, c)` is useful as an
+// alternative for `defer close(c)` if you want to prevent the receiver from
+// seeing the closed channel when there was a context error (which might
+// accidentally let it assume that there was no context error).
+func closeUnlessErr(ctx context.Context, c chan interface{}) {
+	if ctx.Err() == nil {
+		close(c)
+	}
 }

--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -237,5 +238,32 @@ func TestCommands(t *testing.T) {
 		} else if sub == nil {
 			t.Errorf("subcommand %q is nil even though there was no error", path)
 		}
+	}
+}
+
+func TestCloseUnlessErrCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := make(chan interface{})
+	closeUnlessErr(ctx, c)
+
+	go func() {
+		c <- 1
+	}()
+	if _, ok := <-c; !ok {
+		t.Fatal("expected channel to be open")
+	}
+}
+
+func TestCloseUnlessErrNoCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := make(chan interface{})
+	closeUnlessErr(ctx, c)
+
+	if _, ok := <-c; ok {
+		t.Fatal("expected channel to be closed")
 	}
 }

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -91,7 +91,7 @@ var queryDhtCmd = &cmds.Command{
 		res.SetOutput((<-chan interface{})(outChan))
 
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for e := range events {
 				select {
 				case outChan <- e:
@@ -183,7 +183,7 @@ var findProvidersDhtCmd = &cmds.Command{
 
 		pchan := dht.FindProvidersAsync(ctx, c, numProviders)
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for e := range events {
 				select {
 				case outChan <- e:
@@ -307,7 +307,7 @@ var provideRefDhtCmd = &cmds.Command{
 		ctx := notif.RegisterForQueryEvents(req.Context(), events)
 
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for e := range events {
 				select {
 				case outChan <- e:
@@ -437,13 +437,12 @@ var findPeerDhtCmd = &cmds.Command{
 		ctx := notif.RegisterForQueryEvents(req.Context(), events)
 
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for v := range events {
 				select {
 				case outChan <- v:
 				case <-req.Context().Done():
 				}
-
 			}
 		}()
 
@@ -543,7 +542,7 @@ Different key types can specify other 'best' rules.
 		}
 
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for e := range events {
 				select {
 				case outChan <- e:
@@ -660,7 +659,7 @@ NOTE: A value may not exceed 2048 bytes.
 		data := req.Arguments()[1]
 
 		go func() {
-			defer close(outChan)
+			defer closeUnlessErr(req.Context(), outChan)
 			for e := range events {
 				select {
 				case outChan <- e:

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -78,8 +78,7 @@ order to reclaim hard disk space.
 		res.SetOutput(outChan)
 
 		go func() {
-			defer close(outChan)
-
+			defer closeUnlessErr(req.Context(), outChan)
 			if streamErrors {
 				errs := false
 				for res := range gcOutChan {
@@ -282,7 +281,7 @@ var repoVerifyCmd = &oldcmds.Command{
 
 		out := make(chan interface{})
 		res.SetOutput((<-chan interface{})(out))
-		defer close(out)
+		defer closeUnlessErr(req.Context(), out)
 
 		bs := bstore.NewBlockstore(nd.Repo.Datastore())
 		bs.HashOnRead(true)


### PR DESCRIPTION
Previously, the following could happen:
- Producer creates channel.
- Consumer reads from channel.
- Producer observes that the context has errored, and closes the channel.
- Consumer sees the closed channel before seeing the context error, and assumes
  that command completed without a context error.

This change ensures the following:
- Producer creates channel.
- Consumer reads from channel.
- Producer observes that the context has errored, and DOES NOT close the
  channel.
- Consumer sees that the context has errored, and handles the channel
  appropriately.

Note that per the definition of context [1], a context is "done" iff it has not
"errored" (i.e. ctx.Err() is non-nil).

[1] https://godoc.org/context#Context

Updates call sites touched by #4413 and addresses #4414.