### PR TITLE
gateway: expose commands for js-libp2p delegated routing

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -185,6 +185,18 @@ var rootROSubcommands = map[string]*cmds.Command{
 	}),
 	"resolve": lgc.NewCommand(ResolveCmd),
 	"version": lgc.NewCommand(VersionCmd),
+	"refs":    lgc.NewCommand(RefsROCmd),
+	"dht": lgc.NewCommand(&oldcmds.Command{
+		Subcommands: map[string]*oldcmds.Command{
+			"findprovs": findProvidersDhtCmd,
+			"findpeer":  findPeerDhtCmd,
+		},
+	}),
+	"swarm": lgc.NewCommand(&oldcmds.Command{
+		Subcommands: map[string]*oldcmds.Command{
+			"connect": swarmConnectCmd,
+		},
+	}),
 }
 
 func init() {


### PR DESCRIPTION
This enables js-libp2p/js-ipfs to delegate peer routing and content routing to a go-ipfs gateway (usually ipfs.io). It covers:

- Peer routing lookups (`dht/findpeer`)
- Content routing lookups (`dht/findprovs`)
- Content routing writes -- go-libp2p-kad-dht rejects provider records which originate from a different node than the message sender, so we're doing a creative hack here: we'll tell the delegatee to connect to us (`swarm/connect` with a `/p2p-circuit` address), and then to fetch the data from us (`refs?r=true`). This isn't technically content routing, but it makes the data available to the network which is all we need.

Peer routing writes will be a new command that'll be covered in a future PR.

(@diasdavid catch!)