### PR TITLE
expand the issue template and remove the severity field

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,33 +1,38 @@
 <!--
+Welcome to the go-ipfs bug tracker. This is for you! Please read, and then delete this text before posting it.
+
+If you haven't yet searched the issue tracker for an existing report concerning your issue, please do so now.
+
+The go-ipfs issues are only for bug reports and directly actionable feature requests. Read https://github.com/ipfs/community/blob/master/contributing.md#reporting-issues if your issue doesn't fit either of those categories.
+
+If you have a *SUPPORT QUESTION*, please direct it to our forum at https://discuss.ipfs.io.
+
+Read https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue.
+-->
+
+#### Version information:
+<!--
 Output From `ipfs version --all`
 
 If your version is older than *0.4.11* please update
 and re-check if the problem persists.
 -->
-#### Version information:
 
-<!-- Bug, Feature, Enhancement, Etc -->
 #### Type:
-
-<!-- One of following:
-    Critical - System crash, application panic.
-    High - The main functionality of the application does not work, API breakage, repo format breakage, etc.
-    Medium - A non-essential functionality does not work, performance issues, etc.
-    Low - An optional functionality does not work.
-    Very Low - Translation or documentation mistake. Something that really does not matter much but should be noticed for a future release. -->
-#### Severity:
+<!-- Bug, Feature, Enhancement, Etc -->
 
 #### Description:
-
-
-
-
-
-
-
 <!--
-This is for you! Please read, and then delete this text before posting it.
-The go-ipfs issues are only for bug reports and directly actionable features.
-Read https://github.com/ipfs/community/blob/master/contributing.md#reporting-issues if your issue doesn't fit either of those categories.
-Read https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue.
+This is where you get to tell us what went wrong or what feature you need. When doing so, please make sure to include *all* relavent information.
+
+When requesting a feature, please be sure to include:
+
+* Your motivation. Why do you need the feature?
+* How the feature should work.
+
+When reporting a bug, please try to include:
+
+* What you were doing when you experienced the bug.
+* Any error messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
+* When possible, steps to reliably produce the bug.
 -->


### PR DESCRIPTION
* Direct users seeking support to the forums.
* Remove the severity field. It doesn't actually help (especially because we can't filter by it and, anyways, *we* end up deciding the severity).
* Put the section comments *inside* the sections. This has been annoying me from day 1.
* Put the welcome text *at the top* so users actually read it.
* Expand on what we want in a description.