### PR TITLE
minor drive-by code cleanup

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -657,24 +657,28 @@ func deserializeNode(nd *Node, dataFieldEncoding string) (*dag.ProtoNode, error)
 	case "text":
 		dagnode.SetData([]byte(nd.Data))
 	case "base64":
-		data, _ := base64.StdEncoding.DecodeString(nd.Data)
+		data, err := base64.StdEncoding.DecodeString(nd.Data)
+		if err != nil {
+			return nil, err
+		}
 		dagnode.SetData(data)
 	default:
 		return nil, fmt.Errorf("Unkown data field encoding")
 	}
 
-	dagnode.SetLinks(make([]*ipld.Link, len(nd.Links)))
+	links := make([]*ipld.Link, len(nd.Links))
 	for i, link := range nd.Links {
 		c, err := cid.Decode(link.Hash)
 		if err != nil {
 			return nil, err
 		}
-		dagnode.Links()[i] = &ipld.Link{
+		links[i] = &ipld.Link{
 			Name: link.Name,
 			Size: link.Size,
 			Cid:  c,
 		}
 	}
+	dagnode.SetLinks(links)
 
 	return dagnode, nil
 }

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -297,24 +297,28 @@ func deserializeNode(nd *Node, dataFieldEncoding string) (*dag.ProtoNode, error)
 	case "text":
 		dagnode.SetData([]byte(nd.Data))
 	case "base64":
-		data, _ := base64.StdEncoding.DecodeString(nd.Data)
+		data, err := base64.StdEncoding.DecodeString(nd.Data)
+		if err != nil {
+			return nil, err
+		}
 		dagnode.SetData(data)
 	default:
 		return nil, fmt.Errorf("Unkown data field encoding")
 	}
 
-	dagnode.SetLinks(make([]*ipld.Link, len(nd.Links)))
+	links := make([]*ipld.Link, len(nd.Links))
 	for i, link := range nd.Links {
 		c, err := cid.Decode(link.Hash)
 		if err != nil {
 			return nil, err
 		}
-		dagnode.Links()[i] = &ipld.Link{
+		links[i] = &ipld.Link{
 			Name: link.Name,
 			Size: link.Size,
 			Cid:  c,
 		}
 	}
+	dagnode.SetLinks(links)
 
 	return dagnode, nil
 }


### PR DESCRIPTION
We'll dedup the code later, for now:

1. Don't drop errors on the floor.
2. Don't modify anything returned by `Links()` directly...