### PR TITLE
Fix go test on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assets/init-doc/*          binary
+core/coreunix/test_data/** binary

--- a/cmd/ipfs/util/ulimit_test.go
+++ b/cmd/ipfs/util/ulimit_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package util
 
 import (

--- a/pin/pin_test.go
+++ b/pin/pin_test.go
@@ -16,10 +16,12 @@ import (
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
 
+var rand = util.NewTimeSeededRand()
+
 func randNode() (*mdag.ProtoNode, *cid.Cid) {
 	nd := new(mdag.ProtoNode)
 	nd.SetData(make([]byte, 32))
-	util.NewTimeSeededRand().Read(nd.Data())
+	rand.Read(nd.Data())
 	k := nd.Cid()
 	return nd, k
 }

--- a/repo/fsrepo/serialize/serialize_test.go
+++ b/repo/fsrepo/serialize/serialize_test.go
@@ -2,6 +2,7 @@ package fsrepo
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	config "github.com/ipfs/go-ipfs/repo/config"
@@ -27,7 +28,10 @@ func TestConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot stat config file: %v", err)
 	}
-	if g := st.Mode().Perm(); g&0117 != 0 {
-		t.Fatalf("config file should not be executable or accessible to world: %v", g)
+
+	if runtime.GOOS != "windows" { // see https://golang.org/src/os/types_windows.go
+		if g := st.Mode().Perm(); g&0117 != 0 {
+			t.Fatalf("config file should not be executable or accessible to world: %v", g)
+		}
 	}
 }

--- a/routing/mock/centralized_test.go
+++ b/routing/mock/centralized_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	delay "github.com/ipfs/go-ipfs/thirdparty/delay"
-	"gx/ipfs/QmVvkK7s5imCiq3JVbL3pGfnhcCnf3LrFJPF4GE2sAoGZf/go-testutil"
 
 	u "gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
+	testutil "gx/ipfs/QmVvkK7s5imCiq3JVbL3pGfnhcCnf3LrFJPF4GE2sAoGZf/go-testutil"
 	pstore "gx/ipfs/QmXauCuJzmzapetmC6W4TuDJLL1yFFrVzSHoWv8YdbmnxH/go-libp2p-peerstore"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
@@ -164,6 +164,8 @@ func TestValidAfter(t *testing.T) {
 	}
 
 	conf.ValueVisibility.Set(0)
+	time.Sleep(100 * time.Millisecond)
+
 	providersChan = rs.Client(pi).FindProvidersAsync(ctx, key, max)
 	t.Log("providers", providers)
 	for p := range providersChan {


### PR DESCRIPTION
This fixes windows issues @VictorBjelkholm had in https://github.com/ipfs/go-ipfs/pull/4430#issuecomment-352016810.

There is still one test failing:
```
--- FAIL: TestReprovide (0.05s)
        reprovide_test.go:51: Should have gotten a provider
```

This will need a fix in https://github.com/libp2p/go-libp2p-peer/blob/master/test/utils.go#L23. The problem here is that `time.Now().UnixNano()` resolution on windows is really poor (multiple ms)