### PR TITLE
Use a bitswap session for 'Cat'

### DIFF
--- a/merkledag/errservice.go
+++ b/merkledag/errservice.go
@@ -1,0 +1,41 @@
+package merkledag
+
+import (
+	"context"
+
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+// ErrorService implements ipld.DAGService, returning 'Err' for every call.
+type ErrorService struct {
+	Err error
+}
+
+var _ ipld.DAGService = (*ErrorService)(nil)
+
+func (cs *ErrorService) Add(ctx context.Context, nd ipld.Node) error {
+	return cs.Err
+}
+
+func (cs *ErrorService) AddMany(ctx context.Context, nds []ipld.Node) error {
+	return cs.Err
+}
+
+func (cs *ErrorService) Get(ctx context.Context, c *cid.Cid) (ipld.Node, error) {
+	return nil, cs.Err
+}
+
+func (cs *ErrorService) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *ipld.NodeOption {
+	ch := make(chan *ipld.NodeOption)
+	close(ch)
+	return ch
+}
+
+func (cs *ErrorService) Remove(ctx context.Context, c *cid.Cid) error {
+	return cs.Err
+}
+
+func (cs *ErrorService) RemoveMany(ctx context.Context, cids []*cid.Cid) error {
+	return cs.Err
+}

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -146,6 +146,10 @@ func (sg *sesGetter) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *ipld.
 	return getNodesFromBG(ctx, sg.bs, keys)
 }
 
+func (ds *dagService) Session(ctx context.Context) ipld.NodeGetter {
+	return &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
+}
+
 // FetchGraph fetches all nodes that are children of the given node
 func FetchGraph(ctx context.Context, root *cid.Cid, serv ipld.DAGService) error {
 	var ng ipld.NodeGetter = serv

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -146,6 +146,7 @@ func (sg *sesGetter) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *ipld.
 	return getNodesFromBG(ctx, sg.bs, keys)
 }
 
+// Session returns a NodeGetter using a new session for block fetches.
 func (ds *dagService) Session(ctx context.Context) ipld.NodeGetter {
 	return &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
 }

--- a/merkledag/readonly.go
+++ b/merkledag/readonly.go
@@ -6,8 +6,12 @@ import (
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
 )
 
+// ErrReadOnly is used when a read-only datastructure is written to.
 var ErrReadOnly = fmt.Errorf("cannot write to readonly DAGService")
 
+// NewReadOnlyDagService takes a NodeGetter, and returns a full DAGService
+// implementation that returns ErrReadOnly when its 'write' methods are
+// invoked.
 func NewReadOnlyDagService(ng ipld.NodeGetter) ipld.DAGService {
 	return &ComboService{
 		Read:  ng,

--- a/merkledag/readonly.go
+++ b/merkledag/readonly.go
@@ -1,0 +1,16 @@
+package merkledag
+
+import (
+	"fmt"
+
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+var ErrReadOnly = fmt.Errorf("cannot write to readonly DAGService")
+
+func NewReadOnlyDagService(ng ipld.NodeGetter) ipld.DAGService {
+	return &ComboService{
+		Read:  ng,
+		Write: &ErrorService{ErrReadOnly},
+	}
+}

--- a/merkledag/readonly_test.go
+++ b/merkledag/readonly_test.go
@@ -1,0 +1,64 @@
+package merkledag_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/ipfs/go-ipfs/merkledag"
+	dstest "github.com/ipfs/go-ipfs/merkledag/test"
+
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+func TestReadonlyProperties(t *testing.T) {
+	ds := dstest.Mock()
+	ro := NewReadOnlyDagService(ds)
+
+	ctx := context.Background()
+	nds := []ipld.Node{
+		NewRawNode([]byte("foo1")),
+		NewRawNode([]byte("foo2")),
+		NewRawNode([]byte("foo3")),
+		NewRawNode([]byte("foo4")),
+	}
+	cids := []*cid.Cid{
+		nds[0].Cid(),
+		nds[1].Cid(),
+		nds[2].Cid(),
+		nds[3].Cid(),
+	}
+
+	// add to the actual underlying datastore
+	if err := ds.Add(ctx, nds[2]); err != nil {
+		t.Fatal(err)
+	}
+	if err := ds.Add(ctx, nds[3]); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ro.Add(ctx, nds[0]); err != ErrReadOnly {
+		t.Fatal("expected ErrReadOnly")
+	}
+	if err := ro.Add(ctx, nds[2]); err != ErrReadOnly {
+		t.Fatal("expected ErrReadOnly")
+	}
+
+	if err := ro.AddMany(ctx, nds[0:1]); err != ErrReadOnly {
+		t.Fatal("expected ErrReadOnly")
+	}
+
+	if err := ro.Remove(ctx, cids[3]); err != ErrReadOnly {
+		t.Fatal("expected ErrReadOnly")
+	}
+	if err := ro.RemoveMany(ctx, cids[1:2]); err != ErrReadOnly {
+		t.Fatal("expected ErrReadOnly")
+	}
+
+	if _, err := ro.Get(ctx, cids[0]); err != ipld.ErrNotFound {
+		t.Fatal("expected ErrNotFound")
+	}
+	if _, err := ro.Get(ctx, cids[3]); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/merkledag/rwservice.go
+++ b/merkledag/rwservice.go
@@ -1,0 +1,41 @@
+package merkledag
+
+import (
+	"context"
+
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+// ComboService implements ipld.DAGService, using 'Read' for all fetch methods,
+// and 'Write' for all methods that add new objects.
+type ComboService struct {
+	Read  ipld.NodeGetter
+	Write ipld.DAGService
+}
+
+var _ ipld.DAGService = (*ComboService)(nil)
+
+func (cs *ComboService) Add(ctx context.Context, nd ipld.Node) error {
+	return cs.Write.Add(ctx, nd)
+}
+
+func (cs *ComboService) AddMany(ctx context.Context, nds []ipld.Node) error {
+	return cs.Write.AddMany(ctx, nds)
+}
+
+func (cs *ComboService) Get(ctx context.Context, c *cid.Cid) (ipld.Node, error) {
+	return cs.Read.Get(ctx, c)
+}
+
+func (cs *ComboService) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *ipld.NodeOption {
+	return cs.Read.GetMany(ctx, cids)
+}
+
+func (cs *ComboService) Remove(ctx context.Context, c *cid.Cid) error {
+	return cs.Write.Remove(ctx, c)
+}
+
+func (cs *ComboService) RemoveMany(ctx context.Context, cids []*cid.Cid) error {
+	return cs.Write.RemoveMany(ctx, cids)
+}

--- a/merkledag/session.go
+++ b/merkledag/session.go
@@ -1,0 +1,18 @@
+package merkledag
+
+import (
+	"context"
+
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+type SessionMaker interface {
+	Session(context.Context) ipld.NodeGetter
+}
+
+func NewSession(ctx context.Context, g ipld.NodeGetter) ipld.NodeGetter {
+	if sm, ok := g.(SessionMaker); ok {
+		return sm.Session(ctx)
+	}
+	return g
+}

--- a/merkledag/session.go
+++ b/merkledag/session.go
@@ -6,10 +6,13 @@ import (
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
 )
 
+// SessionMaker is an object that can generate a new fetching session.
 type SessionMaker interface {
 	Session(context.Context) ipld.NodeGetter
 }
 
+// NewSession returns a session backed NodeGetter if the given NodeGetter
+// implements SessionMaker.
 func NewSession(ctx context.Context, g ipld.NodeGetter) ipld.NodeGetter {
 	if sm, ok := g.(SessionMaker); ok {
 		return sm.Session(ctx)

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -35,9 +35,9 @@ func (e ErrNoLink) Error() string {
 // TODO: now that this is more modular, try to unify this code with the
 //       the resolvers in namesys
 type Resolver struct {
-	DAG ipld.DAGService
+	DAG ipld.NodeGetter
 
-	ResolveOnce func(ctx context.Context, ds ipld.DAGService, nd ipld.Node, names []string) (*ipld.Link, []string, error)
+	ResolveOnce func(ctx context.Context, ds ipld.NodeGetter, nd ipld.Node, names []string) (*ipld.Link, []string, error)
 }
 
 // NewBasicResolver constructs a new basic resolver.
@@ -124,7 +124,7 @@ func (s *Resolver) ResolvePath(ctx context.Context, fpath Path) (ipld.Node, erro
 
 // ResolveSingle simply resolves one hop of a path through a graph with no
 // extra context (does not opaquely resolve through sharded nodes)
-func ResolveSingle(ctx context.Context, ds ipld.DAGService, nd ipld.Node, names []string) (*ipld.Link, []string, error) {
+func ResolveSingle(ctx context.Context, ds ipld.NodeGetter, nd ipld.Node, names []string) (*ipld.Link, []string, error) {
 	return nd.ResolveLink(names)
 }
 

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -34,7 +34,7 @@ type ReadSeekCloser interface {
 
 // NewDagReader creates a new reader object that reads the data represented by
 // the given node, using the passed in DAGService for data retreival
-func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.DAGService) (DagReader, error) {
+func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagReader, error) {
 	switch n := n.(type) {
 	case *mdag.RawNode:
 		return NewBufDagReader(n.RawData()), nil

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -17,7 +17,7 @@ import (
 
 // DagReader provides a way to easily read the data contained in a dag.
 type pbDagReader struct {
-	serv ipld.DAGService
+	serv ipld.NodeGetter
 
 	// the node being read
 	node *mdag.ProtoNode
@@ -51,7 +51,7 @@ type pbDagReader struct {
 var _ DagReader = (*pbDagReader)(nil)
 
 // NewPBFileReader constructs a new PBFileReader.
-func NewPBFileReader(ctx context.Context, n *mdag.ProtoNode, pb *ftpb.Data, serv ipld.DAGService) *pbDagReader {
+func NewPBFileReader(ctx context.Context, n *mdag.ProtoNode, pb *ftpb.Data, serv ipld.NodeGetter) *pbDagReader {
 	fctx, cancel := context.WithCancel(ctx)
 	curLinks := getLinkCids(n)
 	return &pbDagReader{

--- a/unixfs/io/resolve.go
+++ b/unixfs/io/resolve.go
@@ -12,7 +12,7 @@ import (
 
 // ResolveUnixfsOnce resolves a single hop of a path through a graph in a
 // unixfs context. This includes handling traversing sharded directories.
-func ResolveUnixfsOnce(ctx context.Context, ds ipld.DAGService, nd ipld.Node, names []string) (*ipld.Link, []string, error) {
+func ResolveUnixfsOnce(ctx context.Context, ds ipld.NodeGetter, nd ipld.Node, names []string) (*ipld.Link, []string, error) {
 	switch nd := nd.(type) {
 	case *dag.ProtoNode:
 		upb, err := ft.FromBytes(nd.Data())
@@ -28,7 +28,8 @@ func ResolveUnixfsOnce(ctx context.Context, ds ipld.DAGService, nd ipld.Node, na
 
 		switch upb.GetType() {
 		case ft.THAMTShard:
-			s, err := hamt.NewHamtFromDag(ds, nd)
+			rods := dag.NewReadOnlyDagService(ds)
+			s, err := hamt.NewHamtFromDag(rods, nd)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
I'm actually not happy with how this turned out. Everything worked out fine until I had to deal with the Hamt code. Theres no distinction between reading from a hamt and writing to it. The solution i chose here was to separate that out, its a bit messy. The other approach would be to just make a hybrid `DagService` implementation that passes all Get calls to an underlying session, and then `Add` calls get routed normally. I think that method seems a lot cleaner... 

cc @Stebalien @magik6k @kevina let me know what you all think. 

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>