### PR TITLE
 commands: switch object to CoreAPI

### DIFF
--- a/commands/request.go
+++ b/commands/request.go
@@ -13,9 +13,11 @@ import (
 	"time"
 
 	"github.com/ipfs/go-ipfs/core"
+	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/repo/config"
-	u "gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
 
+	u "gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
 	"gx/ipfs/QmPq2D7Yoyev7yeMuMnkEYBqmQuUu5kb91UXPPoiik1Xyp/go-ipfs-cmds"
 	"gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 	"gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit/files"
@@ -29,6 +31,7 @@ type Context struct {
 	config     *config.Config
 	LoadConfig func(path string) (*config.Config, error)
 
+	api           coreiface.CoreAPI
 	node          *core.IpfsNode
 	ConstructNode func() (*core.IpfsNode, error)
 }
@@ -57,6 +60,19 @@ func (c *Context) GetNode() (*core.IpfsNode, error) {
 		c.node, err = c.ConstructNode()
 	}
 	return c.node, err
+}
+
+// GetApi returns CoreAPI instance backed by ipfs node.
+// It may construct the node with the provided function
+func (c *Context) GetApi() (coreiface.CoreAPI, error) {
+	if c.api == nil {
+		n, err := c.GetNode()
+		if err != nil {
+			return nil, err
+		}
+		c.api = coreapi.NewCoreAPI(n)
+	}
+	return c.api, nil
 }
 
 // NodeWithoutConstructing returns the underlying node variable

--- a/core/commands/object/diff.go
+++ b/core/commands/object/diff.go
@@ -6,10 +6,9 @@ import (
 	"io"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	core "github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
-	path "github.com/ipfs/go-ipfs/path"
+
 	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 )
 
@@ -52,7 +51,7 @@ Example:
 		cmdkit.BoolOption("verbose", "v", "Print extra information."),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		node, err := req.InvocContext().GetNode()
+		api, err := req.InvocContext().GetApi()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -61,39 +60,37 @@ Example:
 		a := req.Arguments()[0]
 		b := req.Arguments()[1]
 
-		pa, err := path.ParsePath(a)
+		pa, err := api.ParsePath(req.Context(), a, api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		pb, err := path.ParsePath(b)
+		pb, err := api.ParsePath(req.Context(), b, api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		ctx := req.Context()
+		changes, err := api.Object().Diff(req.Context(), pa, pb)
 
-		obj_a, err := core.Resolve(ctx, node.Namesys, node.Resolver, pa)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
+		out := make([]*dagutils.Change, len(changes))
+		for i, change := range changes {
+			out[i] = &dagutils.Change{
+				Type: change.Type,
+				Path: change.Path,
+			}
+
+			if change.Before != nil {
+				out[i].Before = change.Before.Cid()
+			}
+
+			if change.After != nil {
+				out[i].After = change.After.Cid()
+			}
 		}
 
-		obj_b, err := core.Resolve(ctx, node.Namesys, node.Resolver, pb)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		changes, err := dagutils.Diff(ctx, node.DAG, obj_a, obj_b)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		res.SetOutput(&Changes{changes})
+		res.SetOutput(&Changes{out})
 	},
 	Type: Changes{},
 	Marshalers: cmds.MarshalerMap{

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -2,22 +2,13 @@ package objectcmd
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs/commands"
-	core "github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
-	dag "github.com/ipfs/go-ipfs/merkledag"
-	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
-	path "github.com/ipfs/go-ipfs/path"
-	ft "github.com/ipfs/go-ipfs/unixfs"
 
-	logging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
 	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 )
-
-var log = logging.Logger("core/commands/object")
 
 var ObjectPatchCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
@@ -71,51 +62,31 @@ the limit will not be respected by the network.
 		cmdkit.FileArg("data", true, false, "Data to append.").EnableStdin(),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		nd, err := req.InvocContext().GetNode()
+		api, err := req.InvocContext().GetApi()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		root, err := path.ParsePath(req.StringArguments()[0])
+		root, err := api.ParsePath(req.Context(), req.StringArguments()[0], api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rootnd, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, root)
+		data, err := req.Files().NextFile()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rtpb, ok := rootnd.(*dag.ProtoNode)
-		if !ok {
-			res.SetError(dag.ErrNotProtobuf, cmdkit.ErrNormal)
-			return
-		}
-
-		fi, err := req.Files().NextFile()
+		p, err := api.Object().AppendData(req.Context(), root, data)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		data, err := ioutil.ReadAll(fi)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		rtpb.SetData(append(rtpb.Data(), data...))
-
-		err = nd.DAG.Add(req.Context(), rtpb)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		res.SetOutput(&Object{Hash: rtpb.Cid().String()})
+		res.SetOutput(&Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},
 	Marshalers: cmds.MarshalerMap{
@@ -139,51 +110,30 @@ Example:
 		cmdkit.FileArg("data", true, false, "The data to set the object to.").EnableStdin(),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		nd, err := req.InvocContext().GetNode()
+		api, err := req.InvocContext().GetApi()
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+		root, err := api.ParsePath(req.Context(), req.StringArguments()[0], api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rp, err := path.ParsePath(req.StringArguments()[0])
+		data, err := req.Files().NextFile()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rp)
+		p, err := api.Object().SetData(req.Context(), root, data)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rtpb, ok := root.(*dag.ProtoNode)
-		if !ok {
-			res.SetError(dag.ErrNotProtobuf, cmdkit.ErrNormal)
-			return
-		}
-
-		fi, err := req.Files().NextFile()
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		data, err := ioutil.ReadAll(fi)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		rtpb.SetData(data)
-
-		err = nd.DAG.Add(req.Context(), rtpb)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		res.SetOutput(&Object{Hash: rtpb.Cid().String()})
+		res.SetOutput(&Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},
 	Marshalers: cmds.MarshalerMap{
@@ -203,49 +153,26 @@ Removes a link by the given name from root.
 		cmdkit.StringArg("link", true, false, "Name of the link to remove."),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		nd, err := req.InvocContext().GetNode()
+		api, err := req.InvocContext().GetApi()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rootp, err := path.ParsePath(req.Arguments()[0])
+		root, err := api.ParsePath(req.Context(), req.Arguments()[0], api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rootp)
+		link := req.Arguments()[1]
+		p, err := api.Object().RmLink(req.Context(), root, link)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rtpb, ok := root.(*dag.ProtoNode)
-		if !ok {
-			res.SetError(dag.ErrNotProtobuf, cmdkit.ErrNormal)
-			return
-		}
-
-		path := req.Arguments()[1]
-
-		e := dagutils.NewDagEditor(rtpb, nd.DAG)
-
-		err = e.RmLink(req.Context(), path)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		nnode, err := e.Finalize(req.Context(), nd.DAG)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		nc := nnode.Cid()
-
-		res.SetOutput(&Object{Hash: nc.String()})
+		res.SetOutput(&Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},
 	Marshalers: cmds.MarshalerMap{
@@ -278,32 +205,21 @@ to a file containing 'bar', and returns the hash of the new object.
 		cmdkit.BoolOption("create", "p", "Create intermediary nodes."),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
-		nd, err := req.InvocContext().GetNode()
+		api, err := req.InvocContext().GetApi()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		rootp, err := path.ParsePath(req.Arguments()[0])
+		root, err := api.ParsePath(req.Context(), req.Arguments()[0], api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		root, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, rootp)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
+		name := req.Arguments()[1]
 
-		rtpb, ok := root.(*dag.ProtoNode)
-		if !ok {
-			res.SetError(dag.ErrNotProtobuf, cmdkit.ErrNormal)
-			return
-		}
-
-		npath := req.Arguments()[1]
-		childp, err := path.ParsePath(req.Arguments()[2])
+		child, err := api.ParsePath(req.Context(), req.Arguments()[2], api.WithResolve(true))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -315,34 +231,14 @@ to a file containing 'bar', and returns the hash of the new object.
 			return
 		}
 
-		var createfunc func() *dag.ProtoNode
-		if create {
-			createfunc = ft.EmptyDirNode
-		}
-
-		e := dagutils.NewDagEditor(rtpb, nd.DAG)
-
-		childnd, err := core.Resolve(req.Context(), nd.Namesys, nd.Resolver, childp)
+		p, err := api.Object().AddLink(req.Context(), root, name, child,
+			api.Object().WithCreate(create))
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		err = e.InsertNodeAtPath(req.Context(), npath, childnd, createfunc)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		nnode, err := e.Finalize(req.Context(), nd.DAG)
-		if err != nil {
-			res.SetError(err, cmdkit.ErrNormal)
-			return
-		}
-
-		nc := nnode.Cid()
-
-		res.SetOutput(&Object{Hash: nc.String()})
+		res.SetOutput(&Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},
 	Marshalers: cmds.MarshalerMap{

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -5,6 +5,7 @@ import (
 
 	core "github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
+	caopts "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 	ipfspath "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -13,11 +14,12 @@ import (
 
 type CoreAPI struct {
 	node *core.IpfsNode
+	*caopts.ApiOptions
 }
 
 // NewCoreAPI creates new instance of IPFS CoreAPI backed by go-ipfs Node.
 func NewCoreAPI(n *core.IpfsNode) coreiface.CoreAPI {
-	api := &CoreAPI{n}
+	api := &CoreAPI{n, nil}
 	return api
 }
 
@@ -98,16 +100,26 @@ type path struct {
 }
 
 // ParsePath parses path `p` using ipfspath parser, returns the parsed path.
-func ParsePath(p string) (coreiface.Path, error) {
+func (api *CoreAPI) ParsePath(ctx context.Context, p string, opts ...caopts.ParsePathOption) (coreiface.Path, error) {
+	options, err := caopts.ParsePathOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	pp, err := ipfspath.ParsePath(p)
 	if err != nil {
 		return nil, err
 	}
-	return &path{path: pp}, nil
+
+	res := &path{path: pp}
+	if options.Resolve {
+		return api.ResolvePath(ctx, res)
+	}
+	return res, nil
 }
 
 // ParseCid parses the path from `c`, retruns the parsed path.
-func ParseCid(c *cid.Cid) coreiface.Path {
+func (api *CoreAPI) ParseCid(c *cid.Cid) coreiface.Path {
 	return &path{path: ipfspath.FromCid(c), cid: c, root: c}
 }
 

--- a/core/coreapi/dag.go
+++ b/core/coreapi/dag.go
@@ -46,7 +46,7 @@ func (api *DagAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.DagPut
 		return nil, err
 	}
 
-	return ParseCid(nds[0].Cid()), nil
+	return api.ParseCid(nds[0].Cid()), nil
 }
 
 // Get resolves `path` using Unixfs resolver, returns the resolved Node.
@@ -68,7 +68,7 @@ func (api *DagAPI) Tree(ctx context.Context, p coreiface.Path, opts ...caopts.Da
 	paths := n.Tree("", settings.Depth)
 	out := make([]coreiface.Path, len(paths))
 	for n, p2 := range paths {
-		out[n], err = ParsePath(gopath.Join(p.String(), p2))
+		out[n], err = api.ParsePath(ctx, gopath.Join(p.String(), p2))
 		if err != nil {
 			return nil, err
 		}

--- a/core/coreapi/dag_test.go
+++ b/core/coreapi/dag_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
-
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 )
 
@@ -72,7 +70,7 @@ func TestPath(t *testing.T) {
 		t.Error(err)
 	}
 
-	p, err := coreapi.ParsePath(path.Join(res.Cid().String(), "lnk"))
+	p, err := api.ParsePath(ctx, path.Join(res.Cid().String(), "lnk"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -73,6 +73,16 @@ type CoreAPI interface {
 	// ResolveNode resolves the path (if not resolved already) using Unixfs
 	// resolver, gets and returns the resolved Node
 	ResolveNode(context.Context, Path) (Node, error)
+
+	// ParsePath parses string path to a Path
+	ParsePath(context.Context, string, ...options.ParsePathOption) (Path, error)
+
+	// WithResolve is an option for ParsePath which when set to true tells
+	// ParsePath to also resolve the path
+	WithResolve(bool) options.ParsePathOption
+
+	// ParseCid creates new path from the provided CID
+	ParseCid(*cid.Cid) Path
 }
 
 // UnixfsAPI is the basic interface to immutable files in IPFS

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -53,6 +53,38 @@ type Key interface {
 	Path() Path
 }
 
+const (
+	// DiffAdd is a Type of ObjectChange where a link was added to the graph
+	DiffAdd = iota
+
+	// DiffRemove is a Type of ObjectChange where a link was removed from the graph
+	DiffRemove
+
+	// DiffMod is a Type of ObjectChange where a link was changed in the graph
+	DiffMod
+)
+
+// ObjectChange represents a change ia a graph
+// TODO: do we want this to be an interface?
+type ObjectChange struct {
+	// Type of the change, either:
+	// * DiffAdd - Added a link
+	// * DiffRemove - Removed a link
+	// * DiffMod - Modified a link
+	Type int
+
+	// Path to the changed link
+	Path string
+
+	// Before holds the link path before the change. Note that when a link is
+	// added, this will be nil.
+	Before Path
+
+	// After holds the link path after the change. Note that when a link is
+	// removed, this will be nil.
+	After Path
+}
+
 // CoreAPI defines an unified interface to IPFS for Go programs.
 type CoreAPI interface {
 	// Unixfs returns an implementation of Unixfs API.
@@ -270,6 +302,10 @@ type ObjectAPI interface {
 
 	// SetData sets the data contained in the node
 	SetData(context.Context, Path, io.Reader) (Path, error)
+
+	// Diff returns a set of changes needed to transform the first object into the
+	// second.
+	Diff(context.Context, Path, Path) ([]ObjectChange, error)
 }
 
 // ObjectStat provides information about dag nodes

--- a/core/coreapi/interface/interface.go
+++ b/core/coreapi/interface/interface.go
@@ -237,6 +237,10 @@ type ObjectAPI interface {
 	// * "base64"
 	WithDataType(t string) options.ObjectPutOption
 
+	// WithPin is an option for Put which specifies whether to pin the added
+	// objects, default is false
+	WithPin(bool) options.ObjectPutOption
+
 	// Get returns the node for the path
 	Get(context.Context, Path) (Node, error)
 

--- a/core/coreapi/interface/options/object.go
+++ b/core/coreapi/interface/options/object.go
@@ -7,6 +7,7 @@ type ObjectNewSettings struct {
 type ObjectPutSettings struct {
 	InputEnc string
 	DataType string
+	Pin      bool
 }
 
 type ObjectAddLinkSettings struct {
@@ -35,6 +36,7 @@ func ObjectPutOptions(opts ...ObjectPutOption) (*ObjectPutSettings, error) {
 	options := &ObjectPutSettings{
 		InputEnc: "json",
 		DataType: "text",
+		Pin:      false,
 	}
 
 	for _, opt := range opts {
@@ -79,6 +81,13 @@ func (api *ObjectOptions) WithInputEnc(e string) ObjectPutOption {
 func (api *ObjectOptions) WithDataType(t string) ObjectPutOption {
 	return func(settings *ObjectPutSettings) error {
 		settings.DataType = t
+		return nil
+	}
+}
+
+func (api *ObjectOptions) WithPin(pin bool) ObjectPutOption {
+	return func(settings *ObjectPutSettings) error {
+		settings.Pin = pin
 		return nil
 	}
 }

--- a/core/coreapi/interface/options/path.go
+++ b/core/coreapi/interface/options/path.go
@@ -1,0 +1,30 @@
+package options
+
+type ParsePathSettings struct {
+	Resolve bool
+}
+
+type ParsePathOption func(*ParsePathSettings) error
+
+func ParsePathOptions(opts ...ParsePathOption) (*ParsePathSettings, error) {
+	options := &ParsePathSettings{
+		Resolve: false,
+	}
+
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return options, nil
+}
+
+type ApiOptions struct{}
+
+func (api *ApiOptions) WithResolve(r bool) ParsePathOption {
+	return func(settings *ParsePathSettings) error {
+		settings.Resolve = r
+		return nil
+	}
+}

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -319,10 +319,16 @@ func (api *ObjectAPI) Diff(ctx context.Context, before coreiface.Path, after cor
 	out := make([]coreiface.ObjectChange, len(changes))
 	for i, change := range changes {
 		out[i] = coreiface.ObjectChange{
-			Type:   change.Type,
-			Path:   change.Path,
-			Before: api.ParseCid(change.Before),
-			After:  api.ParseCid(change.After),
+			Type: change.Type,
+			Path: change.Path,
+		}
+
+		if change.Before != nil {
+			out[i].Before = api.ParseCid(change.Before)
+		}
+
+		if change.After != nil {
+			out[i].After = api.ParseCid(change.After)
 		}
 	}
 

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -124,7 +124,7 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 		return nil, err
 	}
 
-	return ParseCid(dagnode.Cid()), nil
+	return api.ParseCid(dagnode.Cid()), nil
 }
 
 func (api *ObjectAPI) Get(ctx context.Context, path coreiface.Path) (coreiface.Node, error) {
@@ -221,7 +221,7 @@ func (api *ObjectAPI) AddLink(ctx context.Context, base coreiface.Path, name str
 		return nil, err
 	}
 
-	return ParseCid(nnode.Cid()), nil
+	return api.ParseCid(nnode.Cid()), nil
 }
 
 func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link string) (coreiface.Path, error) {
@@ -247,7 +247,7 @@ func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link stri
 		return nil, err
 	}
 
-	return ParseCid(nnode.Cid()), nil
+	return api.ParseCid(nnode.Cid()), nil
 }
 
 func (api *ObjectAPI) AppendData(ctx context.Context, path coreiface.Path, r io.Reader) (coreiface.Path, error) {
@@ -284,7 +284,7 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 		return nil, err
 	}
 
-	return ParseCid(pbnd.Cid()), nil
+	return api.ParseCid(pbnd.Cid()), nil
 }
 
 func (api *ObjectAPI) core() coreiface.CoreAPI {

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -300,6 +300,35 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 	return api.ParseCid(pbnd.Cid()), nil
 }
 
+func (api *ObjectAPI) Diff(ctx context.Context, before coreiface.Path, after coreiface.Path) ([]coreiface.ObjectChange, error) {
+	beforeNd, err := api.core().ResolveNode(ctx, before)
+	if err != nil {
+		return nil, err
+	}
+
+	afterNd, err := api.core().ResolveNode(ctx, after)
+	if err != nil {
+		return nil, err
+	}
+
+	changes, err := dagutils.Diff(ctx, api.node.DAG, beforeNd, afterNd)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]coreiface.ObjectChange, len(changes))
+	for i, change := range changes {
+		out[i] = coreiface.ObjectChange{
+			Type:   change.Type,
+			Path:   change.Path,
+			Before: api.ParseCid(change.Before),
+			After:  api.ParseCid(change.After),
+		}
+	}
+
+	return out, nil
+}
+
 func (api *ObjectAPI) core() coreiface.CoreAPI {
 	return api.CoreAPI
 }

--- a/core/coreapi/object_test.go
+++ b/core/coreapi/object_test.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/ipfs/go-ipfs/core/coreapi/interface"
 )
 
 func TestNew(t *testing.T) {
@@ -381,5 +383,44 @@ func TestObjectSetData(t *testing.T) {
 
 	if string(data) != "bar" {
 		t.Error("unexpected data")
+	}
+}
+
+func TestDiffTest(t *testing.T) {
+	ctx := context.Background()
+	_, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p1, err := api.Object().Put(ctx, strings.NewReader(`{"Data":"foo"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p2, err := api.Object().Put(ctx, strings.NewReader(`{"Data":"bar"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := api.Object().Diff(ctx, p1, p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(changes) != 1 {
+		t.Fatal("unexpected changes len")
+	}
+
+	if changes[0].Type != iface.DiffMod {
+		t.Fatal("unexpected change type")
+	}
+
+	if changes[0].Before.String() != p1.String() {
+		t.Fatal("unexpected before path")
+	}
+
+	if changes[0].After.String() != p2.String() {
+		t.Fatal("unexpected before path")
 	}
 }

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -25,7 +25,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, r io.Reader) (coreiface.Path, err
 	if err != nil {
 		return nil, err
 	}
-	return ParseCid(c), nil
+	return api.core().ParseCid(c), nil
 }
 
 // Cat returns the data contained by an IPFS or IPNS object(s) at path `p`.

--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -205,7 +205,7 @@ func TestCatDir(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	p := coreapi.ParseCid(edir.Cid())
+	p := api.ParseCid(edir.Cid())
 
 	if p.String() != emptyDir.String() {
 		t.Fatalf("expected path %s, got: %s", emptyDir, p)
@@ -230,7 +230,7 @@ func TestCatNonUnixfs(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = api.Unixfs().Cat(ctx, coreapi.ParseCid(nd.Cid()))
+	_, err = api.Unixfs().Cat(ctx, api.ParseCid(nd.Cid()))
 	if !strings.Contains(err.Error(), "proto: required field") {
 		t.Fatalf("expected protobuf error, got: %s", err)
 	}
@@ -326,7 +326,7 @@ func TestLsNonUnixfs(t *testing.T) {
 		t.Error(err)
 	}
 
-	links, err := api.Unixfs().Ls(ctx, coreapi.ParseCid(nd.Cid()))
+	links, err := api.Unixfs().Ls(ctx, api.ParseCid(nd.Cid()))
 	if err != nil {
 		t.Error(err)
 	}

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	core "github.com/ipfs/go-ipfs/core"
-	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/importer"
 	chunk "github.com/ipfs/go-ipfs/importer/chunk"
@@ -161,7 +160,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		ipnsHostname = true
 	}
 
-	parsedPath, err := coreapi.ParsePath(urlPath)
+	parsedPath, err := i.api.ParsePath(ctx, urlPath)
 	if err != nil {
 		webError(w, "invalid ipfs path", err, http.StatusBadRequest)
 		return
@@ -294,7 +293,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 			return
 		}
 
-		dr, err := i.api.Unixfs().Cat(ctx, coreapi.ParseCid(ixnd.Cid()))
+		dr, err := i.api.Unixfs().Cat(ctx, i.api.ParseCid(ixnd.Cid()))
 		if err != nil {
 			internalWebError(w, err)
 			return


### PR DESCRIPTION
This PR wires CoreAPI into command utils and makes `ipfs object *` use the api.

Only changing `ipfs object` to keep this PR small, will open another PRs for other command groups after this one is merged.