### PR TITLE
blockservice: add BlockedFetched/Added/Removed events

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -138,6 +138,8 @@ func (s *blockService) AddBlock(o blocks.Block) error {
 		return err
 	}
 
+	log.Event(context.TODO(), "BlockService.BlockAdded", c)
+
 	if err := s.exchange.HasBlock(o); err != nil {
 		// TODO(#4623): really an error?
 		return errors.New("blockservice is closed")
@@ -169,6 +171,7 @@ func (s *blockService) AddBlocks(bs []blocks.Block) error {
 	}
 
 	for _, o := range toput {
+		log.Event(context.TODO(), "BlockService.BlockAdded", o.Cid())
 		if err := s.exchange.HasBlock(o); err != nil {
 			// TODO(#4623): Should this really *return*?
 			return fmt.Errorf("blockservice is closed (%s)", err)
@@ -207,6 +210,7 @@ func getBlock(ctx context.Context, c *cid.Cid, bs blockstore.Blockstore, f excha
 			}
 			return nil, err
 		}
+		log.Event(ctx, "BlockService.BlockFetched", c)
 		return blk, nil
 	}
 
@@ -236,7 +240,6 @@ func getBlocks(ctx context.Context, ks []*cid.Cid, bs blockstore.Blockstore, f e
 				misses = append(misses, c)
 				continue
 			}
-			log.Debug("Blockservice: Got data in datastore")
 			select {
 			case out <- hit:
 			case <-ctx.Done():
@@ -255,6 +258,7 @@ func getBlocks(ctx context.Context, ks []*cid.Cid, bs blockstore.Blockstore, f e
 		}
 
 		for b := range rblocks {
+			log.Event(ctx, "BlockService.BlockFetched", b.Cid())
 			select {
 			case out <- b:
 			case <-ctx.Done():
@@ -267,7 +271,11 @@ func getBlocks(ctx context.Context, ks []*cid.Cid, bs blockstore.Blockstore, f e
 
 // DeleteBlock deletes a block in the blockservice from the datastore
 func (s *blockService) DeleteBlock(c *cid.Cid) error {
-	return s.blockstore.DeleteBlock(c)
+	err := s.blockstore.DeleteBlock(c)
+	if err == nil {
+		log.Event(context.TODO(), "BlockService.BlockDeleted", c)
+	}
+	return err
 }
 
 func (s *blockService) Close() error {


### PR DESCRIPTION
... and remove a few log lines that don't seem terribly useful.

This will be useful for ipfs-repeater. The `Bitswap.BlockGetRequest` start/end events don't really cut it, they don't tell me that the block has *actually* been fetched and stored, and that the blockservice is able to provide them.

I put in TODO() contexts there, doing context wiring for Add/Delete felt out of scope, but I can do that too.