### PR TITLE
Public connInfos struct

### DIFF
--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -80,7 +80,7 @@ var swarmPeersCmd = &cmds.Command{
 
 		conns := n.PeerHost.Network().Conns()
 
-		var out connInfos
+		var out ConnInfos
 		for _, c := range conns {
 			pid := c.RemotePeer()
 			addr := c.RemoteMultiaddr()
@@ -128,7 +128,7 @@ var swarmPeersCmd = &cmds.Command{
 				return nil, err
 			}
 
-			ci, ok := v.(*connInfos)
+			ci, ok := v.(*ConnInfos)
 			if !ok {
 				return nil, e.TypeErr(ci, v)
 			}
@@ -159,7 +159,7 @@ var swarmPeersCmd = &cmds.Command{
 			return buf, nil
 		},
 	},
-	Type: connInfos{},
+	Type: ConnInfos{},
 }
 
 type streamInfo struct {
@@ -186,19 +186,19 @@ func (ci *connInfo) Swap(i, j int) {
 	ci.Streams[i], ci.Streams[j] = ci.Streams[j], ci.Streams[i]
 }
 
-type connInfos struct {
+type ConnInfos struct {
 	Peers []connInfo
 }
 
-func (ci connInfos) Less(i, j int) bool {
+func (ci ConnInfos) Less(i, j int) bool {
 	return ci.Peers[i].Addr < ci.Peers[j].Addr
 }
 
-func (ci connInfos) Len() int {
+func (ci ConnInfos) Len() int {
 	return len(ci.Peers)
 }
 
-func (ci connInfos) Swap(i, j int) {
+func (ci ConnInfos) Swap(i, j int) {
 	ci.Peers[i], ci.Peers[j] = ci.Peers[j], ci.Peers[i]
 }
 


### PR DESCRIPTION
I tried to do `ipfs swarm peers` using golang. (not command line).
But, `"github.com/ipfs/go-ipfs/core/commands".connInfos` struct is not public.
so I couldn't cast type the struct from `interface{}` to `connInfos`.

This PR changes the private struct to public struct.

I'd like to write code like below.
Let me know if you have better idea. Thanks.

```golang
package main

import (
  "context"
  "fmt"
  "github.com/ipfs/go-ipfs/commands"
  "github.com/ipfs/go-ipfs/core"
  corecmd "github.com/ipfs/go-ipfs/core/commands"
  "github.com/ipfs/go-ipfs/repo/fsrepo"
)

func main() {
  repoPath := "/Users/camelmasa/.ipfs"

  ctx, cancel := context.WithCancel(context.Background())
  defer cancel()

  repo, _ := fsrepo.Open(repoPath)
  config := &core.BuildCfg{
    Repo:      repo,
    Online:    true,
    ExtraOpts: map[string]bool{"mplex": true},
  }

  ipfsNode, _ := core.NewNode(ctx, config)
  ipfsNode.SetLocal(false)

  cmdcontext := &commands.Context{
    ConfigRoot:    repoPath,
    ConstructNode: func() (n *core.IpfsNode, err error) { return ipfsNode, nil },
    ReqLog:        &commands.ReqLog{},
  }
  req, _ := commands.NewRequest([]string{"peers"}, nil, nil, nil, nil, nil)
  req.SetInvocContext(*cmdcontext)

  // HERE:  Cast type
  swarmPeers := corecmd.SwarmCmd.Call(req).Output().(*corecmd.ConnInfos)

  for _, peer := range swarmPeers.Peers {
    fmt.Println("peer:", peer.Peer)
    fmt.Println("addr:", peer.Addr)
  }
}
```
