### PR TITLE
Golint: fix golint warnings in merkledag submodule

### DIFF
--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -102,7 +102,7 @@ func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
 	return n.encoded, nil
 }
 
-// Decoded decodes raw data and returns a new Node instance.
+// DecodeProtobuf decodes raw data and returns a new Node instance.
 func DecodeProtobuf(encoded []byte) (*ProtoNode, error) {
 	n := new(ProtoNode)
 	err := n.unmarshal(encoded)

--- a/merkledag/errservice.go
+++ b/merkledag/errservice.go
@@ -14,34 +14,34 @@ type ErrorService struct {
 
 var _ ipld.DAGService = (*ErrorService)(nil)
 
-// Add returns an error.
+// Add returns the cs.Err.
 func (cs *ErrorService) Add(ctx context.Context, nd ipld.Node) error {
 	return cs.Err
 }
 
-// AddMany returns an error.
+// AddMany returns the cs.Err.
 func (cs *ErrorService) AddMany(ctx context.Context, nds []ipld.Node) error {
 	return cs.Err
 }
 
-// Get returns an error.
+// Get returns the cs.Err.
 func (cs *ErrorService) Get(ctx context.Context, c *cid.Cid) (ipld.Node, error) {
 	return nil, cs.Err
 }
 
-// GetMany many returns an error.
+// GetMany many returns the cs.Err.
 func (cs *ErrorService) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *ipld.NodeOption {
 	ch := make(chan *ipld.NodeOption)
 	close(ch)
 	return ch
 }
 
-// Remove returns an error.
+// Remove returns the cs.Err.
 func (cs *ErrorService) Remove(ctx context.Context, c *cid.Cid) error {
 	return cs.Err
 }
 
-// RemoveMany returns an error.
+// RemoveMany returns the cs.Err.
 func (cs *ErrorService) RemoveMany(ctx context.Context, cids []*cid.Cid) error {
 	return cs.Err
 }

--- a/merkledag/errservice.go
+++ b/merkledag/errservice.go
@@ -14,28 +14,34 @@ type ErrorService struct {
 
 var _ ipld.DAGService = (*ErrorService)(nil)
 
+// Add returns an error.
 func (cs *ErrorService) Add(ctx context.Context, nd ipld.Node) error {
 	return cs.Err
 }
 
+// AddMany returns an error.
 func (cs *ErrorService) AddMany(ctx context.Context, nds []ipld.Node) error {
 	return cs.Err
 }
 
+// Get returns an error.
 func (cs *ErrorService) Get(ctx context.Context, c *cid.Cid) (ipld.Node, error) {
 	return nil, cs.Err
 }
 
+// GetMany many returns an error.
 func (cs *ErrorService) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *ipld.NodeOption {
 	ch := make(chan *ipld.NodeOption)
 	close(ch)
 	return ch
 }
 
+// Remove returns an error.
 func (cs *ErrorService) Remove(ctx context.Context, c *cid.Cid) error {
 	return cs.Err
 }
 
+// RemoveMany returns an error.
 func (cs *ErrorService) RemoveMany(ctx context.Context, cids []*cid.Cid) error {
 	return cs.Err
 }

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -1,4 +1,4 @@
-// package merkledag implements the IPFS Merkle DAG datastructures.
+// Package merkledag implements the IPFS Merkle DAG data structures.
 package merkledag
 
 import (
@@ -23,8 +23,14 @@ func init() {
 	ipld.Register(cid.DagCBOR, ipldcbor.DecodeBlock)
 }
 
+// contextKey is a type to use as value for the ProgressTracker contexts.
+type contextKey string
+
+const progressContextKey contextKey = "progress"
+
 // NewDAGService constructs a new DAGService (using the default implementation).
-func NewDAGService(bs bserv.BlockService) *dagService {
+// Note that the default implementation is also an ipld.LinkGetter.
+func NewDAGService(bs bserv.BlockService) ipld.DAGService {
 	return &dagService{Blocks: bs}
 }
 
@@ -147,8 +153,8 @@ func (sg *sesGetter) GetMany(ctx context.Context, keys []*cid.Cid) <-chan *ipld.
 }
 
 // Session returns a NodeGetter using a new session for block fetches.
-func (ds *dagService) Session(ctx context.Context) ipld.NodeGetter {
-	return &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
+func (n *dagService) Session(ctx context.Context) ipld.NodeGetter {
+	return &sesGetter{bserv.NewSession(ctx, n.Blocks)}
 }
 
 // FetchGraph fetches all nodes that are children of the given node
@@ -159,7 +165,7 @@ func FetchGraph(ctx context.Context, root *cid.Cid, serv ipld.DAGService) error 
 		ng = &sesGetter{bserv.NewSession(ctx, ds.Blocks)}
 	}
 
-	v, _ := ctx.Value("progress").(*ProgressTracker)
+	v, _ := ctx.Value(progressContextKey).(*ProgressTracker)
 	if v == nil {
 		return EnumerateChildrenAsync(ctx, GetLinksDirect(ng), root, cid.NewSet().Visit)
 	}
@@ -168,9 +174,8 @@ func FetchGraph(ctx context.Context, root *cid.Cid, serv ipld.DAGService) error 
 		if set.Visit(c) {
 			v.Increment()
 			return true
-		} else {
-			return false
 		}
+		return false
 	}
 	return EnumerateChildrenAsync(ctx, GetLinksDirect(ng), root, visit)
 }
@@ -179,8 +184,8 @@ func FetchGraph(ctx context.Context, root *cid.Cid, serv ipld.DAGService) error 
 // returns the indexes of any links pointing to it
 func FindLinks(links []*cid.Cid, c *cid.Cid, start int) []int {
 	var out []int
-	for i, lnk_c := range links[start:] {
-		if c.Equals(lnk_c) {
+	for i, lnkC := range links[start:] {
+		if c.Equals(lnkC) {
 			out = append(out, i+start)
 		}
 	}
@@ -265,21 +270,26 @@ func EnumerateChildren(ctx context.Context, getLinks GetLinks, root *cid.Cid, vi
 	return nil
 }
 
+// ProgressTracker is used to show progress when fetching nodes.
 type ProgressTracker struct {
 	Total int
 	lk    sync.Mutex
 }
 
+// DeriveContext returns a new context with value "progress" derived from
+// the given one.
 func (p *ProgressTracker) DeriveContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "progress", p)
+	return context.WithValue(ctx, progressContextKey, p)
 }
 
+// Increment adds one to the total progress.
 func (p *ProgressTracker) Increment() {
 	p.lk.Lock()
 	defer p.lk.Unlock()
 	p.Total++
 }
 
+// Value returns the current progress.
 func (p *ProgressTracker) Value() int {
 	p.lk.Lock()
 	defer p.lk.Unlock()

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -30,7 +30,7 @@ const progressContextKey contextKey = "progress"
 
 // NewDAGService constructs a new DAGService (using the default implementation).
 // Note that the default implementation is also an ipld.LinkGetter.
-func NewDAGService(bs bserv.BlockService) ipld.DAGService {
+func NewDAGService(bs bserv.BlockService) *dagService {
 	return &dagService{Blocks: bs}
 }
 

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -242,8 +242,7 @@ func TestFetchGraph(t *testing.T) {
 	// create an offline dagstore and ensure all blocks were fetched
 	bs := bserv.New(bsis[1].Blockstore(), offline.Exchange(bsis[1].Blockstore()))
 
-	// we know the default dagService implements LinkGetter
-	offlineDS := NewDAGService(bs).(ipld.LinkGetter)
+	offlineDS := NewDAGService(bs)
 
 	err = EnumerateChildren(context.Background(), offlineDS.GetLinks, root.Cid(), func(_ *cid.Cid) bool { return true })
 	if err != nil {
@@ -262,9 +261,8 @@ func TestEnumerateChildren(t *testing.T) {
 	}
 
 	set := cid.NewSet()
-	lg := ds.(ipld.LinkGetter)
 
-	err = EnumerateChildren(context.Background(), lg.GetLinks, root.Cid(), set.Visit)
+	err = EnumerateChildren(context.Background(), ds.GetLinks, root.Cid(), set.Visit)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,7 +493,7 @@ func TestCidRetention(t *testing.T) {
 }
 
 func TestCidRawDoesnNeedData(t *testing.T) {
-	srv := NewDAGService(dstest.Bserv()).(ipld.LinkGetter)
+	srv := NewDAGService(dstest.Bserv())
 	nd := NewRawNode([]byte("somedata"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	blocks "gx/ipfs/Qmej7nf81hi2x2tvjRBF3mcp74sQyuDH4VMYDGd1YtXjb2/go-block-format"
-
 	bserv "github.com/ipfs/go-ipfs/blockservice"
 	bstest "github.com/ipfs/go-ipfs/blockservice/test"
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
@@ -28,6 +26,7 @@ import (
 	u "gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+	blocks "gx/ipfs/Qmej7nf81hi2x2tvjRBF3mcp74sQyuDH4VMYDGd1YtXjb2/go-block-format"
 )
 
 func TestNode(t *testing.T) {

--- a/merkledag/raw.go
+++ b/merkledag/raw.go
@@ -9,6 +9,7 @@ import (
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
 )
 
+// RawNode represents a node which only contains data.
 type RawNode struct {
 	blocks.Block
 }
@@ -52,22 +53,27 @@ func NewRawNodeWPrefix(data []byte, prefix cid.Prefix) (*RawNode, error) {
 	return &RawNode{blk}, nil
 }
 
+// Links returns nil.
 func (rn *RawNode) Links() []*ipld.Link {
 	return nil
 }
 
+// ResolveLink returns an error.
 func (rn *RawNode) ResolveLink(path []string) (*ipld.Link, []string, error) {
 	return nil, nil, ErrLinkNotFound
 }
 
+// Resolve returns an error.
 func (rn *RawNode) Resolve(path []string) (interface{}, []string, error) {
 	return nil, nil, ErrLinkNotFound
 }
 
+// Tree returns nil.
 func (rn *RawNode) Tree(p string, depth int) []string {
 	return nil
 }
 
+// Copy performs a deep copy of this node and returns it as an ipld.Node
 func (rn *RawNode) Copy() ipld.Node {
 	copybuf := make([]byte, len(rn.RawData()))
 	copy(copybuf, rn.RawData())
@@ -80,10 +86,12 @@ func (rn *RawNode) Copy() ipld.Node {
 	return &RawNode{nblk}
 }
 
+// Size returns the size of this node
 func (rn *RawNode) Size() (uint64, error) {
 	return uint64(len(rn.RawData())), nil
 }
 
+// Stat returns some Stats about this node.
 func (rn *RawNode) Stat() (*ipld.NodeStat, error) {
 	return &ipld.NodeStat{
 		CumulativeSize: len(rn.RawData()),

--- a/merkledag/rwservice.go
+++ b/merkledag/rwservice.go
@@ -16,26 +16,32 @@ type ComboService struct {
 
 var _ ipld.DAGService = (*ComboService)(nil)
 
+// Add writes a new node using the Write DAGService.
 func (cs *ComboService) Add(ctx context.Context, nd ipld.Node) error {
 	return cs.Write.Add(ctx, nd)
 }
 
+// AddMany adds nodes using the Write DAGService.
 func (cs *ComboService) AddMany(ctx context.Context, nds []ipld.Node) error {
 	return cs.Write.AddMany(ctx, nds)
 }
 
+// Get fetches a node using the Read DAGService.
 func (cs *ComboService) Get(ctx context.Context, c *cid.Cid) (ipld.Node, error) {
 	return cs.Read.Get(ctx, c)
 }
 
+// GetMany fetches nodes using the Read DAGService.
 func (cs *ComboService) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *ipld.NodeOption {
 	return cs.Read.GetMany(ctx, cids)
 }
 
+// Remove deletes a node using the Write DAGService.
 func (cs *ComboService) Remove(ctx context.Context, c *cid.Cid) error {
 	return cs.Write.Remove(ctx, c)
 }
 
+// RemoveMany deletes nodes using the Write DAGService.
 func (cs *ComboService) RemoveMany(ctx context.Context, cids []*cid.Cid) error {
 	return cs.Write.RemoveMany(ctx, cids)
 }

--- a/merkledag/traverse/traverse.go
+++ b/merkledag/traverse/traverse.go
@@ -11,10 +11,14 @@ import (
 // Order is an identifier for traversal algorithm orders
 type Order int
 
+// These constants define different traversing methods
 const (
-	DFSPre  Order = iota // depth-first pre-order
-	DFSPost              // depth-first post-order
-	BFS                  // breadth-first
+	// DFSPre defines depth-first pre-order
+	DFSPre Order = iota
+	// DFSPost defines depth-first post-order
+	DFSPost
+	// BFS defines breadth-first order
+	BFS
 )
 
 // Options specifies a series of traversal options
@@ -86,9 +90,9 @@ func (t *traversal) getNode(link *ipld.Link) (ipld.Node, error) {
 // If an error is returned, processing stops.
 type Func func(current State) error
 
-// If there is a problem walking to the Node, and ErrFunc is provided, Traverse
-// will call ErrFunc with the error encountered. ErrFunc can decide how to handle
-// that error, and return an error back to Traversal with how to proceed:
+// ErrFunc is provided to handle problems when walking to the Node. Traverse
+// will call ErrFunc with the error encountered. ErrFunc can decide how to
+// handle that error, and return an error back to Traversal with how to proceed:
 //   * nil - skip the Node and its children, but continue processing
 //   * all other errors halt processing immediately.
 //
@@ -98,6 +102,8 @@ type Func func(current State) error
 //
 type ErrFunc func(err error) error
 
+// Traverse initiates a DAG traversal with the given options starting at
+// the given root.
 func Traverse(root ipld.Node, o Options) error {
 	t := traversal{
 		opts: o,
@@ -127,20 +133,14 @@ func dfsPreTraverse(state State, t *traversal) error {
 	if err := t.callFunc(state); err != nil {
 		return err
 	}
-	if err := dfsDescend(dfsPreTraverse, state, t); err != nil {
-		return err
-	}
-	return nil
+	return dfsDescend(dfsPreTraverse, state, t)
 }
 
 func dfsPostTraverse(state State, t *traversal) error {
 	if err := dfsDescend(dfsPostTraverse, state, t); err != nil {
 		return err
 	}
-	if err := t.callFunc(state); err != nil {
-		return err
-	}
-	return nil
+	return t.callFunc(state)
 }
 
 func dfsDescend(df dfsFunc, curr State, t *traversal) error {

--- a/merkledag/utils/utils.go
+++ b/merkledag/utils/utils.go
@@ -15,6 +15,8 @@ import (
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
 )
 
+// Editor represents a ProtoNode tree editor and provides methods to
+// modify it.
 type Editor struct {
 	root *dag.ProtoNode
 
@@ -83,6 +85,7 @@ func addLink(ctx context.Context, ds ipld.DAGService, root *dag.ProtoNode, child
 	return root, nil
 }
 
+// InsertNodeAtPath inserts a new node in the tree and replaces the current root with the new one.
 func (e *Editor) InsertNodeAtPath(ctx context.Context, pth string, toinsert ipld.Node, create func() *dag.ProtoNode) error {
 	splpath := path.SplitList(pth)
 	nd, err := e.insertNodeAtPath(ctx, e.root, splpath, toinsert, create)
@@ -137,6 +140,8 @@ func (e *Editor) insertNodeAtPath(ctx context.Context, root *dag.ProtoNode, path
 	return root, nil
 }
 
+// RmLink removes the link with the given name and updates the root node of
+// the editor.
 func (e *Editor) RmLink(ctx context.Context, pth string) error {
 	splpath := path.SplitList(pth)
 	nd, err := e.rmLink(ctx, e.root, splpath)


### PR DESCRIPTION
This fixes all golint warnings in merkledag (except in protobuf generated code).

Main change of note is that `NewDAGService` returns an `ipld.DAGService` and not a non-exported `dagService`.