### PR TITLE
build: match Go's GOPATH defaults behaviour

### DIFF
--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -7,10 +7,7 @@ if [ -z "$PWD" ]; then
 	exit 1
 fi
 
-if [ -z "$GOPATH" ]; then
-	echo "GOPATH not set, you must have go configured properly to install ipfs"
-	exit 1
-fi
+[ -z "$GOPATH" ] && GOPATH="$HOME/go"
 
 while [ ${#} -gt 1 ]; do
 	if [ "$PWD" = "$2" ]; then

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -7,8 +7,6 @@ if [ -z "$PWD" ]; then
 	exit 1
 fi
 
-[ -z "$GOPATH" ] && GOPATH="$HOME/go"
-
 while [ ${#} -gt 1 ]; do
 	if [ "$PWD" = "$2" ]; then
 		exit 0

--- a/bin/check_go_path
+++ b/bin/check_go_path
@@ -15,5 +15,5 @@ while [ ${#} -gt 1 ]; do
 done
 
 echo "go-ipfs must be built from within your \$GOPATH directory."
-echo "expected within '$GOPATH' but got '$PWD'"
+echo "expected within '$(go env GOPATH)' but got '$PWD'"
 exit 1

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,6 +1,9 @@
 # golang utilities
 GO_MIN_VERSION = 1.9
 
+# match Go's default GOPATH behaviour
+GOPATH ?= $(HOME)/go
+
 # pre-definitions
 GOCC ?= go
 GOTAGS ?=

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,14 +1,15 @@
 # golang utilities
 GO_MIN_VERSION = 1.9
 
-# match Go's default GOPATH behaviour
-GOPATH ?= $(HOME)/go
 
 # pre-definitions
 GOCC ?= go
 GOTAGS ?=
 GOFLAGS ?=
 GOTFLAGS ?=
+
+# match Go's default GOPATH behaviour
+export GOPATH ?= $(shell $(GOCC) env GOPATH)
 
 DEPS_GO :=
 TEST_GO :=


### PR DESCRIPTION
This came up while setting up a new system, and trying to do Go things without explicitly setting GOPATH.