### PR TITLE
Validate size in the DagReaders

### DIFF
--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -188,7 +188,7 @@ test_expect_success "Add compact blocks" '
   printf "foofoo" > expected
 '
 
-test_expect_success "GET compact blocks succeeds" '
+test_expect_failure "GET compact blocks succeeds" '
   curl -o actual "http://127.0.0.1:$port/ipfs/$FOO2_HASH" &&
   test_cmp expected actual
 '

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -188,7 +188,7 @@ test_expect_success "Add compact blocks" '
   printf "foofoo" > expected
 '
 
-test_expect_failure "GET compact blocks succeeds" '
+test_expect_success "GET compact blocks succeeds" '
   curl -o actual "http://127.0.0.1:$port/ipfs/$FOO2_HASH" &&
   test_cmp expected actual
 '

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -193,6 +193,12 @@ test_expect_success "GET compact blocks succeeds" '
   test_cmp expected actual
 '
 
+test_expect_failure "GET compact blocks succeeds with seek" '
+  curl -I "http://127.0.0.1:$port/ipfs/$FOO2_HASH" &&
+  curl -v -o actual -H "Range:bytes=3-" "http://127.0.0.1:$port/ipfs/$FOO2_HASH" &&
+  test_cmp expected actual
+'
+
 test_kill_ipfs_daemon
 
 test_done

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -62,7 +62,10 @@ func (w *Writer) writeFile(nd *mdag.ProtoNode, pb *upb.Data, fpath string) error
 		return err
 	}
 
-	dagr := uio.NewPBFileReader(w.ctx, nd, pb, w.Dag)
+	dagr, err := uio.NewPBFileReader(w.ctx, nd, pb, w.Dag)
+	if err != nil {
+		return err
+	}
 	if _, err := dagr.WriteTo(w.TarW); err != nil {
 		return err
 	}

--- a/unixfs/io/bufdagreader.go
+++ b/unixfs/io/bufdagreader.go
@@ -39,7 +39,7 @@ func (rd *BufDagReader) Offset() int64 {
 	return of
 }
 
-// Size returns the size of the buffer.
+// Size returns the original length of the underlying byte slice.
 func (rd *BufDagReader) Size() uint64 {
 	s := rd.Reader.Size()
 	if s < 0 {

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -55,7 +55,7 @@ func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagRe
 			// Dont allow reading directories
 			return nil, ErrIsDir
 		case ftpb.Data_File, ftpb.Data_Raw:
-			return NewPBFileReader(ctx, n, pb, serv), nil
+			return NewPBFileReader(ctx, n, pb, serv)
 		case ftpb.Data_Metadata:
 			if len(n.Links()) == 0 {
 				return nil, errors.New("incorrectly formatted metadata object")

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -100,8 +100,8 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	blocksize := dr.pbdata.Blocksizes[dr.linkPosition]
 	dr.promises[dr.linkPosition] = nil
+	linkPos := dr.linkPosition
 	dr.linkPosition++
 
 	switch nxt := nxt.(type) {
@@ -134,7 +134,12 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 			return err
 		}
 	}
-	dr.buf = newSizeAdjReadSeekCloser(dr.buf, blocksize)
+	// fixme: a unixfs node with links but no Blocksizes is ill
+	//   defined and should be an error condation, but for now allow it
+	//   to avoid breaking things
+	if linkPos < len(dr.pbdata.Blocksizes) {
+		dr.buf = newSizeAdjReadSeekCloser(dr.buf, dr.pbdata.Blocksizes[linkPos])
+	}
 	return nil
 }
 

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -146,7 +146,11 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 		}
 	}
 	if len(dr.pbdata.Blocksizes) > 0 {
-		dr.buf = newSizeAdjReadSeekCloser(dr.buf, dr.pbdata.Blocksizes[linkPos])
+		// if blocksizes are set, ensure that we read exactly that amount of data
+		dr.buf, err = newSizeAdjReadSeekCloser(dr.buf, dr.pbdata.Blocksizes[linkPos])
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -52,7 +52,7 @@ var _ DagReader = (*PBDagReader)(nil)
 
 // NewPBFileReader constructs a new PBFileReader.
 func NewPBFileReader(ctx context.Context, n *mdag.ProtoNode, pb *ftpb.Data, serv ipld.NodeGetter) (*PBDagReader, error) {
-	err := ft.ValidatePB(n, pb)
+	err := ft.ValidatePB(n.Links(), pb)
 	if err != nil {
 		return nil, err
 	}

--- a/unixfs/io/sizeadj.go
+++ b/unixfs/io/sizeadj.go
@@ -1,0 +1,109 @@
+package io
+
+import (
+	"errors"
+	"io"
+)
+
+func newSizeAdjReadSeekCloser(base ReadSeekCloser, size uint64) *sizeAdjReadSeekCloser {
+	r := &sizeAdjReadSeekCloser{base: base, size: int64(size)}
+	if r.size < 0 {
+		panic("size limited 2^63 − 1")
+	}
+	return r
+}
+
+type sizeAdjReadSeekCloser struct {
+	base   ReadSeekCloser
+	size   int64
+	offset int64
+}
+
+// Read implements the Read method as defined by io.Reader
+func (r *sizeAdjReadSeekCloser) Read(p []byte) (int, error) {
+	if r.offset >= r.size { // EOF
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.size-r.offset { // truncate
+		newsize := r.size - r.offset
+		p = p[:newsize]
+	}
+	n, err := r.base.Read(p)
+	if err == nil {
+		_, err = r.base.Read(nil)
+	}
+	if err != io.EOF { // only pad when we get an EOF
+		r.offset += int64(n)
+		return n, err
+	}
+	for ; n < len(p) && r.offset+int64(n) < r.size; n++ { // pad
+		p[n] = 0
+	}
+	r.offset += int64(n)
+	return n, io.EOF
+}
+
+// Seek implements the Seek method as defined by io.Seeker
+func (r *sizeAdjReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.offset = offset
+	case io.SeekCurrent:
+		r.offset += offset
+	case io.SeekEnd:
+		r.offset = r.size + offset
+	}
+	if r.offset < 0 {
+		return -1, errors.New("Seek will result in negative position")
+	}
+	// Its easier just to always use io.SeekStart rather than
+	// correctly adjust offset for io.SeekCurrent and io.SeekEnd.
+	return r.base.Seek(r.offset, io.SeekStart)
+}
+
+// Close implements the Close method as defined by io.Closer
+func (r *sizeAdjReadSeekCloser) Close() error {
+	return r.base.Close()
+}
+
+// WriteTo implemented WriteTo method as defined by io.WriterTo
+func (r *sizeAdjReadSeekCloser) WriteTo(w io.Writer) (int64, error) {
+	lr := &truncWriter{base: w, size: r.size - r.offset}
+	_, err := r.base.WriteTo(lr)
+	n := lr.offset
+	if err != nil {
+		r.offset += n
+		return n, err
+	}
+	if r.offset+n < r.size {
+		zeros := make([]byte, r.size-(r.offset+n))
+		n0, err0 := w.Write(zeros)
+		n += int64(n0)
+		err = err0
+	}
+	r.offset += n
+	return n, err
+}
+
+// truncWriter accepts all bytes written to it, but discards the tail
+// after size bytes are accepted
+type truncWriter struct {
+	base   io.Writer
+	size   int64
+	offset int64
+}
+
+// Write implemented Write method as defined by io.Writer
+func (w *truncWriter) Write(p []byte) (int, error) {
+	truncC := 0
+	if int64(len(p)) > w.size-w.offset {
+		truncC = int(int64(len(p)) - w.size - w.offset)
+		p = p[:w.size]
+	}
+	if len(p) == 0 {
+		return truncC, nil
+	}
+	n, err := w.base.Write(p)
+	w.offset += int64(n)
+	return n + truncC, err
+}

--- a/unixfs/io/sizeadj.go
+++ b/unixfs/io/sizeadj.go
@@ -29,9 +29,6 @@ func (r *sizeAdjReadSeekCloser) Read(p []byte) (int, error) {
 		p = p[:newsize]
 	}
 	n, err := r.base.Read(p)
-	if err == nil {
-		_, err = r.base.Read(nil)
-	}
 	if err != io.EOF { // only pad when we get an EOF
 		r.offset += int64(n)
 		return n, err

--- a/unixfs/io/sizeadj.go
+++ b/unixfs/io/sizeadj.go
@@ -5,12 +5,12 @@ import (
 	"io"
 )
 
-func newSizeAdjReadSeekCloser(base ReadSeekCloser, size uint64) *sizeAdjReadSeekCloser {
+func newSizeAdjReadSeekCloser(base ReadSeekCloser, size uint64) (*sizeAdjReadSeekCloser, error) {
 	r := &sizeAdjReadSeekCloser{base: base, size: int64(size)}
 	if r.size < 0 {
-		panic("size limited 2^63 − 1")
+		return nil, errors.New("sizeAdjReadSeekCloser: size limited 2^63 − 1")
 	}
-	return r
+	return r, nil
 }
 
 type sizeAdjReadSeekCloser struct {

--- a/unixfs/io/sizeadj.go
+++ b/unixfs/io/sizeadj.go
@@ -100,8 +100,8 @@ type truncWriter struct {
 func (w *truncWriter) Write(p []byte) (int, error) {
 	truncC := 0
 	if int64(len(p)) > w.size-w.offset {
-		truncC = int(int64(len(p)) - w.size - w.offset)
-		p = p[:w.size]
+		truncC = int(int64(len(p)) - (w.size - w.offset))
+		p = p[:w.size-w.offset]
 	}
 	if len(p) == 0 {
 		return truncC, nil

--- a/unixfs/io/sizeadj_test.go
+++ b/unixfs/io/sizeadj_test.go
@@ -2,20 +2,19 @@ package io
 
 import (
 	"bytes"
-	"io"
+	"io/ioutil"
 	"testing"
 )
 
 func testSizeAdjRead(t *testing.T, gen func() (*sizeAdjReadSeekCloser, []byte)) {
 	r, expected := gen()
-	actual := make([]byte, len(expected)+1) // longer then necessary on purpose
-	n, err := r.Read(actual)
-	if err != nil && err != io.EOF {
+	actual, err := ioutil.ReadAll(r)
+	if err != nil {
 		t.Errorf("write failed: %v", err)
 		return
 	}
-	if n != len(expected) {
-		t.Errorf("n != len(expected); %d != %d", n, len(expected))
+	if len(actual) != len(expected) {
+		t.Errorf("len(actual) != len(expected); %d != %d", len(actual), len(expected))
 	}
 }
 

--- a/unixfs/io/sizeadj_test.go
+++ b/unixfs/io/sizeadj_test.go
@@ -1,0 +1,76 @@
+package io
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func testSizeAdjRead(t *testing.T, gen func() (*sizeAdjReadSeekCloser, []byte)) {
+	r, expected := gen()
+	actual := make([]byte, len(expected)+1) // longer then necessary on purpose
+	n, err := r.Read(actual)
+	if err != nil && err != io.EOF {
+		t.Errorf("write failed: %v", err)
+		return
+	}
+	if n != len(expected) {
+		t.Errorf("n != len(expected); %d != %d", n, len(expected))
+	}
+}
+
+func testSizeAdjWriteTo(t *testing.T, gen func() (*sizeAdjReadSeekCloser, []byte)) {
+	r, expected := gen()
+	buf := new(bytes.Buffer)
+	n, err := r.WriteTo(buf)
+	//actual := buf.Bytes()
+	if err != nil {
+		t.Errorf("write failed: %v", err)
+		return
+	}
+	if n != int64(len(expected)) {
+		t.Errorf("n != len(expected); %d != %d", n, len(expected))
+	}
+}
+
+func testBytes() []byte {
+	b := make([]byte, 128)
+	for i := 0; i < 100; i++ {
+		b[i] = byte(i + 1)
+	}
+	return b
+}
+
+// byteReader is bytes.Reader with a noop Close() method
+type byteReader struct {
+	*bytes.Reader
+}
+
+func (byteReader) Close() error { return nil }
+
+func simpleSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
+	b := testBytes()
+	buf := byteReader{bytes.NewReader(b)}
+	return newSizeAdjReadSeekCloser(buf, uint64(len(b))), b
+}
+
+func truncSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
+	b := testBytes()
+	buf := byteReader{bytes.NewReader(b)}
+	return newSizeAdjReadSeekCloser(buf, 100), b[:100]
+}
+
+func padSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
+	b := testBytes()
+	buf := byteReader{bytes.NewReader(b[:100])}
+	return newSizeAdjReadSeekCloser(buf, uint64(len(b))), b
+}
+
+func TestSizeAdj(t *testing.T) {
+	t.Run("Read/Simple", func(t *testing.T) { testSizeAdjRead(t, simpleSizeAdj) })
+	t.Run("Read/Trunc", func(t *testing.T) { testSizeAdjRead(t, truncSizeAdj) })
+	t.Run("Read/Pad", func(t *testing.T) { testSizeAdjRead(t, padSizeAdj) })
+	t.Run("WriteTo/Simple", func(t *testing.T) { testSizeAdjWriteTo(t, simpleSizeAdj) })
+	t.Run("WriteTo/Trunc", func(t *testing.T) { testSizeAdjWriteTo(t, truncSizeAdj) })
+	t.Run("WriteTo/Pad", func(t *testing.T) { testSizeAdjWriteTo(t, padSizeAdj) })
+}

--- a/unixfs/io/sizeadj_test.go
+++ b/unixfs/io/sizeadj_test.go
@@ -50,19 +50,22 @@ func (byteReader) Close() error { return nil }
 func simpleSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
 	b := testBytes()
 	buf := byteReader{bytes.NewReader(b)}
-	return newSizeAdjReadSeekCloser(buf, uint64(len(b))), b
+	r, _ := newSizeAdjReadSeekCloser(buf, uint64(len(b)))
+	return r, b
 }
 
 func truncSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
 	b := testBytes()
 	buf := byteReader{bytes.NewReader(b)}
-	return newSizeAdjReadSeekCloser(buf, 100), b[:100]
+	r, _ := newSizeAdjReadSeekCloser(buf, 100)
+	return r, b[:100]
 }
 
 func padSizeAdj() (*sizeAdjReadSeekCloser, []byte) {
 	b := testBytes()
 	buf := byteReader{bytes.NewReader(b[:100])}
-	return newSizeAdjReadSeekCloser(buf, uint64(len(b))), b
+	r, _ := newSizeAdjReadSeekCloser(buf, uint64(len(b)))
+	return r, b
 }
 
 func TestSizeAdj(t *testing.T) {

--- a/unixfs/io/sizeadj_test.go
+++ b/unixfs/io/sizeadj_test.go
@@ -76,3 +76,32 @@ func TestSizeAdj(t *testing.T) {
 	t.Run("WriteTo/Trunc", func(t *testing.T) { testSizeAdjWriteTo(t, truncSizeAdj) })
 	t.Run("WriteTo/Pad", func(t *testing.T) { testSizeAdjWriteTo(t, padSizeAdj) })
 }
+
+func TestTruncWriter(t *testing.T) {
+	b := testBytes() // 128 bytes
+	buf := new(bytes.Buffer)
+	// note: to correctly test truncWriter size should not be a
+	//   multiple of writeLen
+	tw := truncWriter{base: buf, size: 45}
+	writeLen := 25
+	inCount := 0
+	for len(b) > 0 {
+		j := writeLen
+		if j > len(b) {
+			j = len(b)
+		}
+		n, err := tw.Write(b[:j])
+		if err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		b = b[j:]
+		inCount += n
+	}
+	res := buf.Bytes()
+	if inCount != 128 {
+		t.Fatalf("truncWriter accepted incorrect number of bytes (expected 128): %d", len(res))
+	}
+	if len(res) != 45 {
+		t.Fatalf("truncWriter wrote incorrect number of bytes (expected 45): %d", len(res))
+	}
+}

--- a/unixfs/io/sizeadj_test.go
+++ b/unixfs/io/sizeadj_test.go
@@ -105,3 +105,26 @@ func TestTruncWriter(t *testing.T) {
 		t.Fatalf("truncWriter wrote incorrect number of bytes (expected 45): %d", len(res))
 	}
 }
+
+func TestWriteZeros(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	n, err := writeZeros(buf, 1000)
+	if err != nil {
+		t.Fatalf("writeZeros failed: %v", err)
+	}
+	res := buf.Bytes()
+	if n != 1000 || len(res) != 1000 {
+		t.Fatalf("writeZeros wrote incorrect number of bytes (expected 1000): %d %d", n, len(res))
+	}
+
+	buf.Reset()
+	n, err = writeZeros(buf, 10000)
+	if err != nil {
+		t.Fatalf("writeZeros failed: %v", err)
+	}
+	res = buf.Bytes()
+	if n != 10000 || len(res) != 10000 {
+		t.Fatalf("writeZeros wrote incorrect number of bytes (expected 10000): %d %d", n, len(res))
+	}
+}

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -262,8 +262,11 @@ func EmptyDirNode() *dag.ProtoNode {
 
 // ValidatePB validates a unixfs protonode.
 func ValidatePB(n *dag.ProtoNode, pb *pb.Data) error {
+	if len(pb.Blocksizes) == 0 { // special case
+		return nil
+	}
 	if len(n.Links()) != len(pb.Blocksizes) {
-		return errors.New("unixfs ill-formed, number of links does not batch blocksize count")
+		return errors.New("unixfs ill-formed, number of links does not match blocksize count")
 	}
 	total := uint64(len(pb.GetData()))
 	for _, blocksize := range pb.Blocksizes {

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -5,6 +5,7 @@ package unixfs
 
 import (
 	"errors"
+	"fmt"
 
 	proto "gx/ipfs/QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV/gogo-protobuf/proto"
 
@@ -257,4 +258,21 @@ func BytesForMetadata(m *Metadata) ([]byte, error) {
 // EmptyDirNode creates an empty folder Protonode.
 func EmptyDirNode() *dag.ProtoNode {
 	return dag.NodeWithData(FolderPBData())
+}
+
+// ValidatePB validates a unixfs protonode.
+func ValidatePB(n *dag.ProtoNode, pb *pb.Data) error {
+	if len(n.Links()) != len(pb.Blocksizes) {
+		return errors.New("unixfs ill-formed, number of links does not batch blocksize count")
+	}
+	total := uint64(len(pb.GetData()))
+	for _, blocksize := range pb.Blocksizes {
+		total += blocksize
+	}
+	if total != pb.GetFilesize() {
+		return fmt.Errorf("unixfs ill-formed, actual size of %d does not match size in filesize field with value %d",
+			total, pb.GetFilesize())
+	}
+
+	return nil
 }

--- a/unixfs/unixfs_test.go
+++ b/unixfs/unixfs_test.go
@@ -180,8 +180,8 @@ func TestValidatePB(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = ValidatePB(nd, fd)
-	if err == nil {
-		t.Fatal("invalid unixfs node (with no blocksizes) validated")
+	if err != nil {
+		t.Fatalf("valid node (with no blocksizes) failed to validate: %v", err)
 	}
 	// give node blocksizes
 	fd.Blocksizes = []uint64{3, 3}


### PR DESCRIPTION
If a node is too large, it is truncated; if it is too small, it is zero extended.

Closes #4540.  Closes #4667.


