### PR TITLE
Fix/win make

### DIFF
--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -11,8 +11,12 @@ DISTCLEAN += $(wildcard $(d)/gx-v*) $(wildcard $(d)/gx-go-v*) $(d)/tmp
 PATH := $(realpath $(d)):$(PATH)
 
 $(TGTS_$(d)):
-	rm -f $@
+	rm -f $@$(?exe)
+ifeq ($(WINDOWS),1)
+	cp $^$(?exe) $@$(?exe)
+else
 	ln -s $(notdir $^) $@
+endif
 
 bin/gx-v%:
 	@echo "installing gx $(@:bin/gx-%=%)"

--- a/bin/dist_get
+++ b/bin/dist_get
@@ -57,6 +57,13 @@ unarchive() {
 	ua_infile="$2"
 	ua_outfile="$3"
 	ua_distname="$4"
+	ua_binpostfix=""
+	ua_os=$(uname -o)
+
+	if [ "$ua_os" = "Msys" ] || [ "$ua_os" = "Cygwin" ] ; then
+	    ua_binpostfix=".exe"
+	fi
+	ua_outfile="$ua_outfile$ua_binpostfix"
 
 	if ! check_writeable "$ua_outfile"; then
 		die "unarchive error: cannot write to $ua_outfile"
@@ -66,7 +73,7 @@ unarchive() {
 		tar.gz)
 			if have_binary tar; then
 				echo "==> using 'tar' to extract binary from archive"
-				< "$ua_infile" tar -Ozxf - "$ua_distname/$ua_distname" > "$ua_outfile" \
+				< "$ua_infile" tar -Ozxf - "$ua_distname/$ua_distname$ua_binpostfix" > "$ua_outfile" \
 					|| die "tar has failed"
 			else
 				die "no binary on system for extracting tar files"
@@ -75,7 +82,7 @@ unarchive() {
 		zip)
 			if have_binary unzip; then
 				echo "==> using 'unzip' to extract binary from archive"
-				unzip -p "$ua_infile" "$ua_distname/$ua_distname" > "$ua_outfile" \
+				unzip -p "$ua_infile" "$ua_distname/$ua_distname$ua_binpostfix" > "$ua_outfile" \
 					|| die "unzip has failed"
 			else
 				die "no installed method for extracting .zip archives"


### PR DESCRIPTION
Requesting review from @Kubuxu I'm not very familiar with IPFS's `make` rules or `make` in general so this may need changes.
In my testing this ~~~resolved~~~ partially resolves https://github.com/ipfs/go-ipfs/issues/4510 when using MSYS2 tools.
I'm going to look into gx detection

While working on this I noticed a problem I couldn't work around.
/bin/Rules.mk utilizes a symlink for the binary dependencies, on Windows, by default, users don't have permission to create symlinks with `mklink`, MSYS2's `ln.exe` simply copies the source to the target (not as a link). This ends up not being a problem in practice but I feel the need to mention it. Here's the patch I initially tried without success.

```
diff --git a/bin/Rules.mk b/bin/Rules.mk
index 1a1dd7962..a2576c303 100644
--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -16,7 +16,11 @@ PATH := $(realpath $(d)):$(PATH)

 $(TGTS_$(d)):
        rm -f $@$(binpostfix)
+ifeq ($(OS),Windows_NT)
+       cmd /C mklink "$@$(binpostfix)" "$(notdir $^)$(binpostfix)"
+else
        ln -s $(notdir $^) $@
+endif

 bin/gx-v%:
        @echo "installing gx $(@:bin/gx-%=%)"

```