### PR TITLE
Doc: golint-ify pin package

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -494,7 +494,7 @@ type RefKeyList struct {
 
 func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsNode) (map[string]RefKeyObject, error) {
 
-	mode, ok := pin.StringToPinMode(typeStr)
+	mode, ok := pin.StringToMode(typeStr)
 	if !ok {
 		return nil, fmt.Errorf("invalid pin mode '%s'", typeStr)
 	}


### PR DESCRIPTION
This removes all golint warnings in the `pin` package.

Due to stuttering, I had to rename `pin.PinMode` to `pin.Mode`. I can revert that specific commit though.

Protobuf stuff not touched.