### PR TITLE
Add exchange.SessionExchange interface for exchanges that support sessions

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ipfs/go-ipfs/blocks/blockstore"
 	exchange "github.com/ipfs/go-ipfs/exchange"
-	bitswap "github.com/ipfs/go-ipfs/exchange/bitswap"
 
 	logging "gx/ipfs/QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8/go-log"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
@@ -107,19 +106,22 @@ func (s *blockService) Exchange() exchange.Interface {
 	return s.exchange
 }
 
-// NewSession creates a bitswap session that allows for controlled exchange of
-// wantlists to decrease the bandwidth overhead.
+// NewSession creates a new session that allows for
+// controlled exchange of wantlists to decrease the bandwidth overhead.
+// If the current exchange is a SessionExchange, a new exchange
+// session will be created. Otherwise, the current exchange will be used
+// directly.
 func NewSession(ctx context.Context, bs BlockService) *Session {
-	exchange := bs.Exchange()
-	if bswap, ok := exchange.(*bitswap.Bitswap); ok {
-		ses := bswap.NewSession(ctx)
+	exch := bs.Exchange()
+	if sessEx, ok := exch.(exchange.SessionExchange); ok {
+		ses := sessEx.NewSession(ctx)
 		return &Session{
 			ses: ses,
 			bs:  bs.Blockstore(),
 		}
 	}
 	return &Session{
-		ses: exchange,
+		ses: exch,
 		bs:  bs.Blockstore(),
 	}
 }

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -1,4 +1,4 @@
-// package exchange defines the IPFS exchange interface
+// Package exchange defines the IPFS exchange interface
 package exchange
 
 import (
@@ -10,8 +10,7 @@ import (
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
 
-// Any type that implements exchange.Interface may be used as an IPFS block
-// exchange protocol.
+// Interface defines the functionality of the IPFS block exchange protocol.
 type Interface interface { // type Exchanger interface
 	Fetcher
 
@@ -29,4 +28,11 @@ type Fetcher interface {
 	// GetBlock returns the block associated with a given key.
 	GetBlock(context.Context, *cid.Cid) (blocks.Block, error)
 	GetBlocks(context.Context, []*cid.Cid) (<-chan blocks.Block, error)
+}
+
+// SessionExchange is an exchange.Interface which supports
+// sessions.
+type SessionExchange interface {
+	Interface
+	NewSession(context.Context) Interface
 }


### PR DESCRIPTION
Blockservice has an explicit dependency on bitswap so it can
call NewSession. It should rely on the exchange interfaces though, not
on specific implementations.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>