### PR TITLE
Feat: Separate "path" from "path/resolver"

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -13,7 +13,7 @@ import (
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	filestore "github.com/ipfs/go-ipfs/filestore"
 	dag "github.com/ipfs/go-ipfs/merkledag"
-	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	pin "github.com/ipfs/go-ipfs/pin"
 	repo "github.com/ipfs/go-ipfs/repo"
 	cfg "github.com/ipfs/go-ipfs/repo/config"
@@ -230,7 +230,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		// this is kinda sketchy and could cause data loss
 		n.Pinning = pin.NewPinner(n.Repo.Datastore(), n.DAG, internalDag)
 	}
-	n.Resolver = path.NewBasicResolver(n.DAG)
+	n.Resolver = resolver.NewBasicResolver(n.DAG)
 
 	if cfg.Online {
 		if err := n.startLateOnlineServices(ctx); err != nil {

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -19,6 +19,7 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	mfs "github.com/ipfs/go-ipfs/mfs"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -352,7 +353,7 @@ func getNodeFromPath(ctx context.Context, node *core.IpfsNode, p string) (ipld.N
 			return nil, err
 		}
 
-		resolver := &path.Resolver{
+		resolver := &resolver.Resolver{
 			DAG:         node.DAG,
 			ResolveOnce: uio.ResolveUnixfsOnce,
 		}

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -13,6 +13,7 @@ import (
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
@@ -92,7 +93,7 @@ The JSON output contains type information.
 				return
 			}
 
-			r := &path.Resolver{
+			r := &resolver.Resolver{
 				DAG:         nd.DAG,
 				ResolveOnce: uio.ResolveUnixfsOnce,
 			}

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -15,6 +15,7 @@ import (
 	offline "github.com/ipfs/go-ipfs/exchange/offline"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	pin "github.com/ipfs/go-ipfs/pin"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -387,7 +388,7 @@ new pin and removing the old one.
 			return
 		}
 
-		r := &path.Resolver{
+		r := &resolver.Resolver{
 			DAG:         n.DAG,
 			ResolveOnce: uio.ResolveUnixfsOnce,
 		}
@@ -501,7 +502,7 @@ func pinLsKeys(args []string, typeStr string, ctx context.Context, n *core.IpfsN
 
 	keys := make(map[string]RefKeyObject)
 
-	r := &path.Resolver{
+	r := &resolver.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -7,15 +7,17 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
+
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	unixfspb "github.com/ipfs/go-ipfs/unixfs/pb"
-	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 )
 
 type LsLink struct {
@@ -91,7 +93,7 @@ possible, please use 'ipfs ls' instead.
 		for _, fpath := range paths {
 			ctx := req.Context()
 
-			resolver := &path.Resolver{
+			resolver := &resolver.Resolver{
 				DAG:         node.DAG,
 				ResolveOnce: uio.ResolveUnixfsOnce,
 			}

--- a/core/core.go
+++ b/core/core.go
@@ -33,7 +33,7 @@ import (
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	ipnsrp "github.com/ipfs/go-ipfs/namesys/republisher"
 	p2p "github.com/ipfs/go-ipfs/p2p"
-	path "github.com/ipfs/go-ipfs/path"
+	"github.com/ipfs/go-ipfs/path/resolver"
 	pin "github.com/ipfs/go-ipfs/pin"
 	repo "github.com/ipfs/go-ipfs/repo"
 	config "github.com/ipfs/go-ipfs/repo/config"
@@ -119,7 +119,7 @@ type IpfsNode struct {
 	GCLocker   bstore.GCLocker      // the locker used to protect the blockstore during gc
 	Blocks     bserv.BlockService   // the block service, get/add blocks.
 	DAG        ipld.DAGService      // the merkle dag service, get/add objects.
-	Resolver   *path.Resolver       // the path resolution system
+	Resolver   *resolver.Resolver   // the path resolution system
 	Reporter   metrics.Reporter
 	Discovery  discovery.Service
 	FilesRoot  *mfs.Root

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -7,6 +7,7 @@ import (
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	ipfspath "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
@@ -87,7 +88,7 @@ func resolvePath(ctx context.Context, ng ipld.NodeGetter, nsys namesys.NameSyste
 		return p, nil
 	}
 
-	r := &ipfspath.Resolver{
+	r := &resolver.Resolver{
 		DAG:         ng,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -19,6 +19,7 @@ import (
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	dagutils "github.com/ipfs/go-ipfs/merkledag/utils"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
@@ -445,7 +446,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	var newcid *cid.Cid
 	rnode, err := core.Resolve(ctx, i.node.Namesys, i.node.Resolver, rootPath)
 	switch ev := err.(type) {
-	case path.ErrNoLink:
+	case resolver.ErrNoLink:
 		// ev.Node < node where resolve failed
 		// ev.Name < new link
 		// but we need to patch from the root
@@ -599,7 +600,7 @@ func (i *gatewayHandler) addUserHeaders(w http.ResponseWriter) {
 }
 
 func webError(w http.ResponseWriter, message string, err error, defaultCode int) {
-	if _, ok := err.(path.ErrNoLink); ok {
+	if _, ok := err.(resolver.ErrNoLink); ok {
 		webErrorWithCode(w, message, err, http.StatusNotFound)
 	} else if err == routing.ErrNotFound {
 		webErrorWithCode(w, message, err, http.StatusNotFound)

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/core"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
@@ -27,7 +28,7 @@ import (
 func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
 	out := make([]*cid.Cid, len(paths))
 
-	r := &path.Resolver{
+	r := &resolver.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}
@@ -60,7 +61,7 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 func Unpin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
 	unpinned := make([]*cid.Cid, len(paths))
 
-	r := &path.Resolver{
+	r := &resolver.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -5,11 +5,12 @@ import (
 
 	core "github.com/ipfs/go-ipfs/core"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 )
 
 func Cat(ctx context.Context, n *core.IpfsNode, pstr string) (uio.DagReader, error) {
-	r := &path.Resolver{
+	r := &resolver.Resolver{
 		DAG:         n.DAG,
 		ResolveOnce: uio.ResolveUnixfsOnce,
 	}

--- a/core/pathresolver.go
+++ b/core/pathresolver.go
@@ -7,6 +7,7 @@ import (
 
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	path "github.com/ipfs/go-ipfs/path"
+	resolver "github.com/ipfs/go-ipfs/path/resolver"
 
 	logging "gx/ipfs/QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8/go-log"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
@@ -21,7 +22,7 @@ var ErrNoNamesys = errors.New(
 // Resolve resolves the given path by parsing out protocol-specific
 // entries (e.g. /ipns/<node-key>) and then going through the /ipfs/
 // entries and returning the final node.
-func Resolve(ctx context.Context, nsys namesys.NameSystem, r *path.Resolver, p path.Path) (ipld.Node, error) {
+func Resolve(ctx context.Context, nsys namesys.NameSystem, r *resolver.Resolver, p path.Path) (ipld.Node, error) {
 	if strings.HasPrefix(p.String(), "/ipns/") {
 		evt := log.EventBegin(ctx, "resolveIpnsPath")
 		defer evt.Done()
@@ -70,7 +71,7 @@ func Resolve(ctx context.Context, nsys namesys.NameSystem, r *path.Resolver, p p
 // It first checks if the path is already in the form of just a cid (<cid> or
 // /ipfs/<cid>) and returns immediately if so. Otherwise, it falls back onto
 // Resolve to perform resolution of the dagnode being referenced.
-func ResolveToCid(ctx context.Context, nsys namesys.NameSystem, r *path.Resolver, p path.Path) (*cid.Cid, error) {
+func ResolveToCid(ctx context.Context, nsys namesys.NameSystem, r *resolver.Resolver, p path.Path) (*cid.Cid, error) {
 
 	// If the path is simply a cid, parse and return it. Parsed paths are already
 	// normalized (read: prepended with /ipfs/ if needed), so segment[1] should

--- a/path/resolver/resolver_test.go
+++ b/path/resolver/resolver_test.go
@@ -1,4 +1,4 @@
-package path_test
+package resolver_test
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	dagmock "github.com/ipfs/go-ipfs/merkledag/test"
 	path "github.com/ipfs/go-ipfs/path"
+	"github.com/ipfs/go-ipfs/path/resolver"
 
 	util "gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
@@ -53,7 +54,7 @@ func TestRecurivePathResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resolver := path.NewBasicResolver(dagService)
+	resolver := resolver.NewBasicResolver(dagService)
 	node, err := resolver.ResolvePath(ctx, p)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Currently the "path" module does two very different things:

* Defines how ipfs paths look like and provides tools to parse/split etc.
* Provides a resolver to resolve paths.

This moves the resolver stuff to `path/resolver` and leaves the
path utilities in `path`.

The result is that now the IPFS path is a free module
that can be exported without problems and with that we remove circular
dependency cycles (resolve_test -> merkledag/utils, merkledag->path),
which do prevent exportation of merkledag itself.

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>