### PR TITLE
Disable sorting on unmarshalled blocks and json. 

### DIFF
--- a/core/coreapi/object_test.go
+++ b/core/coreapi/object_test.go
@@ -237,11 +237,11 @@ func TestObjectAddLink(t *testing.T) {
 		t.Errorf("unexpected number of links: %d", len(links))
 	}
 
-	if links[0].Name != "abc" {
+	if links[0].Name != "bar" {
 		t.Errorf("unexpected link 0 name: %s", links[0].Name)
 	}
 
-	if links[1].Name != "bar" {
+	if links[1].Name != "abc" {
 		t.Errorf("unexpected link 1 name: %s", links[1].Name)
 	}
 }
@@ -285,11 +285,11 @@ func TestObjectAddLinkCreate(t *testing.T) {
 		t.Errorf("unexpected number of links: %d", len(links))
 	}
 
-	if links[0].Name != "abc" {
+	if links[0].Name != "bar" {
 		t.Errorf("unexpected link 0 name: %s", links[0].Name)
 	}
 
-	if links[1].Name != "bar" {
+	if links[1].Name != "abc" {
 		t.Errorf("unexpected link 1 name: %s", links[1].Name)
 	}
 }

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -34,8 +34,8 @@ func (n *ProtoNode) unmarshal(encoded []byte) error {
 		}
 		n.links[i].Cid = c
 	}
-	sort.Stable(LinkSlice(n.links)) // keep links sorted
 
+	n.NoSort = true
 	n.data = pbn.GetData()
 	n.encoded = encoded
 	return nil
@@ -58,7 +58,9 @@ func (n *ProtoNode) getPBNode() *pb.PBNode {
 		pbn.Links = make([]*pb.PBLink, len(n.links))
 	}
 
-	sort.Stable(LinkSlice(n.links)) // keep links sorted
+	if n.NoSort == false {
+		sort.Stable(LinkSlice(n.links)) // keep links sorted
+	}
 	for i, l := range n.links {
 		pbn.Links[i] = &pb.PBLink{}
 		pbn.Links[i].Name = &l.Name
@@ -77,7 +79,9 @@ func (n *ProtoNode) getPBNode() *pb.PBNode {
 // EncodeProtobuf returns the encoded raw data version of a Node instance.
 // It may use a cached encoded version, unless the force flag is given.
 func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
-	sort.Stable(LinkSlice(n.links)) // keep links sorted
+	if n.NoSort == false {
+		sort.Stable(LinkSlice(n.links)) // keep links sorted
+	}
 	if n.encoded == nil || force {
 		n.cached = nil
 		var err error


### PR DESCRIPTION
Allow to disable sorting in new ProtoNode.

Fix for: [merkledag\coding.go change links order if it have names in file nodes.](https://github.com/ipfs/go-ipfs/issues/4705)

License: MIT
Signed-off-by: Ivan ivan386@users.noreply.github.com