### PR TITLE
[WIP] Add Filestore support for the trickle DAG builder

### DIFF
--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -134,7 +134,10 @@ func (db *DagBuilderHelper) newUnixfsBlock() *UnixfsNode {
 
 // FillNodeLayer will add datanodes as children to the give node until
 // at most db.indirSize nodes are added.
-func (db *DagBuilderHelper) FillNodeLayer(node *UnixfsNode) error {
+// The parameter offset is used to support Filestore and applies only to
+// nodes stored using this feature, it is adjusted with the sizes of the
+// added nodes.
+func (db *DagBuilderHelper) FillNodeLayer(node *UnixfsNode, offset *uint64) error {
 
 	// while we have room AND we're not done
 	for node.NumChildren() < db.maxlinks && !db.Done() {
@@ -142,10 +145,12 @@ func (db *DagBuilderHelper) FillNodeLayer(node *UnixfsNode) error {
 		if err != nil {
 			return err
 		}
+		db.SetPosInfo(child, *offset)
 
 		if err := node.AddChild(child, db); err != nil {
 			return err
 		}
+		*offset += child.FileSize()
 	}
 
 	return nil


### PR DESCRIPTION
This needs to be updated after https://github.com/ipfs/go-ipfs/issues/5135 is done. Any help from the community is welcome.

---------------
This is a work in progress, not ready to be merged.

As [commented](https://github.com/ipfs/go-ipfs/issues/4052#issuecomment-368146394) in #4052, the support for Filestore will be added only to the `Layout` function for now, not to `Append`. This means that `ipfs add --trickle` will support `--nocopy` (Filestore), but that added node when copied to MFS won't support `ipfs files write` (which uses `Append`).

It builds on top of the #4730 that should be merged first.

Closes #4052.
