### PR TITLE
unixfs: clean path in DagArchive

### DIFF
--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -104,6 +104,14 @@ test_get_cmd() {
     rm -r "$HASH2"
   '
 
+  # Test issue #4720: problems when path contains a trailing slash.
+  test_expect_success "ipfs get with slash (directory)" '
+    ipfs get "$HASH2/" &&
+    test_cmp dir/a "$HASH2"/a &&
+    test_cmp dir/b/c "$HASH2"/b/c &&
+    rm -r "$HASH2"
+  '
+
   test_expect_success "ipfs get -a -C succeeds (directory)" '
     ipfs get "$HASH2" -a -C >actual
   '

--- a/unixfs/archive/archive.go
+++ b/unixfs/archive/archive.go
@@ -33,7 +33,8 @@ func (i *identityWriteCloser) Close() error {
 // DagArchive is equivalent to `ipfs getdag $hash | maybe_tar | maybe_gzip`
 func DagArchive(ctx context.Context, nd ipld.Node, name string, dag ipld.DAGService, archive bool, compression int) (io.Reader, error) {
 
-	_, filename := path.Split(name)
+	cleaned := path.Clean(name)
+	_, filename := path.Split(cleaned)
 
 	// need to connect a writer to a reader
 	piper, pipew := io.Pipe()


### PR DESCRIPTION
Clean the path in the function `DagArchive` that prepares the output in a similar way as the resolver does in [`Segments`](https://github.com/ipfs/go-ipfs/blob/199a52d777e2b292fe430e8470d88037c43ed7ca/path/path.go#L46).

Fixes #4720.
