### PR TITLE
add: hash-only: set the prefix for MFS root

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -283,7 +283,10 @@ You can now check what blocks have been created by:
 
 		if hash {
 			md := dagtest.Mock()
-			mr, err := mfs.NewRoot(req.Context, md, ft.EmptyDirNode(), nil)
+			emptyDirNode := ft.EmptyDirNode()
+			// Use the same prefix for the "empty" MFS root as for the file adder.
+			emptyDirNode.Prefix = *fileAdder.Prefix
+			mr, err := mfs.NewRoot(req.Context, md, emptyDirNode, nil)
 			if err != nil {
 				res.SetError(err, cmdkit.ErrNormal)
 				return

--- a/test/sharness/t0043-add-w.sh
+++ b/test/sharness/t0043-add-w.sh
@@ -149,6 +149,15 @@ test_add_w() {
     echo "$add_w_d1_v1" >expected &&
     test_sort_cmp expected actual
   '
+
+  test_expect_success "ipfs add -w -r -n (dir) --cid-version=1 succeeds" '
+    ipfs add -r -w -n --cid-version=1 m/t_1wp-8a2/_jo7 >actual
+  '
+
+  test_expect_success "ipfs add -w -r -n (dir) --cid-version=1 is correct" '
+    echo "$add_w_d1_v1" > expected &&
+    test_sort_cmp expected actual
+  '
 }
 
 test_init_ipfs


### PR DESCRIPTION
In the case that the `only-hash` option (`-n`) is set for `ipfs add`, use the same prefix from the `fileAdder` for the MFS root so it is processed using the same CID version and hash function.

Fixes #4652.

This is a work in progress, some tests should be added. Also, the comment is not very illustrative, it should clarify why is it that the prefix needs two be specified twice (for the file adder and the MFS root).
