### PR TITLE
[WIP] MFS improvements

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -537,7 +537,7 @@ Examples:
 			return
 		}
 
-		rfd, err := fi.Open(mfs.OpenReadOnly, false)
+		rfd, err := fi.Open(mfs.Flags{Read: true, Sync: false})
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -738,7 +738,7 @@ stat' on the file or any of its ancestors.
 			fi.RawLeaves = rawLeaves
 		}
 
-		wfd, err := fi.Open(mfs.OpenWriteOnly, flush)
+		wfd, err := fi.Open(mfs.Flags{Write: true, Sync: flush})
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -440,19 +440,20 @@ func (dir *Directory) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (fs.Nod
 }
 
 func (fi *FileNode) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
-	var mfsflag int
+	mfsflags := mfs.Flags{Sync: true}
 	switch {
 	case req.Flags.IsReadOnly():
-		mfsflag = mfs.OpenReadOnly
+		mfsflags.Read = true
 	case req.Flags.IsWriteOnly():
-		mfsflag = mfs.OpenWriteOnly
+		mfsflags.Write = true
 	case req.Flags.IsReadWrite():
-		mfsflag = mfs.OpenReadWrite
+		mfsflags.Write = true
+		mfsflags.Read = true
 	default:
 		return nil, errors.New("unsupported flag type")
 	}
 
-	fd, err := fi.fi.Open(mfsflag, true)
+	fd, err := fi.fi.Open(mfsflags)
 	if err != nil {
 		return nil, err
 	}
@@ -508,19 +509,20 @@ func (dir *Directory) Create(ctx context.Context, req *fuse.CreateRequest, resp 
 
 	nodechild := &FileNode{fi: fi}
 
-	var openflag int
+	openflags := mfs.Flags{Sync: true}
 	switch {
 	case req.Flags.IsReadOnly():
-		openflag = mfs.OpenReadOnly
+		openflags.Read = true
 	case req.Flags.IsWriteOnly():
-		openflag = mfs.OpenWriteOnly
+		openflags.Write = true
 	case req.Flags.IsReadWrite():
-		openflag = mfs.OpenReadWrite
+		openflags.Read = true
+		openflags.Write = true
 	default:
 		return nil, nil, errors.New("unsupported open mode")
 	}
 
-	fd, err := fi.Open(openflag, true)
+	fd, err := fi.Open(openflags)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -1,12 +1,22 @@
 package mfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	mod "github.com/ipfs/go-ipfs/unixfs/mod"
 
-	context "context"
+	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
+)
+
+type state uint8
+
+const (
+	stateFlushed state = iota
+	stateSynced
+	stateDirty
+	stateClosed
 )
 
 type FileDescriptor interface {
@@ -26,13 +36,31 @@ type FileDescriptor interface {
 }
 
 type fileDescriptor struct {
-	inode      *File
-	mod        *mod.DagModifier
-	perms      int
-	sync       bool
-	hasChanges bool
+	inode *File
+	mod   *mod.DagModifier
+	flags Flags
 
-	closed bool
+	state state
+}
+
+func (fi *fileDescriptor) checkWrite() error {
+	if fi.state == stateClosed {
+		return ErrClosed
+	}
+	if !fi.flags.Write {
+		return fmt.Errorf("file is read-only")
+	}
+	return nil
+}
+
+func (fi *fileDescriptor) checkRead() error {
+	if fi.state == stateClosed {
+		return ErrClosed
+	}
+	if !fi.flags.Read {
+		return fmt.Errorf("file is write-only")
+	}
+	return nil
 }
 
 // Size returns the size of the file referred to by this descriptor
@@ -42,34 +70,34 @@ func (fi *fileDescriptor) Size() (int64, error) {
 
 // Truncate truncates the file to size
 func (fi *fileDescriptor) Truncate(size int64) error {
-	if fi.perms == OpenReadOnly {
-		return fmt.Errorf("cannot call truncate on readonly file descriptor")
+	if err := fi.checkWrite(); err != nil {
+		return fmt.Errorf("truncate failed: %s", err)
 	}
-	fi.hasChanges = true
+	fi.state = stateDirty
 	return fi.mod.Truncate(size)
 }
 
 // Write writes the given data to the file at its current offset
 func (fi *fileDescriptor) Write(b []byte) (int, error) {
-	if fi.perms == OpenReadOnly {
-		return 0, fmt.Errorf("cannot write on not writeable descriptor")
+	if err := fi.checkWrite(); err != nil {
+		return 0, fmt.Errorf("write failed: %s", err)
 	}
-	fi.hasChanges = true
+	fi.state = stateDirty
 	return fi.mod.Write(b)
 }
 
 // Read reads into the given buffer from the current offset
 func (fi *fileDescriptor) Read(b []byte) (int, error) {
-	if fi.perms == OpenWriteOnly {
-		return 0, fmt.Errorf("cannot read on write-only descriptor")
+	if err := fi.checkRead(); err != nil {
+		return 0, fmt.Errorf("read failed: %s", err)
 	}
 	return fi.mod.Read(b)
 }
 
 // Read reads into the given buffer from the current offset
 func (fi *fileDescriptor) CtxReadFull(ctx context.Context, b []byte) (int, error) {
-	if fi.perms == OpenWriteOnly {
-		return 0, fmt.Errorf("cannot read on write-only descriptor")
+	if err := fi.checkRead(); err != nil {
+		return 0, fmt.Errorf("read failed: %s", err)
 	}
 	return fi.mod.CtxReadFull(ctx, b)
 }
@@ -77,33 +105,17 @@ func (fi *fileDescriptor) CtxReadFull(ctx context.Context, b []byte) (int, error
 // Close flushes, then propogates the modified dag node up the directory structure
 // and signals a republish to occur
 func (fi *fileDescriptor) Close() error {
-	defer func() {
-		switch fi.perms {
-		case OpenReadOnly:
-			fi.inode.desclock.RUnlock()
-		case OpenWriteOnly, OpenReadWrite:
-			fi.inode.desclock.Unlock()
-		}
-	}()
-
-	if fi.closed {
-		panic("attempted to close file descriptor twice!")
+	if fi.state == stateClosed {
+		return ErrClosed
 	}
-
-	if fi.hasChanges {
-		err := fi.mod.Sync()
-		if err != nil {
-			return err
-		}
-
-		fi.hasChanges = false
-
-		// explicitly stay locked for flushUp call,
-		// it will manage the lock for us
-		return fi.flushUp(fi.sync)
+	if fi.flags.Write {
+		defer fi.inode.desclock.Unlock()
+	} else if fi.flags.Read {
+		defer fi.inode.desclock.RUnlock()
 	}
-
-	return nil
+	err := fi.flushUp(fi.flags.Sync)
+	fi.state = stateClosed
+	return err
 }
 
 func (fi *fileDescriptor) Sync() error {
@@ -117,35 +129,61 @@ func (fi *fileDescriptor) Flush() error {
 // flushUp syncs the file and adds it to the dagservice
 // it *must* be called with the File's lock taken
 func (fi *fileDescriptor) flushUp(fullsync bool) error {
-	nd, err := fi.mod.GetNode()
-	if err != nil {
-		return err
+	var nd ipld.Node
+	switch fi.state {
+	case stateDirty:
+		// calls mod.Sync internally.
+		var err error
+		nd, err = fi.mod.GetNode()
+		if err != nil {
+			return err
+		}
+
+		err = fi.inode.dserv.Add(context.TODO(), nd)
+		if err != nil {
+			return err
+		}
+
+		fi.inode.nodelk.Lock()
+		fi.inode.node = nd
+		fi.inode.nodelk.Unlock()
+		fi.state = stateSynced
+		fallthrough
+	case stateSynced:
+		if !fullsync {
+			return nil
+		}
+		if nd == nil {
+			fi.inode.nodelk.Lock()
+			nd = fi.inode.node
+			fi.inode.nodelk.Unlock()
+		}
+
+		if err := fi.inode.parent.closeChild(fi.inode.name, nd, fullsync); err != nil {
+			return err
+		}
+		fi.state = stateFlushed
+		return nil
+	case stateFlushed:
+		return nil
+	default:
+		panic("invalid state")
 	}
-
-	err = fi.inode.dserv.Add(context.TODO(), nd)
-	if err != nil {
-		return err
-	}
-
-	fi.inode.nodelk.Lock()
-	fi.inode.node = nd
-	name := fi.inode.name
-	parent := fi.inode.parent
-	fi.inode.nodelk.Unlock()
-
-	return parent.closeChild(name, nd, fullsync)
 }
 
 // Seek implements io.Seeker
 func (fi *fileDescriptor) Seek(offset int64, whence int) (int64, error) {
+	if fi.state == stateClosed {
+		return 0, fmt.Errorf("seek failed: %s", ErrClosed)
+	}
 	return fi.mod.Seek(offset, whence)
 }
 
 // Write At writes the given bytes at the offset 'at'
 func (fi *fileDescriptor) WriteAt(b []byte, at int64) (int, error) {
-	if fi.perms == OpenReadOnly {
-		return 0, fmt.Errorf("cannot write on not writeable descriptor")
+	if err := fi.checkWrite(); err != nil {
+		return 0, fmt.Errorf("write-at failed: %s", err)
 	}
-	fi.hasChanges = true
+	fi.state = stateDirty
 	return fi.mod.WriteAt(b, at)
 }

--- a/mfs/file.go
+++ b/mfs/file.go
@@ -42,13 +42,8 @@ func NewFile(name string, node ipld.Node, parent childCloser, dserv ipld.DAGServ
 	return fi, nil
 }
 
-const (
-	OpenReadOnly = iota
-	OpenWriteOnly
-	OpenReadWrite
-)
-
-func (fi *File) Open(flags int, sync bool) (FileDescriptor, error) {
+// Open opens a file with the specified flags.
+func (fi *File) Open(flags Flags) (FileDescriptor, error) {
 	fi.nodelk.Lock()
 	node := fi.node
 	fi.nodelk.Unlock()
@@ -72,14 +67,12 @@ func (fi *File) Open(flags int, sync bool) (FileDescriptor, error) {
 		// Ok as well.
 	}
 
-	switch flags {
-	case OpenReadOnly:
-		fi.desclock.RLock()
-	case OpenWriteOnly, OpenReadWrite:
+	if flags.Write {
 		fi.desclock.Lock()
-	default:
-		// TODO: support other modes
-		return nil, fmt.Errorf("mode not supported")
+	} else if flags.Read {
+		fi.desclock.RLock()
+	} else {
+		return nil, fmt.Errorf("file opened for neither reading nor writing")
 	}
 
 	dmod, err := mod.NewDagModifier(context.TODO(), node, fi.dserv, chunker.DefaultSplitter)
@@ -90,8 +83,7 @@ func (fi *File) Open(flags int, sync bool) (FileDescriptor, error) {
 
 	return &fileDescriptor{
 		inode: fi,
-		perms: flags,
-		sync:  sync,
+		flags: flags,
 		mod:   dmod,
 	}, nil
 }
@@ -123,7 +115,7 @@ func (fi *File) GetNode() (ipld.Node, error) {
 
 func (fi *File) Flush() error {
 	// open the file in fullsync mode
-	fd, err := fi.Open(OpenWriteOnly, true)
+	fd, err := fi.Open(Flags{Write: true, Sync: true})
 	if err != nil {
 		return err
 	}

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -161,7 +161,7 @@ func assertFileAtPath(ds ipld.DAGService, root *Directory, expn ipld.Node, pth s
 		return fmt.Errorf("%s was not a file!", pth)
 	}
 
-	rfd, err := file.Open(OpenReadOnly, false)
+	rfd, err := file.Open(Flags{Read: true})
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func TestMfsFile(t *testing.T) {
 		t.Fatal("some is seriously wrong here")
 	}
 
-	wfd, err := fi.Open(OpenReadWrite, true)
+	wfd, err := fi.Open(Flags{Read: true, Write: true, Sync: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -555,7 +555,7 @@ func actorMakeFile(d *Directory) error {
 		return err
 	}
 
-	wfd, err := f.Open(OpenWriteOnly, true)
+	wfd, err := f.Open(Flags{Write: true, Sync: true})
 	if err != nil {
 		return err
 	}
@@ -635,7 +635,7 @@ func actorWriteFile(d *Directory) error {
 		return err
 	}
 
-	wfd, err := fi.Open(OpenWriteOnly, true)
+	wfd, err := fi.Open(Flags{Write: true, Sync: true})
 	if err != nil {
 		return err
 	}
@@ -667,7 +667,7 @@ func actorReadFile(d *Directory) error {
 		return err
 	}
 
-	rfd, err := fi.Open(OpenReadOnly, false)
+	rfd, err := fi.Open(Flags{Read: true})
 	if err != nil {
 		return err
 	}
@@ -869,7 +869,7 @@ func readFile(rt *Root, path string, offset int64, buf []byte) error {
 		return fmt.Errorf("%s was not a file", path)
 	}
 
-	fd, err := fi.Open(OpenReadOnly, false)
+	fd, err := fi.Open(Flags{Read: true})
 	if err != nil {
 		return err
 	}
@@ -947,7 +947,7 @@ func writeFile(rt *Root, path string, data []byte) error {
 		return fmt.Errorf("expected to receive a file, but didnt get one")
 	}
 
-	fd, err := fi.Open(OpenWriteOnly, true)
+	fd, err := fi.Open(Flags{Write: true, Sync: true})
 	if err != nil {
 		return err
 	}
@@ -1015,7 +1015,7 @@ func TestFileDescriptors(t *testing.T) {
 	}
 
 	// test read only
-	rfd1, err := fi.Open(OpenReadOnly, false)
+	rfd1, err := fi.Open(Flags{Read: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1039,7 +1039,7 @@ func TestFileDescriptors(t *testing.T) {
 	go func() {
 		defer close(done)
 		// can open second readonly file descriptor
-		rfd2, err := fi.Open(OpenReadOnly, false)
+		rfd2, err := fi.Open(Flags{Read: true})
 		if err != nil {
 			t.Error(err)
 			return
@@ -1062,7 +1062,7 @@ func TestFileDescriptors(t *testing.T) {
 	done = make(chan struct{})
 	go func() {
 		defer close(done)
-		wfd1, err := fi.Open(OpenWriteOnly, true)
+		wfd1, err := fi.Open(Flags{Write: true, Sync: true})
 		if err != nil {
 			t.Error(err)
 		}
@@ -1091,7 +1091,7 @@ func TestFileDescriptors(t *testing.T) {
 	case <-done:
 	}
 
-	wfd, err := fi.Open(OpenWriteOnly, true)
+	wfd, err := fi.Open(Flags{Write: true, Sync: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mfs/options.go
+++ b/mfs/options.go
@@ -1,0 +1,8 @@
+package mfs
+
+// Flags is an extensible struct used to pass open options.
+type Flags struct {
+	Read  bool
+	Write bool
+	Sync  bool
+}

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -229,9 +229,12 @@ func (p *Republisher) setVal(c *cid.Cid) {
 // current value `val`, else will block until `val` has been published.
 func (p *Republisher) WaitPub() {
 	p.lk.Lock()
-	consistent := p.lastpub == p.val
+	lastpub := p.lastpub
+	val := p.val
 	p.lk.Unlock()
-	if consistent {
+
+	// TODO: Simplify this once Cid.Equals handles nil.
+	if lastpub == val || lastpub != nil && val != nil && lastpub.Equals(val) {
 		return
 	}
 

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -26,6 +26,9 @@ import (
 
 var ErrNotExist = errors.New("no such rootfs")
 
+// ErrClosed indicates an error due to the target file being closed.
+var ErrClosed = errors.New("file closed")
+
 var log = logging.Logger("mfs")
 
 var ErrIsDirectory = errors.New("error: is a directory")


### PR DESCRIPTION
*This is a work in progress, not ready to be merged.*

This PR is a (rebased) copy of #4517, as [discussed](https://github.com/ipfs/go-ipfs/issues/4519#issuecomment-369711759), the idea is to add the fix for #4519 and get it ready to merge.

* Avoid syncing/flushing after closing an fd.
* Avoid reading/writing after closing an fd.
* Use a rw lock to guard the file's node (allows concurrent size checks).
* Improve flags and mode. Make file open options an extensible struct. Unix uses an int because it's easier to pass in a syscall and it has a fixed size. We don't care about that.
* Fix #4514 (take the read/write lock before reading the file's node).
* Avoid syncing/flushing when we don't need to.
* Fixes #4519: `dagTruncate` now preserves the `Type` of the node being truncated.
 