### PR TITLE
dag: diff: check CIDs in base case when comparing nodes

### DIFF
--- a/merkledag/utils/diff.go
+++ b/merkledag/utils/diff.go
@@ -95,7 +95,12 @@ func ApplyChange(ctx context.Context, ds ipld.DAGService, nd *dag.ProtoNode, cs 
 
 // Diff returns a set of changes that transform node 'a' into node 'b'
 func Diff(ctx context.Context, ds ipld.DAGService, a, b ipld.Node) ([]*Change, error) {
+	// Base case where both nodes are leaves, just compare
+	// their CIDs.
 	if len(a.Links()) == 0 && len(b.Links()) == 0 {
+		if a.Cid().Equals(b.Cid()) {
+			return []*Change{}, nil
+		}
 		return []*Change{
 			&Change{
 				Type:   Mod,

--- a/test/sharness/t0052-object-diff.sh
+++ b/test/sharness/t0052-object-diff.sh
@@ -20,7 +20,11 @@ test_expect_success "create some objects for testing diffs" '
   echo "nested" > foo/baz/dog &&
   C=$(ipfs add -r -q foo | tail -n1)
   echo "changed" > foo/bar &&
-  D=$(ipfs add -r -q foo | tail -n1)
+  D=$(ipfs add -r -q foo | tail -n1) &&
+  echo "" > single_file &&
+  SINGLE_FILE=$(ipfs add -r -q single_file | tail -n1) &&
+  mkdir empty_dir
+  EMPTY_DIR=$(ipfs add -r -q empty_dir | tail -n1)
 '
 
 test_expect_success "diff against self is empty" '
@@ -28,6 +32,18 @@ test_expect_success "diff against self is empty" '
 '
 
 test_expect_success "identity diff output looks good" '
+  printf "" > diff_exp &&
+  test_cmp diff_exp diff_out
+'
+
+test_expect_success "diff against self (single file) is empty" '
+  ipfs object diff $SINGLE_FILE $SINGLE_FILE > diff_out
+  printf "" > diff_exp &&
+  test_cmp diff_exp diff_out
+'
+
+test_expect_success "diff against self (empty dir) is empty" '
+  ipfs object diff $EMPTY_DIR $EMPTY_DIR > diff_out
   printf "" > diff_exp &&
   test_cmp diff_exp diff_out
 '


### PR DESCRIPTION
The base case was assuming that the nodes were different (see [issue comment](https://github.com/ipfs/go-ipfs/issues/4591#issuecomment-368596386)).

Fixes #4591.