### PR TITLE
[WIP] Make the Node methods on ProtoNode thread-safe

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -263,7 +263,7 @@ This command outputs data in the following encodings:
 				return nil, err
 			}
 
-			marshaled, err := object.EncodeProtobuf(false)
+			marshaled, err := object.EncodeProtobuf()
 			if err != nil {
 				return nil, err
 			}

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -263,7 +263,7 @@ This command outputs data in the following encodings:
 				return nil, err
 			}
 
-			marshaled, err := object.Marshal()
+			marshaled, err := object.EncodeProtobuf(false)
 			if err != nil {
 				return nil, err
 			}

--- a/merkledag/coding.go
+++ b/merkledag/coding.go
@@ -89,10 +89,9 @@ func (n *ProtoNode) invalidateCache() {
 }
 
 // EncodeProtobuf returns the encoded raw data version of a Node instance.
-// It may use a cached encoded version, unless the force flag is given.
-func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
+func (n *ProtoNode) EncodeProtobuf() ([]byte, error) {
 	sort.Stable(LinkSlice(n.links)) // keep links sorted
-	if n.cache.encodedValue == nil || force {
+	if n.cache.encodedValue == nil {
 		marshaledNode, err := n.marshal()
 		if err != nil {
 			return nil, err

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -50,7 +50,7 @@ func TestNode(t *testing.T) {
 			fmt.Println("-", l.Name, l.Size, l.Cid)
 		}
 
-		e, err := n.EncodeProtobuf(false)
+		e, err := n.EncodeProtobuf()
 		if err != nil {
 			t.Error(err)
 		} else {
@@ -74,7 +74,7 @@ func TestNode(t *testing.T) {
 }
 
 func SubtestNodeStat(t *testing.T, n *ProtoNode) {
-	enc, err := n.EncodeProtobuf(true)
+	enc, err := n.EncodeProtobuf()
 	if err != nil {
 		t.Error("n.EncodeProtobuf(true) failed")
 		return
@@ -351,7 +351,7 @@ func TestUnmarshalFailure(t *testing.T) {
 	}
 
 	n := &ProtoNode{}
-	n.EncodeProtobuf(false)
+	n.EncodeProtobuf()
 }
 
 func TestBasicAddGet(t *testing.T) {

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -351,7 +351,7 @@ func TestUnmarshalFailure(t *testing.T) {
 	}
 
 	n := &ProtoNode{}
-	n.Marshal()
+	n.EncodeProtobuf(false)
 }
 
 func TestBasicAddGet(t *testing.T) {

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
@@ -27,6 +28,11 @@ type ProtoNode struct {
 		encodedValue []byte
 		// Cached CID value.
 		cid *cid.Cid
+		// Lock to initialize cache (just once).
+		initialize sync.Once
+		// If the initialization failed the error needs to be saved
+		// because the marshaling is done only once.
+		initializationError error
 	}
 
 	// Prefix specifies cid version and hashing function

--- a/merkledag/node.go
+++ b/merkledag/node.go
@@ -207,12 +207,16 @@ func (n *ProtoNode) Copy() ipld.Node {
 
 	nnode.Prefix = n.Prefix
 
+	// Invalidate the cache for the copy, which may be modified.
+	// (The cache values are initialized to `nil` but still make it explicit.)
+	nnode.invalidateCache()
+
 	return nnode
 }
 
 // RawData returns the protobuf-encoded version of the node.
 func (n *ProtoNode) RawData() []byte {
-	out, _ := n.EncodeProtobuf(false)
+	out, _ := n.EncodeProtobuf()
 	return out
 }
 
@@ -239,7 +243,7 @@ func (n *ProtoNode) UpdateNodeLink(name string, that *ProtoNode) (*ProtoNode, er
 // Size returns the total size of the data addressed by node,
 // including the total sizes of references.
 func (n *ProtoNode) Size() (uint64, error) {
-	b, err := n.EncodeProtobuf(false)
+	b, err := n.EncodeProtobuf()
 	if err != nil {
 		return 0, err
 	}
@@ -253,7 +257,7 @@ func (n *ProtoNode) Size() (uint64, error) {
 
 // Stat returns statistics on the node.
 func (n *ProtoNode) Stat() (*ipld.NodeStat, error) {
-	enc, err := n.EncodeProtobuf(false)
+	enc, err := n.EncodeProtobuf()
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +325,7 @@ func (n *ProtoNode) Cid() *cid.Cid {
 	// The node should normally have its value encoded before
 	// calling Cid(), but just in case.
 	if n.cache.encodedValue == nil {
-		n.EncodeProtobuf(false)
+		n.EncodeProtobuf()
 	}
 
 	cid, err := n.Prefix.Sum(n.cache.encodedValue)
@@ -344,7 +348,7 @@ func (n *ProtoNode) String() string {
 // Multihash hashes the encoded data of this node.
 func (n *ProtoNode) Multihash() mh.Multihash {
 	// NOTE: EncodeProtobuf generates the hash and puts it in `n.cache.cid`.
-	_, err := n.EncodeProtobuf(false)
+	_, err := n.EncodeProtobuf()
 	if err != nil {
 		// Note: no possibility exists for an error to be returned through here
 		panic(err)

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -333,10 +333,13 @@ func (dm *DagModifier) modifyDag(n ipld.Node, offset uint64, data io.Reader) (*c
 				return nil, false, err
 			}
 
+			// Make a copy of the node before modifying it.
+			node = node.Copy().(*mdag.ProtoNode)
+
 			node.Links()[i].Cid = k
 
 			// Recache serialized node
-			_, err = node.EncodeProtobuf(true)
+			_, err = node.EncodeProtobuf()
 			if err != nil {
 				return nil, false, err
 			}
@@ -575,6 +578,9 @@ func dagTruncate(ctx context.Context, n ipld.Node, size uint64, ds ipld.DAGServi
 		return nil, err
 	}
 
+	// Make a copy of the node before modifying it.
+	nd = nd.Copy().(*mdag.ProtoNode)
+
 	nd.SetLinks(nd.Links()[:end])
 	err = nd.AddNodeLinkClean("", modified)
 	if err != nil {
@@ -589,7 +595,7 @@ func dagTruncate(ctx context.Context, n ipld.Node, size uint64, ds ipld.DAGServi
 	nd.SetData(d)
 
 	// invalidate cache and recompute serialized data
-	_, err = nd.EncodeProtobuf(true)
+	_, err = nd.EncodeProtobuf()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a work in progress, not ready to be merged.

Test of thread-safety of the `ProtoNode` implementation of the `Node` interface (#3991). The `Stat()` method does an in-place [sort](https://github.com/ipfs/go-ipfs/blob/b002acc6896a40a915f10ff1d79ce3130e34f6a6/merkledag/coding.go#L80) that can result in an unordered link slice (giving an [unexpected](https://travis-ci.org/ipfs/go-ipfs/jobs/350140379#L859) hash/CID).

Closes #3991.