### PR TITLE
disable building with go1.10 for release

### DIFF
--- a/cmd/ipfs/break_go10.go
+++ b/cmd/ipfs/break_go10.go
@@ -1,0 +1,4 @@
+// +build go1.10
+package main
+
+var _ = IpfsDoesNotSupportBeingBuiltWithGo1dot10


### PR DESCRIPTION
Something in go1.10 breaks ipfs in some way. This prevents people from building the release on their own and complaining when things break. We will remove this as soon as the 0.4.15 cycle starts.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>