### PR TITLE
Fix get output path

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	gopath "path"
+	"path/filepath"
 	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
@@ -187,8 +187,8 @@ func getOutPath(req *cmds.Request) string {
 	outPath, _ := req.Options["output"].(string)
 	if outPath == "" {
 		trimmed := strings.TrimRight(req.Arguments[0], "/")
-		_, outPath = gopath.Split(trimmed)
-		outPath = gopath.Clean(outPath)
+		_, outPath = filepath.Split(trimmed)
+		outPath = filepath.Clean(outPath)
 	}
 	return outPath
 }


### PR DESCRIPTION
This return value is used to open a platform native handle, as such platform native paths should be used.
Reference: https://github.com/ipfs/go-ipfs/issues/4808

Edit: put angle brackets around email to make gitcop happy