### PR TITLE
ipfs release 0.4.14-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -581,6 +581,6 @@
   "language": "go",
   "license": "MIT",
   "name": "go-ipfs",
-  "version": "0.4.14-rc1"
+  "version": "0.4.14-rc2"
 }
 

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -4,6 +4,6 @@ package config
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.4.14-rc1"
+const CurrentVersionNumber = "0.4.14-rc2"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
Second release candidate, now with go1.10 support

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>