### PR TITLE
Fix t0063-daemon-init.sh by adding test profile to daemon

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -34,6 +34,7 @@ const (
 	adjustFDLimitKwd          = "manage-fdlimit"
 	enableGCKwd               = "enable-gc"
 	initOptionKwd             = "init"
+	initProfileOptionKwd      = "init-profile"
 	ipfsMountKwd              = "mount-ipfs"
 	ipnsMountKwd              = "mount-ipns"
 	migrateKwd                = "migrate"
@@ -148,6 +149,7 @@ Headers.
 
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption(initOptionKwd, "Initialize ipfs with default settings if not already initialized"),
+		cmdkit.StringOption(initProfileOptionKwd, "Configuration profiles to apply for --init. See ipfs init --help for more"),
 		cmdkit.StringOption(routingOptionKwd, "Overrides the routing option").WithDefault("dht"),
 		cmdkit.BoolOption(mountKwd, "Mounts IPFS to the filesystem"),
 		cmdkit.BoolOption(writableKwd, "Enable writing objects (with POST, PUT and DELETE)"),
@@ -222,7 +224,9 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 		cfg := cctx.ConfigRoot
 		if !fsrepo.IsInitialized(cfg) {
-			err := initWithDefaults(os.Stdout, cfg)
+			profiles, _ := req.Options[initProfileOptionKwd].(string)
+
+			err := initWithDefaults(os.Stdout, cfg, profiles)
 			if err != nil {
 				re.SetError(err, cmdkit.ErrNormal)
 				return

--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -134,8 +134,13 @@ var errRepoExists = errors.New(`ipfs configuration file already exists!
 Reinitializing would overwrite your keys.
 `)
 
-func initWithDefaults(out io.Writer, repoRoot string) error {
-	return doInit(out, repoRoot, false, nBitsForKeypairDefault, nil, nil)
+func initWithDefaults(out io.Writer, repoRoot string, profile string) error {
+	var profiles []string
+	if profile != "" {
+		profiles = strings.Split(profile, ",")
+	}
+
+	return doInit(out, repoRoot, false, nBitsForKeypairDefault, profiles, nil)
 }
 
 func doInit(out io.Writer, repoRoot string, empty bool, nBitsForKeypair int, confProfiles []string, conf *config.Config) error {

--- a/test/sharness/t0063-daemon-init.sh
+++ b/test/sharness/t0063-daemon-init.sh
@@ -26,7 +26,7 @@ test_ipfs_daemon_init() {
   # server.
 
   test_expect_success "'ipfs daemon --init' succeeds" '
-    ipfs daemon --init >actual_daemon 2>daemon_err &
+    ipfs daemon --init --init-profile=test >actual_daemon 2>daemon_err &
     IPFS_PID=$!
     sleep 2 &&
     if ! kill -0 $IPFS_PID; then cat daemon_err; return 1; fi


### PR DESCRIPTION
The test wouldn't pass when there was an ipfs daemon running on the system.

Added `init-profile` flag for `ipfs daemon`, works like the one in init.

Fixes #3457