### PR TITLE
upgrade commands that used StringArguments

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -13,7 +13,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	cmds "github.com/ipfs/go-ipfs/commands"
+	oldcmds "github.com/ipfs/go-ipfs/commands"
+	lgc "github.com/ipfs/go-ipfs/commands/legacy"
 	core "github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	dag "github.com/ipfs/go-ipfs/merkledag"
@@ -21,6 +22,7 @@ import (
 	pin "github.com/ipfs/go-ipfs/pin"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 
+	cmds "gx/ipfs/QmabLouZTZwhfALuBcssPvkzhbYGMb4394huT7HY4LQ6d3/go-ipfs-cmds"
 	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 	cmdkit "gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 	ipld "gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"
@@ -55,18 +57,18 @@ directly.`,
 	},
 
 	Subcommands: map[string]*cmds.Command{
-		"data":  ObjectDataCmd,
-		"diff":  ObjectDiffCmd,
-		"get":   ObjectGetCmd,
-		"links": ObjectLinksCmd,
-		"new":   ObjectNewCmd,
+		"data":  lgc.NewCommand(ObjectDataCmd),
+		"diff":  lgc.NewCommand(ObjectDiffCmd),
+		"get":   lgc.NewCommand(ObjectGetCmd),
+		"links": lgc.NewCommand(ObjectLinksCmd),
+		"new":   lgc.NewCommand(ObjectNewCmd),
 		"patch": ObjectPatchCmd,
-		"put":   ObjectPutCmd,
-		"stat":  ObjectStatCmd,
+		"put":   lgc.NewCommand(ObjectPutCmd),
+		"stat":  lgc.NewCommand(ObjectStatCmd),
 	},
 }
 
-var ObjectDataCmd = &cmds.Command{
+var ObjectDataCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Output the raw bytes of an IPFS object.",
 		ShortDescription: `
@@ -85,7 +87,7 @@ is the raw data of the object.
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format.").EnableStdin(),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -114,7 +116,7 @@ is the raw data of the object.
 	},
 }
 
-var ObjectLinksCmd = &cmds.Command{
+var ObjectLinksCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Output the links pointed to by the specified object.",
 		ShortDescription: `
@@ -130,7 +132,7 @@ multihash.
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("headers", "v", "Print table headers (Hash, Size, Name)."),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -157,8 +159,8 @@ multihash.
 		}
 		res.SetOutput(output)
 	},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Text: func(res oldcmds.Response) (io.Reader, error) {
 			v, err := unwrapOutput(res.Output())
 			if err != nil {
 				return nil, err
@@ -185,7 +187,7 @@ multihash.
 	Type: Object{},
 }
 
-var ObjectGetCmd = &cmds.Command{
+var ObjectGetCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Get and serialize the DAG node named by <key>.",
 		ShortDescription: `
@@ -208,7 +210,7 @@ This command outputs data in the following encodings:
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format.").EnableStdin(),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -245,8 +247,8 @@ This command outputs data in the following encodings:
 		res.SetOutput(node)
 	},
 	Type: Node{},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Protobuf: func(res cmds.Response) (io.Reader, error) {
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Protobuf: func(res oldcmds.Response) (io.Reader, error) {
 			v, err := unwrapOutput(res.Output())
 			if err != nil {
 				return nil, err
@@ -272,7 +274,7 @@ This command outputs data in the following encodings:
 	},
 }
 
-var ObjectStatCmd = &cmds.Command{
+var ObjectStatCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Get stats for the DAG node named by <key>.",
 		ShortDescription: `
@@ -290,7 +292,7 @@ var ObjectStatCmd = &cmds.Command{
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format.").EnableStdin(),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -314,8 +316,8 @@ var ObjectStatCmd = &cmds.Command{
 		res.SetOutput(ns)
 	},
 	Type: ipld.NodeStat{},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Text: func(res oldcmds.Response) (io.Reader, error) {
 			v, err := unwrapOutput(res.Output())
 			if err != nil {
 				return nil, err
@@ -341,7 +343,7 @@ var ObjectStatCmd = &cmds.Command{
 	},
 }
 
-var ObjectPutCmd = &cmds.Command{
+var ObjectPutCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Store input as a DAG object, print its key.",
 		ShortDescription: `
@@ -388,7 +390,7 @@ And then run:
 		cmdkit.BoolOption("pin", "Pin this object when adding."),
 		cmdkit.BoolOption("quiet", "q", "Write minimal output."),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -444,8 +446,8 @@ And then run:
 
 		res.SetOutput(&Object{Hash: objectCid.String()})
 	},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Text: func(res oldcmds.Response) (io.Reader, error) {
 			quiet, _, _ := res.Request().Option("quiet").Bool()
 
 			v, err := unwrapOutput(res.Output())
@@ -468,7 +470,7 @@ And then run:
 	Type: Object{},
 }
 
-var ObjectNewCmd = &cmds.Command{
+var ObjectNewCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Create a new object from an ipfs template.",
 		ShortDescription: `
@@ -487,7 +489,7 @@ Available templates:
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("template", false, false, "Template to use. Optional."),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
+	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		n, err := req.InvocContext().GetNode()
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
@@ -512,8 +514,8 @@ Available templates:
 		}
 		res.SetOutput(&Object{Hash: node.Cid().String()})
 	},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
+	Marshalers: oldcmds.MarshalerMap{
+		oldcmds.Text: func(res oldcmds.Response) (io.Reader, error) {
 			v, err := unwrapOutput(res.Output())
 			if err != nil {
 				return nil, err

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -126,7 +126,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"ls":        lgc.NewCommand(LsCmd),
 	"mount":     lgc.NewCommand(MountCmd),
 	"name":      lgc.NewCommand(NameCmd),
-	"object":    lgc.NewCommand(ocmd.ObjectCmd),
+	"object":    ocmd.ObjectCmd,
 	"pin":       lgc.NewCommand(PinCmd),
 	"ping":      lgc.NewCommand(PingCmd),
 	"p2p":       lgc.NewCommand(P2PCmd),


### PR DESCRIPTION
This should make the fix that @Stebalien is working on for the cmds lib argument stdin parsing a little bit simpler.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>