### PR TITLE
Announce relay addresses by default

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -869,17 +869,8 @@ func constructPeerHost(ctx context.Context, id peer.ID, ps pstore.Peerstore, bwr
 		hostOpts = append(hostOpts, opts.ConnectionManager)
 	}
 
-	addrsFactory := opts.AddrsFactory
-	if !opts.DisableRelay {
-		if addrsFactory != nil {
-			addrsFactory = composeAddrsFactory(addrsFactory, filterRelayAddrs)
-		} else {
-			addrsFactory = filterRelayAddrs
-		}
-	}
-
-	if addrsFactory != nil {
-		hostOpts = append(hostOpts, addrsFactory)
+	if opts.AddrsFactory != nil {
+		hostOpts = append(hostOpts, opts.AddrsFactory)
 	}
 
 	host := p2pbhost.New(network, hostOpts...)
@@ -898,24 +889,6 @@ func constructPeerHost(ctx context.Context, id peer.ID, ps pstore.Peerstore, bwr
 	}
 
 	return host, nil
-}
-
-func filterRelayAddrs(addrs []ma.Multiaddr) []ma.Multiaddr {
-	var raddrs []ma.Multiaddr
-	for _, addr := range addrs {
-		_, err := addr.ValueForProtocol(circuit.P_CIRCUIT)
-		if err == nil {
-			continue
-		}
-		raddrs = append(raddrs, addr)
-	}
-	return raddrs
-}
-
-func composeAddrsFactory(f, g p2pbhost.AddrsFactory) p2pbhost.AddrsFactory {
-	return func(addrs []ma.Multiaddr) []ma.Multiaddr {
-		return f(g(addrs))
-	}
 }
 
 // startListening on the network addresses


### PR DESCRIPTION
Depends on https://github.com/libp2p/go-libp2p-swarm/pull/57

With this change we will announce the non-specific relay addresses. From my testing non-specific addresses work well-enough, at least with the current network structure.

There are also a couple of points in https://github.com/ipfs/go-ipfs/issues/4213 which may need to be addressed first for this to work well.