### PR TITLE
sharness/t0010: check that all the commands fail when passed a bad flag

### DIFF
--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -66,7 +66,7 @@ test_expect_success "All commands accept --help" '
   while read -r cmd
   do
     $cmd --help </dev/null >/dev/null ||
-      { echo $cmd doesnt accept --help; echo 1 > fail; }
+      { echo "$cmd doesnt accept --help"; echo 1 > fail; }
   done <commands.txt
 
   if [ $(cat fail) = 1 ]; then
@@ -80,7 +80,7 @@ test_expect_failure "All ipfs root commands are mentioned in base helptext" '
   while read cmd
   do
     grep "  $cmd" help.txt > /dev/null ||
-      { echo missing $cmd from helptext; echo 1 > fail; }
+      { echo "missing $cmd from helptext"; echo 1 > fail; }
   done
 
   if [ $(cat fail) = 1 ]; then
@@ -94,7 +94,7 @@ test_expect_failure "All ipfs commands docs are 80 columns or less" '
   do
     LENGTH="$($cmd --help | awk "{ print length }" | sort -nr | head -1)"
     [ $LENGTH -gt 80 ] &&
-      { echo "$cmd" help text is longer than 79 chars "($LENGTH)"; echo 1 > fail; }
+      { echo "$cmd help text is longer than 79 chars ($LENGTH)"; echo 1 > fail; }
   done <commands.txt
 
   if [ $(cat fail) = 1 ]; then
@@ -107,7 +107,7 @@ test_expect_success "All ipfs commands fail when passed a bad flag" '
   while read -r cmd
   do
     test_must_fail $cmd --badflag >/dev/null ||
-      { echo $cmd exit with code 0 when passed --badflag; echo 1 > fail; }
+      { echo "$cmd exit with code 0 when passed --badflag"; echo 1 > fail; }
   done <commands.txt
 
   if [ $(cat fail) = 1 ]; then

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -102,6 +102,19 @@ test_expect_failure "All ipfs commands docs are 80 columns or less" '
   fi
 '
 
+test_expect_success "All ipfs commands fail when passed a bad flag" '
+  echo 0 > fail
+  while read -r cmd
+  do
+    test_must_fail $cmd --badflag >/dev/null ||
+      { echo $cmd exit with code 0 when passed --badflag; echo 1 > fail; }
+  done <commands.txt
+
+  if [ $(cat fail) = 1 ]; then
+    return 1
+  fi
+'
+
 test_expect_success "'ipfs commands --flags' succeeds" '
   ipfs commands --flags >commands.txt
 '


### PR DESCRIPTION
When any command is passed a flag it doesn't understand, like `--badflag` for example, it should just fail.

Let's check that in a sharness test.

See https://github.com/ipfs/go-ipfs/issues/4841 for more context.