### PR TITLE
No dev null pipe

### DIFF
--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -67,6 +67,8 @@ test_expect_success "All commands accept --help" '
   do
     $cmd --help >/dev/null ||
       { echo "$cmd doesnt accept --help"; echo 1 > fail; }
+    echo stuff | $cmd --help >/dev/null ||
+      { echo "$cmd doesnt accept --help when using stdin"; echo 1 > fail; }
   done <commands.txt
 
   if [ $(cat fail) = 1 ]; then

--- a/test/sharness/t0010-basic-commands.sh
+++ b/test/sharness/t0010-basic-commands.sh
@@ -65,7 +65,7 @@ test_expect_success "All commands accept --help" '
   echo 0 > fail
   while read -r cmd
   do
-    $cmd --help </dev/null >/dev/null ||
+    $cmd --help >/dev/null ||
       { echo "$cmd doesnt accept --help"; echo 1 > fail; }
   done <commands.txt
 


### PR DESCRIPTION
Any IPFS command should accept the `--help` flag even if /dev/null is not piped to it. Let's properly check that this works.  

See https://github.com/ipfs/go-ipfs/issues/4841 for more context.