### PR TITLE
[WIP] Sanitize `get` output paths for external file systems

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	gopath "path"
+	"path/filepath"
 	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
@@ -183,8 +183,8 @@ func getOutPath(req *cmds.Request) string {
 	outPath, _ := req.Options["output"].(string)
 	if outPath == "" {
 		trimmed := strings.TrimRight(req.Arguments[0], "/")
-		_, outPath = gopath.Split(trimmed)
-		outPath = gopath.Clean(outPath)
+		_, outPath = filepath.Split(trimmed)
+		outPath = filepath.Clean(outPath)
 	}
 	return outPath
 }

--- a/thirdparty/tar/sanitize.go
+++ b/thirdparty/tar/sanitize.go
@@ -1,0 +1,9 @@
+// +build !windows,!darwin
+
+package tar
+
+import "path/filepath"
+
+func platformSanitize(pathElements []string) string {
+	return filepath.Join(pathElements...)
+}

--- a/thirdparty/tar/sanitize_darwin.go
+++ b/thirdparty/tar/sanitize_darwin.go
@@ -1,0 +1,11 @@
+package tar
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func platformSanitize(pathElements []string) string {
+	res := filepath.Join(pathElements...)
+	return strings.Replace(res, ":", "-", -1)
+}

--- a/thirdparty/tar/sanitize_windows.go
+++ b/thirdparty/tar/sanitize_windows.go
@@ -1,0 +1,47 @@
+package tar
+
+import (
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+//https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+var reservedNames = [...]string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+
+const reservedCharsRegex = `[<>:"\\|?*]` //NOTE: `/` is not included, files with this in the name will cause problems
+
+func platformSanitize(pathElements []string) string {
+	// first pass: scan and prefix reserved names CON -> _CON
+	for i, pe := range pathElements {
+		for _, rn := range reservedNames {
+			if pe == rn {
+				pathElements[i] = "_" + rn
+				break
+			}
+		}
+		pathElements[i] = strings.TrimRight(pe, ". ") //MSDN: Do not end a file or directory name with a space or a period
+	}
+	//second pass: scan and encode reserved characters ? -> %3F
+	res := strings.Join(pathElements, `/`) // intentionally avoiding [file]path.Clean(), we want `\`'s intact
+	re := regexp.MustCompile(reservedCharsRegex)
+	illegalIndices := re.FindAllStringIndex(res, -1)
+
+	if illegalIndices != nil {
+		var lastIndex int
+		var builder strings.Builder
+		allocAssist := (len(res) - len(illegalIndices)) + (len(illegalIndices) * 3) // 3 = encoded length
+		builder.Grow(allocAssist)
+
+		for _, si := range illegalIndices {
+			builder.WriteString(res[lastIndex:si[0]])              // append up to problem char
+			builder.WriteString(url.QueryEscape(res[si[0]:si[1]])) // escape and append problem char
+			lastIndex = si[1]
+		}
+		builder.WriteString(res[lastIndex:]) // append remainder
+		res = builder.String()
+	}
+
+	return filepath.FromSlash(res)
+}


### PR DESCRIPTION
This allows illegal paths in IPFS to be `get`-able on Windows, it also accounts for `:` on Darwin, other platforms need just implement their own sanitize function and alter the build flag if they have special requirements.

Darwin substitutes `:` with a hyphen `-` as this is what Finder does if you try to make a file with a colon.



TODO:
- See if there's a more optimal way to handle this
- `^` is allowed on Windows/NTFS but not Windows/FAT32, accounting for this requires detecting the output target filesystem.
- Tests
Currently I'm manually using a hash generated via cmd (`^` is the escape character there)
```
ipfs files rm -r /test
ipfs files mkdir -p "/test/badnames/:^>*^"bad^|name^"^\*^<:.   "
ipfs files cp /ipfs/QmakyK2Xktmn9HnVGuaDZGtjkPq3HCfmF7SPJVWvTYwduX "/test/badnames/:^>*^"bad^|name^"^\*^<:.   /Is this a file?  ."
ipfs files stat /test
```
it resolves to `QmP6tsejWJczc348FwKncykrRDvbVdXtb3oCCknFMQUii6\badnames\%3A^%3E%2A^bad%7Cname%5C%2A%3C%3A\Is this a file%3F` which is ugly but better than failure imo.
