### PR TITLE
Update lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,9 +148,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe",
+      "hash": "QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d",
       "name": "lock",
-      "version": "0.0.0"
+      "version": "0.0.2"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/lock/lock.go
+++ b/repo/fsrepo/lock/lock.go
@@ -10,7 +10,7 @@ import (
 
 	"gx/ipfs/QmNiJuT8Ja3hMVpBHXv3Q6dwmperaQ6JjLtpMQgMCD7xvx/go-ipfs-util"
 	logging "gx/ipfs/QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8/go-log"
-	lock "gx/ipfs/QmWi28zbQG6B1xfaaWx5cYoLn3kBFU6pQ6GWQNRV5P6dNe/lock"
+	lock "gx/ipfs/QmVUAoR89E6KDBJmsfRVkAoBMEfgVfy8rRmvzf4y9rWp1d/go4-lock"
 )
 
 // LockFile is the filename of the repo lock, relative to config dir


### PR DESCRIPTION
Includes: https://github.com/camlistore/go4/commit/e6a7f04a962e05f288f348eec6de20fe93b6b292
which resolves: https://github.com/ipfs/go-ipfs/issues/3633