### PR TITLE
Fix go vet warnings

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -173,7 +173,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 
 	// hash security
 	bs := bstore.NewBlockstore(rds)
-	bs = &verifbs.VerifBS{bs}
+	bs = &verifbs.VerifBS{Blockstore: bs}
 
 	opts := bstore.DefaultCacheOpts()
 	conf, err := n.Repo.Config()
@@ -202,7 +202,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		// hash security
 		n.Filestore = filestore.NewFilestore(bs, n.Repo.FileManager())
 		n.Blockstore = bstore.NewGCBlockstore(n.Filestore, n.GCLocker)
-		n.Blockstore = &verifbs.VerifBSGC{n.Blockstore}
+		n.Blockstore = &verifbs.VerifBSGC{GCBlockstore: n.Blockstore}
 	}
 
 	rcfg, err := n.Repo.Config()

--- a/filestore/fsrefstore.go
+++ b/filestore/fsrefstore.go
@@ -77,7 +77,7 @@ func (f *FileManager) AllKeysChan(ctx context.Context) (<-chan *cid.Cid, error) 
 			k := ds.RawKey(v.Key)
 			c, err := dshelp.DsKeyToCid(k)
 			if err != nil {
-				log.Error("decoding cid from filestore: %s", err)
+				log.Errorf("decoding cid from filestore: %s", err)
 				continue
 			}
 

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -619,7 +619,6 @@ func (r *FSRepo) SetConfigKey(key string, value interface{}) error {
 		case string:
 			value, ok = value.(string)
 		default:
-			value = value
 		}
 		if !ok {
 			return fmt.Errorf("Wrong config type, expected %T", oldValue)

--- a/test/dependencies/go-timeout/main.go
+++ b/test/dependencies/go-timeout/main.go
@@ -21,7 +21,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
 
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
 	cmd.Stdin = os.Stdin

--- a/thirdparty/notifier/notifier.go
+++ b/thirdparty/notifier/notifier.go
@@ -40,8 +40,8 @@ type Notifier struct {
 // RateLimited returns a rate limited Notifier. only limit goroutines
 // will be spawned. If limit is zero, no rate limiting happens. This
 // is the same as `Notifier{}`.
-func RateLimited(limit int) Notifier {
-	n := Notifier{}
+func RateLimited(limit int) *Notifier {
+	n := &Notifier{}
 	if limit > 0 {
 		n.lim = ratelimit.NewRateLimiter(process.Background(), limit)
 	}


### PR DESCRIPTION
Before:

```
$ go vet ./...                
core/builder.go:176: github.com/ipfs/go-ipfs/thirdparty/verifbs.VerifBS composite literal uses unkeyed fields
core/builder.go:205: github.com/ipfs/go-ipfs/thirdparty/verifbs.VerifBSGC composite literal uses unkeyed fields
exit status 1
filestore/fsrefstore.go:80: possible formatting directive in Error call
exit status 1
repo/fsrepo/fsrepo.go:622: self-assignment of value to value
exit status 1
test/dependencies/go-timeout/main.go:24: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
exit status 1
thirdparty/notifier/notifier.go:48: return copies lock value: notifier.Notifier contains sync.RWMutex
exit status 1

```