### PR TITLE
Fix 4864

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Please put all issues regarding the Go IPFS _implementation_ in [this repo](http
   - [Some things to try](#some-things-to-try)
   - [Docker usage](#docker-usage)
   - [Troubleshooting](#troubleshooting-1)
-- [Todo](#todo)
 - [Contributing](#contributing)
   - [Want to hack on IPFS?](#want-to-hack-on-ipfs)
   - [Want to read our code?](#want-to-read-our-code)


### PR DESCRIPTION
Resolves https://github.com/ipfs/go-ipfs/issues/4864 (Removes broken "Todo" link in README)