### PR TITLE
bump tar dep to make it resolvable

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -15,7 +15,7 @@ import (
 	path "github.com/ipfs/go-ipfs/path"
 	uarchive "github.com/ipfs/go-ipfs/unixfs/archive"
 
-	tar "gx/ipfs/QmYk64JEF4QWPB9Kqib63g8vfYfv78AmSUyeFaMaX6F9vQ/tar-utils"
+	tar "gx/ipfs/QmQine7gvHncNevKtG9QXxf3nXcwSj6aDDmMm52mHofEEp/tar-utils"
 	"gx/ipfs/QmceUdzxkimdYsgtX733uNgzf1DLHyBKN6ehGSp85ayppM/go-ipfs-cmdkit"
 	"gx/ipfs/QmeWjRodbcZFKe5tMN7poEx3izym6osrLSnTLf9UjJZBbs/pb"
 	"gx/ipfs/QmfAkMSt9Fwzk48QDJecPcwCUjnf2uG7MLnmCGTp4C6ouL/go-ipfs-cmds"

--- a/package.json
+++ b/package.json
@@ -578,9 +578,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYk64JEF4QWPB9Kqib63g8vfYfv78AmSUyeFaMaX6F9vQ",
+      "hash": "QmQine7gvHncNevKtG9QXxf3nXcwSj6aDDmMm52mHofEEp",
       "name": "tar-utils",
-      "version": "0.0.2"
+      "version": "0.0.3"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
It wasn't pinned and `gx publish -f` gave a different hash.

Depends on: https://github.com/whyrusleeping/tar-utils/pull/3