### PR TITLE
gx: update go-ds-flatfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,9 +190,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmPiYdqnkkiPEffrWq2M3Phb3NT8r49kqUXMev2hkkM7uV",
+      "hash": "QmaCTqBCt1aKaGfHfSVzsprqWRXCjHthK8xXrPbUZYCWga",
       "name": "go-ds-flatfs",
-      "version": "1.1.8"
+      "version": "1.1.9"
     },
     {
       "author": "whyrusleeping",

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -12,10 +12,10 @@ import (
 
 	badgerds "gx/ipfs/QmPAiAmc3qhTFwzWnKpxr6WCXGZ5mqpaQ2YEwSTnwyduHo/go-ds-badger"
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
-	flatfs "gx/ipfs/QmPiYdqnkkiPEffrWq2M3Phb3NT8r49kqUXMev2hkkM7uV/go-ds-flatfs"
 	levelds "gx/ipfs/QmVVhwMHaGHPgZY6pi8hbWGLSgMcZUSdEhJBChjxhBMCoy/go-ds-leveldb"
 	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
 	mount "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore/mount"
+	flatfs "gx/ipfs/QmaCTqBCt1aKaGfHfSVzsprqWRXCjHthK8xXrPbUZYCWga/go-ds-flatfs"
 	ldbopts "gx/ipfs/QmbBhyDKsY4mbY6xsKt3qu9Y7FPvMJ6qbD8AMjYYvPRw1g/goleveldb/leveldb/opt"
 	measure "gx/ipfs/QmbJgZGRtkFeSdCxBCPaMKWRDYbqMxHyFfvjQGcWzpqsDe/go-ds-measure"
 )


### PR DESCRIPTION
Includes (at least): https://github.com/ipfs/go-ds-flatfs/commit/ebb0ecaf912f365a40b91abfe82d82e495eb5042
Which fixes: https://github.com/ipfs/go-ipfs/issues/4527
And should fix:  https://github.com/ipfs/go-ipfs/issues/3971, and https://github.com/ipfs/go-ipfs/issues/4710
as well.