### PR TITLE
make the tar writer handle sharded ipfs directories

### DIFF
--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -137,6 +137,10 @@ possible, please use 'ipfs ls' instead.
 			switch t {
 			case unixfspb.Data_File:
 				break
+			case unixfspb.Data_HAMTShard:
+				// We need a streaming ls API for this.
+				res.SetError(fmt.Errorf("cannot list large directories yet"), cmdkit.ErrNormal)
+				return
 			case unixfspb.Data_Directory:
 				links := make([]LsLink, len(merkleNode.Links()))
 				output.Objects[hash].Links = links

--- a/test/sharness/t0260-sharding.sh
+++ b/test/sharness/t0260-sharding.sh
@@ -4,7 +4,7 @@
 # MIT Licensed; see the LICENSE file in this repository.
 #
 
-test_description="Test global enable sharding flag"
+test_description="Test directory sharding"
 
 . lib/test-lib.sh
 
@@ -22,6 +22,10 @@ test_add_large_dir() {
     ipfs add -r -q testdata | tail -n1 > sharddir_out &&
     echo "$exphash" > sharddir_exp &&
     test_cmp sharddir_exp sharddir_out
+  '
+  test_expect_success "ipfs get on very large directory succeeds" '
+    ipfs get -o testdata-out "$exphash" &&
+    test_cmp testdata testdata-out
   '
 }
 

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -53,10 +53,7 @@ func (w *Writer) writeDir(nd *mdag.ProtoNode, fpath string) error {
 			return err
 		}
 		npath := path.Join(fpath, l.Name)
-		if err := w.WriteNode(child, npath); err != nil {
-			return err
-		}
-		return nil
+		return w.WriteNode(child, npath)
 	})
 }
 

--- a/unixfs/archive/tar/writer.go
+++ b/unixfs/archive/tar/writer.go
@@ -39,23 +39,25 @@ func NewWriter(ctx context.Context, dag ipld.DAGService, archive bool, compressi
 }
 
 func (w *Writer) writeDir(nd *mdag.ProtoNode, fpath string) error {
+	dir, err := uio.NewDirectoryFromNode(w.Dag, nd)
+	if err != nil {
+		return err
+	}
 	if err := writeDirHeader(w.TarW, fpath); err != nil {
 		return err
 	}
 
-	for i, ng := range ipld.GetDAG(w.ctx, w.Dag, nd) {
-		child, err := ng.Get(w.ctx)
+	return dir.ForEachLink(w.ctx, func(l *ipld.Link) error {
+		child, err := w.Dag.Get(w.ctx, l.Cid)
 		if err != nil {
 			return err
 		}
-
-		npath := path.Join(fpath, nd.Links()[i].Name)
+		npath := path.Join(fpath, l.Name)
 		if err := w.WriteNode(child, npath); err != nil {
 			return err
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func (w *Writer) writeFile(nd *mdag.ProtoNode, pb *upb.Data, fpath string) error {
@@ -83,7 +85,7 @@ func (w *Writer) WriteNode(nd ipld.Node, fpath string) error {
 		switch pb.GetType() {
 		case upb.Data_Metadata:
 			fallthrough
-		case upb.Data_Directory:
+		case upb.Data_Directory, upb.Data_HAMTShard:
 			return w.writeDir(nd, fpath)
 		case upb.Data_Raw:
 			fallthrough

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -112,7 +112,7 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 		}
 
 		switch pb.GetType() {
-		case ftpb.Data_Directory:
+		case ftpb.Data_Directory, ftpb.Data_HAMTShard:
 			// A directory should not exist within a file
 			return ft.ErrInvalidDirLocation
 		case ftpb.Data_File:


### PR DESCRIPTION
Makes ipfs get work on sharded directories.

fixes #4871