### PR TITLE
gx: bump version for 0.4.14 release

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.14-rc1: QmXporsyf5xMvffd2eiTDoq85dNpYUynGJhfabzDjwP8uR
+0.4.14: QmatUACvrFK3xYg1nd2iLAKfz7Yy5YB56tnzBYHpqiUuhn


### PR DESCRIPTION
The hash is for a clean checkout of the v0.4.14 tag (please verify).