### PR TITLE
don't resolve children unnecessarily when listing a sharded directory

### DIFF
--- a/test/sharness/t0260-sharding.sh
+++ b/test/sharness/t0260-sharding.sh
@@ -65,6 +65,18 @@ test_expect_success "ipfs cat error output the same" '
   test_cmp sharded_err unsharded_err
 '
 
+test_expect_success "'ipfs ls --resolve-type=false' admits missing block" '
+  ipfs ls "$SHARDED" | head -1 > first_file &&
+  read -r HASH _ NAME <first_file &&
+  ipfs pin rm "$SHARDED" "$UNSHARDED" && # To allow us to remove the block
+  ipfs block rm "$HASH" &&
+  test_expect_code 1 ipfs cat "$SHARDED/$NAME" &&
+  test_expect_code 1 ipfs ls "$SHARDED" &&
+  ipfs ls --resolve-type=false "$SHARDED" | sort > missing_out &&
+  test_cmp sharded_out missing_out
+'
+
+
 test_add_large_dir_v1() {
   exphash="$1"
   test_expect_success "ipfs add (CIDv1) on very large directory succeeds" '

--- a/unixfs/hamt/hamt.go
+++ b/unixfs/hamt/hamt.go
@@ -289,13 +289,13 @@ func (ds *Shard) loadChild(ctx context.Context, i int) (child, error) {
 		return nil, fmt.Errorf("invalid link name '%s'", lnk.Name)
 	}
 
-	nd, err := lnk.GetNode(ctx, ds.dserv)
-	if err != nil {
-		return nil, err
-	}
-
 	var c child
 	if len(lnk.Name) == ds.maxpadlen {
+		nd, err := lnk.GetNode(ctx, ds.dserv)
+		if err != nil {
+			return nil, err
+		}
+
 		pbnd, ok := nd.(*dag.ProtoNode)
 		if !ok {
 			return nil, dag.ErrNotProtobuf


### PR DESCRIPTION
We only need to get the child if it's a shard.