### PR TITLE
only visit nodes in EnumerateChildrenAsync when asked

### DIFF
--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -319,17 +319,17 @@ func EnumerateChildrenAsync(ctx context.Context, getLinks GetLinks, c *cid.Cid, 
 	for i := 0; i < FetchGraphConcurrency; i++ {
 		go func() {
 			for ic := range feed {
-				links, err := getLinks(ctx, ic)
-				if err != nil {
-					errChan <- err
-					return
-				}
-
 				setlk.Lock()
-				unseen := visit(ic)
+				shouldVisit := visit(ic)
 				setlk.Unlock()
 
-				if unseen {
+				if shouldVisit {
+					links, err := getLinks(ctx, ic)
+					if err != nil {
+						errChan <- err
+						return
+					}
+
 					select {
 					case out <- links:
 					case <-fetchersCtx.Done():


### PR DESCRIPTION
No idea why this was changed this was introduced in:

08f342e8bada4f4eb0c5462a3623f0c2b828240f (part of #3598)