### PR TITLE
wip: allow multiplexer config from config file (#4893)

### DIFF
--- a/repo/config/swarm.go
+++ b/repo/config/swarm.go
@@ -6,6 +6,7 @@ type SwarmConfig struct {
 	DisableNatPortMap       bool
 	DisableRelay            bool
 	EnableRelayHop          bool
+	Multiplexers            []string
 
 	ConnMgr ConnMgr
 }


### PR DESCRIPTION
@Stebalien is this along the lines of what you were thinking?

the `--enable-mplex-experiment` flag still exists, but it will be ignored if there are multiplexers specified in the config file.  i also made the configuration options simply `yamax` and `mplex` because it looks like the full protocol name was hard coded anyway.

i will update the documentation and command help information if this approach is the direction you want to go in.

thanks!