### PR TITLE
[WIP] multiplexer config file

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -393,15 +393,16 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 	var isYamux, isMplex bool
 
 	for _, multiplexer := range multiplexers {
-		if multiplexer == "yamux" {
+		switch multiplexer {
+		case "yamux":
 			isYamux = true
-		} else if multiplexer == "mplex" {
+		case "mplex":
 			isMplex = true
 			if !mplexExp {
 				log.Error("--enable-mplex-experiment is set to false, but mplex " +
-					"is given as a multiplexer in Swarm.Multiplexers in the config.")
+					"is given as a multiplexer the config (Swarm.Multiplexers).")
 			}
-		} else {
+		default:
 			log.Errorf("Unknown multiplexer specified in config: %s", multiplexer)
 		}
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -432,10 +432,7 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 		mstpt.AddTransport(multiplexerProtocolNames["mplex"], mplex.DefaultTransport)
 	}
 
-	// If there are any multiplexers defined in the config, ignore mplexExp.
 	if len(multiplexers) > 0 {
-		mplexExp = false
-
 		// set order preference to match the order specified in the config
 		multiplexerProtocols := make([]string, len(multiplexers))
 		for i, multiplexer := range multiplexers {

--- a/core/core.go
+++ b/core/core.go
@@ -386,15 +386,15 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 	mstpt := mssmux.NewBlankTransport()
 
 	multiplexerProtocolNames := map[string]string{
-		"yamex": "/yamux/1.0.0",
+		"yamux": "/yamux/1.0.0",
 		"mplex": "/mplex/6.7.0",
 	}
 
-	var isYamex, isMplex bool
+	var isYamux, isMplex bool
 
 	for _, multiplexer := range multiplexers {
-		if multiplexer == "yamex" {
-			isYamex = true
+		if multiplexer == "yamux" {
+			isYamux = true
 		} else if multiplexer == "mplex" {
 			isMplex = true
 			if !mplexExp {
@@ -406,11 +406,11 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 		}
 	}
 
-	if !isMplex && !isYamex {
-		isYamex = true
+	if !isMplex && !isYamux {
+		isYamux = true
 	}
 
-	if isYamex {
+	if isYamux {
 		ymxtpt := &yamux.Transport{
 			AcceptBacklog:          512,
 			ConnectionWriteTimeout: time.Second * 10,
@@ -424,7 +424,7 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 			ymxtpt.LogOutput = os.Stderr
 		}
 
-		mstpt.AddTransport(multiplexerProtocolNames["yamex"], ymxtpt)
+		mstpt.AddTransport(multiplexerProtocolNames["yamux"], ymxtpt)
 	}
 
 	if isMplex || mplexExp {
@@ -438,7 +438,7 @@ func makeSmuxTransport(multiplexers []string, mplexExp bool) smux.Transport {
 		// set order preference to match the order specified in the config
 		multiplexerProtocols := make([]string, len(multiplexers))
 		for i, multiplexer := range multiplexers {
-			if multiplexer == "yamex" || multiplexer == "mplex" {
+			if multiplexer == "yamux" || multiplexer == "mplex" {
 				multiplexerProtocols[i] = multiplexerProtocolNames[multiplexer]
 			}
 		}

--- a/repo/config/swarm.go
+++ b/repo/config/swarm.go
@@ -6,6 +6,7 @@ type SwarmConfig struct {
 	DisableNatPortMap       bool
 	DisableRelay            bool
 	EnableRelayHop          bool
+	Multiplexers            []string
 
 	ConnMgr ConnMgr
 }


### PR DESCRIPTION
@Stebalien is this along the lines of what you were thinking for #4893?

the `--enable-mplex-experiment` flag still exists, but it will be ignored if there are multiplexers specified in the config file. i also made the configuration options simply `yamax` and `mplex` because it looks like the full protocol name was hard coded anyway.

i will update the documentation and command help information if this approach is the direction you want to go in.

thanks!