### PR TITLE
Add --quiet and --type options to `ls` command

### DIFF
--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -150,6 +150,10 @@ test_expect_success "'ipfs ls --resolve-type=false ' ok" '
   ipfs ls --resolve-type=false $DIR > /dev/null
 '
 
+test_expect_success "'ipfs ls --resolve=local ' ok" '
+  ipfs ls --resolve=local $DIR > /dev/null
+'
+
 test_expect_success "'ipfs ls' fails" '
   test_must_fail ipfs ls $DIR
 '
@@ -158,6 +162,10 @@ test_launch_ipfs_daemon --offline
 
 test_expect_success "'ipfs ls --resolve-type=false' ok" '
   ipfs ls --resolve-type=false $DIR > /dev/null
+'
+
+test_expect_success "'ipfs ls --resolve=local' ok" '
+  ipfs ls --resolve=local $DIR > /dev/null
 '
 
 test_expect_success "'ipfs ls' fails" '
@@ -176,6 +184,34 @@ test_launch_ipfs_daemon
 test_expect_success "'ipfs ls --resolve-type=false' ok and does not hang" '
   go-timeout 2 ipfs ls --resolve-type=false $DIR
 '
+
+test_expect_success "'ipfs ls --resolve-type=false' ok and does not hang" '
+  go-timeout 2 ipfs ls --resolve=local $DIR
+'
+
+test_expect_success "'ipfs ls --quiet <three dir hashes>' succeeds" '
+    ipfs ls --quiet QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_quiet
+  '
+
+test_expect_success "'ipfs ls --quiet <three dir hashes>' output looks good" '
+    cat <<-\EOF >expected_ls_quiet &&
+QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+d1/
+d2/
+f1
+f2
+
+QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+1024
+a
+
+QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+128
+a
+
+EOF
+    test_cmp expected_ls_quiet actual_ls_quiet
+  '
 
 test_kill_ipfs_daemon
 


### PR DESCRIPTION
Hello!

This is pull request for issue https://github.com/ipfs/go-ipfs/issues/4891

If --quiet is specified, output only names.
New --type option:
- when it is 'local', resolving is performed offline
- when it is 'never', no links are resolved
Non-resolved link's names are always written without trailing slash.

I am also not sure about the desired behaviour of command when both --resolve-type and --resolve options are provided.

I have not found a way to specify fixed range of string values for Option.
Is it worth to implement such possibility in somewhat generic way?