### PR TITLE
Show diff in 'config profile' commands, add dry-run flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ did allow manually creating them and fetching them from other peers. If you
 currently have objects using insecure hashes in your local ipfs repo, please
 remove them before updating.
 
+#### Changes from rc2 to rc3
+- Fix bug in stdin argument parsing ([ipfs/go-ipfs#4827](https://github.com/ipfs/go-ipfs/pull/4827))
+- Revert commands back to sending a single response ([ipfs/go-ipfs#4822](https://github.com/ipfs/go-ipfs/pull/4822))
+
+#### Changes from rc1 to rc2
+- Fix issue in ipfs get caused by go1.10 changes ([ipfs/go-ipfs#4790](https://github.com/ipfs/go-ipfs/pull/4790))
+
 - Features
   - Pubsub IPNS Publisher and Resolver (experimental) ([ipfs/go-ipfs#4047](https://github.com/ipfs/go-ipfs/pull/4047))
   - Implement coreapi Dag interface ([ipfs/go-ipfs#4471](https://github.com/ipfs/go-ipfs/pull/4471))

--- a/package.json
+++ b/package.json
@@ -581,6 +581,6 @@
   "language": "go",
   "license": "MIT",
   "name": "go-ipfs",
-  "version": "0.4.14-rc2"
+  "version": "0.4.14-rc3"
 }
 

--- a/package.json
+++ b/package.json
@@ -575,6 +575,12 @@
       "hash": "QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2",
       "name": "pubsub",
       "version": "1.0.0"
+    },
+    {
+      "author": "elgris",
+      "hash": "QmfKcSTyzeAvas97dY3BQwvnAPYesEZMR4J1JvRHvuek3y",
+      "name": "jsondiff",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.10.0",

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -4,6 +4,6 @@ package config
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.4.14-rc2"
+const CurrentVersionNumber = "0.4.14-rc3"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
Issue: https://github.com/ipfs/go-ipfs/issues/4914

package jsondiff has been added to gx and is used to show user the difference between the original config and config that will be generated when `config profile apply --dry-run` is run