### PR TITLE
Add information about bloom filter to config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -146,7 +146,7 @@ A number representing the size in bytes of the blockstore's [bloom filter](https
 This site generates useful graphs for various bloom filter values: <https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7>  
 You may use it to find a preferred optimal value, where `m` is `BloomFilterSize` in bits. Remember to convert the value `m` from bits, into bytes for use as `BloomFilterSize` in the config file.  
 For example, for 1,000,000 blocks, expecting a 1% false positive rate, you'd end up with a filter size of 9592955 bits, so for `BloomFilterSize` we'd want to use 1199120 bytes.  
-[Currently](https://github.com/ipfs/go-ipfs/blob/9c194aa7e2febeab0cbd895067d7d90d82b137f9/blocks/blockstore/caching.go), 7 hash functions are used by default, so the constant `k` is 7 in the formula.
+As of writing, [7 hash functions](https://github.com/ipfs/go-ipfs-blockstore/blob/547442836ade055cc114b562a3cc193d4e57c884/caching.go#L22) are used, so the constant `k` is 7 in the formula.
 
 
 Default: `0`

--- a/docs/config.md
+++ b/docs/config.md
@@ -141,8 +141,13 @@ A boolean value. If set to true, all block reads from disk will be hashed and
 verified. This will cause increased CPU utilization.
 
 - `BloomFilterSize`
-A number representing the size in bytes of the blockstore's bloom filter. A
-value of zero represents the feature being disabled.
+A number representing the size in bytes of the blockstore's [bloom filter](https://en.wikipedia.org/wiki/Bloom_filter). A value of zero represents the feature being disabled.  
+
+This site generates useful graphs for various bloom filter values: <https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7>  
+You may use it to find a preferred optimal value, where `m` is `BloomFilterSize` in bits. Remember to convert the value `m` from bits, into bytes for use as `BloomFilterSize` in the config file.  
+For example, for 1,000,000 blocks, expecting a 1% false positive rate, you'd end up with a filter size of 9592955 bits, so for `BloomFilterSize` we'd want to use 1199120 bytes.  
+[Currently](https://github.com/ipfs/go-ipfs/blob/9c194aa7e2febeab0cbd895067d7d90d82b137f9/blocks/blockstore/caching.go), 7 hash functions are used by default, so the constant `k` is 7 in the formula.
+
 
 Default: `0`
 


### PR DESCRIPTION
During an IRC conversation, this information came up. I figured it might make for a useful suggestion here.
yay or nay?

>[2018.04.04] 14:28:47 <@hsanjuan> Can someone remind me the recommended values for bloom filter size in go-ipfs?
[2018.04.04] 14:46:58 <@stebalien> - num_blocks * 1.44 * logtwo(probability_of_false_positive)
[2018.04.04] 14:48:27 < djdv> I wonder if that should be noted in https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#datastore
[2018.04.04] 14:49:02 <@stebalien> So, for a 1% false positive rate and 1m blocks, you'd want a ~1MiB (mebibyte) filter.
[2018.04.04] 14:49:19 <@stebalien> Note: I havent' tested that, I'm just going off of wikipedia.
[2018.04.04] 14:49:28 <@stebalien> https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions