### PR TITLE
Single ConstructNode

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -152,26 +152,26 @@ func mainRet() int {
 			LoadConfig: loadConfig,
 			ReqLog:     &oldcmds.ReqLog{},
 			Plugins:    plugins,
-			ConstructNode: func() (n *core.IpfsNode, err error) {
+			ConstructNode: func(cfg core.BuildCfg, local bool) (n *core.IpfsNode, err error) {
 				if req == nil {
 					return nil, errors.New("constructing node without a request")
 				}
 
-				r, err := fsrepo.Open(repoPath)
-				if err != nil { // repo is owned by the node
-					return nil, err
+				if cfg.Repo == nil {
+					cfg.Repo, err = fsrepo.Open(repoPath)
+					if err != nil { // repo is owned by the node
+						return nil, err
+					}
 				}
 
 				// ok everything is good. set it on the invocation (for ownership)
 				// and return it.
-				n, err = core.NewNode(ctx, &core.BuildCfg{
-					Repo: r,
-				})
+				n, err = core.NewNode(ctx, &cfg)
 				if err != nil {
 					return nil, err
 				}
 
-				n.SetLocal(true)
+				n.SetLocal(local)
 				return n, nil
 			},
 		}, nil

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -212,7 +212,7 @@ func cmdCtx(node *core.IpfsNode, repoPath string) commands.Context {
 		LoadConfig: func(path string) (*config.Config, error) {
 			return node.Repo.Config()
 		},
-		ConstructNode: func() (*core.IpfsNode, error) {
+		ConstructNode: func(cfg core.BuildCfg, local bool) (*core.IpfsNode, error) {
 			return node, nil
 		},
 	}

--- a/commands/context.go
+++ b/commands/context.go
@@ -32,8 +32,8 @@ type Context struct {
 
 	Gateway       bool
 	api           coreiface.CoreAPI
-	node          *core.IpfsNode
-	ConstructNode func() (*core.IpfsNode, error)
+	Node          *core.IpfsNode
+	ConstructNode func(cfg core.BuildCfg, local bool) (*core.IpfsNode, error)
 }
 
 // GetConfig returns the config of the current Command execution
@@ -53,13 +53,13 @@ func (c *Context) GetConfig() (*config.Config, error) {
 // context. It may construct it with the provided function.
 func (c *Context) GetNode() (*core.IpfsNode, error) {
 	var err error
-	if c.node == nil {
+	if c.Node == nil {
 		if c.ConstructNode == nil {
 			return nil, errors.New("nil ConstructNode function")
 		}
-		c.node, err = c.ConstructNode()
+		c.Node, err = c.ConstructNode(core.BuildCfg{}, true)
 	}
-	return c.node, err
+	return c.Node, err
 }
 
 // GetAPI returns CoreAPI instance backed by ipfs node.
@@ -123,8 +123,8 @@ func (c *Context) Close() {
 	// let's not forget teardown. If a node was initialized, we must close it.
 	// Note that this means the underlying req.Context().Node variable is exposed.
 	// this is gross, and should be changed when we extract out the exec Context.
-	if c.node != nil {
+	if c.Node != nil {
 		log.Info("Shutting down node...")
-		c.node.Close()
+		c.Node.Close()
 	}
 }

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -67,7 +67,7 @@ func MockCmdsCtx() (commands.Context, error) {
 		LoadConfig: func(path string) (*config.Config, error) {
 			return &conf, nil
 		},
-		ConstructNode: func() (*core.IpfsNode, error) {
+		ConstructNode: func(cfg core.BuildCfg, local bool) (*core.IpfsNode, error) {
 			return node, nil
 		},
 	}, nil


### PR DESCRIPTION
Refactored ConstructNode usage, as current one is a bit confusing and it's hard to wire in CoreAPI providing for plugins.