### PR TITLE
Fix key rename command output error

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -306,7 +306,11 @@ var keyRenameCmd = &cmds.Command{
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
-			k, ok := res.Output().(*KeyRenameOutput)
+			v, err := unwrapOutput(res.Output())
+			if err != nil {
+				return nil, err
+			}
+			k, ok := v.(*KeyRenameOutput)
 			if !ok {
 				return nil, fmt.Errorf("expected a KeyRenameOutput as command result")
 			}

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -58,6 +58,13 @@ test_key_cmd() {
     test_cmp list_exp list_out
   '
 
+  test_expect_success "key rename rename key output succeeds" '
+    key_content=$(ipfs key gen key1 --type=rsa --size=2048) &&
+    ipfs key rename key1 key2 >rs &&
+    echo "Key $key_content renamed to key2" >expect &&
+    test_cmp rs expect
+  '
+
   test_expect_success "key rename can't rename self" '
     test_must_fail ipfs key rename self bar 2>&1 | tee key_rename_out &&
     grep -q "Error: cannot rename key with name" key_rename_out


### PR DESCRIPTION

fix: Error when renaming keys #4953

License: MIT
Signed-off-by: Xiaoyi Wang <wangxiaoyi@hyperchain.cn>