### PR TITLE
Fix: sharness iptb connect timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
       "version": "0.1.1"
     },
     {
-      "hash": "QmQtAm9iMWkV98JWotgfUQ3RRx7ZhxVDMZFnzEzmFwnKnU",
+      "hash": "QmTD9SdvPDfzdQrBq4iSD3LDDaM3dKHtvvuGbqzMGUHkat",
       "name": "iptb",
-      "version": "1.2.4"
+      "version": "1.3.0"
     },
     {
       "hash": "QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua",

--- a/test/sharness/t0181-private-network.sh
+++ b/test/sharness/t0181-private-network.sh
@@ -61,7 +61,7 @@ test_expect_success "start nodes" '
 '
 
 test_expect_success "try connecting node in public network with priv networks" '
-  iptb connect [1-4] 0
+  iptb connect --timeout=2s [1-4] 0
 '
 
 test_expect_success "node 0 (public network) swarm is empty" '


### PR DESCRIPTION
Resolves the first point in #4961 by adding timeout to connect. Based on  #4965.