### PR TITLE
mk: fix commit string in version

### DIFF
--- a/mk/git.mk
+++ b/mk/git.mk
@@ -1,1 +1,1 @@
-git-commit:=$(shell git rev-parse --short HEAD 2>/dev/null)
+git-hash:=$(shell git rev-parse --short HEAD 2>/dev/null)


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/pull/4920 adds this as "commit"
https://github.com/ipfs/go-ipfs/blob/25352208642a62c23c84245ef64709c38d694b5c/mk/git.mk#L1
but uses it as "hash"
https://github.com/ipfs/go-ipfs/blob/25352208642a62c23c84245ef64709c38d694b5c/cmd/ipfs/Rules.mk#L16
https://github.com/ipfs/go-ipfs/blob/25352208642a62c23c84245ef64709c38d694b5c/mk/tarball.mk#L7-L8
As a result our commit in `ipfs version --all` is empty.