### PR TITLE
gx: update go-ipld-git to fix mergetag resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,9 +429,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmX5GwZzNJ2PhFDPW12MjQWtmE21i4UnHQ2uKtYkp4Ad7a",
+      "hash": "QmZGhwkjJ4cGn2DTN3TYqRNAnC7EeBk7MF9fm3SqSQMUux",
       "name": "go-ipld-git",
-      "version": "0.1.6"
+      "version": "0.2.0"
     },
     {
       "hash": "Qmf2UAmRwDG4TvnkQpHZWPAzw7rpCYVhxmRXmYxXr5LD1g",

--- a/plugin/plugins/git/git.go
+++ b/plugin/plugins/git/git.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ipfs/go-ipfs/core/coredag"
 	"github.com/ipfs/go-ipfs/plugin"
 
-	git "gx/ipfs/QmX5GwZzNJ2PhFDPW12MjQWtmE21i4UnHQ2uKtYkp4Ad7a/go-ipld-git"
+	git "gx/ipfs/QmZGhwkjJ4cGn2DTN3TYqRNAnC7EeBk7MF9fm3SqSQMUux/go-ipld-git"
 	mh "gx/ipfs/QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua/go-multihash"
 	"gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 	"gx/ipfs/Qme5bWv7wtjUNGsK2BNGVUFPKiuxWrsqrtvYwCLRw8YFES/go-ipld-format"


### PR DESCRIPTION
Depends on https://github.com/ipfs/go-ipld-git/pull/19