### PR TITLE
 pin cmd: stream recursive pins

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -127,7 +127,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"mount":     lgc.NewCommand(MountCmd),
 	"name":      lgc.NewCommand(NameCmd),
 	"object":    ocmd.ObjectCmd,
-	"pin":       lgc.NewCommand(PinCmd),
+	"pin":       PinCmd,
 	"ping":      lgc.NewCommand(PingCmd),
 	"p2p":       lgc.NewCommand(P2PCmd),
 	"refs":      lgc.NewCommand(RefsCmd),


### PR DESCRIPTION
This is api breaking change.

When doing `pin ls` on large repos nothing will happen until all pins have been gathered, with this we stream them as we traverse the recursive pin children