### PR TITLE
ci: Use go 1.10 on jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 language: go
 
 go:
-    - 1.9
+    - 1.10.2
 
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-stretch
+FROM golang:1.10-stretch
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # There is a copy of this Dockerfile called Dockerfile.fast,

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,4 +1,4 @@
-FROM golang:1.9-stretch
+FROM golang:1.10-stretch
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # This is a copy of /Dockerfile,

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ With snap, in any of the [supported Linux distributions](https://snapcraft.io/do
 
 #### Install Go
 
-The build process for ipfs requires Go 1.9 or higher. If you don't have it: [Download Go 1.9+](https://golang.org/dl/).
+The build process for ipfs requires Go 1.10 or higher. If you don't have it: [Download Go 1.10+](https://golang.org/dl/).
 
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
@@ -147,7 +147,7 @@ mismatched APIs.
 * Also, [instructions for OpenBSD](docs/openbsd.md).
 * `git` is required in order for `go get` to fetch all dependencies.
 * Package managers often contain out-of-date `golang` packages.
-  Ensure that `go version` reports at least 1.9. See above for how to install go.
+  Ensure that `go version` reports at least 1.10. See above for how to install go.
 * If you are interested in development, please install the development
 dependencies as well.
 * *WARNING: Older versions of OSX FUSE (for Mac OS X) can cause kernel panics when mounting!*

--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -1,9 +1,9 @@
 include mk/header.mk
 
-dist_root_$(d)=/ipfs/QmT3CLJKJzWPuN4NAN4LLy69UpKskMF3AuYhXstKdn8V43
+dist_root_$(d)="/ipfs/QmXtsjCX29kcdeSjrijWiFTK1qwQNW8UrEWDi8okuC2Pog"
 
-$(d)/gx: $(d)/gx-v0.12.1
-$(d)/gx-go: $(d)/gx-go-v1.6.0
+$(d)/gx: $(d)/gx-v0.13.0
+$(d)/gx-go: $(d)/gx-go-v1.7.0
 
 TGTS_$(d) := $(d)/gx $(d)/gx-go
 DISTCLEAN += $(wildcard $(d)/gx-v*) $(wildcard $(d)/gx-go-v*) $(d)/tmp

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -35,7 +35,7 @@ def setupStep(nodeLabel, f) {
     def ps = nodeLabel != 'windows' ? '/' : '\\'
     def psep = nodeLabel != 'windows' ? ':' : ';'
 
-    def root = tool name: '1.9.2', type: 'go'
+    def root = tool name: '1.10.2', type: 'go'
     def jobNameArr = "${JOB_NAME}"
     def jobName = jobNameArr.split("/")[0..1].join(nodeLabel != 'windows' ? '/' : '\\\\').toLowerCase()
     def subName = jobNameArr.split("/")[2].toLowerCase()
@@ -83,6 +83,7 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
       'go vet': {
         setupStep('linux') { run ->
           timeout(time: check_timeout, unit: 'MINUTES') {
+            run 'make gx-deps'
             run 'go vet ./...'
           }
         }

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ machine:
 
   post:
     - sudo rm -rf /usr/local/go
-    - if [ ! -e go1.9.2.linux-amd64.tar.gz ]; then curl -o go1.9.2.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz; fi
-    - sudo tar -C /usr/local -xzf go1.9.2.linux-amd64.tar.gz
+    - if [ ! -e go1.10.2.linux-amd64.tar.gz ]; then curl -o go1.10.2.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz; fi
+    - sudo tar -C /usr/local -xzf go1.10.2.linux-amd64.tar.gz
 
   services:
     - docker
@@ -30,7 +30,7 @@ dependencies:
     - cd "$HOME/.go_workspace/src/$IMPORT_PATH" && make deps
 
   cache_directories:
-    - ~/go1.9.2.linux-amd64.tar.gz
+    - ~/go1.10.2.linux-amd64.tar.gz
     - ~/.go_workspace/src/gx/ipfs
 
 test:

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.9
+GO_MIN_VERSION = 1.10
 
 
 # pre-definitions

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "gx": {
     "dvcsimport": "github.com/ipfs/go-ipfs",
-    "goversion": "1.9"
+    "goversion": "1.10"
   },
   "gxDependencies": [
     {


### PR DESCRIPTION
https://github.com/whyrusleeping/tar-utils/pull/2 uses `strings.Builder` for windows paths, it's a go 1.10 feature.