### PR TITLE
Efficient "repo stat" (DiskUsage) and "--size-only" flag

### DIFF
--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -197,7 +197,6 @@ Version         string The repo version.
 		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {
 			stat, ok := v.(*corerepo.Stat)
 			if !ok {
-				fmt.Println("adios")
 				return e.TypeErr(stat, v)
 			}
 

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -27,6 +27,7 @@ import (
 	ma "gx/ipfs/QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7/go-multiaddr"
 	lockfile "gx/ipfs/QmYzCZUe9CBDkyPNPcRNqXQK8KKhtUfXvc88PkFujAEJPe/go-fs-lock"
 	logging "gx/ipfs/QmcVVHfdyv15GVPk7NrxdWjh2hLVccXnoD8j2tyQShiXJb/go-log"
+	ds "gx/ipfs/QmeiCcJfDW1GJnWUArudsv5rQsihpi4oyddPhdqo3CfX6i/go-datastore"
 )
 
 // LockFile is the filename of the repo lock, relative to config dir
@@ -672,29 +673,7 @@ func (r *FSRepo) Datastore() repo.Datastore {
 
 // GetStorageUsage computes the storage space taken by the repo in bytes
 func (r *FSRepo) GetStorageUsage() (uint64, error) {
-	pth, err := config.PathRoot()
-	if err != nil {
-		return 0, err
-	}
-
-	pth, err = filepath.EvalSymlinks(pth)
-	if err != nil {
-		log.Debugf("filepath.EvalSymlinks error: %s", err)
-		return 0, err
-	}
-
-	var du uint64
-	err = filepath.Walk(pth, func(p string, f os.FileInfo, err error) error {
-		if err != nil {
-			log.Debugf("filepath.Walk error: %s", err)
-			return nil
-		}
-		if f != nil {
-			du += uint64(f.Size())
-		}
-		return nil
-	})
-	return du, err
+	return ds.DiskUsage(r.Datastore())
 }
 
 func (r *FSRepo) SwarmKey() ([]byte, error) {

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -245,6 +245,18 @@ test_expect_success "repo stats are updated correctly" '
   test $(get_field_num "RepoSize" repo-stats-2) -ge $(get_field_num "RepoSize" repo-stats)
 '
 
+test_expect_success "'ipfs repo stat --size-only' succeeds" '
+  ipfs repo stat --size-only > repo-stats-size-only
+'
+
+test_expect_success "repo stats came out correct for --size-only" '
+  grep "RepoSize" repo-stats-size-only &&
+  grep "StorageMax" repo-stats-size-only &&
+  grep -v "RepoPath" repo-stats-size-only &&
+  grep -v "NumObjects" repo-stats-size-only &&
+  grep -v "Version" repo-stats-size-only
+'
+
 test_expect_success "'ipfs repo version' succeeds" '
   ipfs repo version > repo-version
 '


### PR DESCRIPTION
This makes use of the PersistentDatastore DiskUsage method to obtain the Repo's storage usage (GetStorageUsage()).
    
Additionally, the --size-only flag has been added to the "ipfs repo stat" command. This avoids counting the number of objects in the repository and returns faster.

Overseeds #4550 

I had to make some gx magic to fix dependencies and be able to use latest go-datastore. go-libp2p-kad-dht depends on it and afaik the changes there cannot be integrated still etc. I'm happy to leave this hanging until this is sorted out. Thus, tagging this as blocked.