### PR TITLE
Fix goroutine leak in dag put

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -128,7 +128,12 @@ into an object of the specified format.
 
 				cid := nds[0].Cid()
 				cids.Add(cid)
-				outChan <- &OutputObject{Cid: cid}
+
+				select {
+				case outChan <- &OutputObject{Cid: cid}:
+				case <-req.Context().Done():
+					return nil
+				}
 			}
 
 			if err := b.Commit(); err != nil {


### PR DESCRIPTION
In the unlikely case that the context is cancelled, and we're adding more than 8 files.
Part of #4414.