### PR TITLE
build: remove fuse platform constraints

### DIFF
--- a/core/commands/mount_nofuse.go
+++ b/core/commands/mount_nofuse.go
@@ -1,5 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd dragonfly
-// +build nofuse
+// +build !windows,nofuse
 
 package commands
 

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -1,5 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
-// +build !nofuse
+// +build !windows,!nofuse
 
 package commands
 

--- a/fuse/node/mount_nofuse.go
+++ b/fuse/node/mount_nofuse.go
@@ -1,5 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd dragonfly
-// +build nofuse
+// +build !windows,nofuse
 
 package node
 

--- a/fuse/node/mount_unix.go
+++ b/fuse/node/mount_unix.go
@@ -1,5 +1,4 @@
-// +build linux darwin freebsd netbsd openbsd
-// +build !nofuse
+// +build !windows,!nofuse
 
 package node
 
@@ -9,11 +8,12 @@ import (
 	"strings"
 	"sync"
 
+	logging "gx/ipfs/QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8/go-log"
+
 	core "github.com/ipfs/go-ipfs/core"
 	ipns "github.com/ipfs/go-ipfs/fuse/ipns"
 	mount "github.com/ipfs/go-ipfs/fuse/mount"
 	rofs "github.com/ipfs/go-ipfs/fuse/readonly"
-	logging "gx/ipfs/QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8/go-log"
 )
 
 var log = logging.Logger("node")


### PR DESCRIPTION
Followup to: https://github.com/ipfs/go-ipfs/pull/5031
@daftaupe was expressing issues on IRC when trying to build `go-ipfs` on DragonflyBSD. After investigating, it seemed like the only problem was in the build constraints. I suggested adding dragonfly to the list of build targets. This worked fine but may be unnecessary (see: https://github.com/ipfs/go-ipfs/pull/5031#issuecomment-390706466)

It may be best to just remove these constraints so people don't have to rediscovering this and make source modifications when using the `install_unsupported` `make` target on platforms that are not explicitly defined by us.
