### PR TITLE
cmd: fix `files ls` to report hash and size for files

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -462,7 +462,24 @@ Examples:
 			return
 		case *mfs.File:
 			_, name := gopath.Split(path)
-			out := &filesLsOutput{[]mfs.NodeListing{mfs.NodeListing{Name: name, Type: 1}}}
+			out := &filesLsOutput{[]mfs.NodeListing{mfs.NodeListing{Name: name}}}
+			if long {
+				out.Entries[0].Type = int(fsn.Type())
+
+				size, err := fsn.Size()
+				if err != nil {
+					res.SetError(err, cmdkit.ErrNormal)
+					return
+				}
+				out.Entries[0].Size = size
+
+				nd, err := fsn.GetNode()
+				if err != nil {
+					res.SetError(err, cmdkit.ErrNormal)
+					return
+				}
+				out.Entries[0].Hash = nd.Cid().String()
+			}
 			res.SetOutput(out)
 			return
 		default:

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -186,6 +186,12 @@ test_files_api() {
     test_cmp ls_l_expected ls_l_actual
   '
 
+  test_expect_success "file has correct hash and size listed with -l" '
+    echo "file1	$FILE1	4" > ls_l_expected &&
+    ipfs files ls -l /cats/file1 > ls_l_actual &&
+    test_cmp ls_l_expected ls_l_actual
+  '
+
   test_expect_success "can stat file $EXTRA" '
     ipfs files stat /cats/file1 > file1stat_orig
   '

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -192,6 +192,12 @@ test_files_api() {
     test_cmp ls_l_expected ls_l_actual
   '
 
+  test_expect_success "file shows up with the correct name" '
+    echo "file1" > ls_l_expected &&
+    ipfs files ls /cats/file1 > ls_l_actual &&
+    test_cmp ls_l_expected ls_l_actual
+  '
+
   test_expect_success "can stat file $EXTRA" '
     ipfs files stat /cats/file1 > file1stat_orig
   '


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-ipfs/issues/5044.