### PR TITLE
Really run as non-root user in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,14 @@ EXPOSE 8080
 # Swarm Websockets; must be exposed publicly when the node is listening using the websocket transport (/ipX/.../tcp/8081/ws).
 EXPOSE 8081
 
-# Create the fs-repo directory and switch to a non-privileged user.
+# Create the fs-repo directory
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
   && adduser -D -h $IPFS_PATH -u 1000 -G users ipfs \
   && chown ipfs:users $IPFS_PATH
+
+# Switch to a non-privileged user
+USER ipfs
 
 # Expose the fs-repo as a volume.
 # start_ipfs initializes an fs-repo if none is mounted.

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,14 +53,18 @@ EXPOSE 5001
 EXPOSE 8080
 EXPOSE 8081
 
-# Create the fs-repo directory and switch to a non-privileged user.
+# Create the fs-repo directory
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
   && useradd -s /usr/sbin/nologin -d $IPFS_PATH -u 1000 -G users ipfs \
   && chown ipfs:users $IPFS_PATH
 
+# Switch to a non-privileged user
+USER ipfs
+
 # Expose the fs-repo as a volume.
 # start_ipfs initializes an fs-repo if none is mounted.
+# Important this happens after the USER directive so permission are correct.
 VOLUME $IPFS_PATH
 
 # The default logging level


### PR DESCRIPTION
As of now,

    $ docker pull ipfs/go-ipfs
    Using default tag: latest
    latest: Pulling from ipfs/go-ipfs
    Digest: sha256:31cc5713ef3e3e81bf868cbb56c19de2d15d661743d8b6077804dee26e929ac5
    Status: Image is up to date for ipfs/go-ipfs:latest

ipfs daemon will start as root user:

    $ docker run --rm --entrypoint=/bin/sh ipfs/go-ipfs -c whoami
    root

but later on will drop priviledges:

    $ docker logs ipfs/go-ipfs |head -n 1
    Changing user to ipfs

With this change applied, ipfs daemon starts as ipfs user right from
the begining:

    $ docker run --rm --entrypoint=/bin/sh ipfs/go-ipfs -c whoami
    ipfs

License: MIT
Signed-off-by: Mykola Nikishov <mn@mn.com.ua>