### PR TITLE
[wip] ci: Run ipfs/js-ipfs-http-client & ipfs/interop tests

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -28,10 +28,12 @@ def build_platforms = [
   ['freebsd', 'amd64']
 ]
 
-// js-ipfs-api tests
-def js_api_commit = '7e78ee232bea8e5ea92bcfcff949b4ed671c2d50' // 22.0.1
+/* js-* tests */
+def js_api_commit = '80452eb62903bf405a9085cd14a233da8a5e31a4' // 22.3.0
+def interop_commit = '6593ccdca5d7b4c747787f71f7ac4b5f6f1ab10b'
+
 def js_api_platforms = ['linux', 'macos']
-def js_api_node_versions = ['8.11.1', '9.2.0']
+def js_api_node_versions = ['8.11.3', '10.4.1']
 
 def yarn_version = '1.5.1'
 def yarn_path = './node_modules/.bin/yarn'
@@ -108,6 +110,55 @@ def sharness_step = { run, osname, makeargs, ignore ->
   }
 }
 
+/* JS BASED TESTS */
+
+def jsTestStep = { os, nodeVer, repo, commit ->
+  return { ->
+    setupStep(os) {
+      switch (os) {
+        case "linux":
+          unstash("ipfs-linux-amd64")
+          break
+        case "macos":
+          unstash("ipfs-darwin-amd64")
+          break
+      }
+
+      withEnv(['IPFS_GO_EXEC=../cmd/ipfs/ipfs', 'CI=true']) {
+        dir('.js-test') {
+          checkout changelog: false, scm: [$class: 'GitSCM', branches: [[name: commit]], userRemoteConfigs: [[url: repo]]]
+
+          //todo: deduplicate with https://github.com/ipfs/jenkins-libs/blob/master/vars/javascript.groovy somehow
+
+          fileExists 'package.json'
+          nodejs(nodeVer) {
+            sh 'rm -rf node_modules/'
+            sh 'npm install yarn@' + yarn_version
+            sh yarn_path + ' --mutex network --no-lockfile'
+            def runTest = { ->
+              try {
+                sh yarn_path + ' test'
+              } catch(_) {
+              } finally {
+                junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+                cleanWs()
+              }
+            }
+
+            if (os == "linux") {
+              wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
+                runTest()
+              }
+            } else {
+              runTest()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 /* PIPELINE */
 
 def reportedStage(name, fn) {
@@ -119,7 +170,7 @@ def reportedStage(name, fn) {
     }
     githubNotify description: "${name.capitalize()} passed", status: 'SUCCESS', context: "continuous-integration/jenkins/${name}"
   } catch (err) {
-    githubNotify description: '${name.capitalize()} failed', status: 'FAILURE', context: "continuous-integration/jenkins/${name}"
+    githubNotify description: "${name.capitalize()} failed", status: 'FAILURE', context: "continuous-integration/jenkins/${name}"
     throw err
   }
 
@@ -228,56 +279,22 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
     )
   }
 
-  reportedStage('apis') {
-    def jsApiStep = { os, nodeVer ->
-      return { ->
-        setupStep(os) {
-          switch (os) {
-            case "linux":
-              unstash("ipfs-linux-amd64")
-              break
-            case "macos":
-              unstash("ipfs-darwin-amd64")
-              break
-          }
-
-          withEnv(['IPFS_GO_EXEC=../cmd/ipfs/ipfs', 'CI=true']) {
-            dir('.js-ipfs-api') {
-              checkout changelog: false, scm: [$class: 'GitSCM', branches: [[name: "${js_api_commit}"]], userRemoteConfigs: [[url: 'https://github.com/ipfs/js-ipfs-api']]]
-
-              //todo: deduplicate with https://github.com/ipfs/jenkins-libs/blob/master/vars/javascript.groovy somehow
-
-              fileExists 'package.json'
-              nodejs(nodeVer) {
-                sh 'rm -rf node_modules/'
-                sh 'npm install yarn@' + yarn_version
-                sh yarn_path + ' --mutex network --no-lockfile'
-                def runTest = { ->
-                  try {
-                    sh yarn_path + ' test'
-                  } finally {
-                    junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
-                  }
-                }
-
-                if (os == "linux") {
-                  wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
-                    runTest()
-                  }
-                } else {
-                  runTest()
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
+  reportedStage('interop') {
     def steps = [:]
     js_api_platforms.each {os ->
       js_api_node_versions.each { nodeVer ->
-        steps["js-api-${os}-${nodeVer}"] = jsApiStep(os, nodeVer)
+        steps["interop-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/interop', interop_commit)
+      }
+    }
+
+    parallel steps
+  }
+
+  reportedStage('apis') {
+    def steps = [:]
+    js_api_platforms.each {os ->
+      js_api_node_versions.each { nodeVer ->
+        steps["js-api-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/js-ipfs-api', js_api_commit)
       }
     }
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -28,6 +28,15 @@ def build_platforms = [
   ['freebsd', 'amd64']
 ]
 
+// js-ipfs-api tests
+def js_api_commit = '7e78ee232bea8e5ea92bcfcff949b4ed671c2d50' // 22.0.1
+def js_api_platforms = ['linux', 'macos']
+def js_api_node_versions = ['8.11.1', '9.2.0']
+
+def yarn_version = '1.5.1'
+def yarn_path = './node_modules/.bin/yarn'
+
+
 /* PIPELINE UTILS */
 
 def setupStep(nodeLabel, f) {
@@ -69,6 +78,7 @@ def gobuild_step = { list ->
             run "go build -i -ldflags=\"-X github.com/ipfs/go-ipfs/repo/config.CurrentCommit=${env.SUBNAME}-${env.BUILD_NUMBER}\"  -o cmd/ipfs/ipfs github.com/ipfs/go-ipfs/cmd/ipfs"
             run "cp cmd/ipfs/ipfs cmd/ipfs/dist; cd cmd/ipfs/dist; tar -czvf ../go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz ."
             archiveArtifacts artifacts: "cmd/ipfs/go-ipfs_${env.GOOS}-${env.GOARCH}-${env.SUBNAME}-${env.BUILD_NUMBER}.tar.gz", fingerprint: true
+            stash name: "ipfs-${env.GOOS}-${env.GOARCH}", includes: "cmd/ipfs/ipfs"
           }
         }
       }
@@ -100,8 +110,23 @@ def sharness_step = { run, osname, makeargs, ignore ->
 
 /* PIPELINE */
 
+def reportedStage(name, fn) {
+  githubNotify description: "Running ${name}", status: 'PENDING', context: "continuous-integration/jenkins/${name}"
+
+  try {
+    stage(name.capitalize()) {
+      fn()
+    }
+    githubNotify description: "${name.capitalize()} passed", status: 'SUCCESS', context: "continuous-integration/jenkins/${name}"
+  } catch (err) {
+    githubNotify description: '${name.capitalize()} failed', status: 'FAILURE', context: "continuous-integration/jenkins/${name}"
+    throw err
+  }
+
+}
+
 ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
-  stage('Checks') {
+  reportedStage('checks') {
     parallel(
       'go fmt': {
         setupStep('linux') { run ->
@@ -132,7 +157,8 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
     )
   }
 
-  stage('Tests') {
+
+  reportedStage('tests') {
     parallel(
       'go build (other platforms)': {
         gobuild_step(build_platforms)
@@ -201,4 +227,61 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
       //},
     )
   }
+
+  reportedStage('apis') {
+    def jsApiStep = { os, nodeVer ->
+      return { ->
+        setupStep(os) {
+          switch (os) {
+            case "linux":
+              unstash("ipfs-linux-amd64")
+              break
+            case "macos":
+              unstash("ipfs-darwin-amd64")
+              break
+          }
+
+          withEnv(['IPFS_GO_EXEC=../cmd/ipfs/ipfs', 'CI=true']) {
+            dir('.js-ipfs-api') {
+              checkout changelog: false, scm: [$class: 'GitSCM', branches: [[name: "${js_api_commit}"]], userRemoteConfigs: [[url: 'https://github.com/ipfs/js-ipfs-api']]]
+
+              //todo: deduplicate with https://github.com/ipfs/jenkins-libs/blob/master/vars/javascript.groovy somehow
+
+              fileExists 'package.json'
+              nodejs(nodeVer) {
+                sh 'rm -rf node_modules/'
+                sh 'npm install yarn@' + yarn_version
+                sh yarn_path + ' --mutex network --no-lockfile'
+                def runTest = { ->
+                  try {
+                    sh yarn_path + ' test'
+                  } finally {
+                    junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+                  }
+                }
+
+                if (os == "linux") {
+                  wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
+                    runTest()
+                  }
+                } else {
+                  runTest()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    def steps = [:]
+    js_api_platforms.each {os ->
+      js_api_node_versions.each { nodeVer ->
+        steps["js-api-${os}-${nodeVer}"] = jsApiStep(os, nodeVer)
+      }
+    }
+
+    parallel steps
+  }
+
 }}

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -29,7 +29,7 @@ def build_platforms = [
 ]
 
 /* js-* tests */
-def js_api_commit = '80452eb62903bf405a9085cd14a233da8a5e31a4' // 22.3.0
+def js_api_commit = 'e61155ae8edaee902cb3a1dcd8ba3d3afb093d1c' // 24.0.1
 def interop_commit = '6593ccdca5d7b4c747787f71f7ac4b5f6f1ab10b'
 
 def js_api_platforms = ['linux', 'macos']

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -279,16 +279,16 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
     )
   }
 
-  reportedStage('interop') {
-    def steps = [:]
-    js_api_platforms.each {os ->
-      js_api_node_versions.each { nodeVer ->
-        steps["interop-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/interop', interop_commit)
-      }
-    }
-
-    parallel steps
-  }
+  //reportedStage('interop') {
+  //  def steps = [:]
+  //  js_api_platforms.each {os ->
+  //    js_api_node_versions.each { nodeVer ->
+  //      steps["interop-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/interop', interop_commit)
+  //    }
+  //  }
+  //
+  //  parallel steps
+  //}
 
   reportedStage('apis') {
     def steps = [:]

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -29,8 +29,8 @@ def build_platforms = [
 ]
 
 /* js-* tests */
-def js_api_commit = 'e61155ae8edaee902cb3a1dcd8ba3d3afb093d1c' // 24.0.1
-def interop_commit = '6593ccdca5d7b4c747787f71f7ac4b5f6f1ab10b'
+def js_api_commit = '7543c06a1105f6de4fe7c549790d58ac4cf75326' // 25.0.0 - log pr
+def interop_commit = 'e63c532e58af7b6d9924f4ebdbdc26cc317c15e5'
 
 def js_api_platforms = ['linux', 'macos']
 def js_api_node_versions = ['8.11.3', '10.4.1']
@@ -127,8 +127,6 @@ def jsTestStep = { os, nodeVer, repo, commit ->
       withEnv(['IPFS_GO_EXEC=../cmd/ipfs/ipfs', 'CI=true']) {
         dir('.js-test') {
           checkout changelog: false, scm: [$class: 'GitSCM', branches: [[name: commit]], userRemoteConfigs: [[url: repo]]]
-
-          //todo: deduplicate with https://github.com/ipfs/jenkins-libs/blob/master/vars/javascript.groovy somehow
 
           fileExists 'package.json'
           nodejs(nodeVer) {
@@ -279,21 +277,11 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
     )
   }
 
-  //reportedStage('interop') {
-  //  def steps = [:]
-  //  js_api_platforms.each {os ->
-  //    js_api_node_versions.each { nodeVer ->
-  //      steps["interop-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/interop', interop_commit)
-  //    }
-  //  }
-  //
-  //  parallel steps
-  //}
-
-  reportedStage('apis') {
+  reportedStage('interop/apis') {
     def steps = [:]
     js_api_platforms.each {os ->
       js_api_node_versions.each { nodeVer ->
+        steps["interop-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/interop', interop_commit)
         steps["js-api-${os}-${nodeVer}"] = jsTestStep(os, nodeVer, 'https://github.com/ipfs/js-ipfs-api', js_api_commit)
       }
     }

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -29,8 +29,8 @@ def build_platforms = [
 ]
 
 /* js-* tests */
-def js_api_commit = '7543c06a1105f6de4fe7c549790d58ac4cf75326' // 25.0.0 - log pr
-def interop_commit = 'e63c532e58af7b6d9924f4ebdbdc26cc317c15e5'
+def js_api_commit = 'v29.1.0'
+def interop_commit = 'master'
 
 def js_api_platforms = ['linux', 'macos']
 def js_api_node_versions = ['8.11.3', '10.4.1']

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -33,7 +33,7 @@ def js_api_commit = 'v29.1.0'
 def interop_commit = 'master'
 
 def js_api_platforms = ['linux', 'macos']
-def js_api_node_versions = ['8.11.3', '10.4.1']
+def js_api_node_versions = ['10.4.1']
 
 def yarn_version = '1.5.1'
 def yarn_path = './node_modules/.bin/yarn'


### PR DESCRIPTION
This PR:
* Runs tests from https://github.com/ipfs/interop
* And from https://github.com/ipfs/js-ipfs-api
* And pushes more statuses to github so we don't have to wait for everything to finish

TODO:
- [ ] Make sure the tests actually use provided go-ipfs
- [ ] Try to skip parts that don't touch go-ipfs
- [ ] Make sure tests are stable
- [ ] Deduplicate code with jenkins-libs
- [ ] Collect test results
