### PR TITLE
ci: Archive sharness trash dirs

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -68,6 +68,28 @@ def gobuild_step(list) {
   }
 }
 
+def sharness_step = { run, osname, makeargs, ignore ->
+  timeout(time: sharness_timeout, unit: 'MINUTES') {
+    run "make gx-deps"
+
+    try {
+      run "make -j12 ${makeargs} test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1 TEST_NO_DOCKER=1"
+
+      try {
+        // archive trash directories if any
+        run "tar -czf sharnessTrashDirs-${osname}.tar.gz test/sharness/trash\\ *"
+        archiveArtifacts artifacts: "sharnessTrashDirs-${osname}.tar.gz", fingerprint: true
+      } catch (_) {}
+    } catch (err) {
+      throw err
+    } finally {
+      if (!ignore) {
+        junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml'
+      }
+    }
+  }
+}
+
 /* PIPELINE */
 
 ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
@@ -140,36 +162,12 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
       },
       linuxSharness: {
        setupStep('linux') { run ->
-         timeout(time: sharness_timeout, unit: 'MINUTES') {
-            run 'go get -v github.com/jstemmer/go-junit-report'
-            run "make gx-deps"
-
-            try {
-              run "make -j12 -Otarget test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1 TEST_NO_DOCKER=1"
-            } catch (err) {
-              throw err
-            } finally {
-              junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml'
-            }
-          }
+         sharness_step(run, 'linux', '-Otarget', false)
         }
       },
       //macOS: {
       //  setupStep('macos') { run ->
-      //    timeout(time: gotest_timeout, unit: 'MINUTES') {
-      //      run 'go get -v github.com/jstemmer/go-junit-report'
-      //      run "make gx-deps"
-
-      //      try {
-      //        run test + ' -tags="nofuse" 2>&1 | tee output'
-      //        run 'cat output | go-junit-report > junit-report-macos.xml'
-      //      } catch (err) {
-      //        throw err
-      //      } finally {
-      //        /* IGNORE TEST FAILS */
-      //        /* junit 'junit-report-*.xml' */
-      //      }
-      //    }
+      //    sharness_step(run, 'macos', '', true)
       //  }
       //},
       //macSharness: {


### PR DESCRIPTION
With this CI will archive any leftover sharness trash directories, this should help debugging failing sharness tests.

Example: https://ci.ipfs.team/blue/organizations/jenkins/IPFS%2Fgo-ipfs/detail/feat%2Fci%2Farchive-trash-dirs/46/artifacts