### PR TITLE
reduce log level when we can't republish

### DIFF
--- a/namesys/republisher/repub.go
+++ b/namesys/republisher/repub.go
@@ -72,7 +72,7 @@ func (rp *Republisher) Run(proc goprocess.Process) {
 			timer.Reset(rp.Interval)
 			err := rp.republishEntries(proc)
 			if err != nil {
-				log.Error("Republisher failed to republish: ", err)
+				log.Info("republisher failed to republish: ", err)
 				if FailureRetryInterval < rp.Interval {
 					timer.Reset(FailureRetryInterval)
 				}


### PR DESCRIPTION
This is almost never an error, it just means we don't have any connections. We could leave this at Warning but we'd like to be able to turn those on by default at some point.

fixes #5029