### PR TITLE
Update dist_root

### DIFF
--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -1,6 +1,6 @@
 include mk/header.mk
 
-dist_root_$(d)="/ipfs/QmXtsjCX29kcdeSjrijWiFTK1qwQNW8UrEWDi8okuC2Pog"
+dist_root_$(d)="/ipfs/QmYpvspyyUWQTE226NFWteXYJF3x3br25xmB6XzEoqfzyv"
 
 $(d)/gx: $(d)/gx-v0.13.0
 $(d)/gx-go: $(d)/gx-go-v1.7.0


### PR DESCRIPTION
Windows `gx` binaries were missing, they've been added but this reference is outdated.
Hash taken from `ipfs resolve /ipns/dist.ipfs.io`
Without this, builds are broken on Windows: https://github.com/ipfs/go-ipfs/issues/5042