### PR TITLE
Add README to docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ file an issue of your own!
 
 ## Contributing
 
-Please see [Contribute.md](contribute.md)!
+We ❤️ all [our contributors](docs/AUTHORS); this project wouldn’t be what it is without you! If you want to help out, please see [Contribute.md](contribute.md).
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Documentation and Guides
+
+If you’re experiencing an issue with IPFS, **please follow [our issue guide](github-issue-guide.md) when filing an issue!**
+
+Otherwise, check out the following guides to using and developing IPFS:
+
+
+## General Usage
+
+- [Transferring a File Over IPFS](file-transfer.md)
+- [Configuration reference](config.md)
+    - [Datastore configuration](datastores.md)
+    - [Experimental features](experimental-features.md)
+- [Installing command completion](command-completion.md)
+- [Mounting IPFS with FUSE](fuse.md)
+- [Installing plugins](plugins.md)
+
+
+## API Support
+
+- [How to Implement an API Client](implement-api-bindings.md)
+- [Connecting with Websockets](transports.md) — if you want `js-ipfs` nodes in web browsers to connect to your `go-ipfs` node, you will need to turn on websocket support in your `go-ipfs` node.
+
+
+## Developing `go-ipfs`
+
+- Building on…
+    - [Windows](windows.md)
+    - [OpenBSD](openbsd.md)
+- [Performance Debugging Guidelines](debug-guide.md)
+- [Release Checklist](releases.md)
+
+
+## Other
+
+- [Thanks to all our contributors ❤️](AUTHORS) (We use the `generate-authors.sh` script to regenerate this list.)
+- Our [Developer Certificate of Origin (DCO)](developer-certificate-of-origin) — when you sign your commits with `Signed-off-by: <your name>`, you are agreeing to this document.
+- [How to file a GitHub Issue](github-issue-guide.md)


### PR DESCRIPTION
Adds a simple README to the `docs` folder. This is based on [the work in the new docs site](https://ipfs.io/ipfs/QmVUdHfpo9hyC8wXmgd2frRrsp83iRvuL8HWyp1LPzjsPq/reference/go/overview/), but differs slightly since it aims to list all the items in the folder (whereas they are spread across a couple different parts of the docs site).

Also adds a link to the authors list in the top-level README, since that seemed like a nice thing to do.

Fixes #5049.