### PR TITLE
Add initial support for identity hashes (Part 1)

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -196,14 +196,16 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		opts.HasBloomFilterSize = 0
 	}
 
-	cbs, err := bstore.CachedBlockstore(ctx, bs, opts)
+	wbs, err := bstore.CachedBlockstore(ctx, bs, opts)
 	if err != nil {
 		return err
 	}
 
-	n.BaseBlocks = cbs
+	wbs = bstore.NewIdStore(wbs)
+
+	n.BaseBlocks = wbs
 	n.GCLocker = bstore.NewGCLocker()
-	n.Blockstore = bstore.NewGCBlockstore(cbs, n.GCLocker)
+	n.Blockstore = bstore.NewGCBlockstore(wbs, n.GCLocker)
 
 	if conf.Experimental.FilestoreEnabled {
 		// hash security

--- a/test/sharness/t0046-id-hash.sh
+++ b/test/sharness/t0046-id-hash.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+test_description="Test basic operations with identity hash"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+ID_HASH0=z25RnHTQ7DveGAsV6YDSDR8EkWvD
+ID_HASH0_CONTENTS=jkD98jkD975hkD8
+
+test_expect_success "can fetch random id hash" '
+  ipfs cat $ID_HASH0 > expected &&
+  echo $ID_HASH0_CONTENTS > actual &&
+  test_cmp expected actual
+'
+
+test_expect_success "can pin random id hash" '
+  ipfs pin add $ID_HASH0
+'
+
+test_expect_success "ipfs add succeeds with id hash" '
+  echo "djkd7jdkd7jkHHG" > junk.txt &&
+  HASH=$(ipfs add -q --hash=id junk.txt)
+'
+
+test_expect_success "content not actually added" '
+  ipfs refs local | fgrep -q -v $HASH
+'
+
+test_expect_success "but can fetch it anyway" '
+  ipfs cat $HASH > actual &&
+  test_cmp junk.txt actual
+'
+
+test_expect_success "block rm does nothing" '
+  ipfs pin rm $HASH &&
+  ipfs block rm $HASH
+'
+
+test_expect_success "can still fetch it" '
+  ipfs cat $HASH > actual
+  test_cmp junk.txt actual
+'
+
+test_done


### PR DESCRIPTION
This provides support for identity hashes by using the new blockstore in https://github.com/ipfs/go-ipfs-blockstore/pull/4.

This is test and works locally, but to go in https://github.com/ipfs/go-ipfs-blockstore/pull/4 needs to be merged and gx-updated, and then go-ipfs-exchange-offline needs to be updated and gx-published.