### PR TITLE
disable the MacOS tests in jenkins

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -154,41 +154,41 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
           }
         }
       },
-      macOS: {
-        setupStep('macos') { run ->
-          timeout(time: gotest_timeout, unit: 'MINUTES') {
-            run 'go get -v github.com/jstemmer/go-junit-report'
-            run "make gx-deps"
+      //macOS: {
+      //  setupStep('macos') { run ->
+      //    timeout(time: gotest_timeout, unit: 'MINUTES') {
+      //      run 'go get -v github.com/jstemmer/go-junit-report'
+      //      run "make gx-deps"
 
-            try {
-              run test + ' -tags="nofuse" 2>&1 | tee output'
-              run 'cat output | go-junit-report > junit-report-macos.xml'
-            } catch (err) {
-              throw err
-            } finally {
-              /* IGNORE TEST FAILS */
-              /* junit 'junit-report-*.xml' */
-            }
-          }
-        }
-      },
-      macSharness: {
-        setupStep('macos') { run ->
-          timeout(time: sharness_timeout, unit: 'MINUTES') {
-            run 'go get -v github.com/jstemmer/go-junit-report'
-            run "make gx-deps"
+      //      try {
+      //        run test + ' -tags="nofuse" 2>&1 | tee output'
+      //        run 'cat output | go-junit-report > junit-report-macos.xml'
+      //      } catch (err) {
+      //        throw err
+      //      } finally {
+      //        /* IGNORE TEST FAILS */
+      //        /* junit 'junit-report-*.xml' */
+      //      }
+      //    }
+      //  }
+      //},
+      //macSharness: {
+      //  setupStep('macos') { run ->
+      //    timeout(time: sharness_timeout, unit: 'MINUTES') {
+      //      run 'go get -v github.com/jstemmer/go-junit-report'
+      //      run "make gx-deps"
 
-            try {
-              run "make -j12 test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1"
-            } catch (err) {
-              throw err
-            } finally {
-              /* IGNORE TEST FAILS */
-              /* junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml' */
-            }
-          }
-        }
-      },
+      //      try {
+      //        run "make -j12 test/sharness/test-results/sharness.xml CONTINUE_ON_S_FAILURE=1 TEST_NO_FUSE=1"
+      //      } catch (err) {
+      //        throw err
+      //      } finally {
+      //        /* IGNORE TEST FAILS */
+      //        /* junit allowEmptyResults: true, testResults: 'test/sharness/test-results/sharness.xml' */
+      //      }
+      //    }
+      //  }
+      //},
     )
   }
 }}


### PR DESCRIPTION
They've never really been enabled but they:

1. Are causing the tests to fail for various reasons (e.g., out of space).
2. Take time.