### PR TITLE
Add system requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please put all issues regarding the Go IPFS _implementation_ in [this repo](http
 
 - [Security Issues](#security-issues)
 - [Install](#install)
+  - [System Requirements](#system-requirements)
   - [Install prebuilt packages](#install-prebuilt-packages)
   - [From Linux package managers](#from-linux-package-managers)
   - [Build from Source](#build-from-source)
@@ -57,6 +58,10 @@ If the issue is a protocol weakness that cannot be immediately exploited or some
 ## Install
 
 The canonical download instructions for IPFS are over at: http://ipfs.io/docs/install/. It is **highly suggested** you follow those instructions if you are not interested in working on IPFS development.
+
+### System Requirements
+
+IPFS can run on most Linux, macOS, and Windows systems. We recommend running it on a machine with at least 2 GB of RAM (it’ll do fine with only one CPU core), but it should run fine with as little as 1 GB of RAM. On systems with less memory, it may not be completely stable.
 
 ### Install prebuilt packages
 


### PR DESCRIPTION
This adds a short paragraph about system requirements to the “install” section of the README (that seemed like the most applicable place). While writing this, I wondered if it might make sense to add a paragraph about disk space:

> You should also make sure to have about 1.3x the disk space as the amount of data you’d like to be able to store — IPFS takes up a little bit of extra space keeping metadata about your files and about peers on the network. You can also choose [different ways to store your data](https://github.com/ipfs/go-ipfs/blob/master/docs/datastores.md), which will impact the amount of storage space required.

…but I wasn’t sure if that was actually necessary to say or even very accurate (There’s definitely a lot of fudge factor here, and I’m not even sure the 1.3x number is even a great reasonable approximation), so I left it out. I can add it in if people think it’s useful, though.

Fixes #5136.