### PR TITLE
feat: Allow specifing how object data is encoded

### DIFF
--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -47,6 +47,23 @@ test_object_cmd() {
     test_cmp ../t0051-object-data/expected_getOut actual_getOut
   '
 
+  test_expect_success "'ipfs object get' can specify data encoding as base64" '
+    ipfs object get --data-encoding base64 $HASH > obj_out &&
+    echo "{\"Links\":[],\"Data\":\"CAISCkhlbGxvIE1hcnMYCg==\"}" > obj_exp &&
+    test_cmp obj_out obj_exp
+  '
+
+  test_expect_success "'ipfs object get' can specify data encoding as text" '
+    echo "{\"Links\":[],\"Data\":\"Hello Mars\"}" | ipfs object put &&
+    ipfs object get --data-encoding text QmS3hVY6eYrMQ6L22agwrx3YHBEsc3LJxVXCtyQHqRBukH > obj_out &&
+    echo "{\"Links\":[],\"Data\":\"Hello Mars\"}" > obj_exp &&
+    test_cmp obj_out obj_exp
+  '
+
+  test_expect_failure "'ipfs object get' requires known data encoding" '
+    ipfs object get --data-encoding nonsensical-encoding $HASH
+  '
+
   test_expect_success "'ipfs object stat' succeeds" '
     ipfs object stat $HASH >actual_stat
   '


### PR DESCRIPTION
Adds a `--data-encoding` flag to `ipfs object get` to let the user specify base64 encoding for object data.

I've found that the text encoding used by default can get mangled during JSON serialisation/deserialisation so using base64 instead seems to make it more resilient.

This allows the test in ipfs/interface-ipfs-core#302 to pass.

--

I've not written much go, so hopefully this PR is ok - I couldn't find much in the way of unit tests around the `ipfs object` commands though may just have been looking in the wrong place so have added a sharness test.