### PR TITLE
Feat: pin add --max-depth (arbitrary depth recursive pins)

### DIFF
--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -86,18 +86,16 @@ var addPinCmd = &cmds.Command{
 			return
 		}
 
-		if !recursive {
+		switch {
+		case !recursive:
 			maxDepth = 0
-		}
-
-		if recursive && maxDepth == 0 {
+		case recursive && maxDepth == 0:
 			res.SetError(
 				errors.New("invalid --max-depth=0. Use a direct pin instead"),
 				cmdkit.ErrNormal,
 			)
-		}
-
-		if recursive && maxDepth <= 0 {
+			return
+		case !recursive && maxDepth < 0:
 			maxDepth = -1
 		}
 

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	path "github.com/ipfs/go-ipfs/path"
+	"github.com/ipfs/go-ipfs/thirdparty/recpinset"
 
 	ipld "gx/ipfs/QmWi2BYBL5gJ3CiAiQchg6rn1A8iBsrWy51EYxvHVjFvLb/go-ipld-format"
 	cid "gx/ipfs/QmapdYm1b22Frv3k17fqrBYTFRxwiaVJkB299Mfn33edeB/go-cid"
@@ -64,6 +65,7 @@ NOTE: List all references recursively by using the flag '-r'.
 		cmdkit.BoolOption("edges", "e", "Emit edge format: `<from> -> <to>`."),
 		cmdkit.BoolOption("unique", "u", "Omit duplicate refs from output."),
 		cmdkit.BoolOption("recursive", "r", "Recursively list links of child nodes."),
+		cmdkit.IntOption("max-depth", "Only for recursive depths, list down to a maximum branch depth").WithDefault(-1),
 	},
 	Run: func(req cmds.Request, res cmds.Response) {
 		ctx := req.Context()
@@ -83,6 +85,25 @@ NOTE: List all references recursively by using the flag '-r'.
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
+		}
+
+		maxDepth, _, err := req.Option("max-depth").Int()
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
+		switch {
+		case !recursive:
+			maxDepth = 0
+		case recursive && maxDepth == 0:
+			res.SetError(
+				errors.New("invalid --max-depth=0 for recursive references"),
+				cmdkit.ErrNormal,
+			)
+			return
+		case !recursive && maxDepth < 0:
+			maxDepth = -1
 		}
 
 		format, _, err := req.Option("format").String()
@@ -125,6 +146,7 @@ NOTE: List all references recursively by using the flag '-r'.
 				Unique:    unique,
 				PrintFmt:  format,
 				Recursive: recursive,
+				MaxDepth:  maxDepth,
 			}
 
 			for _, o := range objs {
@@ -233,31 +255,45 @@ type RefWriter struct {
 
 	Unique    bool
 	Recursive bool
+	MaxDepth  int
 	PrintFmt  string
 
-	seen *cid.Set
+	explored *recpinset.Set
 }
 
 // WriteRefs writes refs of the given object to the underlying writer.
 func (rw *RefWriter) WriteRefs(n ipld.Node) (int, error) {
+	maxDepth := 1 // single
 	if rw.Recursive {
-		return rw.writeRefsRecursive(n)
+		maxDepth = rw.MaxDepth
 	}
-	return rw.writeRefsSingle(n)
+
+	return rw.writeRefsRecursive(n, maxDepth)
 }
 
-func (rw *RefWriter) writeRefsRecursive(n ipld.Node) (int, error) {
+func (rw *RefWriter) writeRefsRecursive(n ipld.Node, maxDepth int) (int, error) {
+	if maxDepth == 0 {
+		return 0, nil
+	}
+
+	if maxDepth > 0 {
+		maxDepth--
+	}
+
 	nc := n.Cid()
 
 	var count int
 	for i, ng := range ipld.GetDAG(rw.Ctx, rw.DAG, n) {
 		lc := n.Links()[i].Cid
-		if rw.skip(lc) {
+		skipWrite, skipExplore := rw.skip(lc, maxDepth)
+		if skipExplore {
 			continue
 		}
 
-		if err := rw.WriteEdge(nc, lc, n.Links()[i].Name); err != nil {
-			return count, err
+		if !skipWrite {
+			if err := rw.WriteEdge(nc, lc, n.Links()[i].Name); err != nil {
+				return count, err
+			}
 		}
 
 		nd, err := ng.Get(rw.Ctx)
@@ -265,7 +301,7 @@ func (rw *RefWriter) writeRefsRecursive(n ipld.Node) (int, error) {
 			return count, err
 		}
 
-		c, err := rw.writeRefsRecursive(nd)
+		c, err := rw.writeRefsRecursive(nd, maxDepth)
 		count += c
 		if err != nil {
 			return count, err
@@ -274,43 +310,20 @@ func (rw *RefWriter) writeRefsRecursive(n ipld.Node) (int, error) {
 	return count, nil
 }
 
-func (rw *RefWriter) writeRefsSingle(n ipld.Node) (int, error) {
-	c := n.Cid()
-
-	if rw.skip(c) {
-		return 0, nil
-	}
-
-	count := 0
-	for _, l := range n.Links() {
-		lc := l.Cid
-		if rw.skip(lc) {
-			continue
-		}
-
-		if err := rw.WriteEdge(c, lc, l.Name); err != nil {
-			return count, err
-		}
-		count++
-	}
-	return count, nil
-}
-
-// skip returns whether to skip a cid
-func (rw *RefWriter) skip(c *cid.Cid) bool {
+// skip returns whether a cid has been seen (skip write) and whether
+// a cid branch has been explored (skip explore)
+func (rw *RefWriter) skip(c *cid.Cid, depth int) (bool, bool) {
 	if !rw.Unique {
-		return false
+		return false, false
 	}
 
-	if rw.seen == nil {
-		rw.seen = cid.NewSet()
+	if rw.explored == nil {
+		rw.explored = recpinset.New()
 	}
 
-	has := rw.seen.Has(c)
-	if !has {
-		rw.seen.Add(c)
-	}
-	return has
+	skipWrite := rw.explored.Has(c)
+
+	return skipWrite, !rw.explored.Visit(c, depth)
 }
 
 // Write one edge

--- a/core/coreapi/interface/options/pin.go
+++ b/core/coreapi/interface/options/pin.go
@@ -2,6 +2,7 @@ package options
 
 type PinAddSettings struct {
 	Recursive bool
+	MaxDepth  int
 }
 
 type PinLsSettings struct {
@@ -19,6 +20,7 @@ type PinUpdateOption func(*PinUpdateSettings) error
 func PinAddOptions(opts ...PinAddOption) (*PinAddSettings, error) {
 	options := &PinAddSettings{
 		Recursive: true,
+		MaxDepth:  -1,
 	}
 
 	for _, opt := range opts {

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -25,7 +25,10 @@ import (
 	cid "gx/ipfs/QmapdYm1b22Frv3k17fqrBYTFRxwiaVJkB299Mfn33edeB/go-cid"
 )
 
-func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) ([]*cid.Cid, error) {
+// Pin pins the given paths (after resolving) with the given maxDepth. maxDepth=-1
+// means pin "recursively". maxDepth=0 means pin "direct". maxDepth > 0 means
+// pins recursively with a depth limit.
+func Pin(n *core.IpfsNode, ctx context.Context, paths []string, maxDepth int) ([]*cid.Cid, error) {
 	out := make([]*cid.Cid, len(paths))
 
 	r := &resolver.Resolver{
@@ -43,7 +46,7 @@ func Pin(n *core.IpfsNode, ctx context.Context, paths []string, recursive bool) 
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}
-		err = n.Pinning.Pin(ctx, dagnode, recursive)
+		err = n.Pinning.PinMaxDepth(ctx, dagnode, maxDepth)
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}

--- a/merkledag/merkledag_test.go
+++ b/merkledag/merkledag_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/ipfs/go-ipfs/merkledag"
 	mdpb "github.com/ipfs/go-ipfs/merkledag/pb"
 	dstest "github.com/ipfs/go-ipfs/merkledag/test"
+	"github.com/ipfs/go-ipfs/thirdparty/recpinset"
 
 	u "gx/ipfs/QmPdKqUcHGFdeSpvjVoaTRPPstGif9GBZb5Q56RVw9o69A/go-ipfs-util"
 	offline "gx/ipfs/QmPf114DXfa6TqGKYhBGR7EtXRho4rCJgwyA1xkuMY5vwF/go-ipfs-exchange-offline"
@@ -124,6 +125,36 @@ func TestBatchFetch(t *testing.T) {
 func TestBatchFetchDupBlock(t *testing.T) {
 	read := io.LimitReader(devZero{}, 1024*32)
 	runBatchFetchTest(t, read)
+}
+
+// makeDepthTestingGraph makes a small DAG with two levels. The level-two
+// nodes are both children of the root and of one of the level 1 nodes.
+// This is meant to test the EnumerateChildren*MaxDepth functions.
+func makeDepthTestingGraph(t *testing.T, ds ipld.DAGService) ipld.Node {
+	root := NodeWithData(nil)
+	l11 := NodeWithData([]byte("leve1_node1"))
+	l12 := NodeWithData([]byte("leve1_node1"))
+	l21 := NodeWithData([]byte("leve2_node1"))
+	l22 := NodeWithData([]byte("leve2_node2"))
+	l23 := NodeWithData([]byte("leve2_node3"))
+
+	l11.AddNodeLink(l21.Cid().String(), l21)
+	l11.AddNodeLink(l23.Cid().String(), l22)
+	l11.AddNodeLink(l23.Cid().String(), l23)
+
+	root.AddNodeLink(l11.Cid().String(), l11)
+	root.AddNodeLink(l12.Cid().String(), l12)
+	root.AddNodeLink(l23.Cid().String(), l23)
+
+	ctx := context.Background()
+	for _, n := range []ipld.Node{l23, l22, l21, l12, l11, root} {
+		err := ds.Add(ctx, n)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return root
 }
 
 // makeTestDAG creates a simple DAG from the data in a reader.
@@ -293,6 +324,22 @@ func TestFetchGraph(t *testing.T) {
 	}
 }
 
+// Check that all children of root are in the given set and in the datastore
+func traverseAndCheck(t *testing.T, root ipld.Node, ds ipld.DAGService, set *cid.Set) {
+	// traverse dag and check
+	for _, lnk := range root.Links() {
+		c := lnk.Cid
+		if !set.Has(c) {
+			t.Fatal("missing key in set! ", lnk.Cid.String())
+		}
+		child, err := ds.Get(context.Background(), c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		traverseAndCheck(t, child, ds, set)
+	}
+}
+
 func TestEnumerateChildren(t *testing.T) {
 	bsi := bstest.Mocks(1)
 	ds := NewDAGService(bsi[0])
@@ -307,23 +354,100 @@ func TestEnumerateChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var traverse func(n ipld.Node)
-	traverse = func(n ipld.Node) {
-		// traverse dag and check
-		for _, lnk := range n.Links() {
-			c := lnk.Cid
-			if !set.Has(c) {
-				t.Fatal("missing key in set! ", lnk.Cid.String())
-			}
-			child, err := ds.Get(context.Background(), c)
-			if err != nil {
-				t.Fatal(err)
-			}
-			traverse(child)
+	traverseAndCheck(t, root, ds, set)
+}
+
+func TestEnumerateChildrenMaxDepth(t *testing.T) {
+	bsi := bstest.Mocks(1)
+	ds := NewDAGService(bsi[0])
+	root := makeDepthTestingGraph(t, ds)
+
+	type testcase struct {
+		depth       int
+		expectedLen int
+	}
+
+	tests := []testcase{
+		testcase{1, 3},
+		testcase{0, 0},
+		testcase{-1, 5},
+	}
+
+	testF := func(t *testing.T, tc testcase) {
+		set := recpinset.New()
+		err := EnumerateChildrenMaxDepth(
+			context.Background(),
+			ds.GetLinks,
+			root.Cid(),
+			tc.depth,
+			set.Visit,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l := len(set.Keys()); l != tc.expectedLen {
+			t.Errorf("expected %d keys and got %d", tc.expectedLen, l)
 		}
 	}
 
-	traverse(root)
+	for _, tc := range tests {
+		testF(t, tc)
+	}
+}
+
+func TestEnumerateChildrenAsync(t *testing.T) {
+	bsi := bstest.Mocks(1)
+	ds := NewDAGService(bsi[0])
+
+	read := io.LimitReader(u.NewTimeSeededRand(), 1024*1024)
+	root := makeTestDAG(t, read, ds)
+
+	set := cid.NewSet()
+
+	err := EnumerateChildrenAsync(context.Background(), ds.GetLinks, root.Cid(), set.Visit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	traverseAndCheck(t, root, ds, set)
+}
+
+func TestEnumerateChildrenAsyncMaxDepth(t *testing.T) {
+	bsi := bstest.Mocks(1)
+	ds := NewDAGService(bsi[0])
+	root := makeDepthTestingGraph(t, ds)
+
+	type testcase struct {
+		depth       int
+		expectedLen int
+	}
+
+	tests := []testcase{
+		testcase{1, 4},
+		testcase{0, 1},
+		testcase{-1, 6},
+	}
+
+	testF := func(t *testing.T, tc testcase) {
+		set := recpinset.New()
+		err := EnumerateChildrenAsyncMaxDepth(
+			context.Background(),
+			ds.GetLinks,
+			root.Cid(),
+			tc.depth,
+			set.Visit,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l := len(set.Keys()); l != tc.expectedLen {
+			t.Errorf("expected %d keys and got %d", tc.expectedLen, l)
+		}
+	}
+
+	for _, tc := range tests {
+		testF(t, tc)
+	}
 }
 
 func TestFetchFailure(t *testing.T) {

--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -169,7 +169,6 @@ func DescendantsMaxDepth(ctx context.Context, getLinks dag.GetLinks, set *cid.Se
 
 	for _, recPin := range roots {
 		set.Add(recPin.Cid)
-
 		// EnumerateChildren recursively walks the dag and adds the keys to the given set
 		err := dag.EnumerateChildrenMaxDepth(
 			ctx,
@@ -231,10 +230,10 @@ func ColoredSet(ctx context.Context, pn pin.Pinner, ng ipld.NodeGetter, bestEffo
 		gcs.Add(k)
 	}
 
-	err = Descendants(ctx, getLinks, gcs, pn.InternalPins())
-	if err != nil {
-		errors = true
-		output <- Result{Error: err}
+	// Internal pins are direct + recursive + empty + root cid
+	// so we can treat them as direct.
+	for _, k := range pn.InternalPins() {
+		gcs.Add(k)
 	}
 
 	if errors {

--- a/thirdparty/recpinset/recpinset.go
+++ b/thirdparty/recpinset/recpinset.go
@@ -1,0 +1,130 @@
+package recpinset
+
+import (
+	cid "gx/ipfs/QmapdYm1b22Frv3k17fqrBYTFRxwiaVJkB299Mfn33edeB/go-cid"
+)
+
+// Set stores a set of recursive pins (Cid,MaxDepth tuples), indexed by Cid.
+// A MaxDepth of -1 means fully no-limit recursive pin.
+type Set struct {
+	set map[string]int
+}
+
+// RecPin represents a recursive Pin, that is, a CID and a MaxDepth that
+// limits the depth to which the CID is pinned. A negative MaxDepth represents
+// a unlimited-depth pin.
+type RecPin struct {
+	Cid      *cid.Cid
+	MaxDepth int
+}
+
+// New initializes and returns a new Set.
+func New() *Set {
+	return &Set{set: make(map[string]int)}
+}
+
+// Add puts a Cid and the maxDepth associated to it in the Set.
+func (s *Set) Add(c *cid.Cid, maxDepth int) {
+	s.set[string(c.Bytes())] = maxDepth
+}
+
+// Has returns if the Set contains a given Cid.
+func (s *Set) Has(c *cid.Cid) bool {
+	_, ok := s.set[string(c.Bytes())]
+	return ok
+}
+
+// Get returns the RecPin associated to the given Cid.
+func (s *Set) Get(c *cid.Cid) (*RecPin, bool) {
+	md, ok := s.set[string(c.Bytes())]
+	if !ok {
+		return nil, false
+	}
+
+	return &RecPin{c, md}, ok
+}
+
+// MaxDepth returns the MaxDepth associated to the given Cid.
+func (s *Set) MaxDepth(c *cid.Cid) (int, bool) {
+	md, ok := s.set[string(c.Bytes())]
+	return md, ok
+}
+
+// Remove deletes a Cid from the Set.
+func (s *Set) Remove(c *cid.Cid) {
+	delete(s.set, string(c.Bytes()))
+}
+
+// Len returns how many elements the Set has.
+func (s *Set) Len() int {
+	return len(s.set)
+}
+
+// Keys returns the Cids in the set.
+func (s *Set) Keys() []*cid.Cid {
+	out := make([]*cid.Cid, 0, len(s.set))
+	for k := range s.set {
+		c, _ := cid.Cast([]byte(k))
+		out = append(out, c)
+	}
+	return out
+}
+
+// RecPins returns all the Cid+MaxDepths stored in the set,
+// in a slice of RecPins.
+func (s *Set) RecPins() []*RecPin {
+	out := make([]*RecPin, 0, len(s.set))
+	for k, v := range s.set {
+		c, _ := cid.Cast([]byte(k))
+		out = append(out, &RecPin{c, v})
+	}
+	return out
+}
+
+// Visit adds a cid and maxDepth to the set if:
+// - it is not already in the set
+// - if it's in the set but the new maxDepth is greater than
+// the existing.
+// It returns true if the RecPin has been added.
+func (s *Set) Visit(c *cid.Cid, maxDepth int) bool {
+	curMaxDepth, ok := s.set[string(c.Bytes())]
+
+	if !ok || IsDeeper(maxDepth, curMaxDepth) {
+		s.Add(c, maxDepth)
+		return true
+	}
+
+	return false
+}
+
+// ForEach allows to run a custom function on each
+// Cid in the set.
+func (s *Set) ForEach(f func(c *cid.Cid, maxDepth int) error) error {
+	for cs, md := range s.set {
+		c, _ := cid.Cast([]byte(cs))
+		err := f(c, md)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Returns true if d1 is deeper than d2
+// Takes into account that -1 is deeper than anything.
+func IsDeeper(d1, d2 int) bool {
+	// if d2 is negative, nothing is deeper: no
+	if d2 < 0 {
+		return false
+	}
+
+	// d2 is >= 0 here.
+
+	// if d1 is negative, yes
+	if d1 < 0 {
+		return true
+	}
+
+	// if d1 > d2, yes
+	return d1 > d2
+}


### PR DESCRIPTION
This implements #5133 introducing an option to limit how deep we fetch and store
the DAG associated to a recursive pin ("--max-depth"). This feature
comes motivated by the need to fetch and pin partial DAGs in order to do
DAG sharding with IPFS Cluster.

This means that, when pinning something to --max-depth, the DAG will be
fetched only to that depth and not more.

In order to get this, the PR introduces new recursive pin types: "recursive1"
means: the given CID is pinned along with its direct children (maxDepth=1)

"recursive2" means: the given CID is pinned along with its direct children
and its grandchildren.

And so on...

This required introducing "maxDepth" limits to all the functions walking down
DAGs (in merkledag, pin, core/commands, core/coreapi, exchange/reprovide modules).

maxDepth == -1 effectively acts as no-limit, and all these functions behave like
they did before.

In order to facilitate the task, a new CID Set type has been added:
thirdparty/recpinset. This set carries the MaxDepth associated to every Cid.
This allows to shortcut exploring already explored branches just like the original
cid.Set does. It also allows to store the Recursive pinset (and replaces cid.Set).
recpinset should be moved outside to a different repo eventually.

TODO: tests
TODO: refs -r with --max-depth

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>