### PR TITLE
explicitly import go-multiaddr-dns in config/bootstrap_peers

### DIFF
--- a/repo/config/bootstrap_peers.go
+++ b/repo/config/bootstrap_peers.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	iaddr "gx/ipfs/QmaKviZCLQrpuyFdSjteik7kJFcQpcyZgb1VuuwaCBBaEa/go-ipfs-addr"
+	// Needs to be imported so that users can import this package directly
+	// and still parse the bootstrap addresses.
+	_ "gx/ipfs/QmT8461vVVyBPyHJHQ6mvm8UdQ8UZNA5n6Z7kBk7GRf1xu/go-multiaddr-dns"
 )
 
 // DefaultBootstrapAddresses are the hardcoded bootstrap addresses


### PR DESCRIPTION
We need it to parse the dnsaddr addresses. While we import it elsewhere, we
should really be importing it every where we need it so that other users can
import our packages directly.

fixes #5143