### PR TITLE
always try to read ahead by at least 5 blocks in the PBDagReader

### DIFF
--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -75,9 +75,7 @@ func (dr *PBDagReader) preloadNextNodes(ctx context.Context) {
 		end = len(dr.links)
 	}
 
-	for i, p := range ipld.GetNodes(ctx, dr.serv, dr.links[beg:end]) {
-		dr.promises[beg+i] = p
-	}
+	copy(dr.promises[beg:], ipld.GetNodes(ctx, dr.serv, dr.links[beg:end]))
 }
 
 // precalcNextBuf follows the next link in line and loads it from the

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -110,6 +110,11 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 		// In this case, the context used to *preload* the node has been canceled.
 		// We need to retry the load with our context and we might as
 		// well preload some extra nodes while we're at it.
+		//
+		// Note: When using `Read`, this code will never execute as
+		// `Read` will use the global context. It only runs if the user
+		// explicitly reads with a custom context (e.g., by calling
+		// `CtxReadFull`).
 		dr.preload(ctx, dr.linkPosition)
 		nxt, err = dr.promises[dr.linkPosition].Get(ctx)
 		dr.promises[dr.linkPosition] = nil


### PR DESCRIPTION
This should reduce stuttering when streaming.

Also, fix an unlikely bug where canceling a context from one read could fail a future read.