### PR TITLE
core/commands/ls: wrap `NewDirectoryFromNode` error

### DIFF
--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -112,7 +112,7 @@ The JSON output contains type information.
 		for i, dagnode := range dagnodes {
 			dir, err := uio.NewDirectoryFromNode(nd.DAG, dagnode)
 			if err != nil && err != uio.ErrNotADir {
-				res.SetError(err, cmdkit.ErrNormal)
+				res.SetError(fmt.Errorf("the data in %s (at %q) is not a UnixFS directory: %s", dagnode.Cid(), paths[i], err), cmdkit.ErrNormal)
 				return
 			}
 


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-ipfs/issues/5165.