### PR TITLE
[WIP][PoC] analyze MFS `Close()`

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -586,10 +586,6 @@ func (n *IpfsNode) teardown() error {
 	// needs to use another during its shutdown/cleanup process, it should be
 	// closed before that other object
 
-	if n.FilesRoot != nil {
-		closers = append(closers, n.FilesRoot)
-	}
-
 	if n.Exchange != nil {
 		closers = append(closers, n.Exchange)
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -241,11 +241,6 @@ func (adder *Adder) Finalize() (ipld.Node, error) {
 		return nil, err
 	}
 
-	err = mr.Close()
-	if err != nil {
-		return nil, err
-	}
-
 	return root.GetNode()
 }
 

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -102,7 +102,6 @@ type mountWrap struct {
 }
 
 func (m *mountWrap) Close() error {
-	m.Fs.Destroy()
 	m.Mount.Close()
 	return nil
 }

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -62,13 +62,6 @@ func (f *FileSystem) Root() (fs.Node, error) {
 	return f.RootNode, nil
 }
 
-func (f *FileSystem) Destroy() {
-	err := f.RootNode.Close()
-	if err != nil {
-		log.Errorf("Error Shutting Down Filesystem: %s\n", err)
-	}
-}
-
 // Root is the root object of the filesystem tree.
 type Root struct {
 	Ipfs *core.IpfsNode
@@ -217,25 +210,6 @@ func (s *Root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 
 	log.Error("Invalid path.Path: ", resolved)
 	return nil, errors.New("invalid path from ipns record")
-}
-
-func (r *Root) Close() error {
-	for _, mr := range r.Roots {
-		err := mr.root.Close()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Forget is called when the filesystem is unmounted. probably.
-// see comments here: http://godoc.org/bazil.org/fuse/fs#FSDestroyer
-func (r *Root) Forget() {
-	err := r.Close()
-	if err != nil {
-		log.Error(err)
-	}
 }
 
 // ReadDirAll reads a particular directory. Will show locally available keys

--- a/mfs/system.go
+++ b/mfs/system.go
@@ -171,20 +171,6 @@ func (kr *Root) closeChild(name string, nd ipld.Node, sync bool) error {
 	return nil
 }
 
-func (kr *Root) Close() error {
-	nd, err := kr.GetValue().GetNode()
-	if err != nil {
-		return err
-	}
-
-	if kr.repub != nil {
-		kr.repub.Update(nd.Cid())
-		return kr.repub.Close()
-	}
-
-	return nil
-}
-
 // Republisher manages when to publish a given entry.
 type Republisher struct {
 	TimeoutLong  time.Duration


### PR DESCRIPTION
Do not merge.

-------
```
[WIP][PoC] coreunix: remove MFS `Close()` from `Finalize()`

I would tend to think that this is handled through `closeChild()` and
`Directory`'s `Flush()` (if responsibly called).
```
-------
```
[WIP][PoC] mfs: remove `Close()` from `Root()`

And the functions of its only consumer, IPNS.
```
-------

The first commit passes the tests (Jenkins doesn't count), the second one doesn't, which make sense: IPNS doesn't use the `closeChild()` and related functions (I'm imagining), modifications are not signaled to MFS as the `ipfs files` commands do (MFS files are just being modified by the filesystem) so it does need an explicit `Close()` call.

If this reasoning is correct we can eliminate the `Close()` call from the `coreunix` package (first commit) and document the function as being used only by IPNS, this will largely clarify its relationship with `closeChild()`.

To do: address this in https://github.com/ipfs/go-ipfs/issues/5092.
