### PR TITLE
mfs: add `Inode` interface

### DIFF
--- a/mfs/fd.go
+++ b/mfs/fd.go
@@ -122,15 +122,15 @@ func (fi *fileDescriptor) flushUp(fullsync bool) error {
 		return err
 	}
 
-	err = fi.inode.dserv.Add(context.TODO(), nd)
+	err = fi.inode.DagService().Add(context.TODO(), nd)
 	if err != nil {
 		return err
 	}
 
 	fi.inode.nodelk.Lock()
 	fi.inode.node = nd
-	name := fi.inode.name
-	parent := fi.inode.parent
+	name := fi.inode.Name()
+	parent := fi.inode.Parent()
 	fi.inode.nodelk.Unlock()
 
 	return parent.closeChild(name, nd, fullsync)

--- a/mfs/inode.go
+++ b/mfs/inode.go
@@ -1,0 +1,54 @@
+package mfs
+
+import (
+	ipld "gx/ipfs/QmWi2BYBL5gJ3CiAiQchg6rn1A8iBsrWy51EYxvHVjFvLb/go-ipld-format"
+)
+
+// Inode abstracts the common characteristics of the MFS `File`
+// and `Directory`. All of its attributes are initialized at
+// creation and can't be modified.
+type Inode interface {
+
+	// Name of this `Inode` in the MFS path (the same value
+	// is also stored as the name of the DAG link).
+	Name() string
+
+	// Parent directory of this `Inode` (which may be the `Root`).
+	Parent() childCloser
+
+	// DagService used to store modifications made to the contents
+	// of the file or directory the `Inode` belongs to.
+	DagService() ipld.DAGService
+}
+
+// inode implements the `Inode` interface.
+type inode struct {
+	name       string
+	parent     childCloser
+	dagService ipld.DAGService
+}
+
+// NewInode creates a new `inode` structure and returns its pointer
+// as the `Inode` interface.
+func NewInode(name string, parent childCloser, dagService ipld.DAGService) Inode {
+	return &inode{
+		name:       name,
+		parent:     parent,
+		dagService: dagService,
+	}
+}
+
+// Name implements the `Inode` interface.
+func (i *inode) Name() string {
+	return i.name
+}
+
+// Parent implements the `Inode` interface.
+func (i *inode) Parent() childCloser {
+	return i.parent
+}
+
+// DagService implements the `Inode` interface.
+func (i *inode) DagService() ipld.DAGService {
+	return i.dagService
+}

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -555,7 +555,7 @@ func actorMakeFile(d *Directory) error {
 	}
 
 	name := randomName()
-	f, err := NewFile(name, dag.NodeWithData(ft.FilePBData(nil, 0)), d, d.dserv)
+	f, err := NewFile(name, dag.NodeWithData(ft.FilePBData(nil, 0)), d, d.DagService())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As suggested in https://github.com/ipfs/go-ipfs/issues/5094#issuecomment-395710376.

--------------

```
mfs: add `Inode` interface

Abstract common characteristics of the MFS `File` and `Directory` structures
inside a separate interface called `Ìnode`.
```

-----------

Closes #5094.