### PR TITLE
gateway: Mutable Filesystem accessablity

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -546,7 +546,7 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		corehttp.CommandsROOption(*cctx),
 		corehttp.VersionOption(),
 		corehttp.IPNSHostnameOption(),
-		corehttp.GatewayOption(writable, "/ipfs", "/ipns"),
+		corehttp.GatewayOption(writable, "/ipfs", "/ipns", "/~"),
 	}
 
 	if len(cfg.Gateway.RootRedirect) > 0 {

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -35,7 +35,7 @@ import (
 const (
 	ipfsPathPrefix = "/ipfs/"
 	ipnsPathPrefix = "/ipns/"
-	mfsPathPrefix  = "/~/"
+	mfsPathPrefix  = "/local/"
 )
 
 // gatewayHandler is a HTTP handler that serves IPFS objects (accessible by default at /ipfs/<path>)


### PR DESCRIPTION
URL paths beginning with /~/ will grant access to the mfs from the gateway.
The prefix can be changed to /mfs/ if that is more desirable.

License: MIT
Signed-off-by: Jeremia Dominguez <ragef33@gmail.com>