### PR TITLE
Add support for datastore plugins

### DIFF
--- a/plugin/datastore.go
+++ b/plugin/datastore.go
@@ -1,0 +1,14 @@
+package plugin
+
+import (
+	"github.com/ipfs/go-ipfs/repo/fsrepo"
+)
+
+// PluginDatastore is an interface that can be implemented to add handlers for
+// for different datastores
+type PluginDatastore interface {
+	Plugin
+
+	DatastoreTypeName() string
+	DatastoreConfigParser() fsrepo.ConfigFromMap
+}

--- a/plugin/loader/initializer.go
+++ b/plugin/loader/initializer.go
@@ -3,8 +3,9 @@ package loader
 import (
 	"github.com/ipfs/go-ipfs/core/coredag"
 	"github.com/ipfs/go-ipfs/plugin"
-	"gx/ipfs/QmWLWmRVSiagqP15jczsGME1qpob6HDbtbHAY2he9W5iUo/opentracing-go"
+	"github.com/ipfs/go-ipfs/repo/fsrepo"
 
+	"gx/ipfs/QmWLWmRVSiagqP15jczsGME1qpob6HDbtbHAY2he9W5iUo/opentracing-go"
 	ipld "gx/ipfs/QmdDXJs4axxefSPgK6Y1QhpJWKuDPnGJiqgq4uncb4rFHL/go-ipld-format"
 )
 
@@ -29,6 +30,11 @@ func run(plugins []plugin.Plugin) error {
 			}
 		case plugin.PluginTracer:
 			err := runTracerPlugin(pl)
+			if err != nil {
+				return err
+			}
+		case plugin.PluginDatastore:
+			err := fsrepo.AddDatastoreConfigHandler(pl.DatastoreTypeName(), pl.DatastoreConfigParser())
 			if err != nil {
 				return err
 			}

--- a/repo/fsrepo/datastores.go
+++ b/repo/fsrepo/datastores.go
@@ -36,7 +36,12 @@ type DatastoreConfig interface {
 	Create(path string) (repo.Datastore, error)
 }
 
-// DiskSpec is the type returned by the DatastoreConfig's DiskSpec method
+// DiskSpec is a minimal representation of the characteristic values of the
+// datastore. If two diskspecs are the same, the loader assumes that they refer
+// to exactly the same datastore. If they differ at all, it is assumed they are
+// completely different datastores and a migration will be performed. Runtime
+// values such as cache options or concurrency options should not be added
+// here.
 type DiskSpec map[string]interface{}
 
 // Bytes returns a minimal JSON encoding of the DiskSpec
@@ -66,6 +71,16 @@ func init() {
 		"log":      LogDatastoreConfig,
 		"measure":  MeasureDatastoreConfig,
 	}
+}
+
+func AddDatastoreConfigHandler(name string, dsc ConfigFromMap) error {
+	_, ok := datastores[name]
+	if ok {
+		return fmt.Errorf("already have a datastore named %q", name)
+	}
+
+	datastores[name] = dsc
+	return nil
 }
 
 // AnyDatastoreConfig returns a DatastoreConfig from a spec based on


### PR DESCRIPTION
This will make it a little bit easier to write your own datastores for ipfs (at least on platforms that go supports plugins >.>).

The next step is making it easier to initialize ipfs with a given datastore config