### PR TITLE
dagreader: remove `Offset()` method

### DIFF
--- a/unixfs/io/bufdagreader.go
+++ b/unixfs/io/bufdagreader.go
@@ -3,7 +3,6 @@ package io
 import (
 	"bytes"
 	"context"
-	"io"
 )
 
 // BufDagReader implements a DagReader that reads from a byte slice
@@ -28,15 +27,6 @@ func (*BufDagReader) Close() error {
 // CtxReadFull reads the slice onto b.
 func (rd *BufDagReader) CtxReadFull(ctx context.Context, b []byte) (int, error) {
 	return rd.Read(b)
-}
-
-// Offset returns the current offset.
-func (rd *BufDagReader) Offset() int64 {
-	of, err := rd.Seek(0, io.SeekCurrent)
-	if err != nil {
-		panic("this should never happen " + err.Error())
-	}
-	return of
 }
 
 // Size returns the size of the buffer.

--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -27,7 +27,6 @@ type DagReader interface {
 	ReadSeekCloser
 	Size() uint64
 	CtxReadFull(context.Context, []byte) (int, error)
-	Offset() int64
 }
 
 // A ReadSeekCloser implements interfaces to read, copy, seek and close.

--- a/unixfs/io/dagreader_test.go
+++ b/unixfs/io/dagreader_test.go
@@ -57,7 +57,7 @@ func TestSeekAndRead(t *testing.T) {
 	for i := 255; i >= 0; i-- {
 		reader.Seek(int64(i), io.SeekStart)
 
-		if reader.Offset() != int64(i) {
+		if getOffset(reader) != int64(i) {
 			t.Fatal("expected offset to be increased by one after read")
 		}
 
@@ -67,7 +67,7 @@ func TestSeekAndRead(t *testing.T) {
 			t.Fatalf("read %d at index %d, expected %d", out, i, i)
 		}
 
-		if reader.Offset() != int64(i+1) {
+		if getOffset(reader) != int64(i+1) {
 			t.Fatal("expected offset to be increased by one after read")
 		}
 	}
@@ -142,12 +142,12 @@ func TestRelativeSeek(t *testing.T) {
 	}
 
 	for i := 0; i < 256; i++ {
-		if reader.Offset() != int64(i*4) {
-			t.Fatalf("offset should be %d, was %d", i*4, reader.Offset())
+		if getOffset(reader) != int64(i*4) {
+			t.Fatalf("offset should be %d, was %d", i*4, getOffset(reader))
 		}
 		out := readByte(t, reader)
 		if int(out) != i {
-			t.Fatalf("expected to read: %d at %d, read %d", i, reader.Offset()-1, out)
+			t.Fatalf("expected to read: %d at %d, read %d", i, getOffset(reader)-1, out)
 		}
 		if i != 255 {
 			_, err := reader.Seek(3, io.SeekCurrent)
@@ -163,12 +163,12 @@ func TestRelativeSeek(t *testing.T) {
 	}
 
 	for i := 0; i < 256; i++ {
-		if reader.Offset() != int64(1020-i*4) {
-			t.Fatalf("offset should be %d, was %d", 1020-i*4, reader.Offset())
+		if getOffset(reader) != int64(1020-i*4) {
+			t.Fatalf("offset should be %d, was %d", 1020-i*4, getOffset(reader))
 		}
 		out := readByte(t, reader)
 		if int(out) != 255-i {
-			t.Fatalf("expected to read: %d at %d, read %d", 255-i, reader.Offset()-1, out)
+			t.Fatalf("expected to read: %d at %d, read %d", 255-i, getOffset(reader)-1, out)
 		}
 		reader.Seek(-5, io.SeekCurrent) // seek 4 bytes but we read one byte every time so 5 bytes
 	}
@@ -301,4 +301,12 @@ func readByte(t testing.TB, reader DagReader) byte {
 	}
 
 	return out[0]
+}
+
+func getOffset(reader DagReader) int64 {
+	offset, err := reader.Seek(0, io.SeekCurrent)
+	if err != nil {
+		panic("failed to retrieve offset: " + err.Error())
+	}
+	return offset
 }

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -225,11 +225,6 @@ func (dr *PBDagReader) Close() error {
 	return nil
 }
 
-// Offset returns the current reader offset
-func (dr *PBDagReader) Offset() int64 {
-	return dr.offset
-}
-
 // Seek implements io.Seeker, and will seek to a given offset in the file
 // interface matches standard unix seek
 // TODO: check if we can do relative seeks, to reduce the amount of dagreader

--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -663,7 +663,7 @@ func testReadAndSeek(t *testing.T, opts testu.NodeOpts) {
 	// skip 4
 	_, err = dagmod.Seek(1, io.SeekCurrent)
 	if err != nil {
-		t.Fatalf("error: %s, offset %d, reader offset %d", err, dagmod.curWrOff, dagmod.read.Offset())
+		t.Fatalf("error: %s, offset %d, reader offset %d", err, dagmod.curWrOff, getOffset(dagmod.read))
 	}
 
 	//read 5,6,7
@@ -749,4 +749,12 @@ func BenchmarkDagmodWrite(b *testing.B) {
 			b.Fatal("Wrote bad size")
 		}
 	}
+}
+
+func getOffset(reader uio.DagReader) int64 {
+	offset, err := reader.Seek(0, io.SeekCurrent)
+	if err != nil {
+		panic("failed to retrieve offset: " + err.Error())
+	}
+	return offset
 }


### PR DESCRIPTION
Remove `Offset()` from the `DagReader` interface. It's not part of the Unix API
and it wasn't used anywhere except for the tests (a helper function was added to
replace it).