### PR TITLE
when running an external command, only construct a node if running in online mode

### DIFF
--- a/core/commands/external.go
+++ b/core/commands/external.go
@@ -52,8 +52,16 @@ func ExternalBinary() *cmds.Command {
 			// setup env of child program
 			env := os.Environ()
 
-			nd, err := req.InvocContext().GetNode()
-			if err == nil {
+			// Get the node iff already defined.
+			if req.InvocContext().Online {
+				nd, err := req.InvocContext().GetNode()
+				if err != nil {
+					res.SetError(fmt.Errorf(
+						"failed to start ipfs node: %s",
+						err,
+					), cmdkit.ErrFatal)
+					return
+				}
 				env = append(env, fmt.Sprintf("IPFS_ONLINE=%t", nd.OnlineMode()))
 			}
 

--- a/test/sharness/t0063-external.sh
+++ b/test/sharness/t0063-external.sh
@@ -14,17 +14,28 @@ PATH=`pwd`/bin:$PATH
 
 test_init_ipfs
 
-test_launch_ipfs_daemon
-
 test_expect_success "create fake ipfs-update bin" '
   mkdir bin &&
   echo "#!/bin/sh" > bin/ipfs-update &&
   echo "pwd" >> bin/ipfs-update &&
-  chmod +x bin/ipfs-update
+  echo "test -e \"$IPFS_PATH/repo.lock\" || echo \"repo not locked\" " >> bin/ipfs-update &&
+  chmod +x bin/ipfs-update &&
+  mkdir just_for_test
 '
 
-test_expect_success "external command runs from current user directory" '
-  mkdir just_for_test &&
+test_expect_success "external command runs from current user directory and doesn't lock repo" '
+  (cd just_for_test && ipfs update) > actual
+'
+
+test_expect_success "output looks good" '
+  echo `pwd`/just_for_test > exp &&
+  echo "repo not locked" >> exp &&
+  test_cmp exp actual
+'
+
+test_launch_ipfs_daemon
+
+test_expect_success "external command runs from current user directory when daemon is running" '
   (cd just_for_test && ipfs update) > actual
 '
 


### PR DESCRIPTION
This breaks commands like `ipfs update` that expect IPFS to *not* be running.

fixes #5191