### PR TITLE
gateway: fix further resolution of dnslink failures

### DIFF
--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -169,8 +169,8 @@ func TestGatewayGet(t *testing.T) {
 		{"double.example.com", "/", http.StatusOK, "fnord"},
 		{"triple.example.com", "/", http.StatusOK, "fnord"},
 		{"working.example.com", "/ipfs/" + k, http.StatusNotFound, "ipfs resolve -r /ipns/working.example.com/ipfs/" + k + ": no link named \"ipfs\" under " + k + "\n"},
-		{"broken.example.com", "/", http.StatusNotFound, "ipfs resolve -r /ipns/broken.example.com/: " + namesys.ErrResolveFailed.Error() + "\n"},
-		{"broken.example.com", "/ipfs/" + k, http.StatusNotFound, "ipfs resolve -r /ipns/broken.example.com/ipfs/" + k + ": " + namesys.ErrResolveFailed.Error() + "\n"},
+		{"broken.example.com", "/", http.StatusNotFound, "ipfs resolve -r /ipns/broken.example.com: " + namesys.ErrResolveFailed.Error() + "\n"},
+		{"broken.example.com", "/ipfs/" + k, http.StatusNotFound, "ipfs resolve -r /ipns/broken.example.com: " + namesys.ErrResolveFailed.Error() + "\n"},
 	} {
 		var c http.Client
 		r, err := http.NewRequest("GET", ts.URL+test.path, nil)


### PR DESCRIPTION
A while ago, we noticed that if IpnsHostname failed to look up
a dnslink for a hostname in a Host header, it wouldn't respond
with an error, but instead just skip the Host header part and
carry on.

In the issue were this was flagged, the example was:
`_dnslink.tr.wikipedia-on-ipfs.org => /ipns/QmSomeKey`
This key had stopped to resolve, and thus the resolution of
/ipns/tr.wikipedia-on-ipfs.org would fail. Now you'd expect
an error response, but instead it'd happily continue processing
the request, disregarding the Host header, and allowing requests
to e.g. http://tr.wikipedia-on-ipfs.org/ipns/libp2p.io to succeed.

A previous patch (ipfs/go-ipfs#4977) tried to work around this
issue by limiting the recursion depth of Host: header dnslink
resolutions to 1.

In this patch we start to correctly handle the initial resolution
error and stop processing the request, and we remove the earlier
workaround.

License: MIT
Signed-off-by: Lars Gierth <larsg@systemli.org>