### PR TITLE
correctly handle multi-hop dnslink resolution

### DIFF
--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -40,7 +40,10 @@ func (m mockNamesys) Resolve(ctx context.Context, name string, opts ...nsopts.Re
 	if depth == nsopts.UnlimitedDepth {
 		depth = math.MaxUint64
 	}
-	for depth > 0 && strings.HasPrefix(name, "/ipns/") {
+	for strings.HasPrefix(name, "/ipns/") {
+		if depth <= 0 {
+			return value, namesys.ErrResolveRecursion
+		}
 		depth--
 
 		var ok bool

--- a/core/corehttp/ipns_hostname.go
+++ b/core/corehttp/ipns_hostname.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 
 	isd "gx/ipfs/QmZmmuAXgX73UQmX1jRKjTGmjzq24Jinqkq8vzkBtno4uX/go-is-domain"
@@ -25,7 +26,8 @@ func IPNSHostnameOption() ServeOption {
 			host := strings.SplitN(r.Host, ":", 2)[0]
 			if len(host) > 0 && isd.IsDomain(host) {
 				name := "/ipns/" + host
-				if _, err := n.Namesys.Resolve(ctx, name, nsopts.Depth(1)); err == nil {
+				_, err := n.Namesys.Resolve(ctx, name, nsopts.Depth(1))
+				if err == nil || err == namesys.ErrResolveRecursion {
 					r.Header.Set("X-Ipns-Original-Path", r.URL.Path)
 					r.URL.Path = name + r.URL.Path
 				}


### PR DESCRIPTION
Namesys returns `ErrResolveRecursion` when it stops recursing due to a depth limit. It doesn't return success.

Alternative to #5199.