### PR TITLE
unixfs: fix `dagTruncate` to preserve node type

### DIFF
--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -1136,3 +1136,43 @@ func TestTruncateAtSize(t *testing.T) {
 	}
 	fd.Truncate(4)
 }
+
+func TestTruncateAndWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ds, rt := setupRoot(ctx, t)
+
+	dir := rt.GetDirectory()
+
+	nd := dag.NodeWithData(ft.FilePBData(nil, 0))
+	fi, err := NewFile("test", nd, dir, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fd, err := fi.Open(OpenReadWrite, true)
+	defer fd.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 200; i++ {
+		err = fd.Truncate(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		l, err := fd.Write([]byte("test"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if l != len("test") {
+			t.Fatal("incorrect write length")
+		}
+		data, err := ioutil.ReadAll(fd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "test" {
+			t.Errorf("read error at read %d, read: %v", i, data)
+		}
+	}
+}

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -613,7 +613,7 @@ tests_for_files_api() {
   ROOT_HASH=QmcwKfTMCT7AaeiD92hWjnZn9b6eh9NxnhfSzN5x2vnDpt
   CATS_HASH=Qma88m8ErTGkZHbBWGqy1C7VmEmX8wwNDWNpGyCaNmEgwC
   FILE_HASH=QmQdQt9qooenjeaNhiKHF3hBvmNteB4MQBtgu3jxgf9c7i
-  TRUNC_HASH=QmdaQZbLwK5ykweGdCVovNnvBom7QhikovDUVqTPHQG4L8
+  TRUNC_HASH=QmPVnT9gocPbqzN4G6SMp8vAPyzcjDbUJrNdKgzQquuDg4
   test_files_api "($EXTRA)"
 
   test_expect_success "can create some files for testing with raw-leaves ($EXTRA)" '
@@ -629,13 +629,13 @@ tests_for_files_api() {
   ROOT_HASH=QmW3dMSU6VNd1mEdpk9S3ZYRuR1YwwoXjGaZhkyK6ru9YU
   CATS_HASH=QmPqWDEg7NoWRX8Y4vvYjZtmdg5umbfsTQ9zwNr12JoLmt
   FILE_HASH=QmRCgHeoKxCqK2Es6M6nPUDVWz19yNQPnsXGsXeuTkSKpN
-  TRUNC_HASH=QmRFJEKWF5A5FyFYZgNhusLw2UziW9zBKYr4huyHjzcB6o
+  TRUNC_HASH=QmckstrVxJuecVD1FHUiURJiU9aPURZWJieeBVHJPACj8L
   test_files_api "($EXTRA, raw-leaves)" '' --raw-leaves
 
   ROOT_HASH=QmageRWxC7wWjPv5p36NeAgBAiFdBHaNfxAehBSwzNech2
   CATS_HASH=zdj7WkEzPLNAr5TYJSQC8CFcBjLvWFfGdx6kaBrJXnBguwWeX
   FILE_HASH=zdj7WYHvf5sBRgSBjYnq64QFr449CCbgupXfBvoYL3aHC1DzJ
-  TRUNC_HASH=zdj7WYLYbka6Ydg8gZUJRLKnFBVehCADhQKBsFbNiMxZSB5Gj
+  TRUNC_HASH=zdj7Wjr8GHZonPFVCWvz2SLLo9H6MmqBxyeB34ArHfyCbmdJG
   if [ "$EXTRA" = "offline" ]; then
     test_files_api "($EXTRA, cidv1)" --cid-version=1
   fi
@@ -660,7 +660,7 @@ tests_for_files_api() {
     ROOT_HASH=zDMZof1kxEsAwSgCZsGQRVcHCMtHLjkUQoiZUbZ87erpPQJGUeW8
     CATS_HASH=zDMZof1kuAhr3zBkxq48V7o9HJZCTVyu1Wd9wnZtVcPJLW8xnGft
     FILE_HASH=zDMZof1kxbB9CvxgRioBzESbGnZUxtSCsZ18H1EUkxDdWt1DYEkK
-    TRUNC_HASH=zDMZof1kxXqKdVsVo231qVdN3hCTF5a34UuQZpzmm5K7CbRJ4u2S
+    TRUNC_HASH=zDMZof1kpH1vxK3k2TeYc8w59atCbzMzrhZonsztMWSptVro2zQa
     test_files_api "($EXTRA, blake2b-256 root)"
   fi
 

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -201,6 +201,12 @@ func (n *FSNode) BlockSize(i int) uint64 {
 	return n.format.Blocksizes[i]
 }
 
+// RemoveAllBlockSizes removes all the child block sizes of this node.
+func (n *FSNode) RemoveAllBlockSizes() {
+	n.format.Blocksizes = []uint64{}
+	n.format.Filesize = proto.Uint64(uint64(len(n.Data())))
+}
+
 // GetBytes marshals this node as a protobuf message.
 func (n *FSNode) GetBytes() ([]byte, error) {
 	return proto.Marshal(&n.format)


### PR DESCRIPTION
So, in a weird series of coincidences that I don't fully understand I need to fix this old bug (which I already fixed in the PR #4758 that I never finished) to be able to refactor some parts of the code of the DAG reader (see https://github.com/ipfs/go-ipfs/issues/5192#issuecomment-404216727).

I'm selfishly assigning this PR a high priority to get it merged as soon as possible after the upcoming release, as it will simplify my work on the DAG reader.

Fixes #4519.

-----------

```
unixfs: fix `dagTruncate` to preserve node type

Extract the original `FSNode` passed inside the `ipld.Node` argument and modify
its `Blocksizes` (removing all of them and re-adding the ones that were not
truncated). In contrast, the replaced code was creating a new `FSNode` that was
not preserving some of the features of the original one.
```

-----------

```
mfs: add test case for MFS repeated truncation failure
```