### PR TITLE
mfs: remove `sort` from `ListNames()`

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	gopath "path"
+	"sort"
 	"strings"
 
 	bservice "github.com/ipfs/go-ipfs/blockservice"
@@ -405,6 +406,7 @@ Examples:
 	},
 	Options: []cmdkit.Option{
 		cmdkit.BoolOption("l", "Use long listing format."),
+		cmdkit.BoolOption("U", "Do not sort; list entries in directory order."),
 	},
 	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		var arg string
@@ -482,8 +484,15 @@ Examples:
 			}
 
 			buf := new(bytes.Buffer)
-			long, _, _ := res.Request().Option("l").Bool()
 
+			noSort, _, _ := res.Request().Option("U").Bool()
+			if !noSort {
+				sort.Slice(out.Entries, func(i, j int) bool {
+					return strings.Compare(out.Entries[i].Name, out.Entries[j].Name) < 0
+				})
+			}
+
+			long, _, _ := res.Request().Option("l").Bool()
 			for _, o := range out.Entries {
 				if long {
 					fmt.Fprintf(buf, "%s\t%s\t%d\n", o.Name, o.Hash, o.Size)

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sort"
 	"sync"
 	"time"
 
@@ -244,8 +243,6 @@ func (d *Directory) ListNames(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	sort.Strings(out)
 
 	return out, nil
 }

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -56,17 +56,27 @@ test_sharding() {
 
   test_expect_success "can make 100 files in a directory $EXTRA" '
     printf "" > list_exp_raw
-    for i in `seq 100`
+    for i in `seq 100 -1 1`
     do
       echo $i | ipfs files write --create /foo/file$i || return 1
       echo file$i >> list_exp_raw
     done
   '
+  # Create the files in reverse (unsorted) order (`seq 100 -1 1`)
+  # to check the sort in the `ipfs files ls` command. `ProtoNode`
+  # links are always sorted at the DAG layer so the sorting feature
+  # is tested with sharded directories.
 
-  test_expect_success "listing works $EXTRA" '
-    ipfs files ls /foo |sort > list_out &&
+  test_expect_success "sorted listing works $EXTRA" '
+    ipfs files ls /foo > list_out &&
     sort list_exp_raw > list_exp &&
     test_cmp list_exp list_out
+  '
+
+  test_expect_success "unsorted listing works $EXTRA" '
+    ipfs files ls -U /foo > list_out &&
+    sort list_exp_raw > sort_list_not_exp &&
+    ! test_cmp sort_list_not_exp list_out
   '
 
   test_expect_success "can read a file from sharded directory $EXTRA" '


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-ipfs/issues/5181.