### PR TITLE
 unixfs: refactor `precalcNextBuf`

### DIFF
--- a/unixfs/io/dagreader.go
+++ b/unixfs/io/dagreader.go
@@ -3,7 +3,6 @@ package io
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	mdag "github.com/ipfs/go-ipfs/merkledag"
@@ -17,6 +16,7 @@ import (
 var (
 	ErrIsDir            = errors.New("this dag node is a directory")
 	ErrCantReadSymlinks = errors.New("cannot currently read symlinks")
+	ErrUnkownNodeType   = errors.New("unknown node type")
 )
 
 // A DagReader provides read-only read and seek acess to a unixfs file.
@@ -74,6 +74,6 @@ func NewDagReader(ctx context.Context, n ipld.Node, serv ipld.NodeGetter) (DagRe
 			return nil, ft.ErrUnrecognizedType
 		}
 	default:
-		return nil, fmt.Errorf("unrecognized node type")
+		return nil, ErrUnkownNodeType
 	}
 }

--- a/unixfs/io/pbdagreader.go
+++ b/unixfs/io/pbdagreader.go
@@ -106,26 +106,20 @@ func (dr *PBDagReader) precalcNextBuf(ctx context.Context) error {
 		}
 
 		switch fsNode.Type() {
-		case ftpb.Data_Directory, ftpb.Data_HAMTShard:
-			// A directory should not exist within a file
-			return ft.ErrInvalidDirLocation
 		case ftpb.Data_File:
 			dr.buf = NewPBFileReader(dr.ctx, nxt, fsNode, dr.serv)
 			return nil
 		case ftpb.Data_Raw:
 			dr.buf = NewBufDagReader(fsNode.Data())
 			return nil
-		case ftpb.Data_Metadata:
-			return errors.New("shouldnt have had metadata object inside file")
-		case ftpb.Data_Symlink:
-			return errors.New("shouldnt have had symlink inside file")
 		default:
-			return ft.ErrUnrecognizedType
+			return fmt.Errorf("found %s node in unexpected place", fsNode.Type().String())
 		}
+	case *mdag.RawNode:
+		dr.buf = NewBufDagReader(nxt.RawData())
+		return nil
 	default:
-		var err error
-		dr.buf, err = NewDagReader(ctx, nxt, dr.serv)
-		return err
+		return ErrUnkownNodeType
 	}
 }
 

--- a/unixfs/unixfs.go
+++ b/unixfs/unixfs.go
@@ -25,7 +25,6 @@ const (
 // Common errors
 var (
 	ErrMalformedFileFormat = errors.New("malformed data in file format")
-	ErrInvalidDirLocation  = errors.New("found directory node in unexpected place")
 	ErrUnrecognizedType    = errors.New("unrecognized node type")
 )
 


### PR DESCRIPTION
Addresses part of #5192.

--------------------

```
unixfs: refactor switch in `precalcNextBuf`

Do not use `NewDagReader` just for the `RawNode` case.
Treat invalid UnixFS types in the same case.
```

---------------------

```
unixfs: split `precalcNextBuf`

Create new `loadBufNode` function to handle the `buf` logic which is unrelated
to the main `precalcNextBuf` logic of processing promises to fetch nodes.
```