### PR TITLE
unixfs: fix `FSNode` accessor in `NewDirectoryFromNode`

### DIFF
--- a/unixfs/io/directory.go
+++ b/unixfs/io/directory.go
@@ -107,7 +107,7 @@ func NewDirectoryFromNode(dserv ipld.DAGService, node ipld.Node) (Directory, err
 		return nil, err
 	}
 
-	switch fsNode.GetType() {
+	switch fsNode.Type() {
 	case format.TDirectory:
 		return &BasicDirectory{
 			dserv: dserv,


### PR DESCRIPTION
Recently merged PR #5189 conflicted with #5160.