### PR TITLE
fix truncating when already at the correct size

### DIFF
--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -1111,3 +1111,28 @@ func TestFileDescriptors(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTruncateAtSize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ds, rt := setupRoot(ctx, t)
+
+	dir := rt.GetDirectory()
+
+	nd := dag.NodeWithData(ft.FilePBData(nil, 0))
+	fi, err := NewFile("test", nd, dir, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fd, err := fi.Open(OpenReadWrite, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd.Close()
+	_, err = fd.Write([]byte("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd.Truncate(4)
+}

--- a/unixfs/mod/dagmodifier.go
+++ b/unixfs/mod/dagmodifier.go
@@ -481,6 +481,9 @@ func (dm *DagModifier) Truncate(size int64) error {
 	if err != nil {
 		return err
 	}
+	if size == int64(realSize) {
+		return nil
+	}
 
 	// Truncate can also be used to expand the file
 	if size > int64(realSize) {


### PR DESCRIPTION
Fixes #4518.

(Taken from PR https://github.com/ipfs/go-ipfs/pull/4517.)
