### PR TITLE
mfs: seek to 0 before reading in `TestTruncateAndWrite`

### DIFF
--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -1167,12 +1167,18 @@ func TestTruncateAndWrite(t *testing.T) {
 		if l != len("test") {
 			t.Fatal("incorrect write length")
 		}
+
+		_, err = fd.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		data, err := ioutil.ReadAll(fd)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if string(data) != "test" {
-			t.Errorf("read error at read %d, read: %v", i, data)
+			t.Fatalf("read error at read %d, read: %v", i, data)
 		}
 	}
 }


### PR DESCRIPTION
Right now this test isn't failing due to another bug that causes seeking to the end to return to the beginning of the file (https://github.com/ipfs/go-ipfs/issues/5255) and the read call works, but it would be nice to get this test fixed as it's failing in a refactoring of the DAG reader (https://github.com/ipfs/go-ipfs/pull/5257).