### PR TITLE
Release 0.4.17

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.16: QmTRP6dcuYwcGDvAH8HvJtoupPrhZDQ8AoxMEn9gMzbgMy
+0.4.17-rc1: Qma5pGQ9ugGoeAbND8RKPohYfZDyaivSCfRQraKkW8Gu4Y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,65 @@
 # go-ipfs changelog
 
-## 0.4.16
+## 0.4.17-rc1 2018-07-20
+
+Ipfs 0.4.17 is a quick release to fix two important bugs:
+
+1. A major performance regression in bitswap (mostly affecting go-ipfs ->
+   js-ipfs transfers).
+2. A bug resolving files in sharded directories with the gateway.
+
+However, while motivated by those fixes, it contains a few other goodies that
+will excite some users.
+
+The headline feature in this release is [urlstore][] support. Urlstore is a
+generalization of the filestore backend that can fetch file blocks from remote
+URLs on-demand instead of storing them in the local datastore.
+
+Additionally, we've added support for extracting inline blocks from CIDs (blocks
+inlined into CIDs using the identity hash function). However, go-ipfs won't yet
+*create* such CIDs so you're unlikely to see any in the wild.
+
+[urlstore]: https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#ipfs-urlstore
+
+Features:
+
+* URLStore ([ipfs/go-ipfs#4896](https://github.com/ipfs/go-ipfs/pull/4896))
+* Add trickle-dag support to the urlstore ([ipfs/go-ipfs#5245](https://github.com/ipfs/go-ipfs/pull/5245)).
+* Allow specifying how the data field in the `object get` is encoded ([ipfs/go-ipfs#5139](https://github.com/ipfs/go-ipfs/pull/5139))
+* Add a `-U` flag to `files ls` to disable sorting ([ipfs/go-ipfs#5219](https://github.com/ipfs/go-ipfs/pull/5219))
+* Add an efficient `--size-only` flag to the `repo stat` ([ipfs/go-ipfs#5010](https://github.com/ipfs/go-ipfs/pull/5010))
+* Inline blocks in CIDs ([ipfs/go-ipfs#5117](https://github.com/ipfs/go-ipfs/pull/5117))
+
+Changes/Fixes:
+
+* Make `ipfs files ls -l` correctly report the hash and size of files ([ipfs/go-ipfs#5045](https://github.com/ipfs/go-ipfs/pull/5045))
+* Fix sorting of `files ls` ([ipfs/go-ipfs#5219](https://github.com/ipfs/go-ipfs/pull/5219))
+* Improve prefetching in `ipfs cat` and related commands ([ipfs/go-ipfs#5162](https://github.com/ipfs/go-ipfs/pull/5162))
+* Better error message when `ipfs cp` fails ([ipfs/go-ipfs#5218](https://github.com/ipfs/go-ipfs/pull/5218))
+* Don't wait for the peer to close it's end of a bitswap stream before considering the block "sent" ([ipfs/go-ipfs#5258](https://github.com/ipfs/go-ipfs/pull/5258))
+* Fix resolving links in sharded directories via the gateway ([ipfs/go-ipfs#5271](https://github.com/ipfs/go-ipfs/pull/5271))
+* Fix building when there's a space in the current directory ([ipfs/go-ipfs#5261](https://github.com/ipfs/go-ipfs/pull/5261))
+
+Documentation:
+
+* Improve documentation about the bloomfilter config options ([ipfs/go-ipfs#4924](https://github.com/ipfs/go-ipfs/pull/4924))
+
+General refactorings and internal bug fixes:
+
+* Remove the `Offset()` method from the DAGReader ([ipfs/go-ipfs#5190](https://github.com/ipfs/go-ipfs/pull/5190))
+* Fix TestLargeWriteChunks seek behavior ([ipfs/go-ipfs#5276](https://github.com/ipfs/go-ipfs/pull/5276))
+* Add a build tag to disable dynamic plugins ([ipfs/go-ipfs#5274](https://github.com/ipfs/go-ipfs/pull/5274))
+* Use FSNode instead of the Protobuf structure in PBDagReader ([ipfs/go-ipfs#5189](https://github.com/ipfs/go-ipfs/pull/5189))
+* Remove support for non-directory MFS roots ([ipfs/go-ipfs#5170](https://github.com/ipfs/go-ipfs/pull/5170))
+* Remove `UnixfsNode` from the balanced builder ([ipfs/go-ipfs#5118](https://github.com/ipfs/go-ipfs/pull/5118))
+* Fix truncating files (internal) when already at the correct size ([ipfs/go-ipfs#5253](https://github.com/ipfs/go-ipfs/pull/5253))
+* Fix `dagTruncate` (internal) to preserve the node type ([ipfs/go-ipfs#5216](https://github.com/ipfs/go-ipfs/pull/5216))
+* Add an internal interface for unixfs directories ([ipfs/go-ipfs#5160](https://github.com/ipfs/go-ipfs/pull/5160))
+* Refactor the CoreAPI path types and interfaces ([ipfs/go-ipfs#4672](https://github.com/ipfs/go-ipfs/pull/4672))
+* Refactor `precalcNextBuf` in the dag reader ([ipfs/go-ipfs#5237](https://github.com/ipfs/go-ipfs/pull/5237))
+* Update a bunch of dependencies that haven't been updated for a while ([ipfs/go-ipfs#5268](https://github.com/ipfs/go-ipfs/pull/5268))
+
+## 0.4.16 2018-07-13
 
 Ipfs 0.4.16 is a fairly small release in terms of changes to the ipfs codebase,
 but it contains a huge amount of changes and improvements from the libraries we

--- a/package.json
+++ b/package.json
@@ -551,6 +551,6 @@
   "language": "go",
   "license": "MIT",
   "name": "go-ipfs",
-  "version": "0.4.17-dev"
+  "version": "0.4.17-rc1"
 }
 

--- a/repo/config/version.go
+++ b/repo/config/version.go
@@ -4,6 +4,6 @@ package config
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.4.17-dev"
+const CurrentVersionNumber = "0.4.17-rc1"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
This is a relatively small release to fix a performance regression I introduced.
Hopefully, it'll also get us into a fast release cadence.

The downside is that freezing due to an RC slows everything to a grind.