### PR TITLE
build tag to disable dynamic plugins

### DIFF
--- a/plugin/loader/load_linux.go
+++ b/plugin/loader/load_linux.go
@@ -1,3 +1,5 @@
+// +build !noplugin
+
 package loader
 
 import (


### PR DESCRIPTION
Currently it's not possible to debug applications which use the "plugin" package (https://github.com/golang/go/issues/23733)