### PR TITLE
test: testLargeWriteChunks: seek before reading

### DIFF
--- a/unixfs/mod/dagmodifier_test.go
+++ b/unixfs/mod/dagmodifier_test.go
@@ -323,6 +323,11 @@ func testLargeWriteChunks(t *testing.T, opts testu.NodeOpts) {
 		}
 	}
 
+	_, err = dagmod.Seek(0, io.SeekStart)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	out, err := ioutil.ReadAll(dagmod)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This should be the last of the seek-before-reading errors in the tests.

Needed for https://github.com/ipfs/go-ipfs/pull/5257.
