### PR TITLE
Add support for inlinling via the id-hash

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -124,7 +124,7 @@ You can now check what blocks have been created by:
 		cmdkit.IntOption(cidVersionOptionName, "CID version. Defaults to 0 unless an option that depends on CIDv1 is passed. (experimental)"),
 		cmdkit.StringOption(hashOptionName, "Hash function to use. Implies CIDv1 if not sha2-256. (experimental)").WithDefault("sha2-256"),
 		cmdkit.BoolOption(inlineOptionName, "Inline small blocks into CIDs. (experimental)"),
-		cmdkit.IntOption(inlineLimitOptionName, "Maximum block size to inline. (experimental)").WithDefault(64),
+		cmdkit.IntOption(inlineLimitOptionName, "Maximum block size to inline. (experimental)").WithDefault(32),
 	},
 	PreRun: func(req *cmds.Request, env cmds.Environment) error {
 		quiet, _ := req.Options[quietOptionName].(bool)

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -46,7 +46,7 @@ const (
 	cidVersionOptionName  = "cid-version"
 	hashOptionName        = "hash"
 	inlineOptionName      = "inline"
-	idHashLimitOptionName = "id-hash-limit"
+	inlineLimitOptionName = "inline-limit"
 )
 
 const adderOutChanSize = 8
@@ -123,8 +123,8 @@ You can now check what blocks have been created by:
 		cmdkit.BoolOption(fstoreCacheOptionName, "Check the filestore for pre-existing blocks. (experimental)"),
 		cmdkit.IntOption(cidVersionOptionName, "CID version. Defaults to 0 unless an option that depends on CIDv1 is passed. (experimental)"),
 		cmdkit.StringOption(hashOptionName, "Hash function to use. Implies CIDv1 if not sha2-256. (experimental)").WithDefault("sha2-256"),
-		cmdkit.BoolOption(inlineOptionName, "Inline small objects using identity hash. (experimental)"),
-		cmdkit.IntOption(idHashLimitOptionName, "Identity hash maxium size. (experimental)").WithDefault(64),
+		cmdkit.BoolOption(inlineOptionName, "Inline small blocks into CIDs. (experimental)"),
+		cmdkit.IntOption(inlineLimitOptionName, "Maximum block size to inline. (experimental)").WithDefault(64),
 	},
 	PreRun: func(req *cmds.Request, env cmds.Environment) error {
 		quiet, _ := req.Options[quietOptionName].(bool)
@@ -179,7 +179,7 @@ You can now check what blocks have been created by:
 		cidVer, cidVerSet := req.Options[cidVersionOptionName].(int)
 		hashFunStr, _ := req.Options[hashOptionName].(string)
 		inline, _ := req.Options[inlineOptionName].(bool)
-		idHashLimit, _ := req.Options[idHashLimitOptionName].(int)
+		inlineLimit, _ := req.Options[inlineLimitOptionName].(int)
 
 		// The arguments are subject to the following constraints.
 		//
@@ -291,7 +291,8 @@ You can now check what blocks have been created by:
 		if inline {
 			fileAdder.CidBuilder = cidutil.InlineBuilder{
 				Builder: fileAdder.CidBuilder,
-				Limit:   idHashLimit}
+				Limit:   inlineLimit,
+			}
 		}
 
 		if hash {

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -590,7 +590,7 @@ test_add_cat_expensive "--cid-version=1" "zdj7WcatQrtuE4WMkS4XsfsMixuQN2po4irkYh
 # encoded with the blake2b-256 hash funtion
 test_add_cat_expensive '--hash=blake2b-256' "zDMZof1kwndounDzQCANUHjiE3zt1mPEgx7RE3JTHoZrRRa79xcv"
 
-test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&pin=true&progress=true&recursive=true&stream-channels=true:"
+test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&id-hash-limit=64&pin=true&progress=true&recursive=true&stream-channels=true:"
 
 test_add_pwd_is_symlink
 

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -590,7 +590,7 @@ test_add_cat_expensive "--cid-version=1" "zdj7WcatQrtuE4WMkS4XsfsMixuQN2po4irkYh
 # encoded with the blake2b-256 hash funtion
 test_add_cat_expensive '--hash=blake2b-256' "zDMZof1kwndounDzQCANUHjiE3zt1mPEgx7RE3JTHoZrRRa79xcv"
 
-test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&id-hash-limit=64&pin=true&progress=true&recursive=true&stream-channels=true:"
+test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&inline-limit=64&pin=true&progress=true&recursive=true&stream-channels=true:"
 
 test_add_pwd_is_symlink
 

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -590,7 +590,7 @@ test_add_cat_expensive "--cid-version=1" "zdj7WcatQrtuE4WMkS4XsfsMixuQN2po4irkYh
 # encoded with the blake2b-256 hash funtion
 test_add_cat_expensive '--hash=blake2b-256' "zDMZof1kwndounDzQCANUHjiE3zt1mPEgx7RE3JTHoZrRRa79xcv"
 
-test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&inline-limit=64&pin=true&progress=true&recursive=true&stream-channels=true:"
+test_add_named_pipe " Post http://$API_ADDR/api/v0/add?chunker=size-262144&encoding=json&hash=sha2-256&inline-limit=32&pin=true&progress=true&recursive=true&stream-channels=true:"
 
 test_add_pwd_is_symlink
 

--- a/test/sharness/t0046-id-hash.sh
+++ b/test/sharness/t0046-id-hash.sh
@@ -43,6 +43,41 @@ test_expect_success "can still fetch it" '
   test_cmp junk.txt actual
 '
 
+test_expect_success "ipfs add --inline works as expected" '
+  echo $ID_HASH0_CONTENTS > afile &&
+  HASH=$(ipfs add -q --inline afile)
+'
+
+test_expect_success "ipfs add --inline uses id multihash" '
+  MHTYPE=`cid-fmt %h $HASH`
+  echo "mhtype is $MHTYPE"
+  test "$MHTYPE" = id
+'
+
+test_expect_success "ipfs add --inline --raw-leaves works as expected" '
+  echo $ID_HASH0_CONTENTS > afile &&
+  HASH=$(ipfs add -q --inline --raw-leaves afile)
+'
+
+test_expect_success "ipfs add --inline --raw-leaves outputs the correct hash" '
+  echo "$ID_HASH0" = "$HASH" &&
+  test "$ID_HASH0" = "$HASH"
+'
+
+test_expect_success "create 1000 bytes file and get its hash" '
+  random 1000 2 > 1000bytes &&
+  HASH0=$(ipfs add -q --raw-leaves --only-hash 1000bytes)
+'
+
+test_expect_success "ipfs add --inline --raw-leaves works as expected on large file" '
+  HASH=$(ipfs add -q --inline --raw-leaves 1000bytes)
+'
+
+test_expect_success "ipfs add --inline --raw-leaves outputs the correct hash on large file" '
+  echo "$HASH0" = "$HASH" &&
+  test "$HASH0" = "$HASH"
+'
+
 test_expect_success "enable filestore" '
   ipfs config --json Experimental.FilestoreEnabled true
 '


### PR DESCRIPTION
Add support for inlining via the id-hash to the `ipfs add` command using the new Builder interface.
