### PR TITLE
urlstore: Accept "200 OK" in addition to "206 Partial Content".

### DIFF
--- a/filestore/fsrefstore.go
+++ b/filestore/fsrefstore.go
@@ -216,9 +216,9 @@ func (f *FileManager) readURLDataObj(c *cid.Cid, d *pb.DataObj) ([]byte, error) 
 	if err != nil {
 		return nil, &CorruptReferenceError{StatusFileError, err}
 	}
-	if res.StatusCode != http.StatusPartialContent {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusPartialContent {
 		return nil, &CorruptReferenceError{StatusFileError,
-			fmt.Errorf("expected HTTP 206 got %d", res.StatusCode)}
+			fmt.Errorf("expected HTTP 200 or 206 got %d", res.StatusCode)}
 	}
 
 	outbuf := make([]byte, d.GetSize_())


### PR DESCRIPTION
Some servers seem to return 200 OK when range header covers entire file.  If the content is wrong we will detect later so there is no harm in accepting either response.

Closes #5250.