### PR TITLE
optimize filestore verify

### DIFF
--- a/filestore/util.go
+++ b/filestore/util.go
@@ -134,7 +134,7 @@ func listAll(ctx context.Context, fs *Filestore, verify bool) (<-chan *ListRes, 
 		return nil, err
 	}
 
-	output := make(chan *ListRes)
+	output := make(chan *ListRes, 64)
 	var wg sync.WaitGroup
 	wg.Add(listWorkers)
 	qrCh := qr.Next()


### PR DESCRIPTION
This works by spinning up ncores * 2 workers and having them iterate over the
datastore in parallel.

* [x] TODO: Benchmark this. It may not be any faster (but it really should be).
  * Looks 2x faster. I'd appreciate more benchmarks.
* [x] TODO: Consider creating new workers on-demand. The bottleneck here could be
reading from the datastore, not hashing.
  * Not worth it. The bottleneck really is hashing (as far as I can tell, at least).

Also:

* Removes sorting from the filestore functions. This feels like something that belongs in the commands.
* Deduplicates command logic.
* Switches to commands-lib 1.0