### PR TITLE
WIP:  Add global option to specify the multibase encoding.

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -269,6 +269,13 @@ You can now check what blocks have been created by:
 			return
 		}
 
+		baseStr := req.Options[MbaseOption].(string)
+		base, err := GetMultibase(baseStr, "", "")
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
 		fileAdder.Out = outChan
 		fileAdder.Chunker = chunker
 		fileAdder.Progress = progress
@@ -280,6 +287,7 @@ You can now check what blocks have been created by:
 		fileAdder.RawLeaves = rawblks
 		fileAdder.NoCopy = nocopy
 		fileAdder.Prefix = &prefix
+		fileAdder.Base = base
 
 		if hash {
 			md := dagtest.Mock()

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -269,8 +269,7 @@ You can now check what blocks have been created by:
 			return
 		}
 
-		baseStr := req.Options[MbaseOption].(string)
-		base, err := GetMultibase(baseStr, "", "")
+		base, _, err := HandleCidBase(req, env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -77,6 +77,13 @@ The JSON output contains type information.
 			return
 		}
 
+		baseStr, _, _ := req.Option(MbaseOption).String()
+		base, err := GetMultibase(baseStr, "", "")
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
 		dserv := nd.DAG
 		if !resolve {
 			offlineexch := offline.Exchange(nd.Blockstore)
@@ -160,7 +167,7 @@ The JSON output contains type information.
 				}
 				output[i].Links[j] = LsLink{
 					Name: link.Name,
-					Hash: link.Cid.String(),
+					Hash: link.Cid.Encode(base),
 					Size: link.Size,
 					Type: t,
 				}

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -9,6 +9,7 @@ import (
 	blockservice "github.com/ipfs/go-ipfs/blockservice"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	core "github.com/ipfs/go-ipfs/core"
+	misc "github.com/ipfs/go-ipfs/core/misc"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	merkledag "github.com/ipfs/go-ipfs/merkledag"
 	path "github.com/ipfs/go-ipfs/path"
@@ -164,7 +165,7 @@ The JSON output contains type information.
 						t = d.GetType()
 					}
 				}
-				base := GetCidBase(ctx, paths[i])
+				base := misc.GetCidBase(ctx, paths[i])
 				output[i].Links[j] = LsLink{
 					Name: link.Name,
 					Hash: link.Cid.Encode(base),

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -77,7 +77,7 @@ The JSON output contains type information.
 			return
 		}
 
-		base, _, _, err := HandleCidBaseOld(req)
+		_, _, ctx, err := HandleCidBaseOld(req)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -105,7 +105,7 @@ The JSON output contains type information.
 				ResolveOnce: uio.ResolveUnixfsOnce,
 			}
 
-			dagnode, err := core.Resolve(req.Context(), nd.Namesys, r, p)
+			dagnode, err := core.Resolve(ctx, nd.Namesys, r, p)
 			if err != nil {
 				res.SetError(err, cmdkit.ErrNormal)
 				return
@@ -126,7 +126,7 @@ The JSON output contains type information.
 			if dir == nil {
 				links = dagnode.Links()
 			} else {
-				links, err = dir.Links(req.Context())
+				links, err = dir.Links(ctx)
 				if err != nil {
 					res.SetError(err, cmdkit.ErrNormal)
 					return
@@ -146,7 +146,7 @@ The JSON output contains type information.
 					// No need to check with raw leaves
 					t = unixfspb.Data_File
 				case cid.DagProtobuf:
-					linkNode, err := link.GetNode(req.Context(), dserv)
+					linkNode, err := link.GetNode(ctx, dserv)
 					if err == ipld.ErrNotFound && !resolve {
 						// not an error
 						linkNode = nil
@@ -164,6 +164,7 @@ The JSON output contains type information.
 						t = d.GetType()
 					}
 				}
+				base := GetCidBase(ctx, paths[i])
 				output[i].Links[j] = LsLink{
 					Name: link.Name,
 					Hash: link.Cid.Encode(base),

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -77,8 +77,7 @@ The JSON output contains type information.
 			return
 		}
 
-		baseStr, _, _ := req.Option(MbaseOption).String()
-		base, err := GetMultibase(baseStr, "", "")
+		base, _, _, err := HandleCidBaseOld(req)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -77,7 +77,7 @@ The JSON output contains type information.
 			return
 		}
 
-		_, _, ctx, err := HandleCidBaseOld(req)
+		_, _, ctx, err := HandleCidBaseOld(req, req.Context())
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	misc "github.com/ipfs/go-ipfs/core/misc"
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
@@ -335,7 +336,7 @@ func (rw *RefWriter) WriteEdge(from, to *cid.Cid, linkname string) error {
 		}
 	}
 
-	base := GetCidBase(rw.Ctx, "")
+	base := misc.GetCidBase(rw.Ctx, "")
 
 	var s string
 	switch {

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -9,6 +9,7 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
+	misc "github.com/ipfs/go-ipfs/core/misc"
 	ns "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 	path "github.com/ipfs/go-ipfs/path"
@@ -137,7 +138,7 @@ Resolve the value of an IPFS DAG path:
 		}
 
 		c := node.Cid()
-		base := GetCidBase(ctx, name)
+		base := misc.GetCidBase(ctx, name)
 		pathStr := "/ipfs/" + c.Encode(base)
 
 		res.SetOutput(&ResolvedPath{path.FromString(pathStr)})

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -87,7 +87,7 @@ Resolve the value of an IPFS DAG path:
 		name := req.Arguments()[0]
 		recursive, _, _ := req.Option("recursive").Bool()
 
-		_, _, ctx, err := HandleCidBaseOld(req)
+		_, _, ctx, err := HandleCidBaseOld(req, req.Context())
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -87,6 +87,12 @@ Resolve the value of an IPFS DAG path:
 		name := req.Arguments()[0]
 		recursive, _, _ := req.Option("recursive").Bool()
 
+		_, _, ctx, err := HandleCidBaseOld(req)
+		if err != nil {
+			res.SetError(err, cmdkit.ErrNormal)
+			return
+		}
+
 		// the case when ipns is resolved step by step
 		if strings.HasPrefix(name, "/ipns/") && !recursive {
 			rc, rcok, _ := req.Option("dht-record-count").Int()
@@ -107,7 +113,7 @@ Resolve the value of an IPFS DAG path:
 				}
 				ropts = append(ropts, nsopts.DhtTimeout(d))
 			}
-			p, err := n.Namesys.Resolve(req.Context(), name, ropts...)
+			p, err := n.Namesys.Resolve(ctx, name, ropts...)
 			// ErrResolveRecursion is fine
 			if err != nil && err != ns.ErrResolveRecursion {
 				res.SetError(err, cmdkit.ErrNormal)
@@ -124,15 +130,17 @@ Resolve the value of an IPFS DAG path:
 			return
 		}
 
-		node, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, p)
+		node, err := core.Resolve(ctx, n.Namesys, n.Resolver, p)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
 		c := node.Cid()
+		base := GetCidBase(ctx, name)
+		pathStr := "/ipfs/" + c.Encode(base)
 
-		res.SetOutput(&ResolvedPath{path.FromCid(c)})
+		res.SetOutput(&ResolvedPath{path.FromString(pathStr)})
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -242,9 +242,8 @@ func HandleCidBase(req *cmds.Request, env cmds.Environment) (mbase.Encoder, bool
 // HandleCidBaseFlagOld is like HandleCidBase but works with the old
 // commands interface.  Since it is not possible to change the context
 // using this interface and new context is returned instead.
-func HandleCidBaseOld(req oldcmds.Request) (mbase.Encoder, bool, context.Context, error) {
+func HandleCidBaseOld(req oldcmds.Request, ctx context.Context) (mbase.Encoder, bool, context.Context, error) {
 	baseStr, _, _ := req.Option("cid-base").String()
-	ctx := req.Context()
 	if baseStr != "" {
 		encoder, err := mbase.EncoderByName(baseStr)
 		if err != nil {

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -241,7 +241,7 @@ func HandleCidBase(req *cmds.Request, env cmds.Environment) (mbase.Encoder, bool
 
 // HandleCidBaseFlagOld is like HandleCidBase but works with the old
 // commands interface.  Since it is not possible to change the context
-// using this interface and new context is returned instead.
+// using this interface a new context is returned instead.
 func HandleCidBaseOld(req oldcmds.Request, ctx context.Context) (mbase.Encoder, bool, context.Context, error) {
 	baseStr, _, _ := req.Option("cid-base").String()
 	if baseStr != "" {
@@ -254,26 +254,4 @@ func HandleCidBaseOld(req oldcmds.Request, ctx context.Context) (mbase.Encoder, 
 	}
 	encoder, _ := mbase.NewEncoder(mbase.Base58BTC)
 	return encoder, false, ctx, nil
-}
-
-// GetCidBase gets the cid base to use from either the context or
-// another cid or path
-func GetCidBase(ctx context.Context, cidStr string) mbase.Encoder {
-	encoder, ok := ctx.Value("cid-base").(mbase.Encoder)
-	if ok {
-		return encoder
-	}
-	defaultEncoder, _ := mbase.NewEncoder(mbase.Base58BTC)
-	if cidStr != "" {
-		cidStr = strings.TrimPrefix(cidStr, "/ipfs/")
-		if cidStr == "" || strings.HasPrefix(cidStr, "Qm") {
-			return defaultEncoder
-		}
-		encoder, err := mbase.NewEncoder(mbase.Encoding(cidStr[0]))
-		if err != nil {
-			return defaultEncoder
-		}
-		return encoder
-	}
-	return defaultEncoder
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -10,6 +10,7 @@ import (
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	ocmd "github.com/ipfs/go-ipfs/core/commands/object"
 	unixfs "github.com/ipfs/go-ipfs/core/commands/unixfs"
+	path "github.com/ipfs/go-ipfs/path"
 
 	"gx/ipfs/QmNueRyPRQiV7PUEpnP4GgGLuK1rKQLaRW7sfPvUetYig1/go-ipfs-cmds"
 	mbase "gx/ipfs/QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR/go-multibase"
@@ -20,7 +21,8 @@ import (
 var log = logging.Logger("core/commands")
 
 const (
-	ApiOption = "api"
+	ApiOption   = "api"
+	MbaseOption = "mbase"
 )
 
 var Root = &cmds.Command{
@@ -92,6 +94,7 @@ The CLI will exit with one of the following values:
 		cmdkit.BoolOption("h", "Show a short version of the command help text."),
 		cmdkit.BoolOption("local", "L", "Run the command locally, instead of using the daemon."),
 		cmdkit.StringOption(ApiOption, "Use a specific API instance (defaults to /ip4/127.0.0.1/tcp/5001)"),
+		cmdkit.StringOption(MbaseOption, "Multi-base to use to encode version 1 CIDs in output."),
 
 		// global options, added to every command
 		cmds.OptionEncodingType,
@@ -218,4 +221,24 @@ func MessageTextMarshaler(res oldcmds.Response) (io.Reader, error) {
 	}
 
 	return strings.NewReader(out.Message), nil
+}
+
+// GetMultibase extracts the multibase.  If the first argument is
+// defined that is used as the multibase.  It can be either a single
+// letter or a string.  If it is not defined attemt to use the same
+// base as any CIDs definded in the second path argument.  Finally use
+// the third argument as the default if it is defined.  As a last
+// restort use the default base (currently Base58BTC)
+func GetMultibase(mbaseStr string, path path.Path, def string) (mbase.Encoder, error) {
+	baseStr := mbaseStr
+	if baseStr == "" {
+		// FIXME: extract from path
+	}
+	if baseStr == "" {
+		baseStr = def
+	}
+	if baseStr == "" {
+		baseStr = "base58btc"
+	}
+	return mbase.EncoderByName(baseStr)
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -256,3 +256,25 @@ func HandleCidBaseOld(req oldcmds.Request) (mbase.Encoder, bool, context.Context
 	encoder, _ := mbase.NewEncoder(mbase.Base58BTC)
 	return encoder, false, ctx, nil
 }
+
+// GetCidBase gets the cid base to use from either the context or
+// another cid or path
+func GetCidBase(ctx context.Context, cidStr string) mbase.Encoder {
+	encoder, ok := ctx.Value("cid-base").(mbase.Encoder)
+	if ok {
+		return encoder
+	}
+	defaultEncoder, _ := mbase.NewEncoder(mbase.Base58BTC)
+	if cidStr != "" {
+		cidStr = strings.TrimPrefix(cidStr, "/ipfs/")
+		if cidStr == "" || strings.HasPrefix(cidStr, "Qm") {
+			return defaultEncoder
+		}
+		encoder, err := mbase.NewEncoder(mbase.Encoding(cidStr[0]))
+		if err != nil {
+			return defaultEncoder
+		}
+		return encoder
+	}
+	return defaultEncoder
+}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -12,6 +12,7 @@ import (
 	unixfs "github.com/ipfs/go-ipfs/core/commands/unixfs"
 
 	"gx/ipfs/QmNueRyPRQiV7PUEpnP4GgGLuK1rKQLaRW7sfPvUetYig1/go-ipfs-cmds"
+	mbase "gx/ipfs/QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR/go-multibase"
 	logging "gx/ipfs/QmcVVHfdyv15GVPk7NrxdWjh2hLVccXnoD8j2tyQShiXJb/go-log"
 	"gx/ipfs/QmdE4gMduCKCGAcczM2F5ioYDfdeKuPix138wrES1YSr7f/go-ipfs-cmdkit"
 )

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -23,11 +23,11 @@ import (
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
+	multibase "gx/ipfs/QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR/go-multibase"
 	chunker "gx/ipfs/QmVDjhUMtkRskBFAVNwyXuLSKbeAya7JKPnzAxMKDaK4x4/go-ipfs-chunker"
 	cid "gx/ipfs/QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP/go-cid"
 	routing "gx/ipfs/QmZ383TySJVeZWzGnWui6pRcKyYZk9VkKTuW7tmKRWk5au/go-libp2p-routing"
 	ipld "gx/ipfs/QmZtNq8dArGfnpCZfx2pUNY7UcjGhVp5qqwQ4hH6mpTMRQ/go-ipld-format"
-	multibase "gx/ipfs/QmexBtiTTEwwn42Yi6ouKt6VqzpA6wjJgiW1oh9VfaRrup/go-multibase"
 )
 
 const (

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -56,6 +56,7 @@ type AddedObject struct {
 
 // NewAdder Returns a new Adder used for a file add operation.
 func NewAdder(ctx context.Context, p pin.Pinner, bs bstore.GCBlockstore, ds ipld.DAGService) (*Adder, error) {
+	b, _ := mbase.NewEncoder(mbase.Base58BTC)
 	return &Adder{
 		ctx:        ctx,
 		pinning:    p,
@@ -67,6 +68,7 @@ func NewAdder(ctx context.Context, p pin.Pinner, bs bstore.GCBlockstore, ds ipld
 		Trickle:    false,
 		Wrap:       false,
 		Chunker:    "",
+		Base:       b,
 	}, nil
 }
 
@@ -91,6 +93,7 @@ type Adder struct {
 	unlocker   bstore.Unlocker
 	tempRoot   *cid.Cid
 	Prefix     *cid.Prefix
+	Base       mbase.Encoder
 	liveNodes  uint64
 }
 
@@ -277,7 +280,7 @@ func (adder *Adder) outputDirs(path string, fsn mfs.FSNode) error {
 			return err
 		}
 
-		return outputDagnode(adder.Out, path, nd)
+		return outputDagnode(adder.Out, path, nd, adder.Base)
 	default:
 		return fmt.Errorf("unrecognized fsn type: %#v", fsn)
 	}
@@ -399,7 +402,7 @@ func (adder *Adder) addNode(node ipld.Node, path string) error {
 	}
 
 	if !adder.Silent {
-		return outputDagnode(adder.Out, path, node)
+		return outputDagnode(adder.Out, path, node, adder.Base)
 	}
 	return nil
 }
@@ -534,12 +537,12 @@ func (adder *Adder) maybePauseForGC() error {
 }
 
 // outputDagnode sends dagnode info over the output channel
-func outputDagnode(out chan interface{}, name string, dn ipld.Node) error {
+func outputDagnode(out chan interface{}, name string, dn ipld.Node, base mbase.Encoder) error {
 	if out == nil {
 		return nil
 	}
 
-	o, err := getOutput(dn)
+	o, err := getOutput(dn, base)
 	if err != nil {
 		return err
 	}
@@ -554,7 +557,7 @@ func outputDagnode(out chan interface{}, name string, dn ipld.Node) error {
 }
 
 // from core/commands/object.go
-func getOutput(dagnode ipld.Node) (*Object, error) {
+func getOutput(dagnode ipld.Node, base mbase.Encoder) (*Object, error) {
 	c := dagnode.Cid()
 	s, err := dagnode.Size()
 	if err != nil {
@@ -562,7 +565,7 @@ func getOutput(dagnode ipld.Node) (*Object, error) {
 	}
 
 	output := &Object{
-		Hash:  c.String(),
+		Hash:  c.Encode(base),
 		Size:  strconv.FormatUint(s, 10),
 		Links: make([]Link, len(dagnode.Links())),
 	}

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -20,6 +20,7 @@ import (
 	unixfs "github.com/ipfs/go-ipfs/unixfs"
 
 	posinfo "gx/ipfs/QmSHjPDw8yNgLZ7cBfX7w3Smn7PHwYhNEpd4LHQQxUg35L/go-ipfs-posinfo"
+	mbase "gx/ipfs/QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR/go-multibase"
 	chunker "gx/ipfs/QmVDjhUMtkRskBFAVNwyXuLSKbeAya7JKPnzAxMKDaK4x4/go-ipfs-chunker"
 	cid "gx/ipfs/QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP/go-cid"
 	ipld "gx/ipfs/QmZtNq8dArGfnpCZfx2pUNY7UcjGhVp5qqwQ4hH6mpTMRQ/go-ipld-format"

--- a/core/misc/cid.go
+++ b/core/misc/cid.go
@@ -1,0 +1,32 @@
+package misc
+
+import (
+	"context"
+	"strings"
+
+	mbase "gx/ipfs/QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR/go-multibase"	
+)
+
+
+// GetCidBase gets the cid base to use from either the context or
+// another cid or path
+func GetCidBase(ctx context.Context, cidStr string) mbase.Encoder {
+	encoder, ok := ctx.Value("cid-base").(mbase.Encoder)
+	if ok {
+		return encoder
+	}
+	defaultEncoder, _ := mbase.NewEncoder(mbase.Base58BTC)
+	if cidStr != "" {
+		cidStr = strings.TrimPrefix(cidStr, "/ipfs/")
+		if cidStr == "" || strings.HasPrefix(cidStr, "Qm") {
+			return defaultEncoder
+		}
+		encoder, err := mbase.NewEncoder(mbase.Encoding(cidStr[0]))
+		if err != nil {
+			return defaultEncoder
+		}
+		return encoder
+	}
+	return defaultEncoder
+}
+

--- a/mfs/dir.go
+++ b/mfs/dir.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	misc "github.com/ipfs/go-ipfs/core/misc"
 	dag "github.com/ipfs/go-ipfs/merkledag"
 	ft "github.com/ipfs/go-ipfs/unixfs"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
@@ -261,6 +262,7 @@ func (d *Directory) List(ctx context.Context) ([]NodeListing, error) {
 func (d *Directory) ForEachEntry(ctx context.Context, f func(NodeListing) error) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
+	base := misc.GetCidBase(ctx, "")
 	return d.unixfsDir.ForEachLink(ctx, func(l *ipld.Link) error {
 		c, err := d.childUnsync(l.Name)
 		if err != nil {
@@ -275,7 +277,7 @@ func (d *Directory) ForEachEntry(ctx context.Context, f func(NodeListing) error)
 		child := NodeListing{
 			Name: l.Name,
 			Type: int(c.Type()),
-			Hash: nd.Cid().String(),
+			Hash: nd.Cid().Encode(base),
 		}
 
 		if c, ok := c.(*File); ok {

--- a/package.json
+++ b/package.json
@@ -265,9 +265,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmexBtiTTEwwn42Yi6ouKt6VqzpA6wjJgiW1oh9VfaRrup",
+      "hash": "QmSbvata2WqNkqGtZNg8MR3SKwnB8iQ7vTPJgWqB8bC5kR",
       "name": "go-multibase",
-      "version": "0.2.6"
+      "version": "0.2.7"
     },
     {
       "author": "multiformats",


### PR DESCRIPTION
This adds a global option to specify the multibase encoding.  It is global as any command that outputs CID's should eventually be taught to respect this flag.

Several questions:

(1) What should it be called.  Just `--base` is to generic and will conflict with existing flags.  Right now I am using `--mbase` but perhaps `--cid-base` is more obvious to the end user.  Another option is `--encoding` but that is also two generic.

(2) Should this flag imply that new objects are added using CIDv1?  That is should it imply `--cid-version=1` for command that support it?  I am on the fence for this one.

(3) This is related to #5291.  If we implement a flag to convert Cidv0 to CIDv1 for display, should this flag imply that.  I would vote no.

Depends on https://github.com/ipfs/go-cid/pull/60.

Closes #5233. Closes #5234. Towards https://github.com/ipfs/ipfs/issues/337.