### PR TITLE
Include cid-fmt binary in test/bin.

### DIFF
--- a/test/bin/Rules.mk
+++ b/test/bin/Rules.mk
@@ -39,6 +39,12 @@ $(d)/multihash:
 	go build -i $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-multihash)/go-multihash/multihash"
 TGTS_$(d) += $(d)/multihash
 
+# cid-fmt is also special
+$(d)/cid-fmt:
+	go build -i $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-cid)/go-cid/cid-fmt"
+TGTS_$(d) += $(d)/cid-fmt
+
+
 $(TGTS_$(d)): $$(DEPS_GO)
 
 CLEAN += $(TGTS_$(d))

--- a/test/sharness/Rules.mk
+++ b/test/sharness/Rules.mk
@@ -6,7 +6,8 @@ T_$(d) = $(sort $(wildcard $(d)/t[0-9][0-9][0-9][0-9]-*.sh))
 
 DEPS_$(d) := test/bin/random test/bin/multihash test/bin/pollEndpoint \
 	   test/bin/iptb test/bin/go-sleep test/bin/random-files \
-	   test/bin/go-timeout test/bin/hang-fds test/bin/ma-pipe-unidir
+	   test/bin/go-timeout test/bin/hang-fds test/bin/ma-pipe-unidir \
+	   test/bin/cid-fmt
 DEPS_$(d) += cmd/ipfs/ipfs
 DEPS_$(d) += $(d)/clean-test-results
 DEPS_$(d) += $(SHARNESS_$(d))


### PR DESCRIPTION
This utility should allow use to element many of the hard-coded hashes we have in the sharness tests.

Right now I am using it in #5285.
