### PR TITLE
fix: dht findprovs unable to handle /ipfs/hash #5311

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -176,8 +176,8 @@ var findProvidersDhtCmd = &cmds.Command{
 
 		events := make(chan *notif.QueryEvent)
 		ctx := notif.RegisterForQueryEvents(req.Context(), events)
+		c, err := cid.Parse(req.Arguments()[0])
 
-		c, err := cid.Decode(req.Arguments()[0])
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/test/sharness/t0175-reprovider.sh
+++ b/test/sharness/t0175-reprovider.sh
@@ -145,5 +145,9 @@ findprovs_empty '$HASH_0'
 reprovide
 findprovs_expect '$HASH_0' '$PEERID_0'
 
+test_expect_success 'resolve object $HASH_0' '
+  HASH_WITH_PREFIX=$(ipfsi 1 resolve $HASH_0)
+'
+findprovs_expect '$HASH_WITH_PREFIX' '$PEERID_0'
 
 test_done


### PR DESCRIPTION
fix `ipfs dht findprovs` can't handle `/ipfs/$hash`  ref #5311

License: MIT
Signed-off-by: Xiaoyi Wang <wangxiaoyi@hyperchain.cn>