### PR TITLE
RFC: make GC codec agnostic

### DIFF
--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	pin "github.com/ipfs/go-ipfs/pin"
-	dag "gx/ipfs/Qma2BR57Wqp8w9vPreK4dEzoXXk8DFFRL3LresMZg4QpzN/go-merkledag"
-	bserv "gx/ipfs/QmfZ5oGGgsx71QcHb6junfFCMGhYWkK8VV61nkCFyt8e5Q/go-blockservice"
+	bserv "gx/ipfs/QmNqRBAhovtf4jVd5cF7YvHaFSsQHHZBaUFwGQWPM2CV7R/go-blockservice"
+	dag "gx/ipfs/QmRy4Qk9hbgFX9NGJRm8rBThrA8PZhNCitMgeRYyZ67s59/go-merkledag"
 
 	"gx/ipfs/QmQwgv79RHrRnoXmhnpC1BPtY55HHeneGMpPwmmBU1fUAG/go-verifcid"
 	offline "gx/ipfs/QmS6mo1dPpHdYsVkm27BRZDLxpKBCiJKUH8fHX15XFfMez/go-ipfs-exchange-offline"
@@ -76,6 +76,8 @@ func GC(ctx context.Context, bs bstore.GCBlockstore, dstor dstore.Datastore, pn 
 		errors := false
 		var removed uint64
 
+		gchashes := MultihashSetFromCids(gcs)
+
 	loop:
 		for {
 			select {
@@ -83,7 +85,7 @@ func GC(ctx context.Context, bs bstore.GCBlockstore, dstor dstore.Datastore, pn 
 				if !ok {
 					break loop
 				}
-				if !gcs.Has(k) {
+				if !gchashes.Has(k.Hash()) {
 					err := bs.DeleteBlock(k)
 					removed++
 					if err != nil {

--- a/pin/gc/mhset.go
+++ b/pin/gc/mhset.go
@@ -1,0 +1,29 @@
+package gc
+
+import (
+	mh "gx/ipfs/QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8/go-multihash"
+	cid "gx/ipfs/QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP/go-cid"
+)
+
+type MultihashSet map[string]struct{}
+
+func (m MultihashSet) Add(h mh.Multihash) {
+	m[string(h)] = struct{}{}
+}
+
+func (m MultihashSet) Has(h mh.Multihash) bool {
+	_, ok := m[string(h)]
+	return ok
+}
+
+func MultihashSetFromCids(cids *cid.Set) MultihashSet {
+	mhSet := make(MultihashSet, cids.Len())
+
+	if err := cids.ForEach(func(c *cid.Cid) error {
+		mhSet.Add(c.Hash())
+		return nil
+	}); err != nil {
+		log.Panic(err)
+	}
+	return mhSet
+}


### PR DESCRIPTION
This ensures that GC will work regardless of the codec on the CIDs returned by the blockstore.