### PR TITLE
add correct test for 1515

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -394,6 +394,27 @@ file_size() {
     $_STAT "$1"
 }
 
+directory_size() {
+    local total=0
+    local fsize=0
+    local res=0
+    find "$1" -type f | ( while read fname; do
+        fsize=$(file_size "$fname")
+        res=$?
+        if ! test $? -eq 0; then
+            echo "failed to get filesize" >&2
+            return $res
+        fi
+        total=$(expr "$total" + "$fsize")
+        res=$?
+        if ! test $? -eq 0; then
+            echo "filesize not a number: $fsize" >&2
+            return $res
+        fi
+    done
+    echo "$total" ) # do not remove this subshell
+}
+
 test_check_peerid() {
   peeridlen=$(echo "$1" | tr -dC "[:alnum:]" | wc -c | tr -d " ") &&
   test "$peeridlen" = "46" || {

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -48,15 +48,17 @@ test_expect_success "'ipfs pin rm' output looks good" '
   test_cmp expected1 actual1
 '
 
-test_expect_failure "ipfs repo gc fully reverse ipfs add" '
+test_expect_success "ipfs repo gc fully reverse ipfs add" '
   ipfs repo gc &&
   random 100000 41 >gcfile &&
-  disk_usage "$IPFS_PATH/blocks" >expected &&
-  hash=`ipfs add -q gcfile` &&
+  expected="$(directory_size "$IPFS_PATH/blocks")" &&
+  find "$IPFS_PATH/blocks" -type f &&
+  hash=$(ipfs add -q gcfile) &&
   ipfs pin rm -r $hash &&
   ipfs repo gc &&
-  disk_usage "$IPFS_PATH/blocks" >actual &&
-  test_cmp expected actual
+  actual=$(directory_size "$IPFS_PATH/blocks") &&
+  { test "$actual" -eq "$expected" || test_fsh echo "$actual != $expected"; } &&
+  { test "$actual" -gt "0" || test_fsh echo "not($actual > 0)"; }
 '
 
 test_expect_success "file no longer pinned" '


### PR DESCRIPTION
When checking to see if GC fully reverses an `ipfs add`, we should check the size of the actual files, not the directory sizes. A bunch of empty directories won't use *that* much space and really shouldn't count against GC.

closes #1515

I'm not sure why this has been sitting around for so long but I never seem to have created this PR.