### PR TITLE
ci: call cleanWs after each step

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -48,7 +48,11 @@ def setupStep(nodeLabel, f) {
 
         def run = nodeLabel != 'windows' ? this.&sh : this.&bat
 
-        f(run)
+        try {
+          f(run)
+        } finally {
+          cleanWs()
+        }
       }
     }
   }


### PR DESCRIPTION
Might make the builds a bit slower until optimized gx is used here, but the ci should at least be more stable.