### PR TITLE
name cmd: move subcommands to subdirectory

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	"github.com/ipfs/go-ipfs/core/coreunix"
 	filestore "github.com/ipfs/go-ipfs/filestore"
 	ft "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs"
@@ -141,7 +142,7 @@ You can now check what blocks have been created by:
 		return nil
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -7,6 +7,7 @@ import (
 
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	bitswap "gx/ipfs/QmTtmrK4iiM3MxWNA3pvbM9ekQiGZAiFyo57GP8B9FFgtz/go-bitswap"
 	decision "gx/ipfs/QmTtmrK4iiM3MxWNA3pvbM9ekQiGZAiFyo57GP8B9FFgtz/go-bitswap/decision"
@@ -48,7 +49,7 @@ var unwantCmd = &oldcmds.Command{
 		}
 
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -97,7 +98,7 @@ Print out all blocks currently on the bitswap wantlist for the local peer.`,
 		}
 
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -140,14 +141,14 @@ var bitswapStatCmd = &cmds.Command{
 	},
 	Type: bitswap.Stat{},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		nd, err := GetNode(env)
+		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -215,7 +216,7 @@ prints the ledger associated with a given peer.
 		}
 
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -272,7 +273,7 @@ Trigger reprovider to announce our data to network.
 		}
 
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	util "github.com/ipfs/go-ipfs/blocks/blockstoreutil"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 
 	"gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
@@ -137,7 +138,7 @@ than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
 		cmdkit.IntOption("mhlen", "multihash hash length").WithDefault(-1),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -248,7 +249,7 @@ func getBlockForKey(ctx context.Context, env cmds.Environment, skey string) (blo
 		return nil, fmt.Errorf("zero length cid invalid")
 	}
 
-	n, err := GetNode(env)
+	n, err := cmdenv.GetNode(env)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +283,7 @@ It takes a list of base58 encoded multihashes to remove.
 		cmdkit.BoolOption("quiet", "q", "Write minimal output."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	core "github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
 
 	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
@@ -29,7 +30,7 @@ var CatCmd = &cmds.Command{
 		cmdkit.IntOption("length", "l", "Maximum number of bytes to read."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		node, err := GetNode(env)
+		node, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/cmdenv/env.go
+++ b/core/commands/cmdenv/env.go
@@ -1,4 +1,4 @@
-package commands
+package cmdenv
 
 import (
 	"fmt"

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -160,7 +160,7 @@ var findProvidersDhtCmd = &cmds.Command{
 		}
 
 		if n.Routing == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -272,7 +272,7 @@ var provideRefDhtCmd = &cmds.Command{
 		}
 
 		if n.Routing == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -424,7 +424,7 @@ var findPeerDhtCmd = &cmds.Command{
 		}
 
 		if n.Routing == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -529,7 +529,7 @@ Different key types can specify other 'best' rules.
 		}
 
 		if n.Routing == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -643,7 +643,7 @@ NOTE: A value may not exceed 2048 bytes.
 		}
 
 		if n.Routing == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -6,6 +6,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs/commands"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
+	ncmd "github.com/ipfs/go-ipfs/core/commands/name"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 
@@ -72,7 +73,7 @@ The resolver can recursively resolve:
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
-		res.SetOutput(&ResolvedPath{output})
+		res.SetOutput(&ncmd.ResolvedPath{Path: output})
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
@@ -81,12 +82,12 @@ The resolver can recursively resolve:
 				return nil, err
 			}
 
-			output, ok := v.(*ResolvedPath)
+			output, ok := v.(*ncmd.ResolvedPath)
 			if !ok {
 				return nil, e.TypeErr(output, v)
 			}
 			return strings.NewReader(output.Path.String() + "\n"), nil
 		},
 	},
-	Type: ResolvedPath{},
+	Type: ncmd.ResolvedPath{},
 }

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -14,6 +14,7 @@ import (
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
 	core "github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	ft "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs"
 	uio "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/io"
@@ -114,7 +115,7 @@ var filesStatCmd = &cmds.Command{
 			res.SetError(err, cmdkit.ErrClient)
 		}
 
-		node, err := GetNode(env)
+		node, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -745,7 +746,7 @@ stat' on the file or any of its ancestors.
 			return
 		}
 
-		nd, err := GetNode(env)
+		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			re.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/filestore.go
+++ b/core/commands/filestore.go
@@ -9,6 +9,7 @@ import (
 	oldCmds "github.com/ipfs/go-ipfs/commands"
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
 	"github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	"github.com/ipfs/go-ipfs/filestore"
 
@@ -231,7 +232,7 @@ var dupsFileStore = &oldCmds.Command{
 }
 
 func getFilestore(env interface{}) (*core.IpfsNode, *filestore.Filestore, error) {
-	n, err := GetNode(env)
+	n, err := cmdenv.GetNode(env)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -10,15 +10,16 @@ import (
 	"strings"
 
 	core "github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
-	uarchive "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/archive"
-	dag "gx/ipfs/QmRiQCJZ91B7VNmLvA6sxzDuBJGSojS3uXHHVuNr3iueNZ/go-merkledag"
-	path "gx/ipfs/QmdMPBephdLYNESkruDX2hcDTgFYhoCt4LimWhgnomSdV2/go-path"
 
 	"gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
 	"gx/ipfs/QmPtj12fdwuAqj9sBSTNUxBNu8kCGNp8b3o8yUzMm5GHpq/pb"
 	tar "gx/ipfs/QmQine7gvHncNevKtG9QXxf3nXcwSj6aDDmMm52mHofEEp/tar-utils"
+	uarchive "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/archive"
+	dag "gx/ipfs/QmRiQCJZ91B7VNmLvA6sxzDuBJGSojS3uXHHVuNr3iueNZ/go-merkledag"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
+	path "gx/ipfs/QmdMPBephdLYNESkruDX2hcDTgFYhoCt4LimWhgnomSdV2/go-path"
 )
 
 var ErrInvalidCompressionLevel = errors.New("compression level must be between 1 and 9")
@@ -59,7 +60,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return
 		}
 
-		node, err := GetNode(env)
+		node, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"text/tabwriter"
 
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	"github.com/ipfs/go-ipfs/core/commands/e"
 	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 
@@ -66,7 +67,7 @@ var keyGenCmd = &cmds.Command{
 		cmdkit.StringArg("name", true, false, "name of key to create"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		api, err := GetApi(env)
+		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -125,7 +126,7 @@ var keyListCmd = &cmds.Command{
 		cmdkit.BoolOption("l", "Show extra information about keys."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		api, err := GetApi(env)
+		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -163,7 +164,7 @@ var keyRenameCmd = &cmds.Command{
 		cmdkit.BoolOption("force", "f", "Allow to overwrite an existing key."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		api, err := GetApi(env)
+		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -215,7 +216,7 @@ var keyRmCmd = &cmds.Command{
 		cmdkit.BoolOption("l", "Show extra information about keys."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		api, err := GetApi(env)
+		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -91,7 +91,7 @@ baz
 
 		// error if we aren't running node in online mode
 		if node.LocalMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -2,6 +2,7 @@ package name
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 	offline "gx/ipfs/Qmd45r5jHr1PKMNQqifnbZy1ZQwHdtXUDJFamUEvUJE544/go-ipfs-routing/offline"
 	path "gx/ipfs/QmdMPBephdLYNESkruDX2hcDTgFYhoCt4LimWhgnomSdV2/go-path"
-	"fmt"
 )
 
 var log = logging.Logger("core/commands/ipns")
@@ -162,7 +162,7 @@ Resolve the value of a dnslink:
 			if !ok {
 				return e.TypeErr(output, v)
 			}
-			_, err := fmt.Fprintln(w, []byte(output.Path.String()))
+			_, err := fmt.Fprintln(w, output.Path)
 			return err
 		}),
 	},

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -1,4 +1,4 @@
-package commands
+package name
 
 import (
 	"errors"
@@ -6,14 +6,24 @@ import (
 	"strings"
 	"time"
 
-	cmds "github.com/ipfs/go-ipfs/commands"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 
+	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
+	logging "gx/ipfs/QmRREK2CAZ5Re2Bd9zZFG6FeYDppUWt5cMgsoUEp3ktgSr/go-log"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 	offline "gx/ipfs/Qmd45r5jHr1PKMNQqifnbZy1ZQwHdtXUDJFamUEvUJE544/go-ipfs-routing/offline"
+	path "gx/ipfs/QmdMPBephdLYNESkruDX2hcDTgFYhoCt4LimWhgnomSdV2/go-path"
+	"fmt"
 )
+
+var log = logging.Logger("core/commands/ipns")
+
+type ResolvedPath struct {
+	Path path.Path
+}
 
 var IpnsCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
@@ -62,8 +72,8 @@ Resolve the value of a dnslink:
 		cmdkit.UintOption("dht-record-count", "dhtrc", "Number of records to request for DHT resolution."),
 		cmdkit.StringOption("dht-timeout", "dhtt", "Max time to collect values during DHT resolution eg \"30s\". Pass 0 for no timeout."),
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
-		n, err := req.InvocContext().GetNode()
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -77,8 +87,8 @@ Resolve the value of a dnslink:
 			}
 		}
 
-		nocache, _, _ := req.Option("nocache").Bool()
-		local, _, _ := req.Option("local").Bool()
+		nocache, _ := req.Options["nocache"].(bool)
+		local, _ := req.Options["local"].(bool)
 
 		// default to nodes namesys resolver
 		var resolver namesys.Resolver = n.Namesys
@@ -98,7 +108,7 @@ Resolve the value of a dnslink:
 		}
 
 		var name string
-		if len(req.Arguments()) == 0 {
+		if len(req.Arguments) == 0 {
 			if n.Identity == "" {
 				res.SetError(errors.New("identity not loaded"), cmdkit.ErrNormal)
 				return
@@ -106,12 +116,12 @@ Resolve the value of a dnslink:
 			name = n.Identity.Pretty()
 
 		} else {
-			name = req.Arguments()[0]
+			name = req.Arguments[0]
 		}
 
-		recursive, _, _ := req.Option("recursive").Bool()
-		rc, rcok, _ := req.Option("dht-record-count").Int()
-		dhtt, dhttok, _ := req.Option("dht-timeout").String()
+		recursive, _ := req.Options["recursive"].(bool)
+		rc, rcok := req.Options["dht-record-count"].(int)
+		dhtt, dhttok := req.Options["dht-timeout"].(string)
 		var ropts []nsopts.ResolveOpt
 		if !recursive {
 			ropts = append(ropts, nsopts.Depth(1))
@@ -136,7 +146,7 @@ Resolve the value of a dnslink:
 			name = "/ipns/" + name
 		}
 
-		output, err := resolver.Resolve(req.Context(), name, ropts...)
+		output, err := resolver.Resolve(req.Context, name, ropts...)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -144,21 +154,17 @@ Resolve the value of a dnslink:
 
 		// TODO: better errors (in the case of not finding the name, we get "failed to find any peer in table")
 
-		res.SetOutput(&ResolvedPath{output})
+		cmds.EmitOnce(res, &ResolvedPath{output})
 	},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
-			v, err := unwrapOutput(res.Output())
-			if err != nil {
-				return nil, err
-			}
-
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {
 			output, ok := v.(*ResolvedPath)
 			if !ok {
-				return nil, e.TypeErr(output, v)
+				return e.TypeErr(output, v)
 			}
-			return strings.NewReader(output.Path.String() + "\n"), nil
-		},
+			_, err := fmt.Fprintln(w, []byte(output.Path.String()))
+			return err
+		}),
 	},
 	Type: ResolvedPath{},
 }

--- a/core/commands/name/ipnsps.go
+++ b/core/commands/name/ipnsps.go
@@ -1,16 +1,18 @@
-package commands
+package name
 
 import (
 	"errors"
 	"io"
 	"strings"
 
-	cmds "github.com/ipfs/go-ipfs/commands"
-	e "github.com/ipfs/go-ipfs/core/commands/e"
+	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
+	"github.com/ipfs/go-ipfs/core/commands/e"
 
-	peer "gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
-	cmdkit "gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
-	record "gx/ipfs/QmdHb9aBELnQKTVhvvA3hsQbRgUAwsWUzBP2vZ6Y5FBYvE/go-libp2p-record"
+	"gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
+	"gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
+	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
+	"gx/ipfs/QmdHb9aBELnQKTVhvvA3hsQbRgUAwsWUzBP2vZ6Y5FBYvE/go-libp2p-record"
+	"fmt"
 )
 
 type ipnsPubsubState struct {
@@ -19,6 +21,10 @@ type ipnsPubsubState struct {
 
 type ipnsPubsubCancel struct {
 	Canceled bool
+}
+
+type stringList struct {
+	Strings []string
 }
 
 // IpnsPubsubCmd is the subcommand that allows us to manage the IPNS pubsub system
@@ -42,26 +48,21 @@ var ipnspsStateCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Query the state of IPNS pubsub",
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
-		n, err := req.InvocContext().GetNode()
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
 		}
 
-		res.SetOutput(&ipnsPubsubState{n.PSRouter != nil})
+		cmds.EmitOnce(res, &ipnsPubsubState{n.PSRouter != nil})
 	},
 	Type: ipnsPubsubState{},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
-			v, err := unwrapOutput(res.Output())
-			if err != nil {
-				return nil, err
-			}
-
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {
 			output, ok := v.(*ipnsPubsubState)
 			if !ok {
-				return nil, e.TypeErr(output, v)
+				return e.TypeErr(output, v)
 			}
 
 			var state string
@@ -71,8 +72,9 @@ var ipnspsStateCmd = &cmds.Command{
 				state = "disabled"
 			}
 
-			return strings.NewReader(state + "\n"), nil
-		},
+			_, err := fmt.Fprintln(w, []byte(state))
+			return err
+		}),
 	},
 }
 
@@ -80,8 +82,8 @@ var ipnspsSubsCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show current name subscriptions",
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
-		n, err := req.InvocContext().GetNode()
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -106,11 +108,11 @@ var ipnspsSubsCmd = &cmds.Command{
 			paths = append(paths, "/ipns/"+peer.IDB58Encode(pid))
 		}
 
-		res.SetOutput(&stringList{paths})
+		cmds.EmitOnce(res, &stringList{paths})
 	},
 	Type: stringList{},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: stringListMarshaler,
+	Encoders: cmds.EncoderMap{
+		cmds.Text: stringListMarshaler(),
 	},
 }
 
@@ -118,8 +120,8 @@ var ipnspsCancelCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Cancel a name subscription",
 	},
-	Run: func(req cmds.Request, res cmds.Response) {
-		n, err := req.InvocContext().GetNode()
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -130,7 +132,7 @@ var ipnspsCancelCmd = &cmds.Command{
 			return
 		}
 
-		name := req.Arguments()[0]
+		name := req.Arguments[0]
 		name = strings.TrimPrefix(name, "/ipns/")
 		pid, err := peer.IDB58Decode(name)
 		if err != nil {
@@ -139,22 +141,17 @@ var ipnspsCancelCmd = &cmds.Command{
 		}
 
 		ok := n.PSRouter.Cancel("/ipns/" + string(pid))
-		res.SetOutput(&ipnsPubsubCancel{ok})
+		cmds.EmitOnce(res, &ipnsPubsubCancel{ok})
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("name", true, false, "Name to cancel the subscription for."),
 	},
 	Type: ipnsPubsubCancel{},
-	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) (io.Reader, error) {
-			v, err := unwrapOutput(res.Output())
-			if err != nil {
-				return nil, err
-			}
-
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {
 			output, ok := v.(*ipnsPubsubCancel)
 			if !ok {
-				return nil, e.TypeErr(output, v)
+				return e.TypeErr(output, v)
 			}
 
 			var state string
@@ -164,7 +161,26 @@ var ipnspsCancelCmd = &cmds.Command{
 				state = "no subscription"
 			}
 
-			return strings.NewReader(state + "\n"), nil
-		},
+			_, err := fmt.Fprintln(w, []byte(state))
+			return err
+		}),
 	},
+}
+
+func stringListMarshaler() cmds.EncoderFunc {
+	return cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {
+		list, ok := v.(*stringList)
+		if !ok {
+			return e.TypeErr(list, v)
+		}
+
+		for _, s := range list.Strings {
+			_, err := fmt.Fprintln(w, []byte(s))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }

--- a/core/commands/name/ipnsps.go
+++ b/core/commands/name/ipnsps.go
@@ -2,6 +2,7 @@ package name
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -12,7 +13,6 @@ import (
 	"gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 	"gx/ipfs/QmdHb9aBELnQKTVhvvA3hsQbRgUAwsWUzBP2vZ6Y5FBYvE/go-libp2p-record"
-	"fmt"
 )
 
 type ipnsPubsubState struct {
@@ -72,7 +72,7 @@ var ipnspsStateCmd = &cmds.Command{
 				state = "disabled"
 			}
 
-			_, err := fmt.Fprintln(w, []byte(state))
+			_, err := fmt.Fprintln(w, state)
 			return err
 		}),
 	},
@@ -161,7 +161,7 @@ var ipnspsCancelCmd = &cmds.Command{
 				state = "no subscription"
 			}
 
-			_, err := fmt.Fprintln(w, []byte(state))
+			_, err := fmt.Fprintln(w, state)
 			return err
 		}),
 	},
@@ -175,7 +175,7 @@ func stringListMarshaler() cmds.EncoderFunc {
 		}
 
 		for _, s := range list.Strings {
-			_, err := fmt.Fprintln(w, []byte(s))
+			_, err := fmt.Fprintln(w, s)
 			if err != nil {
 				return err
 			}

--- a/core/commands/name/name.go
+++ b/core/commands/name/name.go
@@ -1,8 +1,7 @@
-package commands
+package name
 
 import (
-	cmds "github.com/ipfs/go-ipfs/commands"
-
+	"gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 )
 

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -7,6 +7,7 @@ import (
 
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
@@ -67,7 +68,7 @@ the limit will not be respected by the network.
 		cmdkit.FileArg("data", true, false, "Data to append.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) {
-		api, err := GetApi(env)
+		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			re.SetError(err, cmdkit.ErrNormal)
 			return
@@ -249,16 +250,4 @@ to a file containing 'bar', and returns the hash of the new object.
 	Marshalers: oldcmds.MarshalerMap{
 		oldcmds.Text: objectMarshaler,
 	},
-}
-
-// TODO: fix import loop with core/commands so we don't need that
-// COPIED FROM ONE LEVEL UP
-// GetApi extracts CoreAPI instance from the environment.
-func GetApi(env cmds.Environment) (coreiface.CoreAPI, error) {
-	ctx, ok := env.(*oldcmds.Context)
-	if !ok {
-		return nil, fmt.Errorf("expected env to be of type %T, got %T", ctx, env)
-	}
-
-	return ctx.GetApi()
 }

--- a/core/commands/p2p.go
+++ b/core/commands/p2p.go
@@ -405,7 +405,7 @@ func getNode(req cmds.Request) (*core.IpfsNode, error) {
 	}
 
 	if !n.OnlineMode() {
-		return nil, errNotOnline
+		return nil, ErrNotOnline
 	}
 
 	return n, nil

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -78,7 +78,7 @@ trip latency information.
 
 		// Must be online!
 		if !n.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/ipfs/go-ipfs/core"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 
 	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
@@ -73,7 +74,7 @@ This command outputs data in the following encodings:
 		cmdkit.BoolOption("discover", "try to discover other peers subscribed to the same topic"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -81,7 +82,7 @@ This command outputs data in the following encodings:
 
 		// Must be online!
 		if !n.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -206,7 +207,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 		cmdkit.StringArg("data", true, true, "Payload of message to publish.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -214,7 +215,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 
 		// Must be online!
 		if !n.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -253,7 +254,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 `,
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -261,7 +262,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 
 		// Must be online!
 		if !n.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -310,7 +311,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 		cmdkit.StringArg("topic", false, false, "topic to list connected peers of"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -318,7 +319,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 
 		// Must be online!
 		if !n.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 

--- a/core/commands/repo.go
+++ b/core/commands/repo.go
@@ -11,6 +11,7 @@ import (
 
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
@@ -165,7 +166,7 @@ Version         string The repo version.
 		cmdkit.BoolOption("human", "Output sizes in MiB."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -9,16 +9,13 @@ import (
 	cmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
+	ncmd "github.com/ipfs/go-ipfs/core/commands/name"
 	ns "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 	path "gx/ipfs/QmdMPBephdLYNESkruDX2hcDTgFYhoCt4LimWhgnomSdV2/go-path"
 
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 )
-
-type ResolvedPath struct {
-	Path path.Path
-}
 
 var ResolveCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
@@ -113,7 +110,7 @@ Resolve the value of an IPFS DAG path:
 				res.SetError(err, cmdkit.ErrNormal)
 				return
 			}
-			res.SetOutput(&ResolvedPath{p})
+			res.SetOutput(&ncmd.ResolvedPath{Path: p})
 			return
 		}
 
@@ -132,7 +129,7 @@ Resolve the value of an IPFS DAG path:
 
 		c := node.Cid()
 
-		res.SetOutput(&ResolvedPath{path.FromCid(c)})
+		res.SetOutput(&ncmd.ResolvedPath{Path: path.FromCid(c)})
 	},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
@@ -141,12 +138,12 @@ Resolve the value of an IPFS DAG path:
 				return nil, err
 			}
 
-			output, ok := v.(*ResolvedPath)
+			output, ok := v.(*ncmd.ResolvedPath)
 			if !ok {
 				return nil, e.TypeErr(output, v)
 			}
 			return strings.NewReader(output.Path.String() + "\n"), nil
 		},
 	},
-	Type: ResolvedPath{},
+	Type: ncmd.ResolvedPath{},
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"io"
 	"strings"
 
@@ -8,6 +9,7 @@ import (
 	lgc "github.com/ipfs/go-ipfs/commands/legacy"
 	dag "github.com/ipfs/go-ipfs/core/commands/dag"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
+	name "github.com/ipfs/go-ipfs/core/commands/name"
 	ocmd "github.com/ipfs/go-ipfs/core/commands/object"
 	unixfs "github.com/ipfs/go-ipfs/core/commands/unixfs"
 
@@ -17,6 +19,8 @@ import (
 )
 
 var log = logging.Logger("core/commands")
+
+var ErrNotOnline = errors.New("this command must be run in online mode. Try running 'ipfs daemon' first")
 
 const (
 	ApiOption = "api"
@@ -125,7 +129,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"log":       lgc.NewCommand(LogCmd),
 	"ls":        lgc.NewCommand(LsCmd),
 	"mount":     lgc.NewCommand(MountCmd),
-	"name":      lgc.NewCommand(NameCmd),
+	"name":      name.NameCmd,
 	"object":    ocmd.ObjectCmd,
 	"pin":       lgc.NewCommand(PinCmd),
 	"ping":      lgc.NewCommand(PingCmd),
@@ -160,11 +164,11 @@ var rootROSubcommands = map[string]*cmds.Command{
 	"get": GetCmd,
 	"dns": lgc.NewCommand(DNSCmd),
 	"ls":  lgc.NewCommand(LsCmd),
-	"name": lgc.NewCommand(&oldcmds.Command{
-		Subcommands: map[string]*oldcmds.Command{
-			"resolve": IpnsCmd,
+	"name": &cmds.Command{
+		Subcommands: map[string]*cmds.Command{
+			"resolve": name.IpnsCmd,
 		},
-	}),
+	},
 	"object": lgc.NewCommand(&oldcmds.Command{
 		Subcommands: map[string]*oldcmds.Command{
 			"data":  ocmd.ObjectDataCmd,

--- a/core/commands/shutdown.go
+++ b/core/commands/shutdown.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"fmt"
 
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
+
 	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 )
@@ -12,7 +14,7 @@ var daemonShutdownCmd = &cmds.Command{
 		Tagline: "Shut down the ipfs daemon",
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) {
-		nd, err := GetNode(env)
+		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			re.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
+
 	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
 	peer "gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
@@ -80,7 +82,7 @@ Example:
 	},
 
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
-		nd, err := GetNode(env)
+		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return
@@ -88,7 +90,7 @@ Example:
 
 		// Must be online!
 		if !nd.OnlineMode() {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -72,7 +72,7 @@ var swarmPeersCmd = &cmds.Command{
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -223,7 +223,7 @@ var swarmAddrsCmd = &cmds.Command{
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -291,7 +291,7 @@ var swarmAddrsLocalCmd = &cmds.Command{
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -331,7 +331,7 @@ var swarmAddrsListenCmd = &cmds.Command{
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -381,7 +381,7 @@ ipfs swarm connect /ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3
 		addrs := req.Arguments()
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -446,7 +446,7 @@ it will reconnect.
 		addrs := req.Arguments()
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrClient)
+			res.SetError(ErrNotOnline, cmdkit.ErrClient)
 			return
 		}
 
@@ -593,7 +593,7 @@ Filters default to those specified under the "Swarm.AddrFilters" config key.
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -641,7 +641,7 @@ add your filters to the ipfs config file.
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 
@@ -714,7 +714,7 @@ remove your filters from the ipfs config file.
 		}
 
 		if n.PeerHost == nil {
-			res.SetError(errNotOnline, cmdkit.ErrNormal)
+			res.SetError(ErrNotOnline, cmdkit.ErrNormal)
 			return
 		}
 

--- a/core/commands/urlstore.go
+++ b/core/commands/urlstore.go
@@ -5,13 +5,14 @@ import (
 	"io"
 	"net/http"
 
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	filestore "github.com/ipfs/go-ipfs/filestore"
-	balanced "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/balanced"
-	ihelper "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/helpers"
-	trickle "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/trickle"
 
 	cmds "gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
 	mh "gx/ipfs/QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8/go-multihash"
+	balanced "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/balanced"
+	ihelper "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/helpers"
+	trickle "gx/ipfs/QmQjEpRiwVvtowhq69dAtB4jhioPVFXiCcWZm9Sfgn7eqc/go-unixfs/importer/trickle"
 	cmdkit "gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
 	chunk "gx/ipfs/QmXzBbJo2sLf3uwjNTeoWYiJV7CjAhkiA4twtLvwJSSNdK/go-ipfs-chunker"
 	cid "gx/ipfs/QmZFbDTY9jfSBms2MchvYM9oYRbAF19K7Pby47yDBfpPrb/go-cid"
@@ -53,7 +54,7 @@ time.
 
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) {
 		url := req.Arguments[0]
-		n, err := GetNode(env)
+		n, err := cmdenv.GetNode(env)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return


### PR DESCRIPTION
Just wanted to do this before `ipfs name resolve --stream`

* Moves `GetApi`/`GetNode` utils to subpkg to avoid duplicating them
* Port name commands to the new lib
* Move `ipns name` commands into a sub-package
