### PR TITLE
directly parse peer IDs as peer IDs

### DIFF
--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -58,7 +58,7 @@ func (r *IpnsResolver) resolveOnce(ctx context.Context, name string, options *op
 	pid, err := peer.IDB58Decode(name)
 	if err != nil {
 		// name should be a multihash. if it isn't, error out here.
-		log.Debugf("RoutingResolver: bad input hash: [%s]\n", name)
+		log.Debugf("RoutingResolver: IPNS address not a valid peer ID: [%s]\n", name)
 		return "", 0, err
 	}
 

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -55,16 +55,10 @@ func (r *IpnsResolver) resolveOnce(ctx context.Context, name string, options *op
 	}
 
 	name = strings.TrimPrefix(name, "/ipns/")
-	hash, err := mh.FromB58String(name)
+	pid, err := peer.IDB58Decode(name)
 	if err != nil {
 		// name should be a multihash. if it isn't, error out here.
 		log.Debugf("RoutingResolver: bad input hash: [%s]\n", name)
-		return "", 0, err
-	}
-
-	pid, err := peer.IDFromBytes(hash)
-	if err != nil {
-		log.Debugf("RoutingResolver: could not convert public key hash %s to peer ID: %s\n", name, err)
 		return "", 0, err
 	}
 

--- a/test/sharness/t0236-cli-api-dns-resolve.sh
+++ b/test/sharness/t0236-cli-api-dns-resolve.sh
@@ -13,7 +13,7 @@ test_init_ipfs
 test_expect_success "can make http request against dns resolved nc server" '
   nc -ld 5005 > nc_out &
   NCPID=$!
-  go-sleep 0.5s && kill "$NCPID" &
+  go-sleep 1s && kill "$NCPID" &
   ipfs cat /ipfs/Qmabcdef --api /dns4/localhost/tcp/5005 || true
 '
 


### PR DESCRIPTION
No need to parse it as a hash first.