### PR TITLE
ci: test on 32bit os

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -98,6 +98,21 @@ def sharness_step = { run, osname, makeargs, ignore ->
   }
 }
 
+def gotest_step = { run ->
+  timeout(time: gotest_timeout, unit: 'MINUTES') {
+    run "make gx-deps"
+
+    try {
+      run test + ' -tags="nofuse" 2>&1 | tee output'
+      run 'cat output | go-junit-report > junit-report-linux.xml'
+    } catch (err) {
+      throw err
+    } finally {
+      junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+    }
+  }
+}
+
 /* PIPELINE */
 
 ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
@@ -157,24 +172,28 @@ ansiColor('xterm') { withEnv(['TERM=xterm-color']) {
       },
       linux: {
         setupStep('linux') { run ->
-          timeout(time: gotest_timeout, unit: 'MINUTES') {
-            run 'go get -v github.com/jstemmer/go-junit-report'
-            run "make gx-deps"
-
-            try {
-              run test + ' -tags="nofuse" 2>&1 | tee output'
-              run 'cat output | go-junit-report > junit-report-linux.xml'
-            } catch (err) {
-              throw err
-            } finally {
-              junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
-            }
-          }
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          gotest_step(run)
         }
       },
       linuxSharness: {
        setupStep('linux') { run ->
          sharness_step(run, 'linux', '-Otarget', false)
+        }
+      },
+      linux32: {
+        setupStep('linux') { run ->
+          run 'go get -v github.com/jstemmer/go-junit-report'
+          withEnv(["GOARCH=386"]) {
+            gotest_step(run)
+          }
+        }
+      },
+      linux32Sharness: {
+        setupStep('linux') { run ->
+          withEnv(["GOARCH=386", "TEST_NO_PLUGIN=1"]) {
+            sharness_step(run, 'linux', '-Otarget', false)
+          }
         }
       },
       //macOS: {

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -41,7 +40,8 @@ func (m mockNamesys) Resolve(ctx context.Context, name string, opts ...nsopts.Re
 	}
 	depth := cfg.Depth
 	if depth == nsopts.UnlimitedDepth {
-		depth = math.MaxUint64
+		// max uint
+		depth = ^uint(0)
 	}
 	for strings.HasPrefix(name, "/ipns/") {
 		if depth <= 0 {

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -26,7 +26,7 @@ go-tags=$(if $(GOTAGS), -tags="$(call join-with,$(space),$(GOTAGS))")
 go-flags-with-tags=$(GOFLAGS)$(go-tags)
 
 define go-build
-$(GOCC) build -i $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
+$(GOCC) build $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"
 endef
 
 define go-try-build

--- a/test/bin/Rules.mk
+++ b/test/bin/Rules.mk
@@ -30,18 +30,18 @@ TGTS_GX_$(d) := hang-fds
 TGTS_GX_$(d) := $(addprefix $(d)/,$(TGTS_GX_$(d)))
 
 $(TGTS_GX_$(d)):
-	go build -i $(go-flags-with-tags) -o "$@" "$(call gx-path,$(notdir $@))"
+	go build $(go-flags-with-tags) -o "$@" "$(call gx-path,$(notdir $@))"
 
 TGTS_$(d) += $(TGTS_GX_$(d))
 
 # multihash is special
 $(d)/multihash:
-	go build -i $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-multihash)/go-multihash/multihash"
+	go build $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-multihash)/go-multihash/multihash"
 TGTS_$(d) += $(d)/multihash
 
 # cid-fmt is also special
 $(d)/cid-fmt:
-	go build -i $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-cidutil)/go-cidutil/cid-fmt"
+	go build $(go-flags-with-tags) -o "$@" "gx/ipfs/$(shell gx deps find go-cidutil)/go-cidutil/cid-fmt"
 TGTS_$(d) += $(d)/cid-fmt
 
 # random is also special


### PR DESCRIPTION
To test for stuff like https://github.com/ipfs/go-ipfs/issues/5367

There is also one test fail in gateway test code:
```
core/corehttp/gateway_test.go:42:9: constant 18446744073709551615 overflows uint
```

