### PR TITLE
fix output of object command

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -160,7 +160,7 @@ multihash.
 			}
 		}
 
-		out := Object{
+		out := &Object{
 			Hash:  rp.Cid().String(),
 			Links: outLinks,
 		}

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -183,10 +183,10 @@ multihash.
 			w := tabwriter.NewWriter(buf, 1, 2, 1, ' ', 0)
 			headers, _, _ := res.Request().Option("headers").Bool()
 			if headers {
-				fmt.Fprintln(w, "Hash\tSize\tName\t")
+				fmt.Fprintln(w, "Hash\tSize\tName")
 			}
 			for _, link := range object.Links {
-				fmt.Fprintf(w, "%s\t%v\t%s\t\n", link.Hash, link.Size, link.Name)
+				fmt.Fprintf(w, "%s\t%v\t%s\n", link.Hash, link.Size, link.Name)
 			}
 			w.Flush()
 			return buf, nil

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -223,6 +223,12 @@ test_object_cmd() {
     ipfs object stat $OUTPUT
   '
 
+  test_expect_success "'ipfs object links' gives the correct results" '
+    echo "$EMPTY_DIR" 4 foo > expected &&
+    ipfs object links "$OUTPUT" > actual &&
+    test_cmp expected actual
+  '
+
   test_expect_success "'ipfs object patch add-link' should work with paths" '
     EMPTY_DIR=$(ipfs object new unixfs-dir) &&
     N1=$(ipfs object patch $EMPTY_DIR add-link baz $EMPTY_DIR) &&


### PR DESCRIPTION
We're expecting a pointer, not a value. This works in daemon mode but not in offline mode.

fixes #5458

---

see: https://github.com/ipfs/go-ipfs-cmds/issues/120