### PR TITLE
fix behaviour of key rename to same name

### DIFF
--- a/core/coreapi/key.go
+++ b/core/coreapi/key.go
@@ -8,10 +8,10 @@ import (
 
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	caopts "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
-	ipfspath "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
 
 	crypto "gx/ipfs/QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n/go-libp2p-crypto"
 	peer "gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
+	ipfspath "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
 )
 
 type KeyAPI CoreAPI
@@ -157,6 +157,12 @@ func (api *KeyAPI) Rename(ctx context.Context, oldName string, newName string, o
 	pid, err := peer.IDFromPublicKey(pubKey)
 	if err != nil {
 		return nil, false, err
+	}
+
+	// This is important, because future code will delete key `oldName`
+	// even if it is the same as newName.
+	if newName == oldName {
+		return &key{oldName, pid}, false, nil
 	}
 
 	overwrite := false

--- a/core/coreapi/key_test.go
+++ b/core/coreapi/key_test.go
@@ -366,6 +366,62 @@ func TestRenameOverwrite(t *testing.T) {
 	}
 }
 
+func TestRenameSameNameNoForce(t *testing.T) {
+	ctx := context.Background()
+	_, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = api.Key().Generate(ctx, "foo")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	k, overwrote, err := api.Key().Rename(ctx, "foo", "foo")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if overwrote {
+		t.Error("overwrote should be false")
+	}
+
+	if k.Name() != "foo" {
+		t.Errorf("returned key should be called 'foo', got '%s'", k.Name())
+	}
+}
+
+func TestRenameSameName(t *testing.T) {
+	ctx := context.Background()
+	_, api, err := makeAPI(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = api.Key().Generate(ctx, "foo")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	k, overwrote, err := api.Key().Rename(ctx, "foo", "foo", opt.Key.Force(true))
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if overwrote {
+		t.Error("overwrote should be false")
+	}
+
+	if k.Name() != "foo" {
+		t.Errorf("returned key should be called 'foo', got '%s'", k.Name())
+	}
+}
+
 func TestRemove(t *testing.T) {
 	ctx := context.Background()
 	_, api, err := makeAPI(ctx)


### PR DESCRIPTION
Corrects and amends what happens when keys are renamed to the same name.

Also mildly changed the order of imports in key.go because the VS Code Go linter wasn't quite happy with it.

Fixed #5450 