### PR TITLE
docker: allow IPFS_PROFILE to choose the profile for `ipfs init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ Stop the running container:
 
     docker stop ipfs_host
 
+When starting a container running ipfs for the first time with an empty data directory, it will call `ipfs init` to initialize configuration files and generate a new keypair. At this time, you can choose which profile to apply using the `IPFS_PROFILE` environment variable:
+
+    docker run -d --name ipfs_host -e IPFS_PROFILE=server -v $ipfs_staging:/export -v $ipfs_data:/data/ipfs -p 4001:4001 -p 127.0.0.1:8080:8080 -p 127.0.0.1:5001:5001 ipfs/go-ipfs:latest
+
 ### Troubleshooting
 
 If you have previously installed IPFS before and you are running into problems getting a newer version to work, try deleting (or backing up somewhere else) your IPFS config directory (~/.ipfs by default) and rerunning `ipfs init`. This will reinitialize the config file to its defaults and clear out the local datastore of any bad entries.

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -17,9 +17,9 @@ ipfs version
 if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
-  case $IPFS_PROFILE in
-    "") INIT_ARGS= ;;
-    *) INIT_ARGS=--profile=$IPFS_PROFILE ;;
+  case "$IPFS_PROFILE" in
+    "") INIT_ARGS="" ;;
+    *) INIT_ARGS="--profile=$IPFS_PROFILE" ;;
   esac
   ipfs init $INIT_ARGS
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -17,7 +17,11 @@ ipfs version
 if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
-  ipfs init
+  case $IPFS_PROFILE in
+    "") INIT_ARGS= ;;
+    *) INIT_ARGS=--profile=$IPFS_PROFILE ;;
+  esac
+  ipfs init $INIT_ARGS
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi


### PR DESCRIPTION
Added support for an `IPFS_PROFILE` environment variable in the `bin/container_daemon`. The variable, if present, is used with `ipfs init` to add a `--profile=$IPFS_PROFILE` argument which will apply to chosen profile to the newly created configuration.

This is useful for automatic IPFS deployments in hosted container environments, e.g. Kubernetes. In such situations, it's essential to use `--profile=server`.

Pull request helm/charts#7746 requires this change in order to add the `profile` configurable parameter to the IPFS Helm chart.