### PR TITLE
2018 Q4 OKR Planning

### DIFF
--- a/OKR.md
+++ b/OKR.md
@@ -9,7 +9,7 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 - `P0` @hannahhoward - List a sharded directory with 1M entries over LAN in under 1 minute, with less than a second to the first entry.
 - `PX` - There is a prototype implementation of GraphSync for go-ipfs
 - `P0` @magik6k - There is a better and more performant datastore module (e.g Badger or better)
-- `P1` - Rewrite pinning data structures to support large data sets / many files performantly
+- `P1` - Rewrite pinning data structure to support large pinsets and flexible pin modes
 
 **The bandwidth usage is reduced significantly and is well kept under control**
 - `PX` - Spec and draft implementation of allowing users to opt out of providing every IPLD node (and only provide root hashes)

--- a/OKR.md
+++ b/OKR.md
@@ -29,15 +29,20 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 - `P0` @eingenito - Every non-trivial PR is first reviewed by someone other than @Stebalien before he looks at it.
 - `P2` - Every package has tests and tests+code coverage are running on Jenkins
 - `P2` - There is an up-to-date Architecture Diagram of the Go implementation of IPFS that links packages to subsystems to workflows
+- `P2` @schomatis - go-unixfs is more maintainable with improved code, comments and documentation
+
+@momack2 Could you help me phrase these ones with a KR-oriented approach?
 
 **gx becomes a beloved tool by the Go Core Contributors**
-- `P0` - You can update a minor version of a transitive dependancy without updating intermediate dependancies
-- `P0` - go-ipfs doesn't have checked-in gx paths
+- `P0` @travisperson - You can update a minor version of a transitive dependancy without updating intermediate dependancies
+- `P0` @travisperson - go-ipfs doesn't have checked-in gx paths
 
 **Complete outstanding endeavours and still high priorities from Q3**
 - `P0` @kevina - base32 is supported and enabled by default
 - `P1` - go-ipfs gets a unixfsV2 spec and prototype
-- `P2` @djdv - Add mutable methods (r+w) to the new mount implementation and get it building+tested on all supported platforms
+- `P2` @djdv - Add mutable methods (r+w) to the new mount implementation and get it building+tested on all supported
+platforms
+- `P1` @schomatis - MFS behavior and implementation is performant and correct
 
 ## 2018 Q3
 

--- a/OKR.md
+++ b/OKR.md
@@ -18,9 +18,7 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 **It is a joy to use go-ipfs programatically**
 - `PX` @magik6k - The Core API is finalized and released. Make it easier to import go-ipfs as a package
 - `PX` - go-ipfs-api exposes the new Core API
-- `PX` - go-ipfs Daemon uses the new Core API
-- `PX` - go-ipfs Gateway uses the new Core API
-- `PX` - go-ipfs-cms uses uses the new Core API
+- `PX` - go-ipfs Daemon, Gateway, and cmds library use the new Core API
 - `PX` - The legacy non Core API is deprecated and the diagram on go-ipfs README is updated
 
 **go-ipfs becomes a well maintained project**

--- a/OKR.md
+++ b/OKR.md
@@ -24,9 +24,9 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 - `PX` - The legacy non Core API is deprecated and the diagram on go-ipfs README is updated
 
 **go-ipfs becomes a well maintained project**
-- `PX` - The Go Contributing Guidelines are updated to contemplate expecations from Core Devs and instructions on how to be an effective contributor (e.g include PR templates)
-- `PX` - A Lead Maintainer Protocol equivalent is proposed, reviewed by the team, merged and implemented
-- `PX` - Every issue on https://waffle.io/ipfs/go-ipfs gets triaged (reviewed and labeled following https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md)
+- `PX` @eingenito - The Go Contributing Guidelines are updated to contemplate expecations from Core Devs and instructions on how to be an effective contributor (e.g include PR templates)
+- `PX` @eingenito - A Lead Maintainer Protocol equivalent is proposed, reviewed by the team, merged and implemented
+- `PX` @eingenito - Every issue on https://waffle.io/ipfs/go-ipfs gets triaged (reviewed and labeled following https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md)
 - `PX` - Every package has tests and tests+code coverage are running on Jenkins
 - `PX` - There is an up-to-date Architecture Diagram of the Go implementation of IPFS that links packages to subsystems to workflows
 

--- a/OKR.md
+++ b/OKR.md
@@ -7,6 +7,7 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 **go-ipfs handles large datasets (1TB++) without a sweat**
 - `PX` - It takes less than 48 hours to transfer 1TB dataset over Fast Ethernet (100Mbps)
 - `PX` - It takes less than 12 hours to transfer 200GB sharded dataset over Fast Ethernet (100Mbps)
+- `PX` - There is a prototype implementation of GraphSync for go-ipfs
 - `PX` - There is a better and more performant datastore module (e.g Badger or better)
 - `P1` - Rewrite pinning data structures to support large data sets / many files performantly
 

--- a/OKR.md
+++ b/OKR.md
@@ -5,37 +5,39 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 ## 2018 Q4
 
 **go-ipfs handles large datasets (1TB++) without a sweat**
-- `PX` - It takes less than 48 hours to transfer 1TB dataset over Fast Ethernet (100Mbps)
-- `PX` - It takes less than 12 hours to transfer 200GB sharded dataset over Fast Ethernet (100Mbps)
+- `P0` - It takes less than 48 hours to transfer 1TB dataset over Fast Ethernet (100Mbps)
+- `P0` @hannahhoward - List a sharded directory with 1M entries over LAN in under 1 minute, with less than a second to the first entry.
 - `PX` - There is a prototype implementation of GraphSync for go-ipfs
-- `PX` - There is a better and more performant datastore module (e.g Badger or better)
+- `P0` @magik6k - There is a better and more performant datastore module (e.g Badger or better)
 - `P1` - Rewrite pinning data structures to support large data sets / many files performantly
 
 **The bandwidth usage is reduced significantly and is well kept under control**
-- `PX` - Users can opt out of providing every IPLD node (and only provide root hashes)
-- `PX` - "Bitswap improvements around reducing chattiness, decreasing bandwidth usage (fewer dupe blocks), and increasing throughput"
+- `PX` - Spec and draft implementation of allowing users to opt out of providing every IPLD node (and only provide root hashes)
+- `PX` - Bitswap improvements reduce number of duplicate blocks downloaded by 75%
+- `PX` @stebalien - The number of messages sent by Bitswap is on average <= 2x the number of blocks received
 
 **It is a joy to use go-ipfs programatically**
 - `PX` @magik6k - The Core API is finalized and released. Make it easier to import go-ipfs as a package
-- `PX` - go-ipfs-api exposes the new Core API
-- `PX` - go-ipfs Daemon, Gateway, and cmds library use the new Core API
-- `PX` - The legacy non Core API is deprecated and the diagram on go-ipfs README is updated
+- `PX` @magik6k - go-ipfs-api exposes the new Core API
+- `PX` @magik6k - go-ipfs Daemon, Gateway, and cmds library use the new Core API
+- `PX` @magik6k - The legacy non Core API is deprecated and the diagram on go-ipfs README is updated
 
 **go-ipfs becomes a well maintained project**
-- `PX` @eingenito - The Go Contributing Guidelines are updated to contemplate expecations from Core Devs and instructions on how to be an effective contributor (e.g include PR templates)
-- `PX` @eingenito - A Lead Maintainer Protocol equivalent is proposed, reviewed by the team, merged and implemented
-- `PX` @eingenito - Every issue on https://waffle.io/ipfs/go-ipfs gets triaged (reviewed and labeled following https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md)
-- `PX` - Every package has tests and tests+code coverage are running on Jenkins
-- `PX` - There is an up-to-date Architecture Diagram of the Go implementation of IPFS that links packages to subsystems to workflows
+- `P2` @eingenito - The Go Contributing Guidelines are updated to contemplate expecations from Core Devs and instructions on how to be an effective contributor (e.g include PR templates)
+- `P1` @eingenito - A Lead Maintainer Protocol equivalent is proposed, reviewed by the team, merged and implemented
+- `P0` @eingenito - Every issue on https://waffle.io/ipfs/go-ipfs gets triaged (reviewed and labeled following https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md)
+- `P0` @eingenito - Every non-trivial PR is first reviewed by someone other than @Stebalien before he looks at it.
+- `P2` - Every package has tests and tests+code coverage are running on Jenkins
+- `P2` - There is an up-to-date Architecture Diagram of the Go implementation of IPFS that links packages to subsystems to workflows
 
 **gx becomes a beloved tool by the Go Core Contributors**
-- `PX` - 
-- `PX` - 
+- `P0` - You can update a minor version of a transitive dependancy without updating intermediate dependancies
+- `P0` - go-ipfs doesn't have checked-in gx paths
 
 **Complete outstanding endeavours and still high priorities from Q3**
 - `P0` @kevina - base32 is supported and enabled by default
-- `PX` - go-ipfs gets a unixfsV2 prototype
-- `PX` @djdv - IPFS Mount
+- `P1` - go-ipfs gets a unixfsV2 spec and prototype
+- `P2` @djdv - Add mutable methods (r+w) to the new mount implementation and get it building+tested on all supported platforms
 
 ## 2018 Q3
 

--- a/OKR.md
+++ b/OKR.md
@@ -8,7 +8,7 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 - `P0` - It takes less than 48 hours to transfer 1TB dataset over Fast Ethernet (100Mbps)
 - `P0` @hannahhoward - List a sharded directory with 1M entries over LAN in under 1 minute, with less than a second to the first entry.
 - `PX` - There is a prototype implementation of GraphSync for go-ipfs
-- `P0` @magik6k - There is a better and more performant datastore module (e.g Badger or better)
+- `P0` @schomatis - There is a better and more performant datastore module (e.g Badger or better)
 - `P1` - Rewrite pinning data structure to support large pinsets and flexible pin modes
 
 **The bandwidth usage is reduced significantly and is well kept under control**

--- a/OKR.md
+++ b/OKR.md
@@ -12,9 +12,9 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 - `P1` - Rewrite pinning data structure to support large pinsets and flexible pin modes
 
 **The bandwidth usage is reduced significantly and is well kept under control**
-- `PX` - Spec and draft implementation of allowing users to opt out of providing every IPLD node (and only provide root hashes)
-- `PX` - Bitswap improvements reduce number of duplicate blocks downloaded by 75%
-- `PX` @stebalien - The number of messages sent by Bitswap is on average <= 2x the number of blocks received
+- `P1` - Spec and draft implementation of allowing users to opt out of providing every IPLD node (and only provide root hashes)
+- `P0` - Bitswap improvements reduce number of duplicate blocks downloaded by 75%
+- `P0` @stebalien - The number of messages sent by Bitswap is on average <= 2x the number of blocks received
 
 **It is a joy to use go-ipfs programatically**
 - `PX` @magik6k - The Core API is finalized and released. Make it easier to import go-ipfs as a package

--- a/OKR.md
+++ b/OKR.md
@@ -1,0 +1,19 @@
+# Quarterly Objectives and Key Results
+
+We try to frame our ongoing work using a process based on quarterly Objectives and Key Results (OKRs). Objectives reflect outcomes that are challenging, but realistic. Results are tangible and measurable.
+
+## 2018 Q4
+
+Writting in Progress
+
+## 2018 Q3
+
+Find the **go-ipfs OKRs** for 2018 Q3 at the [2018 Q3 IPFS OKRs Spreadsheet](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/edit#gid=274358435)
+
+## 2018 Q2
+
+Find the **go-ipfs OKRs** for 2018 Q2 at the [2018 Q2 IPFS OKRs Spreadsheet](https://docs.google.com/spreadsheets/d/1xIhKROxFlsY9M9on37D5rkbSsm4YtjRQvG2unHScApA/edit#gid=274358435)
+
+## 2018 Q1
+
+Find the **go-ipfs OKRs** for 2018 Q1 at the [2018 Q1 IPFS OKRs Spreadsheet](https://docs.google.com/spreadsheets/u/1/d/1clB-W489rJpbOEs2Q7Q2Jf1WMXHQxXgccBcUJS9QTiI/edit#gid=2079514081)

--- a/OKR.md
+++ b/OKR.md
@@ -4,7 +4,39 @@ We try to frame our ongoing work using a process based on quarterly Objectives a
 
 ## 2018 Q4
 
-Writting in Progress
+**go-ipfs handles large datasets (1TB++) without a sweat**
+- `PX` - It takes less than 48 hours to transfer 1TB dataset over Fast Ethernet (100Mbps)
+- `PX` - It takes less than 12 hours to transfer 200GB sharded dataset over Fast Ethernet (100Mbps)
+- `PX` - There is a better and more performant datastore module (e.g Badger or better)
+- `P1` - Rewrite pinning data structures to support large data sets / many files performantly
+
+**The bandwidth usage is reduced significantly and is well kept under control**
+- `PX` - Users can opt out of providing every IPLD node (and only provide root hashes)
+- `PX` - "Bitswap improvements around reducing chattiness, decreasing bandwidth usage (fewer dupe blocks), and increasing throughput"
+
+**It is a joy to use go-ipfs programatically**
+- `PX` @magik6k - The Core API is finalized and released. Make it easier to import go-ipfs as a package
+- `PX` - go-ipfs-api exposes the new Core API
+- `PX` - go-ipfs Daemon uses the new Core API
+- `PX` - go-ipfs Gateway uses the new Core API
+- `PX` - go-ipfs-cms uses uses the new Core API
+- `PX` - The legacy non Core API is deprecated and the diagram on go-ipfs README is updated
+
+**go-ipfs becomes a well maintained project**
+- `PX` - The Go Contributing Guidelines are updated to contemplate expecations from Core Devs and instructions on how to be an effective contributor (e.g include PR templates)
+- `PX` - A Lead Maintainer Protocol equivalent is proposed, reviewed by the team, merged and implemented
+- `PX` - Every issue on https://waffle.io/ipfs/go-ipfs gets triaged (reviewed and labeled following https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md)
+- `PX` - Every package has tests and tests+code coverage are running on Jenkins
+- `PX` - There is an up-to-date Architecture Diagram of the Go implementation of IPFS that links packages to subsystems to workflows
+
+**gx becomes a beloved tool by the Go Core Contributors**
+- `PX` - 
+- `PX` - 
+
+**Complete outstanding endeavours and still high priorities from Q3**
+- `P0` @kevina - base32 is supported and enabled by default
+- `PX` - go-ipfs gets a unixfsV2 prototype
+- `PX` @djdv - IPFS Mount
 
 ## 2018 Q3
 


### PR DESCRIPTION
Ref: https://github.com/ipfs/pm/issues/698

Urls:
- [2018 Q3 Retrospective Document](https://docs.google.com/document/d/15m28CgV8aksgHsS_MlQKJhTP0LtgYobIkOIuSXew4WE/edit#heading=h.7bczaod8nf6g). Please complete this ASAP.
- [2018 Q4 OKR Spreadsheet](https://docs.google.com/spreadsheets/d/139lROP7-Ee4M4S7A_IO4iIgSgugYm7dct620LYnalII/edit)

It's time to do the OKR Planning for Q4 \o/. This is the first time that the go-ipfs team is going to do it this way, you can find a lot of information at https://github.com/ipfs/pm/issues/698. Please make sure to read it to get the full context in how we are going to do this (Retrospective + Open OKR Planning).

