### PR TITLE
fix fuse unmount test

### DIFF
--- a/fuse/mount/mount.go
+++ b/fuse/mount/mount.go
@@ -38,14 +38,9 @@ func ForceUnmount(m Mount) error {
 	point := m.MountPoint()
 	log.Warningf("Force-Unmounting %s...", point)
 
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("diskutil", "umount", "force", point)
-	case "linux":
-		cmd = exec.Command("fusermount", "-u", point)
-	default:
-		return fmt.Errorf("unmount: unimplemented")
+	cmd, err := UnmountCmd(point)
+	if err != nil {
+		return err
 	}
 
 	errc := make(chan error, 1)
@@ -66,6 +61,19 @@ func ForceUnmount(m Mount) error {
 		return fmt.Errorf("umount timeout")
 	case err := <-errc:
 		return err
+	}
+}
+
+// UnmountCmd creates an exec.Cmd that is GOOS-specific
+// for unmount a FUSE mount
+func UnmountCmd(point string) (*exec.Cmd, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("diskutil", "umount", "force", point), nil
+	case "linux":
+		return exec.Command("fusermount", "-u", point), nil
+	default:
+		return nil, fmt.Errorf("unmount: unimplemented")
 	}
 }
 

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -5,7 +5,6 @@ package node
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -77,24 +76,21 @@ func TestExternalUnmount(t *testing.T) {
 	}
 
 	// Run shell command to externally unmount the directory
-	cmd := "fusermount"
-	args := []string{"-u", ipnsDir}
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	cmd, err := mount.UnmountCmd(ipfsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
 
 	// TODO(noffle): it takes a moment for the goroutine that's running fs.Serve to be notified and do its cleanup.
 	time.Sleep(time.Millisecond * 100)
 
-	// Attempt to unmount IPNS; check that it was already unmounted.
-	err = node.Mounts.Ipns.Unmount()
-	if err != mount.ErrNotMounted {
-		t.Fatal("Unmount should have failed")
-	}
-
 	// Attempt to unmount IPFS; it should unmount successfully.
 	err = node.Mounts.Ipfs.Unmount()
-	if err != nil {
-		t.Fatal(err)
+	if err != mount.ErrNotMounted {
+		t.Fatal("Unmount should have failed")
 	}
 }


### PR DESCRIPTION
Fuse unmount test uses ipfs instead of ipns, because offline nodes dont actually mount ipns.

Factored out GOOS-aware function to determine unmount command in fuse/mount.

fixed #5475

License: MIT
Signed-off-by: Rob Deutsch <rdeutschob@gmail.com>