### PR TITLE
switch to go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 language: go
 
 go:
-    - 1.10.2
+    - 1.11
 
 env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.11-stretch
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # There is a copy of this Dockerfile called Dockerfile.fast,

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.11-stretch
 MAINTAINER Lars Gierth <lgierth@ipfs.io>
 
 # This is a copy of /Dockerfile,

--- a/bin/Rules.mk
+++ b/bin/Rules.mk
@@ -1,9 +1,9 @@
 include mk/header.mk
 
-dist_root_$(d)="/ipfs/QmYpvspyyUWQTE226NFWteXYJF3x3br25xmB6XzEoqfzyv"
+dist_root_$(d)="/ipfs/QmPrXH9jRVwvd7r5MC5e6nV4uauQGzLk1i2647Ye9Vbbwe"
 
-$(d)/gx: $(d)/gx-v0.13.0
-$(d)/gx-go: $(d)/gx-go-v1.7.0
+$(d)/gx: $(d)/gx-v0.14.0
+$(d)/gx-go: $(d)/gx-go-v1.9.0
 
 TGTS_$(d) := $(d)/gx $(d)/gx-go
 DISTCLEAN += $(wildcard $(d)/gx-v*) $(wildcard $(d)/gx-go-v*) $(d)/tmp

--- a/ci/Dockerfile.buildenv
+++ b/ci/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 MAINTAINER Jakub Sztandera <kubuxu@ipfs.io>
 
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -35,7 +35,7 @@ def setupStep(nodeLabel, f) {
     def ps = nodeLabel != 'windows' ? '/' : '\\'
     def psep = nodeLabel != 'windows' ? ':' : ';'
 
-    def root = tool name: '1.10.2', type: 'go'
+    def root = tool name: '1.11', type: 'go'
     def jobNameArr = "${JOB_NAME}"
     def jobName = jobNameArr.split("/")[0..1].join(nodeLabel != 'windows' ? '/' : '\\\\').toLowerCase()
     def subName = jobNameArr.split("/")[2].toLowerCase()

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ machine:
 
   post:
     - sudo rm -rf /usr/local/go
-    - if [ ! -e go1.10.2.linux-amd64.tar.gz ]; then curl -o go1.10.2.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz; fi
-    - sudo tar -C /usr/local -xzf go1.10.2.linux-amd64.tar.gz
+    - if [ ! -e go1.11.linux-amd64.tar.gz ]; then curl -o go1.11.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz; fi
+    - sudo tar -C /usr/local -xzf go1.11.linux-amd64.tar.gz
 
   services:
     - docker
@@ -30,7 +30,7 @@ dependencies:
     - cd "$HOME/.go_workspace/src/$IMPORT_PATH" && make deps
 
   cache_directories:
-    - ~/go1.10.2.linux-amd64.tar.gz
+    - ~/go1.11.linux-amd64.tar.gz
     - ~/.go_workspace/src/gx/ipfs
 
 test:

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -290,9 +290,9 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// Start assembling node config
 	ncfg := &core.BuildCfg{
-		Repo:      repo,
-		Permanent: true, // It is temporary way to signify that node is permanent
-		Online:    !offline,
+		Repo:                        repo,
+		Permanent:                   true, // It is temporary way to signify that node is permanent
+		Online:                      !offline,
 		DisableEncryptedConnections: unencrypted,
 		ExtraOpts: map[string]bool{
 			"pubsub": pubsub,

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.10
+GO_MIN_VERSION = 1.11
 
 
 # pre-definitions

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "gx": {
     "dvcsimport": "github.com/ipfs/go-ipfs",
-    "goversion": "1.10"
+    "goversion": "1.11"
   },
   "gxDependencies": [
     {


### PR DESCRIPTION
Go 1.11 changes the output of `go fmt` slightly so we either need to
all *downgrade* or *upgrade*. Let's upgrade.