### PR TITLE
resolve: use unixfs ResolveOnce

### DIFF
--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -14,7 +14,9 @@ import (
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 	path "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
 
+	uio "gx/ipfs/QmPL8bYtbACcSFFiSr4s2du7Na382NxRADR8hC7D9FkEA2/go-unixfs/io"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
+	resolver "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path/resolver"
 )
 
 var ResolveCmd = &cmds.Command{
@@ -121,7 +123,12 @@ Resolve the value of an IPFS DAG path:
 			return
 		}
 
-		node, err := core.Resolve(req.Context(), n.Namesys, n.Resolver, p)
+		r := &resolver.Resolver{
+			DAG:         n.DAG,
+			ResolveOnce: uio.ResolveUnixfsOnce,
+		}
+
+		node, err := core.Resolve(req.Context(), n.Namesys, r, p)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -11,8 +11,9 @@ import (
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	ncmd "github.com/ipfs/go-ipfs/core/commands/name"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
-	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
+	options "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 	ns "github.com/ipfs/go-ipfs/namesys"
+	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
 	path "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
 
 	"gx/ipfs/QmPTfgFTo9PFr1PvPKyKoeMgBvYPh6cX3aDP7DHKVbnCbi/go-ipfs-cmds"
@@ -93,12 +94,14 @@ Resolve the value of an IPFS DAG path:
 
 		// the case when ipns is resolved step by step
 		if strings.HasPrefix(name, "/ipns/") && !recursive {
-			rc, rcok := req.Options["dht-record-count"].(int)
+			rc, rcok := req.Options["dht-record-count"].(uint)
 			dhtt, dhttok := req.Options["dht-timeout"].(string)
-			ropts := []options.NameResolveOption{options.Name.Depth(1)}
+			ropts := []options.NameResolveOption{
+				options.Name.ResolveOption(nsopts.Depth(1)),
+			}
 
 			if rcok {
-				ropts = append(ropts, options.Name.DhtRecordCount(rc))
+				ropts = append(ropts, options.Name.ResolveOption(nsopts.DhtRecordCount(rc)))
 			}
 			if dhttok {
 				d, err := time.ParseDuration(dhtt)
@@ -110,7 +113,7 @@ Resolve the value of an IPFS DAG path:
 					res.SetError(errors.New("DHT timeout value must be >= 0"), cmdkit.ErrNormal)
 					return
 				}
-				ropts = append(ropts, options.Name.DhtTimeout(d))
+				ropts = append(ropts, options.Name.ResolveOption(nsopts.DhtTimeout(d)))
 			}
 			p, err := api.Name().Resolve(req.Context, name, ropts...)
 			// ErrResolveRecursion is fine

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -135,7 +135,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"ping":      lgc.NewCommand(PingCmd),
 	"p2p":       lgc.NewCommand(P2PCmd),
 	"refs":      lgc.NewCommand(RefsCmd),
-	"resolve":   lgc.NewCommand(ResolveCmd),
+	"resolve":   ResolveCmd,
 	"swarm":     lgc.NewCommand(SwarmCmd),
 	"tar":       lgc.NewCommand(TarCmd),
 	"file":      lgc.NewCommand(unixfs.UnixFSCmd),
@@ -183,7 +183,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 			"resolve": dag.DagResolveCmd,
 		},
 	}),
-	"resolve": lgc.NewCommand(ResolveCmd),
+	"resolve": ResolveCmd,
 	"version": lgc.NewCommand(VersionCmd),
 }
 

--- a/core/coreapi/interface/options/name.go
+++ b/core/coreapi/interface/options/name.go
@@ -2,6 +2,8 @@ package options
 
 import (
 	"time"
+
+	ropts "github.com/ipfs/go-ipfs/namesys/opts"
 )
 
 const (
@@ -14,12 +16,10 @@ type NamePublishSettings struct {
 }
 
 type NameResolveSettings struct {
-	Depth int
 	Local bool
 	Cache bool
 
-	DhtRecordCount int
-	DhtTimeout     time.Duration
+	ResolveOpts []ropts.ResolveOpt
 }
 
 type NamePublishOption func(*NamePublishSettings) error
@@ -43,12 +43,8 @@ func NamePublishOptions(opts ...NamePublishOption) (*NamePublishSettings, error)
 
 func NameResolveOptions(opts ...NameResolveOption) (*NameResolveSettings, error) {
 	options := &NameResolveSettings{
-		Depth: 1,
 		Local: false,
 		Cache: true,
-
-		DhtRecordCount: 16,
-		DhtTimeout:     time.Minute,
 	}
 
 	for _, opt := range opts {
@@ -86,15 +82,6 @@ func (nameOpts) Key(key string) NamePublishOption {
 	}
 }
 
-// Depth is an option for Name.Resolve which specifies the maximum depth of a
-// recursive lookup. Default value is false
-func (nameOpts) Depth(depth int) NameResolveOption {
-	return func(settings *NameResolveSettings) error {
-		settings.Depth = depth
-		return nil
-	}
-}
-
 // Local is an option for Name.Resolve which specifies if the lookup should be
 // offline. Default value is false
 func (nameOpts) Local(local bool) NameResolveOption {
@@ -113,21 +100,10 @@ func (nameOpts) Cache(cache bool) NameResolveOption {
 	}
 }
 
-// DhtRecordCount is an option for Name.Resolve which specifies how many records
-// we want to validate before selecting the best one (newest). Note that setting
-// this value too low will have security implications
-func (nameOpts) DhtRecordCount(rc int) NameResolveOption {
+//
+func (nameOpts) ResolveOption(opt ropts.ResolveOpt) NameResolveOption {
 	return func(settings *NameResolveSettings) error {
-		settings.DhtRecordCount = rc
-		return nil
-	}
-}
-
-// DhtTimeout is an option for Name.Resolve which specifies timeout for
-// DHT lookup
-func (nameOpts) DhtTimeout(timeout time.Duration) NameResolveOption {
-	return func(settings *NameResolveSettings) error {
-		settings.DhtTimeout = timeout
+		settings.ResolveOpts = append(settings.ResolveOpts, opt)
 		return nil
 	}
 }

--- a/core/coreapi/interface/options/name.go
+++ b/core/coreapi/interface/options/name.go
@@ -14,9 +14,12 @@ type NamePublishSettings struct {
 }
 
 type NameResolveSettings struct {
-	Recursive bool
-	Local     bool
-	Cache     bool
+	Depth int
+	Local bool
+	Cache bool
+
+	DhtRecordCount int
+	DhtTimeout     time.Duration
 }
 
 type NamePublishOption func(*NamePublishSettings) error
@@ -40,9 +43,12 @@ func NamePublishOptions(opts ...NamePublishOption) (*NamePublishSettings, error)
 
 func NameResolveOptions(opts ...NameResolveOption) (*NameResolveSettings, error) {
 	options := &NameResolveSettings{
-		Recursive: false,
-		Local:     false,
-		Cache:     true,
+		Depth: 1,
+		Local: false,
+		Cache: true,
+
+		DhtRecordCount: 16,
+		DhtTimeout:     time.Minute,
 	}
 
 	for _, opt := range opts {
@@ -80,11 +86,11 @@ func (nameOpts) Key(key string) NamePublishOption {
 	}
 }
 
-// Recursive is an option for Name.Resolve which specifies whether to perform a
+// Depth is an option for Name.Resolve which specifies the maximum depth of a
 // recursive lookup. Default value is false
-func (nameOpts) Recursive(recursive bool) NameResolveOption {
+func (nameOpts) Depth(depth int) NameResolveOption {
 	return func(settings *NameResolveSettings) error {
-		settings.Recursive = recursive
+		settings.Depth = depth
 		return nil
 	}
 }
@@ -103,6 +109,25 @@ func (nameOpts) Local(local bool) NameResolveOption {
 func (nameOpts) Cache(cache bool) NameResolveOption {
 	return func(settings *NameResolveSettings) error {
 		settings.Cache = cache
+		return nil
+	}
+}
+
+// DhtRecordCount is an option for Name.Resolve which specifies how many records
+// we want to validate before selecting the best one (newest). Note that setting
+// this value too low will have security implications
+func (nameOpts) DhtRecordCount(rc int) NameResolveOption {
+	return func(settings *NameResolveSettings) error {
+		settings.DhtRecordCount = rc
+		return nil
+	}
+}
+
+// DhtTimeout is an option for Name.Resolve which specifies timeout for
+// DHT lookup
+func (nameOpts) DhtTimeout(timeout time.Duration) NameResolveOption {
+	return func(settings *NameResolveSettings) error {
+		settings.DhtTimeout = timeout
 		return nil
 	}
 }

--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -119,9 +119,10 @@ func (api *NameAPI) Resolve(ctx context.Context, name string, opts ...caopts.Nam
 		name = "/ipns/" + name
 	}
 
-	var ropts []nsopts.ResolveOpt
-	if !options.Recursive {
-		ropts = append(ropts, nsopts.Depth(1))
+	ropts := []nsopts.ResolveOpt{
+		nsopts.Depth(uint(options.Depth)),
+		nsopts.DhtRecordCount(uint(options.DhtRecordCount)),
+		nsopts.DhtTimeout(options.DhtTimeout),
 	}
 
 	output, err := resolver.Resolve(ctx, name, ropts...)

--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -7,17 +7,16 @@ import (
 	"strings"
 	"time"
 
-	core "github.com/ipfs/go-ipfs/core"
+	"github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	caopts "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
-	keystore "github.com/ipfs/go-ipfs/keystore"
-	namesys "github.com/ipfs/go-ipfs/namesys"
-	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
+	"github.com/ipfs/go-ipfs/keystore"
+	"github.com/ipfs/go-ipfs/namesys"
 	ipath "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
 
-	crypto "gx/ipfs/QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n/go-libp2p-crypto"
-	peer "gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
-	offline "gx/ipfs/QmSNe4MWVxZWk6UxxW2z2EKofFo4GdFzud1vfn1iVby3mj/go-ipfs-routing/offline"
+	"gx/ipfs/QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n/go-libp2p-crypto"
+	"gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
+	"gx/ipfs/QmSNe4MWVxZWk6UxxW2z2EKofFo4GdFzud1vfn1iVby3mj/go-ipfs-routing/offline"
 )
 
 type NameAPI CoreAPI
@@ -119,13 +118,7 @@ func (api *NameAPI) Resolve(ctx context.Context, name string, opts ...caopts.Nam
 		name = "/ipns/" + name
 	}
 
-	ropts := []nsopts.ResolveOpt{
-		nsopts.Depth(uint(options.Depth)),
-		nsopts.DhtRecordCount(uint(options.DhtRecordCount)),
-		nsopts.DhtTimeout(options.DhtTimeout),
-	}
-
-	output, err := resolver.Resolve(ctx, name, ropts...)
+	output, err := resolver.Resolve(ctx, name, options.ResolveOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -1,53 +1,44 @@
 package coreapi
 
 import (
-	context "context"
-	fmt "fmt"
+	"context"
+	"fmt"
 	gopath "path"
 
-	core "github.com/ipfs/go-ipfs/core"
+	"github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
-	namesys "github.com/ipfs/go-ipfs/namesys"
 	uio "gx/ipfs/QmPL8bYtbACcSFFiSr4s2du7Na382NxRADR8hC7D9FkEA2/go-unixfs/io"
 	ipfspath "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path"
-	resolver "gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path/resolver"
+	"gx/ipfs/QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A/go-path/resolver"
 
-	cid "gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
+	"gx/ipfs/QmPSQnBKM9g7BaUcZCvswUJVscQ1ipjmwxN5PXCjkp9EQ7/go-cid"
 	ipld "gx/ipfs/QmdDXJs4axxefSPgK6Y1QhpJWKuDPnGJiqgq4uncb4rFHL/go-ipld-format"
 )
 
 // ResolveNode resolves the path `p` using Unixfs resolver, gets and returns the
 // resolved Node.
 func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (ipld.Node, error) {
-	return resolveNode(ctx, api.node.DAG, api.node.Namesys, p)
-}
-
-// ResolvePath resolves the path `p` using Unixfs resolver, returns the
-// resolved path.
-func (api *CoreAPI) ResolvePath(ctx context.Context, p coreiface.Path) (coreiface.ResolvedPath, error) {
-	return resolvePath(ctx, api.node.DAG, api.node.Namesys, p)
-}
-
-func resolveNode(ctx context.Context, ng ipld.NodeGetter, nsys namesys.NameSystem, p coreiface.Path) (ipld.Node, error) {
-	rp, err := resolvePath(ctx, ng, nsys, p)
+	rp, err := api.ResolvePath(ctx, p)
 	if err != nil {
 		return nil, err
 	}
 
-	node, err := ng.Get(ctx, rp.Cid())
+	node, err := api.node.DAG.Get(ctx, rp.Cid())
 	if err != nil {
 		return nil, err
 	}
 	return node, nil
 }
 
-func resolvePath(ctx context.Context, ng ipld.NodeGetter, nsys namesys.NameSystem, p coreiface.Path) (coreiface.ResolvedPath, error) {
+// ResolvePath resolves the path `p` using Unixfs resolver, returns the
+// resolved path.
+func (api *CoreAPI) ResolvePath(ctx context.Context, p coreiface.Path) (coreiface.ResolvedPath, error) {
 	if _, ok := p.(coreiface.ResolvedPath); ok {
 		return p.(coreiface.ResolvedPath), nil
 	}
 
 	ipath := ipfspath.Path(p.String())
-	ipath, err := core.ResolveIPNS(ctx, nsys, ipath)
+	ipath, err := core.ResolveIPNS(ctx, api.node.Namesys, ipath)
 	if err == core.ErrNoNamesys {
 		return nil, coreiface.ErrOffline
 	} else if err != nil {
@@ -66,7 +57,7 @@ func resolvePath(ctx context.Context, ng ipld.NodeGetter, nsys namesys.NameSyste
 	}
 
 	r := &resolver.Resolver{
-		DAG:         ng,
+		DAG:         api.node.DAG,
 		ResolveOnce: resolveOnce,
 	}
 

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -32,7 +32,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, r io.Reader) (coreiface.ResolvedP
 func (api *UnixfsAPI) Cat(ctx context.Context, p coreiface.Path) (coreiface.Reader, error) {
 	dget := api.node.DAG // TODO: use a session here once routing perf issues are resolved
 
-	dagnode, err := resolveNode(ctx, dget, api.node.Namesys, p)
+	dagnode, err := api.core().ResolveNode(ctx, p)
 	if err != nil {
 		return nil, err
 	}

--- a/test/sharness/t0260-sharding.sh
+++ b/test/sharness/t0260-sharding.sh
@@ -84,6 +84,12 @@ test_expect_success "gateway can resolve sharded dirs" '
   test_cmp expected actual
 '
 
+test_expect_success "'ipfs resolve' can resolve sharded dirs" '
+  echo /ipfs/QmZ3RfWk1u5LEGYLHA633B5TNJy3Du27K6Fny9wcxpowGS > expected &&
+  ipfs resolve "/ipfs/$SHARDED/file100" > actual &&
+  test_cmp expected actual
+'
+
 test_kill_ipfs_daemon
 
 test_add_large_dir_v1() {


### PR DESCRIPTION
(This is assuming we want to make `ipfs resolve` operate on unixfs paths instead of ipld)

Fixes https://github.com/ipfs/go-ipfs/issues/5270#issuecomment-422112136