### PR TITLE
add quieter option to name publish

### DIFF
--- a/core/commands/name/publish.go
+++ b/core/commands/name/publish.go
@@ -12,7 +12,7 @@ import (
 	e "github.com/ipfs/go-ipfs/core/commands/e"
 	keystore "github.com/ipfs/go-ipfs/keystore"
 
-	"gx/ipfs/QmPXR4tNdLbp8HsZiPMjpsgqphX9Vhw2J6Jh5MKH2ovW3D/go-ipfs-cmds"
+	cmds "gx/ipfs/QmPXR4tNdLbp8HsZiPMjpsgqphX9Vhw2J6Jh5MKH2ovW3D/go-ipfs-cmds"
 	crypto "gx/ipfs/QmPvyPwuCgJ7pDmrKDxRtsScJgBaM5h4EpRL2qQJsmXf4n/go-libp2p-crypto"
 	peer "gx/ipfs/QmQsErDt8Qgw1XrsXf2BpEzDgGWtB1YLsTAARBup5b6B9W/go-libp2p-peer"
 	"gx/ipfs/QmSP88ryZkHSRn1fnngAaV2Vcn63WUJzAavnRM9CVdU1Ky/go-ipfs-cmdkit"
@@ -32,6 +32,7 @@ const (
 	lifeTimeOptionName     = "lifetime"
 	ttlOptionName          = "ttl"
 	keyOptionName          = "key"
+	quieterOptionName      = "quieter"
 )
 
 var PublishCmd = &cmds.Command{
@@ -86,6 +87,7 @@ Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by
 		cmdkit.BoolOption(allowOfflineOptionName, "When offline, save the IPNS record to the the local datastore without broadcasting to the network instead of simply failing."),
 		cmdkit.StringOption(ttlOptionName, "Time duration this record should be cached for (caution: experimental)."),
 		cmdkit.StringOption(keyOptionName, "k", "Name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'. Default: <<default>>.").WithDefault("self"),
+		cmdkit.BoolOption(quieterOptionName, "Q", "Write only final hash."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		n, err := cmdenv.GetNode(env)
@@ -161,7 +163,13 @@ Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by
 				return e.TypeErr(entry, v)
 			}
 
-			_, err := fmt.Fprintf(w, "Published to %s: %s\n", entry.Name, entry.Value)
+			var err error
+			quieter, _ := req.Options[quieterOptionName].(bool)
+			if quieter {
+				_, err = fmt.Fprintln(w, entry.Name)
+			} else {
+				_, err = fmt.Fprintf(w, "Published to %s: %s\n", entry.Name, entry.Value)
+			}
 			return err
 		}),
 	},

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -33,6 +33,29 @@ test_expect_success "resolve output looks good" '
   test_cmp expected2 output
 '
 
+# test publishing with -Q option
+
+
+test_expect_success "'ipfs name publish --quieter' succeeds" '
+  PEERID=`ipfs id --format="<id>"` &&
+  test_check_peerid "${PEERID}" &&
+  ipfs name publish --allow-offline  -Q "/ipfs/$HASH_WELCOME_DOCS" >publish_out
+'
+
+test_expect_success "pubrmlish --quieter output looks good" '
+  echo "${PEERID}" >expected1 &&
+  test_cmp expected1 publish_out
+'
+
+test_expect_success "'ipfs name resolve' succeeds" '
+  ipfs name resolve "$PEERID" >output
+'
+
+test_expect_success "resolve output looks good" '
+  printf "/ipfs/%s\n" "$HASH_WELCOME_DOCS" >expected2 &&
+  test_cmp expected2 output
+'
+
 # now test with a path
 
 test_expect_success "'ipfs name publish --allow-offline' succeeds" '
@@ -96,6 +119,14 @@ test_expect_success "publish an explicit node ID as key name looks good" '
 
 test_expect_success "'ipfs name publish' fails" '
   printf '' | test_expect_code 1 ipfs name publish --allow-offline  >publish_out 2>&1
+'
+
+test_expect_success "publish output has the correct error" '
+  grep "argument \"ipfs-path\" is required" publish_out
+'
+
+test_expect_success "'ipfs name publish' fails" '
+  printf '' | test_expect_code 1 ipfs name publish -Q --allow-offline  >publish_out 2>&1
 '
 
 test_expect_success "publish output has the correct error" '


### PR DESCRIPTION
**Note:** I would thoroughly appreciate if someone could do a real live test on their machine. My IPFS node is a tad broken at the moment.

**Motivation:** [This post on reddit](https://www.reddit.com/r/ipfs/comments/9h4wsn/is_there_a_way_to_get_ipfs_name_publish_to_output/
). 

**Details:**

Added a quieter/Q option to 'name publish' that, consistent with 'add', only outputs the value that was published.