### PR TITLE
fixed tests of raised fd limits

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -201,8 +201,12 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	managefd, _ := req.Options[adjustFDLimitKwd].(bool)
 	if managefd {
-		if err := utilmain.ManageFdLimit(); err != nil {
+		if changedFds, newFdsLimit, err := utilmain.ManageFdLimit(); err != nil {
 			log.Errorf("setting file descriptor limit: %s", err)
+		} else {
+			if changedFds {
+				fmt.Printf("Successfully raised file descriptor limit to %d.\n", newFdsLimit)
+			}
 		}
 	}
 

--- a/cmd/ipfs/util/ulimit.go
+++ b/cmd/ipfs/util/ulimit.go
@@ -16,9 +16,9 @@ var (
 	supportsFDManagement = false
 
 	// getlimit returns the soft and hard limits of file descriptors counts
-	getLimit func() (int64, int64, error)
+	getLimit func() (uint64, uint64, error)
 	// set limit sets the soft and hard limits of file descriptors counts
-	setLimit func(int64, int64) error
+	setLimit func(uint64, uint64) error
 )
 
 // maxFds is the maximum number of file descriptors that go-ipfs
@@ -56,9 +56,7 @@ func ManageFdLimit() error {
 		return err
 	}
 
-	max := int64(maxFds)
-
-	if max <= soft {
+	if maxFds <= soft {
 		return nil
 	}
 
@@ -67,25 +65,25 @@ func ManageFdLimit() error {
 	// the hard limit acts as a ceiling for the soft limit
 	// an unprivileged process may only set it's soft limit to a
 	// alue in the range from 0 up to the hard limit
-	if err = setLimit(max, max); err != nil {
+	if err = setLimit(maxFds, maxFds); err != nil {
 		if err != syscall.EPERM {
 			return fmt.Errorf("error setting: ulimit: %s", err)
 		}
 
 		// the process does not have permission so we should only
 		// set the soft value
-		if max > hard {
+		if maxFds > hard {
 			return errors.New(
 				"cannot set rlimit, IPFS_FD_MAX is larger than the hard limit",
 			)
 		}
 
-		if err = setLimit(max, hard); err != nil {
+		if err = setLimit(maxFds, hard); err != nil {
 			return fmt.Errorf("error setting ulimit wihout hard limit: %s", err)
 		}
 	}
 
-	fmt.Printf("Successfully raised file descriptor limit to %d.\n", max)
+	fmt.Printf("Successfully raised file descriptor limit to %d.\n", maxFds)
 
 	return nil
 }

--- a/cmd/ipfs/util/ulimit_test.go
+++ b/cmd/ipfs/util/ulimit_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestManageFdLimit(t *testing.T) {
 	t.Log("Testing file descriptor count")
-	if err := ManageFdLimit(); err != nil {
+	if _, _, err := ManageFdLimit(); err != nil {
 		t.Errorf("Cannot manage file descriptors")
 	}
 
@@ -41,7 +41,7 @@ func TestManageInvalidNFds(t *testing.T) {
 	// call to check and set the maximum file descriptor from the env
 	setMaxFds()
 
-	if err = ManageFdLimit(); err == nil {
+	if _, _, err := ManageFdLimit(); err == nil {
 		t.Errorf("ManageFdLimit should return an error")
 	} else if err != nil {
 		flag := strings.Contains(err.Error(),
@@ -79,7 +79,7 @@ func TestManageFdLimitWithEnvSet(t *testing.T) {
 		t.Errorf("The maxfds is not set from IPFS_FD_MAX")
 	}
 
-	if err = ManageFdLimit(); err != nil {
+	if _, _, err = ManageFdLimit(); err != nil {
 		t.Errorf("Cannot manage file descriptor count")
 	}
 

--- a/cmd/ipfs/util/ulimit_unix.go
+++ b/cmd/ipfs/util/ulimit_unix.go
@@ -12,16 +12,16 @@ func init() {
 	setLimit = unixSetLimit
 }
 
-func unixGetLimit() (int64, int64, error) {
+func unixGetLimit() (uint64, uint64, error) {
 	rlimit := unix.Rlimit{}
 	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit)
-	return int64(rlimit.Cur), int64(rlimit.Max), err
+	return rlimit.Cur, rlimit.Max, err
 }
 
-func unixSetLimit(soft int64, max int64) error {
+func unixSetLimit(soft uint64, max uint64) error {
 	rlimit := unix.Rlimit{
-		Cur: uint64(soft),
-		Max: uint64(max),
+		Cur: soft,
+		Max: max,
 	}
 	return unix.Setrlimit(unix.RLIMIT_NOFILE, &rlimit)
 }

--- a/mk/util.mk
+++ b/mk/util.mk
@@ -20,6 +20,8 @@ SUPPORTED_PLATFORMS += linux-amd64
 SUPPORTED_PLATFORMS += darwin-386
 SUPPORTED_PLATFORMS += darwin-amd64
 
+SUPPORTED_PLATFORMS += freebsd-amd64
+
 space:=
 space+=
 comma:=,


### PR DESCRIPTION
Raising FD limits was erroring when the OS's max was at the maximum signed integer value. Switched the code to using uint64 instead of int64.

Could someone please review, in particular, the FreeBSD parts? Integer checks are not my forte, and I don't have a FreeBSD machine to test on.

fixed #5495

Bonus: The `ManageFdLimit()` function contained a `fmt.Print` statement. That's really annoying because it was printing during tests. I've changed the `ManageFdLimit()` function so that it returns the new limit, and the calling function can do the fmt.Print statement (if it wishes).