### PR TITLE
fix(unixfs): issue #5217 (Avoid use of `pb.Data`)

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -223,25 +223,25 @@ func statNode(nd ipld.Node) (*statOutput, error) {
 
 	switch n := nd.(type) {
 	case *dag.ProtoNode:
-		d, err := ft.FromBytes(n.Data())
+		d, err := ft.FSNodeFromBytes(n.Data())
 		if err != nil {
 			return nil, err
 		}
 
 		var ndtype string
-		switch d.GetType() {
+		switch d.Type() {
 		case ft.TDirectory, ft.THAMTShard:
 			ndtype = "directory"
 		case ft.TFile, ft.TMetadata, ft.TRaw:
 			ndtype = "file"
 		default:
-			return nil, fmt.Errorf("unrecognized node type: %s", d.GetType())
+			return nil, fmt.Errorf("unrecognized node type: %s", d.Type())
 		}
 
 		return &statOutput{
 			Hash:           c.String(),
 			Blocks:         len(nd.Links()),
-			Size:           d.GetFilesize(),
+			Size:           d.FileSize(),
 			CumulativeSize: cumulsize,
 			Type:           ndtype,
 		}, nil

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -150,12 +150,12 @@ The JSON output contains type information.
 					}
 
 					if pn, ok := linkNode.(*merkledag.ProtoNode); ok {
-						d, err := unixfs.FromBytes(pn.Data())
+						d, err := unixfs.FSNodeFromBytes(pn.Data())
 						if err != nil {
 							res.SetError(err, cmdkit.ErrNormal)
 							return
 						}
-						t = d.GetType()
+						t = d.Type()
 					}
 				}
 				output[i].Links[j] = LsLink{

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -120,18 +120,18 @@ possible, please use 'ipfs ls' instead.
 				return
 			}
 
-			unixFSNode, err := unixfs.FromBytes(ndpb.Data())
+			unixFSNode, err := unixfs.FSNodeFromBytes(ndpb.Data())
 			if err != nil {
 				res.SetError(err, cmdkit.ErrNormal)
 				return
 			}
 
-			t := unixFSNode.GetType()
+			t := unixFSNode.Type()
 
 			output.Objects[hash] = &LsObject{
 				Hash: c.String(),
 				Type: t.String(),
-				Size: unixFSNode.GetFilesize(),
+				Size: unixFSNode.FileSize(),
 			}
 
 			switch t {
@@ -156,19 +156,19 @@ possible, please use 'ipfs ls' instead.
 						return
 					}
 
-					d, err := unixfs.FromBytes(lnpb.Data())
+					d, err := unixfs.FSNodeFromBytes(lnpb.Data())
 					if err != nil {
 						res.SetError(err, cmdkit.ErrNormal)
 						return
 					}
-					t := d.GetType()
+					t := d.Type()
 					lsLink := LsLink{
 						Name: link.Name,
 						Hash: link.Cid.String(),
 						Type: t.String(),
 					}
 					if t == unixfspb.Data_File {
-						lsLink.Size = d.GetFilesize()
+						lsLink.Size = d.FileSize()
 					} else {
 						lsLink.Size = link.Size
 					}


### PR DESCRIPTION
License: MIT
Signed-off-by: Overbool <overbool.xu@gmail.com>

Fixes: https://github.com/ipfs/go-ipfs/issues/5217