### PR TITLE
mk: embed CurrentCommit in the right place

### DIFF
--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -13,7 +13,7 @@ PATH := $(realpath $(d)):$(PATH)
 # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
 # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
 
-$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs/repo".CurrentCommit=$(git-hash)"
+$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs".CurrentCommit=$(git-hash)"
 
 $(d)-try-build $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
 


### PR DESCRIPTION
This somehow slipped in https://github.com/ipfs/go-ipfs/pull/5277

Found in https://github.com/ipfs/go-ipfs/pull/5503