### PR TITLE
Add sessions when fetching MerkleDAG in LS

### DIFF
--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -108,9 +108,11 @@ The JSON output contains type information.
 		}
 
 		output := make([]LsObject, len(req.Arguments()))
+		ng := merkledag.NewSession(req.Context(), nd.DAG)
+		ro := merkledag.NewReadOnlyDagService(ng)
 
 		for i, dagnode := range dagnodes {
-			dir, err := uio.NewDirectoryFromNode(nd.DAG, dagnode)
+			dir, err := uio.NewDirectoryFromNode(ro, dagnode)
 			if err != nil && err != uio.ErrNotADir {
 				res.SetError(fmt.Errorf("the data in %s (at %q) is not a UnixFS directory: %s", dagnode.Cid(), paths[i], err), cmdkit.ErrNormal)
 				return


### PR DESCRIPTION
# Goals

Improve bandwidth usage for LS by adding Sessions

# Implementation

This is simply the code by @whyrusleeping referenced here -- https://github.com/ipfs/go-ipfs/compare/feat/ls-session?expand=1 - in #4979 . Regardless of the ultimate solution we end up using for HAMT directory speedup (#4908 ), is there any reason this can't be merged now? This seems like a tangible improvement, if not in speed at least in bandwidth usage