### PR TITLE
Fix inability to pin two things at once

### DIFF
--- a/pin/pin.go
+++ b/pin/pin.go
@@ -228,16 +228,20 @@ func (p *pinner) Pin(ctx context.Context, node ipld.Node, recurse bool) error {
 		if p.directPin.Has(c) {
 			p.directPin.Remove(c)
 		}
-
+		p.lock.Unlock()
 		// fetch entire graph
 		err := mdag.FetchGraph(ctx, c, p.dserv)
+		p.lock.Lock()
 		if err != nil {
 			return err
 		}
 
 		p.recursePin.Add(c)
 	} else {
-		if _, err := p.dserv.Get(ctx, c); err != nil {
+		p.lock.Unlock()
+		_, err := p.dserv.Get(ctx, c)
+		p.lock.Lock()
+		if err != nil {
 			return err
 		}
 

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -236,6 +236,14 @@ func (p *pinner) Pin(ctx context.Context, node ipld.Node, recurse bool) error {
 			return err
 		}
 
+		if p.recursePin.Has(c) {
+			return nil
+		}
+
+		if p.directPin.Has(c) {
+			p.directPin.Remove(c)
+		}
+
 		p.recursePin.Add(c)
 	} else {
 		p.lock.Unlock()


### PR DESCRIPTION
## Goals

Fix #5376 by allowing content to be fetched concurrently when pinning multiple hashes.

## Implementation

Simply release the pinner lock when fetching content and re-lock it immediately afterwards.

## For Discussion

- Maybe this implementation is naive, but it appears to do the trick. Let me know what I've missed.
- @Stebalien mentioned using `GCLocker`, but it appears that gc locking is managed here: https://github.com/ipfs/go-ipfs/blob/def80817224835a4965849bd3ac1a1a8da458601/core/commands/pin.go#L71 Which, I think, can be left alone for now.
- This implementation allows for the following scenario:

```sh
ipfs dag put <<<'{"link": {"/": "QmdZmoS1b1jp9vL5vgTyebEYUVH6zjd6erhp3fpqV1Zktx"}}'
ipfs pin add zdpuAsWv1LNwtxvFB3iTQjtwDLxPxRaa3WeE4i6BoDuKDy4gf &
echo "thing" | ipfs add
```
- This implementation still blocks gc:
```sh
ipfs dag put <<<'{"link": {"/": "QmdZmoS1b1jp9vL5vgTyebEYUVH6zjd6erhp3fpqV1Zktx"}}'
ipfs pin add zdpuAsWv1LNwtxvFB3iTQjtwDLxPxRaa3WeE4i6BoDuKDy4gf &
ipfs repo gc
```