### PR TITLE
[RFC] implement systemd socket activation

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -282,9 +282,9 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// Start assembling node config
 	ncfg := &core.BuildCfg{
-		Repo:      repo,
-		Permanent: true, // It is temporary way to signify that node is permanent
-		Online:    !offline,
+		Repo:                        repo,
+		Permanent:                   true, // It is temporary way to signify that node is permanent
+		Online:                      !offline,
 		DisableEncryptedConnections: unencrypted,
 		ExtraOpts: map[string]bool{
 			"pubsub": pubsub,
@@ -402,7 +402,7 @@ func serveHTTPApi(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, error
 
 	listeners, err := sockets.TakeSockets("io.ipfs.api")
 	if err != nil {
-		return nil, fmt.Errorf("serveHTTPGateway: socket activation failed: %s", err)
+		return nil, fmt.Errorf("serveHTTPApi: socket activation failed: %s", err)
 	}
 
 	if len(listeners) == 0 {

--- a/cmd/ipfs/sockets/sockets.go
+++ b/cmd/ipfs/sockets/sockets.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package sockets
+
+import (
+	manet "gx/ipfs/QmV6FjemM1K8oXjrvuq3wuVWWoU2TLDPmNnKrxHzY3v6Ai/go-multiaddr-net"
+)
+
+// TakeSockets takes the sockets associated with the given name.
+func TakeSockets(name string) ([]manet.Listener, error) {
+	return nil, nil
+}

--- a/cmd/ipfs/sockets/sockets_linux.go
+++ b/cmd/ipfs/sockets/sockets_linux.go
@@ -1,0 +1,61 @@
+// +build linux
+
+package sockets
+
+import (
+	"net"
+	"sync"
+
+	logging "gx/ipfs/QmRREK2CAZ5Re2Bd9zZFG6FeYDppUWt5cMgsoUEp3ktgSr/go-log"
+	manet "gx/ipfs/QmV6FjemM1K8oXjrvuq3wuVWWoU2TLDPmNnKrxHzY3v6Ai/go-multiaddr-net"
+	activation "gx/ipfs/QmW2mADUYMw9sKTtL59oa84WwMPV9scVR7n3Ji9gTRPW5d/go-systemd-activation"
+)
+
+var log = logging.Logger("socket-activation")
+
+var socketsMu sync.Mutex
+var sockets map[string][]manet.Listener
+
+func initSockets() {
+	if sockets != nil {
+		return
+	}
+	nlisteners, err := activation.ListenersWithNames()
+	// Do this before checking the error. We need this to be non-nil so we
+	// don't try again.
+	sockets = make(map[string][]manet.Listener, len(nlisteners))
+	if err != nil {
+		log.Errorf("error parsing systemd sockets: %s", err)
+		return
+	}
+	for name, nls := range nlisteners {
+		mls := make([]manet.Listener, 0, len(nls))
+		for _, nl := range nls {
+			ml, err := manet.WrapNetListener(nl)
+			if err != nil {
+				log.Errorf("error converting a systemd-socket to a multiaddr listener: %s", err)
+				nl.Close()
+				continue
+			}
+			mls = append(mls, ml)
+		}
+		sockets[name] = mls
+	}
+}
+
+func mapListeners(nls []net.Listener) ([]manet.Listener, error) {
+	mls := make([]manet.Listener, len(nls))
+	return mls, nil
+}
+
+// TakeSockets takes the sockets associated with the given name.
+func TakeSockets(name string) ([]manet.Listener, error) {
+	socketsMu.Lock()
+	defer socketsMu.Unlock()
+	initSockets()
+
+	s := sockets[name]
+	delete(sockets, name)
+
+	return s, nil
+}

--- a/cmd/ipfs/sockets/sockets_linux.go
+++ b/cmd/ipfs/sockets/sockets_linux.go
@@ -13,8 +13,10 @@ import (
 
 var log = logging.Logger("socket-activation")
 
-var socketsMu sync.Mutex
-var sockets map[string][]manet.Listener
+var (
+	socketsMu sync.Mutex
+	sockets   map[string][]manet.Listener
+)
 
 func initSockets() {
 	if sockets != nil {

--- a/misc/systemd/ipfs-api.socket
+++ b/misc/systemd/ipfs-api.socket
@@ -1,0 +1,15 @@
+# Enabling this will *completely override* any API listeners configured in your
+# config.
+
+[Unit]
+Description=IPFS API Socket
+
+[Socket]
+Service=ipfs.service
+FileDescriptorName=io.ipfs.api
+BindIPv6Only=true
+ListenStream=127.0.0.1:5001
+ListenStream=[::1]:5001
+
+[Install]
+WantedBy=sockets.target

--- a/misc/systemd/ipfs-gateway.socket
+++ b/misc/systemd/ipfs-gateway.socket
@@ -1,0 +1,15 @@
+# Enabling this will *completely override* any Gateway listeners configured in
+# your config.
+
+[Unit]
+Description=IPFS Gateway Socket
+
+[Socket]
+Service=ipfs.service
+FileDescriptorName=io.ipfs.gateway
+BindIPv6Only=true
+ListenStream=127.0.0.1:8080
+ListenStream=[::1]:8080
+
+[Install]
+WantedBy=sockets.target

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=IPFS Daemon
+
+[Service]
+ExecStart=/usr/bin/ipfs daemon --init --migrate
+KillSignal=SIGINT
+
+[Install]
+WantedBy=default.target

--- a/package.json
+++ b/package.json
@@ -574,6 +574,12 @@
       "hash": "QmbyJLe6SdVR5VLjtcoLdKhUuV4RT9a1FxX28zaWnY34d8",
       "name": "go-random-files",
       "version": "1.0.0"
+    },
+    {
+      "author": "coreos",
+      "hash": "QmW2mADUYMw9sKTtL59oa84WwMPV9scVR7n3Ji9gTRPW5d",
+      "name": "go-systemd-activation",
+      "version": "0.17.0"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
It works but it could probably be prettier. Thoughts?

Basically, this patch checks for sockets passed via systemd socket-activation and, if present, ignores all other configured listen addresses and uses those. Currently, it only supports socket activation of the gateway and the API.

Motivation: this allows me to auto-start IPFS when I actually need it (but not until then).