### PR TITLE
added binary executable files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@ Dockerfile.fast
 !.git/refs/
 !.git/packed-refs
 test/sharness/lib/sharness/
+
+# The Docker client might not be running on Linux
+# so delete any compiled binaries
+bin/gx
+bin/gx*
+bin/tmp


### PR DESCRIPTION
The Docker client was blindly copying binaries from the bin/ directory to the Docker server, and then the Docker server would just try and run them blindly - causing an error.

It's better to not upload these binaries, and let the Docker server itself fetch the binaries that it wants.

Fixes #5038 