### PR TITLE
debug-guide.md added memory statistics command

### DIFF
--- a/docs/debug-guide.md
+++ b/docs/debug-guide.md
@@ -20,6 +20,8 @@ profiling information.
   - `curl localhost:5001/debug/pprof/profile > ipfs.cpuprof`
 - heap trace dump
   - `curl localhost:5001/debug/pprof/heap > ipfs.heap`
+- memory statistics (in json, see "memstats" object)
+  - `curl localhost:5001/debug/pprof/vars > ipfs.vars`
 - system information
   - `ipfs diag sys > ipfs.sysinfo`
 


### PR DESCRIPTION
This would've been valuable to me while investigating #5530.

I discovered that more debug commands are also available, but I don't know enough about them to add them myself (e.g. `debug/pprof-mutex`, `debug/metrics/prometheus`).