### PR TITLE
gateway: make API commands configurable

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -567,7 +567,7 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		corehttp.GatewayOption(writable, "/ipfs", "/ipns"),
 		corehttp.VersionOption(),
 		corehttp.CheckVersionOption(),
-		corehttp.CommandsROOption(*cctx),
+		corehttp.GatewayCommandsOption(*cctx, cfg.Gateway.APICommands),
 	}
 
 	if len(cfg.Gateway.RootRedirect) > 0 {

--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -17,31 +17,17 @@ func collectPaths(prefix string, cmd *cmds.Command, out map[string]struct{}) {
 
 func TestROCommands(t *testing.T) {
 	list := []string{
-		"/block",
-		"/block/get",
-		"/block/stat",
 		"/cat",
-		"/commands",
-		"/dag",
-		"/dag/get",
-		"/dag/resolve",
-		"/dns",
-		"/get",
 		"/ls",
-		"/name",
-		"/name/resolve",
-		"/object",
-		"/object/data",
-		"/object/get",
-		"/object/links",
-		"/object/stat",
-		"/refs",
-		"/resolve",
-		"/version",
+	}
+
+	root, err := RootSubset([]string{"ls", "cat"})
+	if err != nil {
+		t.Errorf("RootSubset error: %s", err)
 	}
 
 	cmdSet := make(map[string]struct{})
-	collectPaths("", RootRO, cmdSet)
+	collectPaths("", root, cmdSet)
 
 	for _, path := range list {
 		if _, ok := cmdSet[path]; !ok {
@@ -58,7 +44,7 @@ func TestROCommands(t *testing.T) {
 	for _, path := range list {
 		path = path[1:] // remove leading slash
 		split := strings.Split(path, "/")
-		sub, err := RootRO.Get(split)
+		sub, err := root.Get(split)
 		if err != nil {
 			t.Errorf("error getting subcommand %q: %v", path, err)
 		} else if sub == nil {

--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -16,12 +16,25 @@ func collectPaths(prefix string, cmd *cmds.Command, out map[string]struct{}) {
 }
 
 func TestROCommands(t *testing.T) {
-	list := []string{
-		"/cat",
-		"/ls",
+	whitelist := []string{
+		"ls",
+		"cat",
+		"dag", // only included for the check afterwards
+		"dag/resolve",
+		"dag/get",
 	}
 
-	root, err := RootSubset([]string{"ls", "cat"})
+	list := func() []string {
+		out := make([]string, len(whitelist))
+
+		for i, line := range whitelist {
+			out[i] = "/" + line
+		}
+
+		return out
+	}()
+
+	root, err := RootSubset(whitelist)
 	if err != nil {
 		t.Errorf("RootSubset error: %s", err)
 	}
@@ -52,6 +65,7 @@ func TestROCommands(t *testing.T) {
 		}
 	}
 }
+
 func TestCommands(t *testing.T) {
 	list := []string{
 		"/add",

--- a/core/commands/root_test.go
+++ b/core/commands/root_test.go
@@ -18,5 +18,4 @@ func TestCommandTree(t *testing.T) {
 		}
 	}
 	printErrors(Root.DebugValidate())
-	printErrors(RootRO.DebugValidate())
 }

--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -37,6 +37,26 @@ cli arguments:
 // APIPath is the path at which the API is mounted.
 const APIPath = "/api/v0"
 
+var GatewayAPICommands = []string{
+	"commands",
+	"cat",
+	"get",
+	"ls",
+	"resolve",
+	"name/resolve",
+	"dag/get",
+	"dag/resolve",
+	"object/data",
+	"object/links",
+	"object/get",
+	"object/stat",
+	"refs",
+	"block/stat",
+	"block/get",
+	"dns",
+	"version",
+}
+
 var defaultLocalhostOrigins = []string{
 	"http://127.0.0.1:<port>",
 	"https://127.0.0.1:<port>",
@@ -143,8 +163,17 @@ func CommandsOption(cctx oldcmds.Context) ServeOption {
 
 // CommandsROOption constructs a ServerOption for hooking the read-only commands
 // into the HTTP server.
-func CommandsROOption(cctx oldcmds.Context) ServeOption {
-	return commandsOption(cctx, corecommands.RootRO)
+func GatewayCommandsOption(cctx oldcmds.Context, allowed []string) ServeOption {
+	if len(allowed) == 0 {
+		allowed = append(allowed, GatewayAPICommands...)
+	}
+	root, err := corecommands.RootSubset(allowed)
+	if err != nil {
+		return func(n *core.IpfsNode, l net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+			return nil, err
+		}
+	}
+	return commandsOption(cctx, root)
 }
 
 // CheckVersionOption returns a ServeOption that checks whether the client ipfs version matches. Does nothing when the user agent string does not contain `/go-ipfs/`

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -13,6 +13,7 @@ import (
 
 	version "github.com/ipfs/go-ipfs"
 	core "github.com/ipfs/go-ipfs/core"
+	commands "github.com/ipfs/go-ipfs/core/commands"
 	coreunix "github.com/ipfs/go-ipfs/core/coreunix"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/go-ipfs/namesys/opts"
@@ -596,4 +597,25 @@ func TestVersion(t *testing.T) {
 	if !strings.Contains(s, "Protocol Version: "+id.LibP2PVersion) {
 		t.Fatalf("response doesn't contain protocol version:\n%s", s)
 	}
+}
+
+func TestCommands(t *testing.T) {
+	printErrors := func(errs map[string][]error) {
+		if errs == nil {
+			return
+		}
+		t.Error("In Root command tree:")
+		for cmd, err := range errs {
+			t.Errorf("  In X command %s:", cmd)
+			for _, e := range err {
+				t.Errorf("    %s", e)
+			}
+		}
+	}
+
+	gwroot, err := commands.RootSubset(GatewayAPICommands)
+	if err != nil {
+		t.Errorf("RootSubset error: %s", err)
+	}
+	printErrors(gwroot.DebugValidate())
 }

--- a/test/sharness/t0113-gateway-api.sh
+++ b/test/sharness/t0113-gateway-api.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 Protocol Labs Inc.
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test API on Gateway"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+test_launch_ipfs_daemon
+
+port=$GWAY_PORT
+
+for cmd in add  \
+           block/put \
+           bootstrap \
+           config \
+           dht \
+           diag \
+           id \
+           mount \
+           name/publish \
+           object/put \
+           object/new \
+           object/patch \
+           pin \
+           ping \
+           repo \
+           stats \
+           swarm \
+           file \
+           update \
+           bitswap
+do
+  test_expect_success "test gateway api is sanitized: $cmd" '
+    test_curl_resp_http_code "http://127.0.0.1:$port/api/v0/$cmd" "HTTP/1.1 404 Not Found"
+  '
+done
+
+# This one is different. `local` will be interpreted as a path if the command isn't defined.
+test_expect_success "test gateway api is sanitized: refs/local" '
+    echo "Error: invalid '"'ipfs ref'"' path" > refs_local_expected &&
+    ! ipfs --api /ip4/127.0.0.1/tcp/$port refs local > refs_local_actual 2>&1 &&
+    test_cmp refs_local_expected refs_local_actual
+  '
+
+test_expect_success "GET IPFS directory path succeeds" '
+  mkdir dir &&
+  echo "12345" >dir/test &&
+  ipfs add -r -q dir >actual &&
+  HASH2=$(tail -n 1 actual)
+'
+
+test_curl_gateway_api() {
+  curl -sfo actual "http://127.0.0.1:$port/api/v0/$1"
+}
+
+test_expect_success "get IPFS directory file through readonly API succeeds" '
+  test_curl_gateway_api "cat?arg=$HASH2/test"
+'
+
+test_expect_success "get IPFS directory file through readonly API output looks good" '
+  test_cmp dir/test actual
+'
+
+test_expect_success "refs IPFS directory file through readonly API succeeds" '
+  test_curl_gateway_api "refs?arg=$HASH2/test"
+'
+
+test_kill_ipfs_daemon
+test_done

--- a/test/sharness/t0401-api.sh
+++ b/test/sharness/t0401-api.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 Protocol Labs Inc.
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test API on Gateway"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+test_launch_ipfs_daemon
+
+apiport=$API_PORT
+
+test_expect_success "GET /webui returns code expected" '
+  test_curl_resp_http_code "http://127.0.0.1:$apiport/webui" "HTTP/1.1 302 Found" "HTTP/1.1 301 Moved Permanently"
+'
+
+test_expect_success "GET /webui/ returns code expected" '
+  test_curl_resp_http_code "http://127.0.0.1:$apiport/webui/" "HTTP/1.1 302 Found" "HTTP/1.1 301 Moved Permanently"
+'
+
+test_expect_success "GET /logs returns logs" '
+  test_expect_code 28 curl http://127.0.0.1:$apiport/logs -m1 > log_out
+'
+
+test_expect_success "log output looks good" '
+  grep "log API client connected" log_out
+'
+
+test_expect_success "GET /api/v0/version succeeds" '
+  curl -v "http://127.0.0.1:$apiport/api/v0/version" 2> version_out
+'
+
+test_expect_success "output only has one transfer encoding header" '
+  grep "Transfer-Encoding: chunked" version_out | wc -l | xargs echo > tecount_out &&
+  echo "1" > tecount_exp &&
+  test_cmp tecount_out tecount_exp
+'
+
+curl_pprofmutex() {
+  curl -f -X POST "http://127.0.0.1:$apiport/debug/pprof-mutex/?fraction=$1"
+}
+
+test_expect_success "set mutex fraction for pprof (negative so it doesn't enable)" '
+  curl_pprofmutex -1
+'
+
+test_expect_success "test failure conditions of mutex pprof endpoint" '
+  test_must_fail curl_pprofmutex &&
+    test_must_fail curl_pprofmutex that_is_string &&
+    test_must_fail curl -f -X GET "http://127.0.0.1:$apiport/debug/pprof-mutex/?fraction=-1"
+'
+
+test_kill_ipfs_daemon
+test_done


### PR DESCRIPTION
This is for Delegated Routing in js-libp2p (ipfs/js-ipfs#1459 & libp2p/js-libp2p#120) and supersedes #4595.

It lets us configure the commands available through :8080/api/v0/ -- for delegated routing, we would then e.g. expose `swarm/connect`, `refs`, `dht/findprovs`, and `dht/findpeer`.

By default, `Gateway.APICommands` is empty, which means go-ipfs will use the default :8080 commands.

```sh
> ipfs init
> ipfs &
> curl localhost:5001/api/v0/config?arg=Gateway.APICommands | jq -r .Value
[]
> curl localhost:8080/api/v0/commands | jq -r .Subcommands[].Name
dns
version
commands
cat
get
dag
refs
block
ls
resolve
name
object
> killall ipfs

> ipfs config Gateway.APICommands --json '["config"]'
> ipfs daemon &
> curl localhost:8080/api/v0/commands | jq -r .Subcommands[].Name
config
commands
> killall ipfs
```