### PR TITLE
Adding caching to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,6 @@ RUN set -x \
   && cd $SRC_DIR \
   && gx install
 
-COPY . $SRC_DIR
-
-# Build the thing.
-# Also: fix getting HEAD commit hash via git rev-parse.
-RUN set -x \
-  && cd $SRC_DIR \
-  && mkdir .git/objects \
-  && make build
-
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers
 ENV SUEXEC_VERSION v0.2
@@ -42,6 +33,15 @@ RUN set -x \
   && cd /tmp \
   && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
   && chmod +x tini
+
+COPY . $SRC_DIR
+
+# Build the thing.
+# Also: fix getting HEAD commit hash via git rev-parse.
+RUN set -x \
+  && cd $SRC_DIR \
+  && mkdir .git/objects \
+  && make build
 
 # Get the TLS CA certificates, they're not provided by busybox.
 RUN apt-get update && apt-get install -y ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,24 @@ MAINTAINER Lars Gierth <lgierth@ipfs.io>
 ENV GX_IPFS ""
 ENV SRC_DIR /go/src/github.com/ipfs/go-ipfs
 
+COPY ./package.json $SRC_DIR/package.json
+
+# Fetch dependencies.
+# Also: allow using a custom IPFS API endpoint.
+RUN set -x \
+  && go get github.com/whyrusleeping/gx \
+  && go get github.com/whyrusleeping/gx-go \
+  && ([ -z "$GX_IPFS" ] || echo $GX_IPFS > /root/.ipfs/api) \
+  && cd $SRC_DIR \
+  && gx install
+
 COPY . $SRC_DIR
 
 # Build the thing.
 # Also: fix getting HEAD commit hash via git rev-parse.
-# Also: allow using a custom IPFS API endpoint.
-RUN cd $SRC_DIR \
+RUN set -x \
+  && cd $SRC_DIR \
   && mkdir .git/objects \
-  && ([ -z "$GX_IPFS" ] || echo $GX_IPFS > /root/.ipfs/api) \
   && make build
 
 # Get su-exec, a very minimal tool for dropping privileges,

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -20,17 +20,6 @@ RUN set -x \
   && cd $SRC_DIR \
   && gx install
 
-COPY . $SRC_DIR
-
-# Build the thing.
-# Also: fix getting HEAD commit hash via git rev-parse.
-RUN set -x \
-  && cd $SRC_DIR \
-  && mkdir .git/objects \
-  && make build \
-  && mv cmd/ipfs/ipfs /usr/local/bin/ipfs \
-  && mv bin/container_daemon /usr/local/bin/start_ipfs
-
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers
 ENV SUEXEC_VERSION v0.2
@@ -45,6 +34,17 @@ RUN set -x \
   && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
   && chmod +x tini \
   && mv su-exec/su-exec tini /sbin/ # Install them
+
+COPY . $SRC_DIR
+
+# Build the thing.
+# Also: fix getting HEAD commit hash via git rev-parse.
+RUN set -x \
+  && cd $SRC_DIR \
+  && mkdir .git/objects \
+  && make build \
+  && mv cmd/ipfs/ipfs /usr/local/bin/ipfs \
+  && mv bin/container_daemon /usr/local/bin/start_ipfs
 
 # Ports for Swarm TCP, Swarm uTP, API, Gateway, Swarm Websockets
 EXPOSE 4001


### PR DESCRIPTION
`Dockerfile.fast` is neat because it caches the gx dependancies in an intermediary image before building go-ipfs. It will cache these dependancies until `package.json` changes.

I can't see any reason why `Dockerfile` shouldn't do the same caching.

I've also rejigged the order of both Dockerfiles so that su-exec and tini are cached.