### PR TITLE
fix: maketarball.sh for OSX

### DIFF
--- a/bin/maketarball.sh
+++ b/bin/maketarball.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 
-OUTPUT=$(realpath ${1:-go-ipfs-source.tar.gz})
+OUTPUT="${1:-go-ipfs-source.tar.gz}"
 
 TMPDIR="$(mktemp -d)"
 NEWIPFS="$TMPDIR/github.com/ipfs/go-ipfs"


### PR DESCRIPTION
Just stop using realpath, should not matter.

Resolves #5064

License: MIT