### PR TITLE
downgrade iptb to a 1.3 patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
       "version": "0.1.3"
     },
     {
-      "hash": "QmZ7Kqf9pbNvopSpC6L1UbV3ZbphShuv4554QdYGjKY2rM",
+      "hash": "QmbBkvKTxnM5xR9u2KDxQXfGzABq6FWsnuCj4raDFFHphf",
       "name": "iptb",
-      "version": "99.3.9"
+      "version": "1.3.16"
     },
     {
       "hash": "QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8",


### PR DESCRIPTION
Using version 99 for these is going to cause *major* semver issues.