### PR TITLE
add support for IPLD over IPNS

### DIFF
--- a/namesys/base.go
+++ b/namesys/base.go
@@ -25,15 +25,6 @@ func resolve(ctx context.Context, r resolver, name string, options *opts.Resolve
 		}
 		log.Debugf("resolved %s to %s", name, p.String())
 
-		if strings.HasPrefix(p.String(), "/ipfs/") {
-			// we've bottomed out with an IPFS path
-			return p, nil
-		}
-
-		if depth == 1 {
-			return p, ErrResolveRecursion
-		}
-
 		matched := false
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(p.String(), prefix) {
@@ -45,10 +36,17 @@ func resolve(ctx context.Context, r resolver, name string, options *opts.Resolve
 			}
 		}
 
+		// Not something we can resolve, return it.
 		if !matched {
 			return p, nil
 		}
 
+		// No more depth left, return it.
+		if depth == 1 {
+			return p, ErrResolveRecursion
+		}
+
+		// Depth could be 0.
 		if depth > 1 {
 			depth--
 		}

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -53,15 +53,15 @@ const DefaultResolverCacheTTL = time.Minute
 
 // Resolve implements Resolver.
 func (ns *mpns) Resolve(ctx context.Context, name string, options ...opts.ResolveOpt) (path.Path, error) {
-	if strings.HasPrefix(name, "/ipfs/") {
-		return path.ParsePath(name)
+	if strings.HasPrefix(name, "/ipns/") {
+		return resolve(ctx, ns, name, opts.ProcessOpts(options), "/ipns/")
 	}
-
 	if !strings.HasPrefix(name, "/") {
 		return path.ParsePath("/ipfs/" + name)
 	}
+	// TODO: Forbid this case.
+	return path.ParsePath("/ipfs/" + name)
 
-	return resolve(ctx, ns, name, opts.ProcessOpts(options), "/ipns/")
 }
 
 // resolveOnce implements resolver.

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -114,6 +114,32 @@ test_expect_success "publish an explicit node ID as key name looks good" '
   test_cmp expected_node_id_publish actual_node_id_publish
 '
 
+# test IPNS + IPLD
+
+test_expect_success "'ipfs dag put' succeeds" '
+  HELLO_HASH="$(echo "\"hello world\"" | ipfs dag put)" &&
+  OBJECT_HASH="$(echo "{\"thing\": {\"/\": \"${HELLO_HASH}\" }}" | ipfs dag put)"
+'
+
+test_expect_success "'ipfs name publish --allow-offline /ipld/...' succeeds" '
+  PEERID=`ipfs id --format="<id>"` &&
+  test_check_peerid "${PEERID}" &&
+  ipfs name publish --allow-offline "/ipld/$OBJECT_HASH/thing" >publish_out
+'
+
+test_expect_success "publish a path looks good" '
+  echo "Published to ${PEERID}: /ipld/$OBJECT_HASH/thing" >expected3 &&
+  test_cmp expected3 publish_out
+'
+
+test_expect_success "'ipfs name resolve' succeeds" '
+  ipfs name resolve "$PEERID" >output
+'
+
+test_expect_success "resolve output looks good" '
+  printf "/ipld/%s/thing\n" "$OBJECT_HASH" >expected4 &&
+  test_cmp expected4 output
+'
 
 # test publishing nothing
 


### PR DESCRIPTION
It's not *perfect* but at least `ipfs name resolve` can resolve IPNS records pointing to IPLD paths. `ipfs dag get /ipns` still doesn't work but we can *make* it work once we switch to CoreAPI.

I thought this would be difficult, apparently not...