### PR TITLE
object patch rm-link: change arg from 'link' to 'name'

### DIFF
--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -145,14 +145,14 @@ Example:
 
 var patchRmLinkCmd = &oldcmds.Command{
 	Helptext: cmdkit.HelpText{
-		Tagline: "Remove a link from an object.",
+		Tagline: "Remove a link from a given object.",
 		ShortDescription: `
-Removes a link by the given name from root.
+Remove a Merkle-link from the given object and return the hash of the result.
 `,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("root", true, false, "The hash of the node to modify."),
-		cmdkit.StringArg("link", true, false, "Name of the link to remove."),
+		cmdkit.StringArg("name", true, false, "Name of the link to remove."),
 	},
 	Run: func(req oldcmds.Request, res oldcmds.Response) {
 		api, err := req.InvocContext().GetApi()
@@ -167,8 +167,8 @@ Removes a link by the given name from root.
 			return
 		}
 
-		link := req.Arguments()[1]
-		p, err := api.Object().RmLink(req.Context(), root, link)
+		name := req.Arguments()[1]
+		p, err := api.Object().RmLink(req.Context(), root, name)
 		if err != nil {
 			res.SetError(err, cmdkit.ErrNormal)
 			return


### PR DESCRIPTION
This improves the docs and semantics of rm-link to be consistent with add-link, clarifying that you should specify the link _name_ as the thing to remove. I found the current docs, `<link>` ambiguous as to whether it was the name or the hash. 

#### New output for `Ipfs object patch --help`
```
USAGE
  ipfs object patch - Create a new merkledag object based on an existing one.

SYNOPSIS
  ipfs object patch

DESCRIPTION

  'ipfs object patch <root> <cmd> <args>' is a plumbing command used to
  build custom DAG objects. It mutates objects, creating new objects as a
  result. This is the Merkle-DAG version of modifying an object.

SUBCOMMANDS
  ipfs object patch add-link <root> <name> <ref> - Add a link to a given object.
  ipfs object patch append-data <root> <data>    - Append data to the data segment of a dag node.
  ipfs object patch rm-link <root> <name>        - Remove a link from a given object.
  ipfs object patch set-data <root> <data>       - Set the data field of an IPFS object.

  Use 'ipfs object patch <subcmd> --help' for more information about each command.
```
#### New output for `ipfs object patch rm-link --help`
```
USAGE
  ipfs object patch rm-link <root> <name> - Remove a link from a given object.

SYNOPSIS
  ipfs object patch rm-link [--] <root> <name>

ARGUMENTS

  <root> - The hash of the node to modify.
  <name> - Name of the link to remove.

DESCRIPTION

  Remove a Merkle-link from the given object and return the hash of the result.
```