### PR TITLE
commands: fix a bunch of tiny commands-lib issues

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -188,7 +188,7 @@ format.
 			}
 			out = final
 		}
-		return res.Emit(&out)
+		return cmds.EmitOnce(res, &out)
 	},
 }
 
@@ -219,7 +219,7 @@ var DagResolveCmd = &cmds.Command{
 			return err
 		}
 
-		return res.Emit(&ResolveOutput{
+		return cmds.EmitOnce(res, &ResolveOutput{
 			Cid:     lastCid,
 			RemPath: path.Join(rem),
 		})

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -77,7 +77,7 @@ The resolver can recursively resolve:
 		if err != nil {
 			return err
 		}
-		return res.Emit(&ncmd.ResolvedPath{Path: output})
+		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: output})
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *ncmd.ResolvedPath) error {

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -105,12 +105,14 @@ This command outputs data in the following encodings:
 				return err
 			}
 
-			res.Emit(&pubsubMessage{
+			if err := res.Emit(&pubsubMessage{
 				Data:     msg.Data(),
 				From:     []byte(msg.From()),
 				Seqno:    msg.Seq(),
 				TopicIDs: msg.Topics(),
-			})
+			}); err != nil {
+				return err
+			}
 		}
 	},
 	Encoders: cmds.EncoderMap{

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -127,14 +127,20 @@ Example:
 		for {
 			if pfound {
 				stats := nd.Reporter.GetBandwidthForPeer(pid)
-				res.Emit(&stats)
+				if err := res.Emit(&stats); err != nil {
+					return err
+				}
 			} else if tfound {
 				protoId := protocol.ID(tstr)
 				stats := nd.Reporter.GetBandwidthForProtocol(protoId)
-				res.Emit(&stats)
+				if err := res.Emit(&stats); err != nil {
+					return err
+				}
 			} else {
 				totals := nd.Reporter.GetBandwidthTotals()
-				res.Emit(&totals)
+				if err := res.Emit(&totals); err != nil {
+					return err
+				}
 			}
 			if !doPoll {
 				return nil
@@ -142,7 +148,7 @@ Example:
 			select {
 			case <-time.After(interval):
 			case <-req.Context.Done():
-				return nil
+				return req.Context.Err()
 			}
 		}
 	},

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -57,7 +57,7 @@ represent it.
 		c := node.Cid()
 
 		fi.FileName()
-		return res.Emit(&coreiface.AddEvent{
+		return cmds.EmitOnce(res, &coreiface.AddEvent{
 			Name: fi.FileName(),
 			Hash: c.String(),
 		})

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -40,7 +40,7 @@ var VersionCmd = &cmds.Command{
 		cmdkit.BoolOption(versionAllOptionName, "Show all version information"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		return res.Emit(&VersionOutput{
+		return cmds.EmitOnce(res, &VersionOutput{
 			Version: version.CurrentVersionNumber,
 			Commit:  version.CurrentCommit,
 			Repo:    fmt.Sprint(fsrepo.RepoVersion),


### PR DESCRIPTION
* Always check errors returned by emit. Otherwise, we may not notice when the client goes away.
* Make sure to use EmitOnce instead of Emit when appropriate. Otherwise, we break javascript.

(thanks Magik6k for finding this before we cut the release...)