### PR TITLE
coreapi: fix errisdir

### DIFF
--- a/core/coreapi/interface/errors.go
+++ b/core/coreapi/interface/errors.go
@@ -3,6 +3,6 @@ package iface
 import "errors"
 
 var (
-	ErrIsDir   = errors.New("object is a directory")
+	ErrIsDir   = errors.New("this dag node is a directory")
 	ErrOffline = errors.New("this action must be run in online mode, try running 'ipfs daemon' first")
 )


### PR DESCRIPTION
JavaScript expects this to be "this dag node is a directory". I'm almost of a mind to say "don't parse errors" but, well, we don't give any better alternatives.