### PR TITLE
fix: return the shortest, completely resolved path in the resolve command

### DIFF
--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -140,13 +140,12 @@ Resolve the value of an IPFS DAG path:
 			return err
 		}
 
-		if rp.Remainder() != "" {
-			// TODO: js expects this error. Instead of fixing this
-			// error, we should fix #5703.
-			return fmt.Errorf("found non-link at given path")
+		encoded := "/" + rp.Namespace() + "/" + enc.Encode(rp.Cid())
+		if remainder := rp.Remainder(); remainder != "" {
+			encoded += "/" + remainder
 		}
 
-		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: path.Path("/" + rp.Namespace() + "/" + enc.Encode(rp.Cid()))})
+		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: path.Path(encoded)})
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, rp *ncmd.ResolvedPath) error {

--- a/test/sharness/t0160-resolve.sh
+++ b/test/sharness/t0160-resolve.sh
@@ -18,7 +18,7 @@ test_expect_success "resolve: prepare files" '
 '
 
 test_expect_success "resolve: prepare dag" '
-  dag_hash=$(ipfs dag put <<<"{\"a\": {\"b\": {\"c\": \"asdfasdfasdf\"}}}")
+  dag_hash=$(ipfs dag put <<<"{\"i\": {\"j\": {\"k\": \"asdfasdfasdf\"}}}")
 '
 
 test_resolve_setup_name() {
@@ -65,6 +65,9 @@ test_resolve_cmd() {
   test_resolve "/ipfs/$a_hash/b" "/ipfs/$b_hash"
   test_resolve "/ipfs/$a_hash/b/c" "/ipfs/$c_hash"
   test_resolve "/ipfs/$b_hash/c" "/ipfs/$c_hash"
+  test_resolve "/ipld/$dag_hash/i/j/k" "/ipld/$dag_hash/i/j/k"
+  test_resolve "/ipld/$dag_hash/i/j" "/ipld/$dag_hash/i/j"
+  test_resolve "/ipld/$dag_hash/i" "/ipld/$dag_hash/i"
 
   test_resolve_setup_name "/ipfs/$a_hash"
   test_resolve "/ipns/$id_hash" "/ipfs/$a_hash"
@@ -124,10 +127,9 @@ test_resolve_cmd_fail() {
   test_resolve "/ipfs/$a_hash/b/c" "/ipfs/$c_hash"
   test_resolve "/ipfs/$b_hash/c" "/ipfs/$c_hash"
   test_resolve "/ipld/$dag_hash" "/ipld/$dag_hash"
-
-  test_resolve_fail "/ipld/$dag_hash/a/b/c" "/ipld/$dag_hash/a/b/c"
-  test_resolve_fail "/ipld/$dag_hash/a/b" "/ipld/$dag_hash/a/b"
-  test_resolve_fail "/ipld/$dag_hash/a" "/ipld/$dag_hash/a"
+  test_resolve "/ipld/$dag_hash/i/j/k" "/ipld/$dag_hash/i/j/k"
+  test_resolve "/ipld/$dag_hash/i/j" "/ipld/$dag_hash/i/j"
+  test_resolve "/ipld/$dag_hash/i" "/ipld/$dag_hash/i"
 
   test_resolve_setup_name_fail "/ipfs/$a_hash"
   test_resolve_fail "/ipns/$id_hash" "/ipfs/$a_hash"


### PR DESCRIPTION
fixes #5703

This is a *breaking change*. We *used* to return an error if the path didn't end at a CID but, IMO, that's incorrect. We *should* allow resolution of paths that stop in the middle of an object.