### PR TITLE
error on resolving non-terminal paths

### DIFF
--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -135,9 +135,11 @@ Resolve the value of an IPFS DAG path:
 			return err
 		}
 
-		c := rp.Cid()
+		if rp.Remainder() != "" {
+			return fmt.Errorf("path does not end on a dag-node boundary")
+		}
 
-		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: path.FromCid(c)})
+		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: path.Path("/" + rp.Namespace() + "/" + rp.Cid().String())})
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeEncoder(func(req *cmds.Request, w io.Writer, v interface{}) error {

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -136,7 +136,9 @@ Resolve the value of an IPFS DAG path:
 		}
 
 		if rp.Remainder() != "" {
-			return fmt.Errorf("path does not end on a dag-node boundary")
+			// TODO: js expects this error. Instead of fixing this
+			// error, we should fix #5703.
+			return fmt.Errorf("found non-link at given path")
 		}
 
 		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: path.Path("/" + rp.Namespace() + "/" + rp.Cid().String())})

--- a/test/sharness/t0160-resolve.sh
+++ b/test/sharness/t0160-resolve.sh
@@ -14,6 +14,10 @@ test_expect_success "resolve: prepare files" '
   c_hash=$(ipfs add -q -r a/b/c | tail -n1)
 '
 
+test_expect_success "resolve: prepare dag" '
+  dag_hash=$(ipfs dag put <<<"{\"a\": {\"b\": {\"c\": \"asdfasdfasdf\"}}}")
+'
+
 test_resolve_setup_name() {
   ref=$1
 
@@ -92,6 +96,11 @@ test_resolve_cmd_fail() {
   test_resolve "/ipfs/$a_hash/b" "/ipfs/$b_hash"
   test_resolve "/ipfs/$a_hash/b/c" "/ipfs/$c_hash"
   test_resolve "/ipfs/$b_hash/c" "/ipfs/$c_hash"
+  test_resolve "/ipld/$dag_hash" "/ipld/$dag_hash"
+
+  test_resolve_fail "/ipld/$dag_hash/a/b/c" "/ipld/$dag_hash/a/b/c"
+  test_resolve_fail "/ipld/$dag_hash/a/b" "/ipld/$dag_hash/a/b"
+  test_resolve_fail "/ipld/$dag_hash/a" "/ipld/$dag_hash/a"
 
   test_resolve_setup_name_fail "/ipfs/$a_hash"
   test_resolve_fail "/ipns/$id_hash" "/ipfs/$a_hash"


### PR DESCRIPTION
This isn't the *correct* fix but it (mostly) restores the previous behavior.

Note 1: It *also* fixes resolution of `/ipld` paths by avoiding `path.FromCid`.
Note 2: This does not preserve the error. That was a DagCBOR specific error that has nothing to do with the issue.