### PR TITLE
[WIP] Simple bitswap performance test

### DIFF
--- a/test/sharness/t0126-bitswap-perf.sh
+++ b/test/sharness/t0126-bitswap-perf.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test multiple ipfs nodes transferring files via bitswap"
+timing_file="`basename "$0"`-timings.tmp"
+node_count=8
+file_size_kb=10000
+
+. lib/test-lib.sh
+
+time_expect_success() {
+    { time {
+    test_expect_success "$1" "$2";
+    TIMEFORMAT=%5R;
+    }; } 2>> $timing_file
+}
+
+check_file_fetch() {
+  node=$1
+  fhash=$2
+  fname=$3
+
+  echo -n "node$1-receive-elapsed-sec: " >> $timing_file
+  time_expect_success "node$node can fetch file" '
+    ipfsi $node cat $fhash > fetch_out$node
+  '
+
+  test_expect_success "file looks good" '
+    test_cmp $fname fetch_out$node
+  '
+
+  echo -n "node$1-receive-duplicate_blocks: " >> $timing_file &&
+  ipfsi $1 bitswap stat | sed -n -e 's/[[:space:]]dup blocks received: \([0-9].*\)$/\1/p' >> $timing_file
+}
+
+echo '' > $timing_file
+
+test_expect_success "set up tcp testbed" '
+  iptb init -n $node_count -p 0 -f --bootstrap=none
+'
+
+startup_cluster $node_count
+
+# Clean out all the repos
+for i in $(test_seq 0 $(expr $node_count - 1))
+do
+  test_expect_success "clean node $i repo before test" '
+    ipfsi $i repo gc > /dev/null
+  '
+done
+
+# Create a big'ish file
+test_expect_success "add a file on node0" '
+  random $(($file_size_kb * 1024)) > filea &&
+  FILEA_HASH=$(ipfsi 0 add -q filea)
+'
+
+# Fetch the file with each node in succession (time each)
+for i in $(test_seq 1 $(expr $node_count - 1))
+do
+  check_file_fetch $i $FILEA_HASH filea
+  sleep 2
+done
+
+# shutdown
+test_expect_success "shut down nodes" '
+  iptb stop && iptb_wait_stop
+'
+
+cat $timing_file
+
+test_done


### PR DESCRIPTION
**Goal** 
We'd like a way to create a suite of tests to check/measure relative performance, initially of bitswap changes. This is a simple example of that, and I'm curious what people think. It's got some benefits:
* Really fast to write: iptb is hard to beat for orchestrating ipfs nodes
* Easy to simulate simple interactions between nodes
* Probably pretty easy to set up a variety of DAG tree shapes for testing
* Perfectly good smoke test - these are full IPFS nodes going about their business

It's got a lot of problems:
* Not easy to simulate different network conditions
* It's resource intensive and the timings will approach meaninglessness at some no. of nodes.
* It's hard to build up useful performance data to report (like dupes, bytes/sec, bitswap broadcasts etc.) because ipfs doesn't make them readily available. Output here looks like:
```

node1-receive-elapsed-sec: 0.370
node1-receive-duplicate_blocks: 0
node2-receive-elapsed-sec: 0.444
node2-receive-duplicate_blocks: 35
node3-receive-elapsed-sec: 0.571
node3-receive-duplicate_blocks: 78
node4-receive-elapsed-sec: 0.924
node4-receive-duplicate_blocks: 113
node5-receive-elapsed-sec: 0.725
node5-receive-duplicate_blocks: 157
node6-receive-elapsed-sec: 0.837
node6-receive-duplicate_blocks: 180
node7-receive-elapsed-sec: 1.074
node7-receive-duplicate_blocks: 231
```

**Alternatives**
* There are already some tests that do much more than this in https://github.com/ipfs/go-bitswap using a mocked network. 
* We could drive iptb with Go for better control over iptb and better reports. 
* We could drive tests with JS like our interop tests.

**Todo**
This is just a trial effort; we'd want these in test/bench with their own make target, and we'd want to test some more diverse data. 

**Question**
Do we want benchmarks like this? 