### PR TITLE
re-format log output as ndjson

### DIFF
--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -110,6 +110,8 @@ Outputs event log messages (not other log messages) as they are generated.
 			defer w1.Close()
 			<-ctx.Done()
 		}()
+		// Reformat the logs as ndjson
+		// TODO: remove this: #5709
 		go func() {
 			defer w2.Close()
 			decoder := json.NewDecoder(r1)

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -103,13 +104,26 @@ Outputs event log messages (not other log messages) as they are generated.
 
 	Run: func(req cmds.Request, res cmds.Response) {
 		ctx := req.Context()
-		r, w := io.Pipe()
+		r1, w1 := io.Pipe()
+		r2, w2 := io.Pipe()
 		go func() {
-			defer w.Close()
+			defer w1.Close()
 			<-ctx.Done()
 		}()
-		lwriter.WriterGroup.AddWriter(w)
-		res.SetOutput(r)
+		go func() {
+			defer w2.Close()
+			decoder := json.NewDecoder(r1)
+			encoder := json.NewEncoder(w2)
+			for {
+				var obj interface{}
+				if decoder.Decode(&obj) != nil || encoder.Encode(obj) != nil {
+					return
+				}
+			}
+		}()
+
+		lwriter.WriterGroup.AddWriter(w1)
+		res.SetOutput(r2)
 	},
 }
 


### PR DESCRIPTION
Apparently, js-ipfs-api expects this. Really, I'm not sure why js-ipfs-api even cares about this endpoint but that's a different issue.

The real fix is to change back to ndjson in go-log but that would force us to update every package (not good when we're trying to push out a release like this).