### PR TITLE
Add ceph rados plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_go_expensive
   - TEST_NO_FUSE=1 TEST_VERBOSE=1 TEST_SUITE=test_sharness_expensive
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y librados-dev; fi
+
 install:
   - make install
 

--- a/package.json
+++ b/package.json
@@ -595,9 +595,9 @@
     },
     {
       "author": "bjzhang",
-      "hash": "QmdZuk8xgy7o832HfhMEYFpVfWjGFm9FdgRW4ZatK1nwwQ",
+      "hash": "QmYyMML9pPAFqQAtHW56YHzUXK7CBnubB1g7kK123eo98G",
       "name": "go-ds-rados",
-      "version": "0.0.3"
+      "version": "0.0.4"
     }
   ],
   "gxVersion": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -592,6 +592,12 @@
       "hash": "QmTzWwfHZr9N6Tnk4iDTtKMWY57D3wik73qNCVo21Bu1UP",
       "name": "iptb-plugins",
       "version": "1.0.3"
+    },
+    {
+      "author": "bjzhang",
+      "hash": "QmdZuk8xgy7o832HfhMEYFpVfWjGFm9FdgRW4ZatK1nwwQ",
+      "name": "go-ds-rados",
+      "version": "0.0.3"
     }
   ],
   "gxVersion": "0.10.0",

--- a/plugin/plugins/Rules.mk
+++ b/plugin/plugins/Rules.mk
@@ -1,6 +1,6 @@
 include mk/header.mk
 
-$(d)_plugins:=$(d)/git $(d)/badgerds $(d)/flatfs $(d)/levelds
+$(d)_plugins:=$(d)/git $(d)/badgerds $(d)/flatfs $(d)/levelds $(d)/rados
 $(d)_plugins_so:=$(addsuffix .so,$($(d)_plugins))
 $(d)_plugins_main:=$(addsuffix /main/main.go,$($(d)_plugins))
 

--- a/plugin/plugins/rados/rados.go
+++ b/plugin/plugins/rados/rados.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ipfs/go-ipfs/repo"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 
-	rados "gx/ipfs/QmdZuk8xgy7o832HfhMEYFpVfWjGFm9FdgRW4ZatK1nwwQ/go-ds-rados"
+	rados "gx/ipfs/QmYyMML9pPAFqQAtHW56YHzUXK7CBnubB1g7kK123eo98G/go-ds-rados"
 )
 
 // Plugins is exported list of plugins that will be loaded

--- a/plugin/plugins/rados/rados.go
+++ b/plugin/plugins/rados/rados.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package radosds
 
 import (

--- a/plugin/plugins/rados/rados.go
+++ b/plugin/plugins/rados/rados.go
@@ -1,0 +1,78 @@
+package radosds
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ipfs/go-ipfs/plugin"
+	"github.com/ipfs/go-ipfs/repo"
+	"github.com/ipfs/go-ipfs/repo/fsrepo"
+
+	rados "github.com/ipfs/go-ds-rados"
+)
+
+// Plugins is exported list of plugins that will be loaded
+var Plugins = []plugin.Plugin{
+	&radosPlugin{},
+}
+
+type radosPlugin struct{}
+
+var _ plugin.PluginDatastore = (*radosPlugin)(nil)
+
+func (*radosPlugin) Name() string {
+	return "ds-rados"
+}
+
+func (*radosPlugin) Version() string {
+	return "0.1.0"
+}
+
+func (*radosPlugin) Init() error {
+	return nil
+}
+
+func (*radosPlugin) DatastoreTypeName() string {
+	return "rados"
+}
+
+type radosDatastoreConfig struct {
+	confPath string
+	pool     string
+}
+
+func (*radosPlugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
+	return func(params map[string]interface{}) (fsrepo.DatastoreConfig, error) {
+		var c radosDatastoreConfig
+		var ok bool
+		c.confPath, ok = params["confpath"].(string)
+		if !ok {
+			return nil, fmt.Errorf("confpath filed is missing or not string")
+		}
+		c.pool, ok = params["pool"].(string)
+		if !ok {
+			return nil, fmt.Errorf("'pool' filed is missing or not string")
+		}
+		return &c, nil
+	}
+}
+
+func (c *radosDatastoreConfig) DiskSpec() fsrepo.DiskSpec {
+	return map[string]interface{}{
+		"type":     "rados",
+		"confpath": c.confPath,
+		"pool":     c.pool,
+	}
+}
+
+func (c *radosDatastoreConfig) Create(string) (repo.Datastore, error) {
+	_, err := os.Open(c.confPath)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("Config file for rados doesn't exist:%s", c.confPath)
+	}
+	if os.IsPermission(err) {
+		return nil, fmt.Errorf("Permission deny for file:%s", c.confPath)
+	}
+
+	return rados.NewDatastore(c.confPath, c.pool)
+}

--- a/plugin/plugins/rados/rados.go
+++ b/plugin/plugins/rados/rados.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ipfs/go-ipfs/repo"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 
-	rados "github.com/ipfs/go-ds-rados"
+	rados "gx/ipfs/QmdZuk8xgy7o832HfhMEYFpVfWjGFm9FdgRW4ZatK1nwwQ/go-ds-rados"
 )
 
 // Plugins is exported list of plugins that will be loaded


### PR DESCRIPTION
In https://github.com/ipfs/go-datastore/issues/101, @magik6k agree that we could contribute a new ceph rados datastore for go-ipfs datastore(public repo: https://github.com/ipbit/go-ds-rados). 
 As you know, RADOS(Reliable Autonomic Distributed Object Store) provides an extremely scalable storage service for variably sized objects. Basically, it is a distributed key-value store which is suitable for storing files. 

These series patches implement the datastore plugin for ceph rados. Such plugin is based on our public repo: https://github.com/ipbit/go-ds-rados . Test passed in our environment.  In our work, We read carefully and follow the guideline in https://github.com/ipfs/community/blob/master/CONTRIBUTING_GO.md . 

Any feedback is welcome. Thanks in advance.