### PR TITLE
Suppress bootstrap error

### DIFF
--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -77,6 +77,12 @@ func Bootstrap(n *IpfsNode, cfg BootstrapConfig) (io.Closer, error) {
 	// make a signal to wait for one bootstrap round to complete.
 	doneWithRound := make(chan struct{})
 
+	if len(cfg.BootstrapPeers()) == 0 {
+		// We *need* to bootstrap but we have no bootstrap peers
+		// configured *at all*, inform the user.
+		log.Error("no bootstrap nodes configured: go-ipfs may have difficulty connecting to the network")
+	}
+
 	// the periodic bootstrap function -- the connection supervisor
 	periodic := func(worker goprocess.Process) {
 		ctx := procctx.OnClosingContext(worker)
@@ -138,11 +144,6 @@ func bootstrapRound(ctx context.Context, host host.Host, cfg BootstrapConfig) er
 	// if connected to all bootstrap peer candidates, exit
 	if len(notConnected) < 1 {
 		log.Debugf("%s no more bootstrap peers to create %d connections", id, numToDial)
-		if len(peers) == 0 {
-			// We *need* to bootstrap but we have no bootstrap peers
-			// configured *at all*, inform the user.
-			log.Error("no bootstrap nodes configured: go-ipfs may have difficulty connecting to the network")
-		}
 		return ErrNotEnoughBootstrapPeers
 	}
 


### PR DESCRIPTION
When used in private network mode with `Bootstrap` set to `[]`, the daemon currently spits out the following message ever 30 seconds:

```
ERROR       core: no bootstrap nodes configured: go-ipfs may have difficulty connecting to the network bootstrap.go:144
```

While it is good to mention, I see two issues with this:

* In regular environments, running the daemon with no bootstrap nodes will in fact render it unusable, so there should be an error at daemon start time instead of a repetitive message
* For private network setups where nodes discover themselves via MDNS, this message is unnecessary.

This PR changes both the above, with one patch for each of them.