### PR TITLE
ISSUE_TEMPLATE: move the support question comment to the very top

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,13 +1,14 @@
 <!--
-Welcome to the go-ipfs bug tracker. This is for you! Please read, and then delete this text before posting it.
+🔥❓ If you have a *SUPPORT QUESTION*, please direct it to our forum at https://discuss.ipfs.io. 🔥❓
 
 If you haven't yet searched the issue tracker for an existing report concerning your issue, please do so now.
 
 The go-ipfs issues are only for bug reports and directly actionable feature requests. Read https://github.com/ipfs/community/blob/master/contributing.md#reporting-issues if your issue doesn't fit either of those categories.
 
-If you have a *SUPPORT QUESTION*, please direct it to our forum at https://discuss.ipfs.io.
 
 Read https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue.
+
+This text is for you; please delete it before posting.
 -->
 
 #### Version information:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,39 +1,24 @@
-<!--
-🔥❓ If you have a *SUPPORT QUESTION*, please direct it to our forum at https://discuss.ipfs.io. 🔥❓
+<!-- 🔥❓ If you have a *QUESTION* about IPFS, please direct it to our forum at https://discuss.ipfs.io. 🔥❓
 
-If you haven't yet searched the issue tracker for an existing report concerning your issue, please do so now.
-
-The go-ipfs issues are only for bug reports and directly actionable feature requests. Read https://github.com/ipfs/community/blob/master/contributing.md#reporting-issues if your issue doesn't fit either of those categories.
-
-
-Read https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue.
-
-This text is for you; please delete it before posting.
--->
+The go-ipfs issues are *only for bug reports and directly actionable feature requests*. Please direct all other questions, ideas, or suggestions to our discuss forum. Remember to search the issue tracker for an existing report concerning your issue before posting, and see https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue. -->
 
 #### Version information:
-<!--
-Output From `ipfs version --all`
+<!-- Output From `ipfs version --all`
 
-Please check dist.ipfs.io for a newer version of go-ipfs
-and update if neccessary, then check again if the problem persists.
--->
+Please check dist.ipfs.io for a newer version of go-ipfs and update if necessary, report back if the problem persists. -->
 
 #### Type:
 <!-- Bug, Feature, Enhancement, Etc -->
 
 #### Description:
-<!--
-This is where you get to tell us what went wrong or what feature you need. When doing so, please make sure to include *all* relevant information.
+<!-- This is where you get to tell us what went wrong or your specific feature request. When doing so, please make sure to include *all* relevant information.
 
-When requesting a feature, please be sure to include:
+When _reporting a bug_, please try to include:
+  * What you were doing when you experienced the bug.
+  * Any error messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
+  * When possible, steps to reliably produce the bug.
 
-* Your motivation. Why do you need the feature?
-* How the feature should work.
-
-When reporting a bug, please try to include:
-
-* What you were doing when you experienced the bug.
-* Any error messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
-* When possible, steps to reliably produce the bug.
+When requesting a _feature_, please be sure to include:
+  * Your motivation. Why do you need the feature?
+  * How the feature should work.
 -->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-<!-- 🔥❓ If you have a *QUESTION* about IPFS, please direct it to our forum at https://discuss.ipfs.io. 🔥❓
+<!-- 🔥❓If you have a *QUESTION* about IPFS, please ask on our forum at https://discuss.ipfs.io 🔥❓
 
-The go-ipfs issues are *only for bug reports and directly actionable feature requests*. Please direct all other questions, ideas, or suggestions to our discuss forum. Remember to search the issue tracker for an existing report concerning your issue before posting, and see https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue. -->
+The go-ipfs issues are *only* for bug reports and directly actionable feature requests. Please direct all other questions, ideas, or suggestions to our discuss forum. Remember to search the issue tracker for an existing report concerning your issue before posting, and see https://github.com/ipfs/go-ipfs/blob/master/docs/github-issue-guide.md if you are not sure how to fill in this issue. -->
 
 #### Version information:
 <!-- Output From `ipfs version --all`
 
-Please check dist.ipfs.io for a newer version of go-ipfs and update if necessary, report back if the problem persists. -->
+Please check dist.ipfs.io for a newer version of go-ipfs and update if necessary. Report back if the problem persists. -->
 
 #### Type:
 <!-- Bug, Feature, Enhancement, Etc -->
@@ -13,7 +13,7 @@ Please check dist.ipfs.io for a newer version of go-ipfs and update if necessary
 #### Description:
 <!-- This is where you get to tell us what went wrong or your specific feature request. When doing so, please make sure to include *all* relevant information.
 
-When _reporting a bug_, please try to include:
+When reporting a _bug_, please try to include:
   * What you were doing when you experienced the bug.
   * Any error messages you saw, *where* you saw them, and what you believe may have caused them (if you have any ideas).
   * When possible, steps to reliably produce the bug.


### PR DESCRIPTION
The issue template is long. We need to make this *really* obvious*.