### PR TITLE
Switch to using request.Context()

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -64,22 +64,10 @@ func (i *gatewayHandler) newDagFromReader(r io.Reader) (ipld.Node, error) {
 		chunker.DefaultSplitter(r))
 }
 
-// TODO(btc): break this apart into separate handlers using a more expressive muxer
 func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(i.node.Context(), time.Hour)
 	// the hour is a hard fallback, we don't expect it to happen, but just in case
+	ctx, cancel := context.WithTimeout(r.Context(), time.Hour)
 	defer cancel()
-
-	if cn, ok := w.(http.CloseNotifier); ok {
-		clientGone := cn.CloseNotify()
-		go func() {
-			select {
-			case <-clientGone:
-			case <-ctx.Done():
-			}
-			cancel()
-		}()
-	}
 
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Was looking through the http handler code. When we figured out this CloseNotify stuff initially, I remember being super excited. That was quite some time ago, things have gotten better since then. The request.Context() now will cancel when the client leaves, or when the http server is shutdown, which is exactly what we want here. 

This approach also frees us from having to run another extra goroutine. Yay.

License: MIT
Signed-off-by: Jeromy <jeromyj@gmail.com>