### PR TITLE
Improve the Filestore document

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -181,7 +181,11 @@ Modify your ipfs config:
 ipfs config --json Experimental.FilestoreEnabled true
 ```
 
-And then pass the `--nocopy` flag when running `ipfs add`
+Need to re-init ipfs node because the Filestore is created along with new ipfs
+node. Otherwise `ipfs add` will not complain and `ipfs filestore` will raise
+error.
+
+Then pass the `--nocopy` flag when running `ipfs add`
 
 ### Road to being a real feature
 - [ ] Needs more people to use and report on how well it works.


### PR DESCRIPTION
Fix for the #5746.

I am sure if re-init the ipfs node is intended. In my test, after enable filestore by `ipfs config --json Experimental.FilestoreEnabled true`. Restart ipfs daemon is not worked. It is only worked if I delete the whole ~/.ipfs and re-do `ipfs init'

Thanks.