### PR TITLE
Improve the Filestore document

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -181,7 +181,10 @@ Modify your ipfs config:
 ipfs config --json Experimental.FilestoreEnabled true
 ```
 
-And then pass the `--nocopy` flag when running `ipfs add`
+Restart ipfs node. Otherwise `ipfs add` will not complain and `ipfs filestore`
+will raise error.
+
+Then pass the `--nocopy` flag when running `ipfs add`
 
 ### Road to being a real feature
 - [ ] Needs more people to use and report on how well it works.


### PR DESCRIPTION
Fix for the #5746. Switch to Filestore need to restart the ipfs node.

License: MIT
Signed-off-by: Bamvor Zhang <jian.zhang@ipfsbit.com>