### PR TITLE
Move provide from bitswap to ipfs 

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -6,14 +6,14 @@ import (
 	"os"
 	"strings"
 
-	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
+	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
-	options "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
+	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 
-	pb "gx/ipfs/QmPtj12fdwuAqj9sBSTNUxBNu8kCGNp8b3o8yUzMm5GHpq/pb"
-	files "gx/ipfs/QmZMWMvWMVKCbHetJ4RgndbuEF1io2UpUxwQwtNjtYPzSC/go-ipfs-files"
-	cmds "gx/ipfs/Qma6uuSyjkecGhMFFLfzyJDPyoDtNJSHJNweDccZhaWkgU/go-ipfs-cmds"
-	cmdkit "gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+	"gx/ipfs/QmPtj12fdwuAqj9sBSTNUxBNu8kCGNp8b3o8yUzMm5GHpq/pb"
+	"gx/ipfs/QmZMWMvWMVKCbHetJ4RgndbuEF1io2UpUxwQwtNjtYPzSC/go-ipfs-files"
+	"gx/ipfs/Qma6uuSyjkecGhMFFLfzyJDPyoDtNJSHJNweDccZhaWkgU/go-ipfs-cmds"
+	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
 	mh "gx/ipfs/QmerPMzPk1mJVowm8KgmoknWa4yCYvvugMPsgWmDNUvDLW/go-multihash"
 )
 

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -184,6 +184,8 @@ than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
 		}
 
 		return cmds.EmitOnce(res, &BlockStat{
+			// TODO be careful checking ErrNotFound. If the underlying
+			// implementation changes, this will break.
 			Key:  p.Path().Cid().String(),
 			Size: p.Size(),
 		})

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -63,6 +63,11 @@ into an object of the specified format.
 		cmdkit.StringOption("hash", "Hash function to use").WithDefault(""),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			return err
@@ -138,7 +143,11 @@ into an object of the specified format.
 				return err
 			}
 		}
-		return nil
+
+		return cids.ForEach(func(cid cid.Cid) error {
+			api.Provider().Provide(cid)
+			return nil
+		})
 	},
 	Type: OutputObject{},
 	Encoders: cmds.EncoderMap{
@@ -161,6 +170,11 @@ format.
 		cmdkit.StringArg("ref", true, false, "The object to get").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			return err
@@ -179,6 +193,8 @@ format.
 		if err != nil {
 			return err
 		}
+
+		api.Provider().Provide(obj.Cid())
 
 		var out interface{} = obj
 		if len(rem) > 0 {
@@ -204,6 +220,11 @@ var DagResolveCmd = &cmds.Command{
 		cmdkit.StringArg("ref", true, false, "The path to resolve").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			return err
@@ -218,6 +239,8 @@ var DagResolveCmd = &cmds.Command{
 		if err != nil {
 			return err
 		}
+
+		api.Provider().Provide(lastCid)
 
 		return cmds.EmitOnce(res, &ResolveOutput{
 			Cid:     lastCid,

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -66,6 +66,11 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return err
 		}
 
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		node, err := cmdenv.GetNode(env)
 		if err != nil {
 			return err
@@ -90,6 +95,8 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		default:
 			return err
 		}
+
+		api.Provider().Provide(dn.Cid())
 
 		archive, _ := req.Options[archiveOptionName].(bool)
 		reader, err := uarchive.DagArchive(ctx, dn, p.String(), node.DAG, archive, cmplvl)

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -141,6 +141,8 @@ The JSON output contains type information.
 					Hash:  paths[i],
 					Links: outputLinks,
 				}
+
+				api.Provider().Provide(dagnode.Cid())
 			}
 
 			return cmds.EmitOnce(res, &LsOutput{output})
@@ -177,6 +179,8 @@ The JSON output contains type information.
 					return err
 				}
 			}
+
+			api.Provider().Provide(dagnode.Cid())
 		}
 		return nil
 	},

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"io"
 	"strings"
 
@@ -73,6 +74,11 @@ NOTE: List all references recursively by using the flag '-r'.
 			return err
 		}
 
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		ctx := req.Context
 		n, err := cmdenv.GetNode(env)
 		if err != nil {
@@ -97,7 +103,7 @@ NOTE: List all references recursively by using the flag '-r'.
 			format = "<src> -> <dst>"
 		}
 
-		objs, err := objectsForPaths(ctx, n, req.Arguments)
+		objs, err := objectsForPaths(ctx, n, api, req.Arguments)
 		if err != nil {
 			return err
 		}
@@ -159,7 +165,7 @@ Displays the hashes of all local objects.
 	Type:     RefWrapper{},
 }
 
-func objectsForPaths(ctx context.Context, n *core.IpfsNode, paths []string) ([]ipld.Node, error) {
+func objectsForPaths(ctx context.Context, n *core.IpfsNode, api coreiface.CoreAPI, paths []string) ([]ipld.Node, error) {
 	objects := make([]ipld.Node, len(paths))
 	for i, sp := range paths {
 		p, err := path.ParsePath(sp)
@@ -171,6 +177,9 @@ func objectsForPaths(ctx context.Context, n *core.IpfsNode, paths []string) ([]i
 		if err != nil {
 			return nil, err
 		}
+
+		api.Provider().Provide(o.Cid())
+
 		objects[i] = o
 	}
 	return objects, nil

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -39,6 +39,11 @@ represent it.
 		cmdkit.FileArg("file", true, false, "Tar file to add.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		api, err := cmdenv.GetApi(env)
+		if err != nil {
+			return err
+		}
+
 		nd, err := cmdenv.GetNode(env)
 		if err != nil {
 			return err
@@ -56,6 +61,9 @@ represent it.
 
 		c := node.Cid()
 
+		api.Provider().Provide(c)
+
+		// TODO: why is this here?
 		fi.FileName()
 		return cmds.EmitOnce(res, &coreiface.AddEvent{
 			Name: fi.FileName(),

--- a/core/core.go
+++ b/core/core.go
@@ -322,8 +322,9 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	// Provider
 
 	// TODO: Make strategy configurable
-	strategy := provider.NewProvideAllStrategy(n.DAG)
-	n.Provider = provider.NewProvider(ctx, strategy, n.Routing)
+	strategy := provider.NewAnchorAllStrategy(n.DAG)
+	eligible := provider.NewEligibleOnlyOnceStrategy()
+	n.Provider = provider.NewProvider(ctx, strategy, eligible, n.Routing)
 	go n.Provider.Run()
 
 	// Reprovider

--- a/core/core.go
+++ b/core/core.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	provider "github.com/ipfs/go-ipfs/provider"
 	version "github.com/ipfs/go-ipfs"
 	rp "github.com/ipfs/go-ipfs/exchange/reprovide"
 	filestore "github.com/ipfs/go-ipfs/filestore"
@@ -133,6 +134,7 @@ type IpfsNode struct {
 	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
 	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
 	Reprovider   *rp.Reprovider      // the value reprovider system
+	Provider     *provider.Provider  // the value provider system
 	IpnsRepub    *ipnsrp.Republisher
 
 	PubSub   *pubsub.PubSub
@@ -316,6 +318,15 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Provider
+
+	// TODO: Make strategy configurable
+	strategy := provider.NewProvideAllStrategy(n.DAG)
+	n.Provider = provider.NewProvider(ctx, strategy, n.Routing)
+	go n.Provider.Run()
+
+	// Reprovider
 
 	var keyProvider rp.KeyChanFunc
 

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -48,6 +48,8 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 		return nil, err
 	}
 
+	api.core().Provider().Provide(b.Cid())
+
 	return &BlockStat{path: coreiface.IpldPath(b.Cid()), size: len(data)}, nil
 }
 
@@ -61,6 +63,8 @@ func (api *BlockAPI) Get(ctx context.Context, p coreiface.Path) (io.Reader, erro
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(rp.Cid())
 
 	return bytes.NewReader(b.RawData()), nil
 }
@@ -113,6 +117,8 @@ func (api *BlockAPI) Stat(ctx context.Context, p coreiface.Path) (coreiface.Bloc
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(b.Cid())
 
 	return &BlockStat{
 		path: coreiface.IpldPath(b.Cid()),

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -15,8 +15,7 @@ package coreapi
 
 import (
 	"context"
-
-	core "github.com/ipfs/go-ipfs/core"
+	"github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 
 	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
@@ -85,6 +84,10 @@ func (api *CoreAPI) Swarm() coreiface.SwarmAPI {
 // PubSub returns the PubSubAPI interface implementation backed by the go-ipfs node
 func (api *CoreAPI) PubSub() coreiface.PubSubAPI {
 	return (*PubSubAPI)(api)
+}
+
+func (api *CoreAPI) Provider() coreiface.ProviderAPI {
+	return (*ProviderAPI)(api)
 }
 
 // getSession returns new api backed by the same node with a read-only session DAG

--- a/core/coreapi/interface/coreapi.go
+++ b/core/coreapi/interface/coreapi.go
@@ -37,6 +37,9 @@ type CoreAPI interface {
 	// Swarm returns an implementation of Swarm API
 	Swarm() SwarmAPI
 
+	// Provider returns an implementation of ProvideAPI
+	Provider() ProviderAPI
+
 	// PubSub returns an implementation of PubSub API
 	PubSub() PubSubAPI
 

--- a/core/coreapi/interface/provider.go
+++ b/core/coreapi/interface/provider.go
@@ -1,0 +1,9 @@
+package iface
+
+import "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+type ProviderAPI interface {
+	// Announce that the given cid is being provided
+	Provide(cid.Cid)
+}
+

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -54,6 +54,9 @@ func (api *ObjectAPI) New(ctx context.Context, opts ...caopts.ObjectNewOption) (
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(n.Cid())
+
 	return n, nil
 }
 
@@ -133,6 +136,8 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 			return nil, err
 		}
 	}
+
+	api.core().Provider().Provide(dagnode.Cid())
 
 	return coreiface.IpfsPath(dagnode.Cid()), nil
 }
@@ -231,6 +236,8 @@ func (api *ObjectAPI) AddLink(ctx context.Context, base coreiface.Path, name str
 		return nil, err
 	}
 
+	api.core().Provider().Provide(nnode.Cid())
+
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
 
@@ -256,6 +263,8 @@ func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link stri
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -293,6 +302,8 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(pbnd.Cid())
 
 	return coreiface.IpfsPath(pbnd.Cid()), nil
 }

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -27,6 +27,9 @@ func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (ipld.Nod
 	if err != nil {
 		return nil, err
 	}
+
+	api.Provider().Provide(node.Cid())
+
 	return node, nil
 }
 

--- a/core/coreapi/provider.go
+++ b/core/coreapi/provider.go
@@ -1,0 +1,10 @@
+package coreapi
+
+import "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+type ProviderAPI CoreAPI
+
+func (api *ProviderAPI) Provide(cid cid.Cid) {
+	api.node.Provider.Provide(cid)
+}
+

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -130,6 +130,11 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.File, opts ...options
 	if err != nil {
 		return nil, err
 	}
+
+	if !settings.Local {
+		api.core().Provider().Provide(nd.Cid())
+	}
+
 	return coreiface.IpfsPath(nd.Cid()), nil
 }
 
@@ -140,6 +145,8 @@ func (api *UnixfsAPI) Get(ctx context.Context, p coreiface.Path) (coreiface.Unix
 	if err != nil {
 		return nil, err
 	}
+
+	api.core().Provider().Provide(nd.Cid())
 
 	return newUnixfsFile(ctx, ses.dag, nd, "", nil)
 }

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -499,6 +499,8 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	i.api.Provider().Provide(newcid)
+
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", newcid.String())
 	http.Redirect(w, r, gopath.Join(ipfsPathPrefix, newcid.String(), newPath), http.StatusCreated)
@@ -575,6 +577,8 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to new path
 	ncid := newnode.Cid()
+
+	i.api.Provider().Provide(ncid)
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", ncid.String())

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,142 @@
+package provider
+
+import (
+	"context"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmZBH87CAPFHcc7cYmBqeSQ98zQ3SX9KUxiYgzPmLWNVKz/go-libp2p-routing"
+	logging "gx/ipfs/QmcuXC5cxs79ro2cUuHs4HQ2bkDLJUYokwL8aivcX6HW3C/go-log"
+	"time"
+)
+
+var (
+	log = logging.Logger("provider")
+)
+
+const (
+	provideOutgoingLimit 	= 512
+	provideOutgoingTimeout  = time.Second * 15
+)
+
+type Strategy func(context.Context, chan cid.Cid, cid.Cid)
+
+type Provider struct {
+	ctx context.Context
+
+	// cids we want to provide
+	incoming chan cid.Cid
+	// cids we are working on providing now
+	outgoing chan cid.Cid
+
+	// strategy for deciding which cids, given a cid, should be provided
+	strategy Strategy
+
+	contentRouting routing.ContentRouting // TODO: temp, maybe
+}
+
+func NewProvider(ctx context.Context, strategy Strategy, contentRouting routing.ContentRouting) *Provider {
+	return &Provider{
+		ctx: ctx,
+		outgoing: make(chan cid.Cid),
+		incoming: make(chan cid.Cid),
+		strategy: strategy,
+		contentRouting: contentRouting,
+	}
+}
+
+// Start workers to handle provide requests.
+func (p *Provider) Run() {
+	go p.handleIncoming()
+	go p.handleOutgoing()
+}
+
+// Provider the given cid using specified strategy.
+func (p *Provider) Provide(root cid.Cid) {
+	p.strategy(p.ctx, p.incoming, root)
+}
+
+// Announce to the world that a block is provided.
+//
+// TODO: Refactor duplication between here and the reprovider.
+func (p *Provider) Announce(cid cid.Cid) {
+	ctx, cancel := context.WithTimeout(p.ctx, provideOutgoingTimeout)
+	defer cancel()
+
+	if err := p.contentRouting.Provide(ctx, cid, true); err != nil {
+		log.Warning("Failed to provide key: %s", err)
+	}
+}
+
+// Workers
+
+// Handle incoming requests to provide blocks
+//
+// Basically, buffer everything that comes through the incoming channel.
+// Then, whenever the outgoing channel is ready to receive a value, pull
+// a value out of the buffer and put it onto the outgoing channel.
+func (p *Provider) handleIncoming() {
+	var buffer []cid.Cid // unbounded buffer between incoming/outgoing
+	var nextKey cid.Cid
+	var keys chan cid.Cid
+
+	for {
+		select {
+		case key, ok := <-p.incoming:
+			if !ok {
+				log.Debug("incoming channel closed")
+				return
+			}
+
+			if keys == nil {
+				nextKey = key
+				keys = p.outgoing
+			} else {
+				buffer = append(buffer, key)
+			}
+		case keys <- nextKey:
+			if len(buffer) > 0 {
+				nextKey = buffer[0]
+				buffer = buffer[1:]
+			} else {
+				keys = nil
+			}
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+// Handle all outgoing cids by providing them
+func (p *Provider) handleOutgoing() {
+	limit := make(chan struct{}, provideOutgoingLimit)
+	limitedProvide := func(cid cid.Cid, workerId int) {
+		defer func() {
+			<-limit
+		}()
+
+		ev := logging.LoggableMap{"ID": workerId}
+		// TODO: EventBegin deprecated?
+		defer log.EventBegin(p.ctx, "Ipfs.Provider.Worker.Work", ev, cid)
+
+		p.Announce(cid)
+	}
+
+	for workerId := 0; ; workerId++ {
+		ev := logging.LoggableMap{"ID": workerId}
+		log.Event(p.ctx, "Ipfs.Provider.Worker.Loop", ev)
+		select {
+		case key, ok := <-p.outgoing:
+			if !ok {
+				log.Debug("outgoing channel closed")
+				return
+			}
+			select {
+			case limit <- struct{}{}:
+				go limitedProvide(key, workerId)
+			case <-p.ctx.Done():
+				return
+			}
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}

--- a/provider/strategy.go
+++ b/provider/strategy.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"context"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmdURv6Sbob8TVW2tFFve9vcEWrSUgwPqeqnXyvYhLrkyd/go-merkledag"
+	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
+)
+
+func NewProvideAllStrategy(dag ipld.DAGService) Strategy {
+	return func(ctx context.Context, cids chan cid.Cid, root cid.Cid) {
+		cids <- root
+		// TODO: Use schomatis' dag walker instead of this enumerate?
+		merkledag.EnumerateChildren(ctx, merkledag.GetLinksWithDAG(dag), root, func(cid cid.Cid) bool {
+			cids <- cid
+			return true
+		})
+	}
+}

--- a/provider/strategy.go
+++ b/provider/strategy.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"context"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmdURv6Sbob8TVW2tFFve9vcEWrSUgwPqeqnXyvYhLrkyd/go-merkledag"
 	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
+	"gx/ipfs/QmdURv6Sbob8TVW2tFFve9vcEWrSUgwPqeqnXyvYhLrkyd/go-merkledag"
 )
 
-func NewProvideAllStrategy(dag ipld.DAGService) Strategy {
+// anchor picker strategies
+
+func NewAnchorAllStrategy(dag ipld.DAGService) AnchorStrategy {
 	return func(ctx context.Context, cids chan cid.Cid, root cid.Cid) {
 		cids <- root
 		// TODO: Use schomatis' dag walker instead of this enumerate?
@@ -15,5 +17,18 @@ func NewProvideAllStrategy(dag ipld.DAGService) Strategy {
 			cids <- cid
 			return true
 		})
+	}
+}
+
+// eligibility strategies
+
+func NewEligibleOnlyOnceStrategy() EligibleStrategy {
+	provided := cid.NewSet()
+	return func(root cid.Cid) bool {
+		eligible := !provided.Has(root)
+		if eligible {
+			provided.Add(root)
+		}
+		return eligible
 	}
 }


### PR DESCRIPTION
## Overview
The purpose of this PR is to address the first few steps of the providing strategy work that is being tracked here: https://github.com/ipfs/go-ipfs/issues/5774. Ultimately, I'd like to get this merged, but am putting up the PR now because I've run into an issue that will likely require quite a bit more work. I'm wondering, is it worth merging this PR in the meantime? Please read the known issues and discuss.

Things in this PR:
- A `Provider` has been added to `IpfsNode`
- A `Provider` has been added to `CoreAPI`
- `CoreAPI.Provider` is being used by the rest of `CoreAPI` (and more) to provide blocks as they are added and received

Things **not** in this PR:
- `Reprovider` anything
- robust providing strategy

## Known Issues
I'm looking for feedback on these things:

- The most glaring issue, I think, is that cids are always provided when fetching, regardless of whether or not the blocks received come from the network. This means that running `ipfs ls` twice on, say, npm will cause all of npm to be provided twice. **I put up this PR because solving this issue might require a more involved change and so I want to discuss it here before starting down a specific path.** Some options (thanks @hannahhoward @eingenito):

    - Change the `Blockservice.GetBlock` interface so that I know whether or not the block returned came from the network. I could then use that information to decide whether or not to provide that block. This is perhaps both the simplest and the worst option.

    - Wrap the blockservice with something like a `ProvideService`, which keeps track of the blocks, perhaps in memory or a database, and also does the provide when necessary. In this case, whether or not we provide isn't based on whether the block came from the network, but rather whether or not we have any indication we haven't provided the block yet (based on the blocks we're keeping track of).

    - Mark the blocks to be provided themselves and continue to provide blocks as soon as they're received (from bitswap) just taking the new "provide markers" into account. In this case, I don't know that different repos will be able to have different providing strategies or at the very least we'd need to program for that if it were desired.

    - Or, there's some other, better idea that I'm not thinking of.

- Not all of the provide calls happen in `CoreAPI`. This is because some things simply don't use `CoreAPI`. I think the solution to this is to change these areas that don't use `CoreAPI` so that they do. I hope we can solve this in a follow up PR.

- No tests. No good, I'll get them added before merging.

- Not rebased. I'll work on that as well.