### PR TITLE
startup: always load the private key

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -237,10 +237,5 @@ func initializeIpnsKeyspace(repoRoot string) error {
 	}
 	defer nd.Close()
 
-	err = nd.SetupOfflineRouting()
-	if err != nil {
-		return err
-	}
-
 	return namesys.InitializeKeyspace(ctx, nd.Namesys, nd.Pinning, nd.PrivateKey)
 }

--- a/core/builder.go
+++ b/core/builder.go
@@ -10,16 +10,14 @@ import (
 	"time"
 
 	filestore "github.com/ipfs/go-ipfs/filestore"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 	pin "github.com/ipfs/go-ipfs/pin"
 	repo "github.com/ipfs/go-ipfs/repo"
 	cidv0v1 "github.com/ipfs/go-ipfs/thirdparty/cidv0v1"
 	"github.com/ipfs/go-ipfs/thirdparty/verifbs"
-	bserv "gx/ipfs/QmPoh3SrQzFBWtdGK6qmHDV4EanKR6kYPj4DD3J2NLoEmZ/go-blockservice"
-	resolver "gx/ipfs/QmZErC2Ay6WuGi96CPg316PwitdwgLo6RxZRqVjJjRj2MR/go-path/resolver"
-	dag "gx/ipfs/QmdV35UHnL1FM52baPkeUo6u7Fxm2CRUkPTLRPxeF8a4Ap/go-merkledag"
-	uio "gx/ipfs/QmdYvDbHp7qAhZ7GsCj6e1cMo55ND6y2mjWVzwdvcv4f12/go-unixfs/io"
 
 	ci "gx/ipfs/QmNiJiXwWE3kRhZrC5ej3kSjWHm337pYfhjLGSCDNKJP2s/go-libp2p-crypto"
+	bserv "gx/ipfs/QmPoh3SrQzFBWtdGK6qmHDV4EanKR6kYPj4DD3J2NLoEmZ/go-blockservice"
 	ipns "gx/ipfs/QmPrt2JqvtFcgMBmYBjtZ5jFzq6HoFXy8PTwLb2Dpm2cGf/go-ipns"
 	libp2p "gx/ipfs/QmRBaUEQEeFWywfrZJ64QgsmvcqgLSK3VbvGMR2NM2Edpf/go-libp2p"
 	bstore "gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
@@ -29,6 +27,10 @@ import (
 	cfg "gx/ipfs/QmYyzmMnhNTtoXx5ttgUaRdHHckYnQWjPL98hgLAR2QLDD/go-ipfs-config"
 	pstore "gx/ipfs/QmZ9zH2FnLcxv1xyzFeUpDUeo55xEhZQHgveZijcxr7TLj/go-libp2p-peerstore"
 	pstoremem "gx/ipfs/QmZ9zH2FnLcxv1xyzFeUpDUeo55xEhZQHgveZijcxr7TLj/go-libp2p-peerstore/pstoremem"
+	resolver "gx/ipfs/QmZErC2Ay6WuGi96CPg316PwitdwgLo6RxZRqVjJjRj2MR/go-path/resolver"
+	dag "gx/ipfs/QmdV35UHnL1FM52baPkeUo6u7Fxm2CRUkPTLRPxeF8a4Ap/go-merkledag"
+	uio "gx/ipfs/QmdYvDbHp7qAhZ7GsCj6e1cMo55ND6y2mjWVzwdvcv4f12/go-unixfs/io"
+	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 	metrics "gx/ipfs/QmekzFM3hPZjTjUFGTABdQkEnQ3PTiMstY198PwSFr5w1Q/go-metrics-interface"
 	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
 	retry "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/retrystore"
@@ -176,8 +178,13 @@ func isTooManyFDError(err error) bool {
 }
 
 func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
-	// setup local peer ID (private key is loaded in online setup)
+	// setup local identity
 	if err := n.loadID(); err != nil {
+		return err
+	}
+
+	// load the private key
+	if err := n.loadPrivateKey(); err != nil {
 		return err
 	}
 
@@ -254,6 +261,14 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		}
 	} else {
 		n.Exchange = offline.Exchange(n.Blockstore)
+		n.Routing = offroute.NewOfflineRouter(n.Repo.Datastore(), n.RecordValidator)
+
+		size, err := n.getCacheSize()
+		if err != nil {
+			return err
+		}
+
+		n.Namesys = namesys.NewNameSystem(n.Routing, n.Repo.Datastore(), size)
 	}
 
 	n.Blocks = bserv.New(n.Blockstore, n.Exchange)

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -33,20 +33,9 @@ var CatCmd = &cmds.Command{
 		cmdkit.Int64Option(lengthOptionName, "l", "Maximum number of bytes to read."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		node, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
 		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			return err
-		}
-
-		if !node.OnlineMode() {
-			if err := node.SetupOfflineRouting(); err != nil {
-				return err
-			}
 		}
 
 		offset, _ := req.Options[offsetOptionName].(int64)

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -176,12 +176,6 @@ func printSelf(node *core.IpfsNode) (interface{}, error) {
 	info := new(IdOutput)
 	info.ID = node.Identity.Pretty()
 
-	if node.PrivateKey == nil {
-		if err := node.LoadPrivateKey(); err != nil {
-			return nil, err
-		}
-	}
-
 	pk := node.PrivateKey.GetPublic()
 	pkb, err := ic.MarshalPublicKey(pk)
 	if err != nil {

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -79,18 +79,6 @@ Resolve the value of an IPFS DAG path:
 			return err
 		}
 
-		n, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		if !n.OnlineMode() {
-			err := n.SetupOfflineRouting()
-			if err != nil {
-				return err
-			}
-		}
-
 		name := req.Arguments[0]
 		recursive, _ := req.Options[resolveRecursiveOptionName].(bool)
 

--- a/core/core.go
+++ b/core/core.go
@@ -71,7 +71,6 @@ import (
 	merkledag "gx/ipfs/QmdV35UHnL1FM52baPkeUo6u7Fxm2CRUkPTLRPxeF8a4Ap/go-merkledag"
 	ft "gx/ipfs/QmdYvDbHp7qAhZ7GsCj6e1cMo55ND6y2mjWVzwdvcv4f12/go-unixfs"
 	nilrouting "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/none"
-	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 	yamux "gx/ipfs/Qmdps3CYh5htGQSrPvzg5PHouVexLmtpbuLCqc4vuej8PC/go-smux-yamux"
 	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
 	record "gx/ipfs/QmfARXVCzpwFXQdepAJZuqyNDgV9doEsMnVCo1ssmuSe1U/go-libp2p-record"
@@ -158,11 +157,6 @@ type Mounts struct {
 func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption RoutingOption, hostOption HostOption, do DiscoveryOption, pubsub, ipnsps, mplex bool) error {
 	if n.PeerHost != nil { // already online.
 		return errors.New("node already online")
-	}
-
-	// load private key
-	if err := n.LoadPrivateKey(); err != nil {
-		return err
 	}
 
 	// get undialable addrs from config
@@ -779,7 +773,7 @@ func (n *IpfsNode) GetKey(name string) (ic.PrivKey, error) {
 	}
 }
 
-func (n *IpfsNode) LoadPrivateKey() error {
+func (n *IpfsNode) loadPrivateKey() error {
 	if n.Identity == "" || n.Peerstore == nil {
 		return errors.New("loaded private key out of order")
 	}
@@ -861,32 +855,6 @@ func (n *IpfsNode) loadFilesRoot() error {
 	}
 
 	n.FilesRoot = mr
-	return nil
-}
-
-// SetupOfflineRouting instantiates a routing system in offline mode. This is
-// primarily used for offline ipns modifications.
-func (n *IpfsNode) SetupOfflineRouting() error {
-	if n.Routing != nil {
-		// Routing was already set up
-		return nil
-	}
-
-	// TODO: move this somewhere else.
-	err := n.LoadPrivateKey()
-	if err != nil {
-		return err
-	}
-
-	n.Routing = offroute.NewOfflineRouter(n.Repo.Datastore(), n.RecordValidator)
-
-	size, err := n.getCacheSize()
-	if err != nil {
-		return err
-	}
-
-	n.Namesys = namesys.NewNameSystem(n.Routing, n.Repo.Datastore(), size)
-
 	return nil
 }
 

--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -48,10 +48,6 @@ func (api *NameAPI) Publish(ctx context.Context, p coreiface.Path, opts ...caopt
 		if !options.AllowOffline {
 			return nil, coreiface.ErrOffline
 		}
-		err := n.SetupOfflineRouting()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if n.Mounts.Ipns != nil && n.Mounts.Ipns.IsActive() {
@@ -96,13 +92,6 @@ func (api *NameAPI) Search(ctx context.Context, name string, opts ...caopts.Name
 	}
 
 	n := api.node
-
-	if !n.OnlineMode() {
-		err := n.SetupOfflineRouting()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	var resolver namesys.Resolver = n.Namesys
 

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -13,12 +13,10 @@ import (
 	"testing"
 
 	core "github.com/ipfs/go-ipfs/core"
-	namesys "github.com/ipfs/go-ipfs/namesys"
 
 	u "gx/ipfs/QmNohiVssaPw3KVLZik59DBVGTSm2dGvYT9eoXt5DQ36Yz/go-ipfs-util"
 	ci "gx/ipfs/QmPuhRE325DR8ChNcFtgd6F1eANCHy1oohXZPpYop4xsK6/go-testutil/ci"
 	fstest "gx/ipfs/QmSJBsmLP1XMjv8hxYg2rUMdPDB7YUpyBo9idjrJ6Cmq6F/fuse/fs/fstestutil"
-	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 	racedet "gx/ipfs/Qmf7HqcW7LtCi1W8y2bdx2eJpze74jkbKqpByxgXikdbLF/go-detect-race"
 )
 
@@ -116,14 +114,6 @@ func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *mountWra
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		err = node.LoadPrivateKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.RecordValidator)
-		node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore(), 0)
 
 		err = InitializeKeyspace(node, node.PrivateKey)
 		if err != nil {

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -13,10 +13,8 @@ import (
 	core "github.com/ipfs/go-ipfs/core"
 	ipns "github.com/ipfs/go-ipfs/fuse/ipns"
 	mount "github.com/ipfs/go-ipfs/fuse/mount"
-	namesys "github.com/ipfs/go-ipfs/namesys"
 
 	ci "gx/ipfs/QmPuhRE325DR8ChNcFtgd6F1eANCHy1oohXZPpYop4xsK6/go-testutil/ci"
-	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 )
 
 func maybeSkipFuseTests(t *testing.T) {
@@ -45,14 +43,6 @@ func TestExternalUnmount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = node.LoadPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.RecordValidator)
-	node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore(), 0)
 
 	err = ipns.InitializeKeyspace(node, node.PrivateKey)
 	if err != nil {


### PR DESCRIPTION
Loading this at the last minute means we need a bunch of special cases in *every* command that needs routing, namesys, or even the public key.

If we ever have a case where we don't want to do this, we can add an option to the (eventual) IPFS constructor. Handling this up-front is going to be significantly less error prone.

Motivation: https://github.com/ipfs/go-ipfs/pull/5825/files#diff-fe35ea64d478c4f3fb767a3f618e5d01R863