### PR TITLE
startup: always load the private key

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -237,10 +237,5 @@ func initializeIpnsKeyspace(repoRoot string) error {
 	}
 	defer nd.Close()
 
-	err = nd.SetupOfflineRouting()
-	if err != nil {
-		return err
-	}
-
 	return namesys.InitializeKeyspace(ctx, nd.Namesys, nd.Pinning, nd.PrivateKey)
 }

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -33,20 +33,9 @@ var CatCmd = &cmds.Command{
 		cmdkit.Int64Option(lengthOptionName, "l", "Maximum number of bytes to read."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		node, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
 		api, err := cmdenv.GetApi(env)
 		if err != nil {
 			return err
-		}
-
-		if !node.OnlineMode() {
-			if err := node.SetupOfflineRouting(); err != nil {
-				return err
-			}
 		}
 
 		offset, _ := req.Options[offsetOptionName].(int64)

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -176,12 +176,6 @@ func printSelf(node *core.IpfsNode) (interface{}, error) {
 	info := new(IdOutput)
 	info.ID = node.Identity.Pretty()
 
-	if node.PrivateKey == nil {
-		if err := node.LoadPrivateKey(); err != nil {
-			return nil, err
-		}
-	}
-
 	pk := node.PrivateKey.GetPublic()
 	pkb, err := ic.MarshalPublicKey(pk)
 	if err != nil {

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -79,18 +79,6 @@ Resolve the value of an IPFS DAG path:
 			return err
 		}
 
-		n, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		if !n.OnlineMode() {
-			err := n.SetupOfflineRouting()
-			if err != nil {
-				return err
-			}
-		}
-
 		name := req.Arguments[0]
 		recursive, _ := req.Options[resolveRecursiveOptionName].(bool)
 

--- a/core/core.go
+++ b/core/core.go
@@ -159,6 +159,10 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 		return errors.New("node already online")
 	}
 
+	if n.PrivateKey == nil {
+		return fmt.Errorf("private key not available")
+	}
+
 	// get undialable addrs from config
 	cfg, err := n.Repo.Config()
 	if err != nil {
@@ -767,6 +771,9 @@ func (n *IpfsNode) loadID() error {
 // GetKey will return a key from the Keystore with name `name`.
 func (n *IpfsNode) GetKey(name string) (ic.PrivKey, error) {
 	if name == "self" {
+		if n.PrivateKey == nil {
+			return nil, fmt.Errorf("private key not available")
+		}
 		return n.PrivateKey, nil
 	} else {
 		return n.Repo.Keystore().Get(name)

--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -48,10 +48,6 @@ func (api *NameAPI) Publish(ctx context.Context, p coreiface.Path, opts ...caopt
 		if !options.AllowOffline {
 			return nil, coreiface.ErrOffline
 		}
-		err := n.SetupOfflineRouting()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if n.Mounts.Ipns != nil && n.Mounts.Ipns.IsActive() {
@@ -96,13 +92,6 @@ func (api *NameAPI) Search(ctx context.Context, name string, opts ...caopts.Name
 	}
 
 	n := api.node
-
-	if !n.OnlineMode() {
-		err := n.SetupOfflineRouting()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	var resolver namesys.Resolver = n.Namesys
 

--- a/core/coreapi/unixfs_test.go
+++ b/core/coreapi/unixfs_test.go
@@ -707,23 +707,6 @@ func TestGetNonUnixfs(t *testing.T) {
 	}
 }
 
-func TestCatOffline(t *testing.T) {
-	ctx := context.Background()
-	_, api, err := makeAPI(ctx)
-	if err != nil {
-		t.Error(err)
-	}
-
-	p, err := coreiface.ParsePath("/ipns/Qmfoobar")
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = api.Unixfs().Get(ctx, p)
-	if err != coreiface.ErrOffline {
-		t.Fatalf("expected ErrOffline, got: %s", err)
-	}
-}
-
 func TestLs(t *testing.T) {
 	ctx := context.Background()
 	node, api, err := makeAPI(ctx)

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -13,12 +13,10 @@ import (
 	"testing"
 
 	core "github.com/ipfs/go-ipfs/core"
-	namesys "github.com/ipfs/go-ipfs/namesys"
 
 	u "gx/ipfs/QmNohiVssaPw3KVLZik59DBVGTSm2dGvYT9eoXt5DQ36Yz/go-ipfs-util"
 	ci "gx/ipfs/QmPuhRE325DR8ChNcFtgd6F1eANCHy1oohXZPpYop4xsK6/go-testutil/ci"
 	fstest "gx/ipfs/QmSJBsmLP1XMjv8hxYg2rUMdPDB7YUpyBo9idjrJ6Cmq6F/fuse/fs/fstestutil"
-	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 	racedet "gx/ipfs/Qmf7HqcW7LtCi1W8y2bdx2eJpze74jkbKqpByxgXikdbLF/go-detect-race"
 )
 
@@ -116,14 +114,6 @@ func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *mountWra
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		err = node.LoadPrivateKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.RecordValidator)
-		node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore(), 0)
 
 		err = InitializeKeyspace(node, node.PrivateKey)
 		if err != nil {

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -13,10 +13,8 @@ import (
 	core "github.com/ipfs/go-ipfs/core"
 	ipns "github.com/ipfs/go-ipfs/fuse/ipns"
 	mount "github.com/ipfs/go-ipfs/fuse/mount"
-	namesys "github.com/ipfs/go-ipfs/namesys"
 
 	ci "gx/ipfs/QmPuhRE325DR8ChNcFtgd6F1eANCHy1oohXZPpYop4xsK6/go-testutil/ci"
-	offroute "gx/ipfs/QmdmWkx54g7VfVyxeG8ic84uf4G6Eq1GohuyKA3XDuJ8oC/go-ipfs-routing/offline"
 )
 
 func maybeSkipFuseTests(t *testing.T) {
@@ -45,14 +43,6 @@ func TestExternalUnmount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = node.LoadPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	node.Routing = offroute.NewOfflineRouter(node.Repo.Datastore(), node.RecordValidator)
-	node.Namesys = namesys.NewNameSystem(node.Routing, node.Repo.Datastore(), 0)
 
 	err = ipns.InitializeKeyspace(node, node.PrivateKey)
 	if err != nil {


### PR DESCRIPTION
Loading this at the last minute means we need a bunch of special cases in *every* command that needs routing, namesys, or even the public key.

If we ever have a case where we don't want to do this, we can add an option to the (eventual) IPFS constructor. Handling this up-front is going to be significantly less error prone.

Motivation: https://github.com/ipfs/go-ipfs/pull/5825/files#diff-fe35ea64d478c4f3fb767a3f618e5d01R863