### PR TITLE
RFC#2: Add provider to ipfs and provide when adding/fetching (WIP)

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -26,7 +26,6 @@ var BitswapCmd = &cmds.Command{
 		"stat":      bitswapStatCmd,
 		"wantlist":  showWantlistCmd,
 		"ledger":    ledgerCmd,
-		"reprovide": reprovideCmd,
 	},
 }
 
@@ -202,31 +201,5 @@ prints the ledger associated with a given peer.
 				out.Sent, out.Recv)
 			return nil
 		}),
-	},
-}
-
-var reprovideCmd = &cmds.Command{
-	Helptext: cmdkit.HelpText{
-		Tagline: "Trigger reprovider.",
-		ShortDescription: `
-Trigger reprovider to announce our data to network.
-`,
-	},
-	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		nd, err := cmdenv.GetNode(env)
-		if err != nil {
-			return err
-		}
-
-		if !nd.IsOnline {
-			return ErrNotOnline
-		}
-
-		err = nd.Reprovider.Trigger(req.Context)
-		if err != nil {
-			return err
-		}
-
-		return nil
 	},
 }

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -194,7 +194,7 @@ format.
 			return err
 		}
 
-		nd.Provider.Provide(obj.Cid())
+		//nd.Provider.Provide(obj.Cid())
 
 		var out interface{} = obj
 		if len(rp.Remainder()) > 0 {
@@ -236,7 +236,7 @@ var DagResolveCmd = &cmds.Command{
 			return err
 		}
 
-		nd.Provider.Provide(lastCid)
+		//nd.Provider.Provide(lastCid)
 
 		return cmds.EmitOnce(res, &ResolveOutput{
 			Cid:     rp.Cid(),

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -128,7 +128,26 @@ into an object of the specified format.
 			return err
 		}
 
+//<<<<<<< HEAD
 		return nil
+//=======
+//		if dopin {
+//			cids.ForEach(func(c cid.Cid) error {
+//				nd.Pinning.PinWithMode(c, pin.Recursive)
+//				return nil
+//			})
+//
+//			err := nd.Pinning.Flush()
+//			if err != nil {
+//				return err
+//			}
+//		}
+//
+//		return cids.ForEach(func(cid cid.Cid) error {
+//			nd.Provider.Provide(cid)
+//			return nil
+//		})
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 	},
 	Type: OutputObject{},
 	Encoders: cmds.EncoderMap{
@@ -175,6 +194,8 @@ format.
 			return err
 		}
 
+		nd.Provider.Provide(obj.Cid())
+
 		var out interface{} = obj
 		if len(rp.Remainder()) > 0 {
 			rem := strings.Split(rp.Remainder(), "/")
@@ -214,6 +235,8 @@ var DagResolveCmd = &cmds.Command{
 		if err != nil {
 			return err
 		}
+
+		nd.Provider.Provide(lastCid)
 
 		return cmds.EmitOnce(res, &ResolveOutput{
 			Cid:     rp.Cid(),

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -86,7 +86,11 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return err
 		}
 
+//<<<<<<< HEAD
 		res.SetLength(uint64(size))
+//=======
+//		node.Provider.Provide(dn.Cid())
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 
 		archive, _ := req.Options[archiveOptionName].(bool)
 		reader, err := fileArchive(file, p.String(), archive, cmplvl)

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -86,11 +86,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			return err
 		}
 
-//<<<<<<< HEAD
 		res.SetLength(uint64(size))
-//=======
-//		node.Provider.Provide(dn.Cid())
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
 
 		archive, _ := req.Options[archiveOptionName].(bool)
 		reader, err := fileArchive(file, p.String(), archive, cmplvl)

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -120,6 +120,17 @@ The JSON output contains type information.
 							Links: outputLinks,
 						}
 					}
+//<<<<<<< HEAD
+//=======
+//					outputLinks[j] = *lsLink
+//				}
+//				output[i] = LsObject{
+//					Hash:  paths[i],
+//					Links: outputLinks,
+//				}
+//
+//				nd.Provider.Provide(dagnode.Cid())
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 			}
 
 			done = func() error {
@@ -155,7 +166,12 @@ The JSON output contains type information.
 					return err
 				}
 			}
+//<<<<<<< HEAD
 			dirDone(i)
+//=======
+//
+//			nd.Provider.Provide(dagnode.Cid())
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 		}
 		return done()
 	},

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -120,17 +120,6 @@ The JSON output contains type information.
 							Links: outputLinks,
 						}
 					}
-//<<<<<<< HEAD
-//=======
-//					outputLinks[j] = *lsLink
-//				}
-//				output[i] = LsObject{
-//					Hash:  paths[i],
-//					Links: outputLinks,
-//				}
-//
-//				nd.Provider.Provide(dagnode.Cid())
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
 			}
 
 			done = func() error {
@@ -166,12 +155,7 @@ The JSON output contains type information.
 					return err
 				}
 			}
-//<<<<<<< HEAD
 			dirDone(i)
-//=======
-//
-//			nd.Provider.Provide(dagnode.Cid())
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
 		}
 		return done()
 	},

--- a/core/commands/provider.go
+++ b/core/commands/provider.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
+
+	cmds "gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
+	cmdkit "gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+)
+
+var ProviderCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline:          "Interact with the provider module.",
+		ShortDescription: ``,
+	},
+
+	Subcommands: map[string]*cmds.Command{
+		"reprovide": reprovideCmd,
+	},
+}
+
+var reprovideCmd = &cmds.Command{
+	Helptext: cmdkit.HelpText{
+		Tagline: "Trigger reprovider.",
+		ShortDescription: `
+Trigger reprovider to announce our data to network.
+`,
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		nd, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		if !nd.OnlineMode() {
+			return ErrNotOnline
+		}
+
+		err = nd.Reprovider.Trigger(req.Context)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/core/commands/provider.go
+++ b/core/commands/provider.go
@@ -3,8 +3,8 @@ package commands
 import (
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
-	cmds "gx/ipfs/QmQtQrtNioesAWtrx8csBvfY37gTe94d6wQ3VikZUjxD39/go-ipfs-cmds"
-	cmdkit "gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+	cmds "github.com/ipfs/go-ipfs-cmds"
+	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 )
 
 var ProviderCmd = &cmds.Command{
@@ -31,7 +31,7 @@ Trigger reprovider to announce our data to network.
 			return err
 		}
 
-		if !nd.OnlineMode() {
+		if !nd.IsOnline {
 			return ErrNotOnline
 		}
 

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -177,6 +177,9 @@ func objectsForPaths(ctx context.Context, n *core.IpfsNode, paths []string) ([]i
 		if err != nil {
 			return nil, err
 		}
+
+		n.Provider.Provide(o.Cid())
+
 		objects[i] = o
 	}
 	return objects, nil

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -57,6 +57,7 @@ ADVANCED COMMANDS
   stats         Various operational stats
   p2p           Libp2p stream mounting
   filestore     Manage the filestore (experimental)
+  provider      Manage the provider system
 
 NETWORK COMMANDS
   id            Show info about IPFS peers
@@ -140,6 +141,7 @@ var rootSubcommands = map[string]*cmds.Command{
 	"pin":       PinCmd,
 	"ping":      PingCmd,
 	"p2p":       P2PCmd,
+	"provider":  ProviderCmd,
 	"refs":      RefsCmd,
 	"resolve":   ResolveCmd,
 	"swarm":     SwarmCmd,

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -61,9 +61,18 @@ represent it.
 
 		c := node.Cid()
 
+//<<<<<<< HEAD
 		return cmds.EmitOnce(res, &AddEvent{
 			Name: it.Name(),
 			Hash: enc.Encode(c),
+//=======
+//		nd.Provider.Provide(c)
+//
+//		fi.FileName()
+//		return cmds.EmitOnce(res, &coreiface.AddEvent{
+//			Name: fi.FileName(),
+//			Hash: c.String(),
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 		})
 	},
 	Type: AddEvent{},

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -43,6 +43,11 @@ represent it.
 			return err
 		}
 
+		api, err := cmdenv.GetApi(env, req)
+		if err != nil {
+			return err
+		}
+
 		enc, err := cmdenv.GetCidEncoder(req)
 		if err != nil {
 			return err
@@ -60,19 +65,11 @@ represent it.
 		}
 
 		c := node.Cid()
+		api.Provider().Provide(c)
 
-//<<<<<<< HEAD
 		return cmds.EmitOnce(res, &AddEvent{
 			Name: it.Name(),
 			Hash: enc.Encode(c),
-//=======
-//		nd.Provider.Provide(c)
-//
-//		fi.FileName()
-//		return cmds.EmitOnce(res, &coreiface.AddEvent{
-//			Name: fi.FileName(),
-//			Hash: c.String(),
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
 		})
 	},
 	Type: AddEvent{},

--- a/core/core.go
+++ b/core/core.go
@@ -357,38 +357,6 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	n.Reprovider = provider.NewReprovider(ctx, rq, tracker, reproviderInterval, n.Blockstore, n.Routing)
 	n.Reprovider.Run()
 
-	/*
-	// Reprovider - old
-
-	var keyProvider rp.KeyChanFunc
-
-	switch cfg.Reprovider.Strategy {
-	case "all":
-		fallthrough
-	case "":
-		keyProvider = rp.NewBlockstoreProvider(n.Blockstore)
-	case "roots":
-		keyProvider = rp.NewPinnedProvider(n.Pinning, n.DAG, true)
-	case "pinned":
-		keyProvider = rp.NewPinnedProvider(n.Pinning, n.DAG, false)
-	default:
-		return fmt.Errorf("unknown reprovider strategy '%s'", cfg.Reprovider.Strategy)
-	}
-	n.Reprovider = rp.NewReprovider(ctx, n.Routing, keyProvider)
-
-	reproviderInterval := kReprovideFrequency
-	if cfg.Reprovider.Interval != "" {
-		dur, err := time.ParseDuration(cfg.Reprovider.Interval)
-		if err != nil {
-			return err
-		}
-
-		reproviderInterval = dur
-	}
-
-	go n.Reprovider.Run(reproviderInterval)
-	*/
-
 	return nil
 }
 

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -75,7 +75,7 @@ func (api *BlockAPI) Get(ctx context.Context, p coreiface.Path) (io.Reader, erro
 		return nil, err
 	}
 
-	api.node.Provider.Provide(rp.Cid())
+	//api.node.Provider.Provide(rp.Cid())
 
 	return bytes.NewReader(b.RawData()), nil
 }
@@ -129,7 +129,7 @@ func (api *BlockAPI) Stat(ctx context.Context, p coreiface.Path) (coreiface.Bloc
 		return nil, err
 	}
 
-	api.node.Provider.Provide(b.Cid())
+	//api.node.Provider.Provide(b.Cid())
 
 	return &BlockStat{
 		path: coreiface.IpldPath(b.Cid()),

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -53,9 +53,13 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 		return nil, err
 	}
 
+//<<<<<<< HEAD
 	if settings.Pin {
 		api.pinning.PinWithMode(b.Cid(), pin.Recursive)
 	}
+//=======
+//	api.node.Provider.Provide(b.Cid())
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 
 	return &BlockStat{path: coreiface.IpldPath(b.Cid()), size: len(data)}, nil
 }
@@ -70,6 +74,8 @@ func (api *BlockAPI) Get(ctx context.Context, p coreiface.Path) (io.Reader, erro
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(rp.Cid())
 
 	return bytes.NewReader(b.RawData()), nil
 }
@@ -122,6 +128,8 @@ func (api *BlockAPI) Stat(ctx context.Context, p coreiface.Path) (coreiface.Bloc
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(b.Cid())
 
 	return &BlockStat{
 		path: coreiface.IpldPath(b.Cid()),

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -53,13 +53,11 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 		return nil, err
 	}
 
-//<<<<<<< HEAD
 	if settings.Pin {
 		api.pinning.PinWithMode(b.Cid(), pin.Recursive)
 	}
-//=======
-//	api.node.Provider.Provide(b.Cid())
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
+
+	api.provider.Provide(b.Cid())
 
 	return &BlockStat{path: coreiface.IpldPath(b.Cid()), size: len(data)}, nil
 }
@@ -75,7 +73,7 @@ func (api *BlockAPI) Get(ctx context.Context, p coreiface.Path) (io.Reader, erro
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(rp.Cid())
+	api.provider.Provide(rp.Cid())
 
 	return bytes.NewReader(b.RawData()), nil
 }
@@ -129,7 +127,7 @@ func (api *BlockAPI) Stat(ctx context.Context, p coreiface.Path) (coreiface.Bloc
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(b.Cid())
+	api.provider.Provide(b.Cid())
 
 	return &BlockStat{
 		path: coreiface.IpldPath(b.Cid()),

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ipfs/go-ipfs/provider"
 
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/namesys"
@@ -67,6 +68,9 @@ type CoreAPI struct {
 	routing routing.IpfsRouting
 
 	pubSub *pubsub.PubSub
+
+	provider *provider.Provider
+	reprovider *provider.Reprovider
 
 	checkPublishAllowed func() error
 	checkOnline         func(allowOffline bool) error
@@ -139,6 +143,10 @@ func (api *CoreAPI) PubSub() coreiface.PubSubAPI {
 	return (*PubSubAPI)(api)
 }
 
+func (api *CoreAPI) Provider() coreiface.ProviderAPI {
+	return (*ProviderAPI)(api)
+}
+
 // WithOptions returns api with global options applied
 func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, error) {
 	settings := api.parentOpts // make sure to copy
@@ -175,6 +183,9 @@ func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, e
 		routing:         n.Routing,
 
 		pubSub: n.PubSub,
+
+		provider: n.Provider,
+		reprovider: n.Reprovider,
 
 		nd:         n,
 		parentOpts: settings,

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -54,6 +54,9 @@ func (api *ObjectAPI) New(ctx context.Context, opts ...caopts.ObjectNewOption) (
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(n.Cid())
+
 	return n, nil
 }
 
@@ -133,6 +136,8 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 			return nil, err
 		}
 	}
+
+	api.node.Provider.Provide(dagnode.Cid())
 
 	return coreiface.IpfsPath(dagnode.Cid()), nil
 }
@@ -231,6 +236,8 @@ func (api *ObjectAPI) AddLink(ctx context.Context, base coreiface.Path, name str
 		return nil, err
 	}
 
+	api.node.Provider.Provide(nnode.Cid())
+
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
 
@@ -256,6 +263,8 @@ func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link stri
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -293,6 +302,8 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(pbnd.Cid())
 
 	return coreiface.IpfsPath(pbnd.Cid()), nil
 }

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -55,7 +55,7 @@ func (api *ObjectAPI) New(ctx context.Context, opts ...caopts.ObjectNewOption) (
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(n.Cid())
+	api.provider.Provide(n.Cid())
 
 	return n, nil
 }
@@ -137,7 +137,7 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 		}
 	}
 
-	//api.node.Provider.Provide(dagnode.Cid())
+	api.provider.Provide(dagnode.Cid())
 
 	return coreiface.IpfsPath(dagnode.Cid()), nil
 }
@@ -236,7 +236,7 @@ func (api *ObjectAPI) AddLink(ctx context.Context, base coreiface.Path, name str
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(nnode.Cid())
+	api.provider.Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -264,7 +264,7 @@ func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link stri
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(nnode.Cid())
+	api.provider.Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -303,7 +303,7 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(pbnd.Cid())
+	api.provider.Provide(pbnd.Cid())
 
 	return coreiface.IpfsPath(pbnd.Cid()), nil
 }

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -55,7 +55,7 @@ func (api *ObjectAPI) New(ctx context.Context, opts ...caopts.ObjectNewOption) (
 		return nil, err
 	}
 
-	api.node.Provider.Provide(n.Cid())
+	//api.node.Provider.Provide(n.Cid())
 
 	return n, nil
 }
@@ -137,7 +137,7 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 		}
 	}
 
-	api.node.Provider.Provide(dagnode.Cid())
+	//api.node.Provider.Provide(dagnode.Cid())
 
 	return coreiface.IpfsPath(dagnode.Cid()), nil
 }
@@ -236,7 +236,7 @@ func (api *ObjectAPI) AddLink(ctx context.Context, base coreiface.Path, name str
 		return nil, err
 	}
 
-	api.node.Provider.Provide(nnode.Cid())
+	//api.node.Provider.Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -264,7 +264,7 @@ func (api *ObjectAPI) RmLink(ctx context.Context, base coreiface.Path, link stri
 		return nil, err
 	}
 
-	api.node.Provider.Provide(nnode.Cid())
+	//api.node.Provider.Provide(nnode.Cid())
 
 	return coreiface.IpfsPath(nnode.Cid()), nil
 }
@@ -303,7 +303,7 @@ func (api *ObjectAPI) patchData(ctx context.Context, path coreiface.Path, r io.R
 		return nil, err
 	}
 
-	api.node.Provider.Provide(pbnd.Cid())
+	//api.node.Provider.Provide(pbnd.Cid())
 
 	return coreiface.IpfsPath(pbnd.Cid()), nil
 }

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -27,6 +27,9 @@ func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (ipld.Nod
 	if err != nil {
 		return nil, err
 	}
+
+	api.node.Provider.Provide(node.Cid())
+
 	return node, nil
 }
 

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -28,7 +28,7 @@ func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (ipld.Nod
 		return nil, err
 	}
 
-	//api.node.Provider.Provide(node.Cid())
+	api.provider.Provide(node.Cid())
 
 	return node, nil
 }

--- a/core/coreapi/path.go
+++ b/core/coreapi/path.go
@@ -28,7 +28,7 @@ func (api *CoreAPI) ResolveNode(ctx context.Context, p coreiface.Path) (ipld.Nod
 		return nil, err
 	}
 
-	api.node.Provider.Provide(node.Cid())
+	//api.node.Provider.Provide(node.Cid())
 
 	return node, nil
 }

--- a/core/coreapi/provider.go
+++ b/core/coreapi/provider.go
@@ -1,0 +1,15 @@
+package coreapi
+
+import (
+	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+)
+
+type ProviderAPI CoreAPI
+
+func (api *ProviderAPI) Provide(root cid.Cid) error {
+	return api.provider.Provide(root)
+}
+
+func (api *ProviderAPI) Unprovide(root cid.Cid) error {
+	return api.provider.Unprovide(root)
+}

--- a/core/coreapi/provider.go
+++ b/core/coreapi/provider.go
@@ -1,7 +1,7 @@
 package coreapi
 
 import (
-	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	cid "github.com/ipfs/go-cid"
 )
 
 type ProviderAPI CoreAPI

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -130,9 +130,9 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		return nil, err
 	}
 
-	if !settings.Local {
-		api.node.Provider.Provide(nd.Cid())
-	}
+	//if !settings.Local {
+	//	api.node.Provider.Provide(nd.Cid())
+	//}
 
 	return coreiface.IpfsPath(nd.Cid()), nil
 }

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -129,6 +129,11 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 	if err != nil {
 		return nil, err
 	}
+
+	if !settings.Local {
+		api.node.Provider.Provide(nd.Cid())
+	}
+
 	return coreiface.IpfsPath(nd.Cid()), nil
 }
 
@@ -140,7 +145,13 @@ func (api *UnixfsAPI) Get(ctx context.Context, p coreiface.Path) (files.Node, er
 		return nil, err
 	}
 
+//<<<<<<< HEAD
 	return unixfile.NewUnixfsFile(ctx, ses.dag, nd)
+//=======
+//	api.node.Provider.Provide(nd.Cid())
+//
+//	return newUnixfsFile(ctx, ses.dag, nd, "", nil)
+//>>>>>>> Add provider to ipfs and provide when adding/fetching
 }
 
 // Ls returns the contents of an IPFS or IPNS object(s) at path p, with the format:

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -130,9 +130,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		return nil, err
 	}
 
-	//if !settings.Local {
-	//	api.node.Provider.Provide(nd.Cid())
-	//}
+	api.provider.Provide(nd.Cid())
 
 	return coreiface.IpfsPath(nd.Cid()), nil
 }
@@ -145,13 +143,8 @@ func (api *UnixfsAPI) Get(ctx context.Context, p coreiface.Path) (files.Node, er
 		return nil, err
 	}
 
-//<<<<<<< HEAD
+    api.provider.Provide(nd.Cid())
 	return unixfile.NewUnixfsFile(ctx, ses.dag, nd)
-//=======
-//	api.node.Provider.Provide(nd.Cid())
-//
-//	return newUnixfsFile(ctx, ses.dag, nd, "", nil)
-//>>>>>>> Add provider to ipfs and provide when adding/fetching
 }
 
 // Ls returns the contents of an IPFS or IPNS object(s) at path p, with the format:

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -489,6 +489,8 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	i.node.Provider.Provide(newcid)
+
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", newcid.String())
 	http.Redirect(w, r, gopath.Join(ipfsPathPrefix, newcid.String(), newPath), http.StatusCreated)
@@ -565,6 +567,8 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to new path
 	ncid := newnode.Cid()
+
+	i.node.Provider.Provide(ncid)
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", ncid.String())

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -489,7 +489,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	i.node.Provider.Provide(newcid)
+	i.api.Provider().Provide(newcid)
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", newcid.String())
@@ -568,7 +568,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 	// Redirect to new path
 	ncid := newnode.Cid()
 
-	i.node.Provider.Provide(ncid)
+	i.api.Provider().Provide(ncid)
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", ncid.String())

--- a/go.mod
+++ b/go.mod
@@ -114,3 +114,5 @@ require (
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gotest.tools/gotestsum v0.3.3
 )
+
+replace github.com/ipfs/interface-go-ipfs-core v0.0.1 => ../interface-go-ipfs-core

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,155 @@
+// Package provider implements structures and methods to provide blocks,
+// keep track of which blocks are provided, and to allow those blocks to
+// be reprovided.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	bstore "gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
+	"gx/ipfs/QmZBH87CAPFHcc7cYmBqeSQ98zQ3SX9KUxiYgzPmLWNVKz/go-libp2p-routing"
+	logging "gx/ipfs/QmcuXC5cxs79ro2cUuHs4HQ2bkDLJUYokwL8aivcX6HW3C/go-log"
+	"time"
+)
+
+var (
+	log = logging.Logger("provider")
+)
+
+const (
+	provideOutgoingWorkerLimit = 8
+	provideOutgoingTimeout     = 15 * time.Second
+)
+
+type Strategy func(context.Context, cid.Cid) <-chan cid.Cid
+
+// Provider announces blocks to the network, tracks which blocks are
+// being provided, and untracks blocks when they're no longer in the blockstore.
+type Provider struct {
+	ctx context.Context
+
+	// strategy for deciding which CIDs, given a CID, should be provided
+	strategy Strategy
+	// keeps track of which CIDs have been provided already
+	tracker *Tracker
+	// the CIDs for which provide announcements should be made
+	queue *Queue
+	// where the blocks live
+	blockstore bstore.Blockstore
+	// used to announce providing to the network
+	contentRouting routing.ContentRouting
+}
+
+func NewProvider(ctx context.Context, strategy Strategy, tracker *Tracker, queue *Queue, blockstore bstore.Blockstore, contentRouting routing.ContentRouting) *Provider {
+	return &Provider{
+		ctx:            ctx,
+		strategy:       strategy,
+		tracker:        tracker,
+		queue:          queue,
+		blockstore:   	blockstore,
+		contentRouting: contentRouting,
+	}
+}
+
+// Start workers to handle provide requests.
+func (p *Provider) Run() {
+	p.handleAnnouncements()
+}
+
+// Provide the given cid using specified strategy.
+func (p *Provider) Provide(root cid.Cid) error {
+	cids := p.strategy(p.ctx, root)
+
+	for cid := range cids {
+		isTracking, err := p.tracker.IsTracking(cid)
+		if err != nil {
+			return err
+		}
+		if isTracking {
+			continue
+		}
+		if err := p.queue.Enqueue(cid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Stop providing a block
+func (p *Provider) Unprovide(cid cid.Cid) error {
+	return p.tracker.Untrack(cid)
+}
+
+// Handle all outgoing cids by providing (announcing) them
+func (p *Provider) handleAnnouncements() {
+	for workers := 0; workers < provideOutgoingWorkerLimit; workers++ {
+		go func() {
+			for {
+				select {
+				case <-p.ctx.Done():
+					return
+				case entry := <-p.queue.Dequeue():
+					// skip if already tracking
+					isTracking, err := p.tracker.IsTracking(entry.cid)
+					if err != nil {
+						log.Warningf("Unable to check provider tracking on outgoing: %s, %s", entry.cid, err)
+						continue
+					}
+					if isTracking {
+						if err := entry.Complete(); err != nil {
+							log.Warningf("Unable to complete queue entry when already tracking: %s, %s", entry.cid, err)
+						}
+						continue
+					}
+
+					if err := doProvide(p.ctx, p.tracker, p.blockstore, p.contentRouting, entry.cid); err != nil {
+						log.Warningf("Unable to provide entry: %s, %s", entry.cid, err)
+					}
+
+					if err := entry.Complete(); err != nil {
+						log.Warningf("Unable to complete queue entry when providing: %s, %s", entry.cid, err)
+					}
+				}
+			}
+		}()
+	}
+}
+
+// TODO: better document this provide logic
+func doProvide(ctx context.Context, tracker *Tracker, blockstore bstore.Blockstore, contentRouting routing.ContentRouting, key cid.Cid) error {
+	// if not in blockstore, skip and stop tracking
+	inBlockstore, err := blockstore.Has(key)
+	if err != nil {
+		log.Warningf("Unable to check for presence in blockstore: %s, %s", key, err)
+		return err
+	}
+	if !inBlockstore {
+		if err := tracker.Untrack(key); err != nil {
+			log.Warningf("Unable to untrack: %s, %s", key, err)
+			return err
+		}
+		return nil
+	}
+
+	// announce
+	fmt.Println("announce - start - ", key)
+	ctx, cancel := context.WithTimeout(ctx, provideOutgoingTimeout)
+	if err := contentRouting.Provide(ctx, key, true); err != nil {
+		log.Warningf("Failed to provide cid: %s", err)
+		// TODO: Maybe put these failures onto a failures queue?
+		cancel()
+		return err
+	}
+	cancel()
+	fmt.Println("announce - end - ", key)
+
+	// track entry
+	if err := tracker.Track(key); err != nil {
+		log.Warningf("Unable to track: %s, %s", key, err)
+        return err
+	}
+
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
 	bstore "gx/ipfs/QmXjKkjMDTtXAiLBwstVexofB8LeruZmE2eBd85GwGFFLA/go-ipfs-blockstore"
 	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
 	"gx/ipfs/QmcxZXMqFu4vjLQRfG2tAcg6DPQNurgZ2SQ5iQVk6dXQjn/go-libp2p-routing"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -6,10 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	bstore "gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
-	"gx/ipfs/QmZBH87CAPFHcc7cYmBqeSQ98zQ3SX9KUxiYgzPmLWNVKz/go-libp2p-routing"
-	logging "gx/ipfs/QmcuXC5cxs79ro2cUuHs4HQ2bkDLJUYokwL8aivcX6HW3C/go-log"
+	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	bstore "gx/ipfs/QmXjKkjMDTtXAiLBwstVexofB8LeruZmE2eBd85GwGFFLA/go-ipfs-blockstore"
+	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
+	"gx/ipfs/QmcxZXMqFu4vjLQRfG2tAcg6DPQNurgZ2SQ5iQVk6dXQjn/go-libp2p-routing"
 	"time"
 )
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -6,10 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
-	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	bstore "gx/ipfs/QmXjKkjMDTtXAiLBwstVexofB8LeruZmE2eBd85GwGFFLA/go-ipfs-blockstore"
-	logging "gx/ipfs/QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF/go-log"
-	"gx/ipfs/QmcxZXMqFu4vjLQRfG2tAcg6DPQNurgZ2SQ5iQVk6dXQjn/go-libp2p-routing"
+	cid "github.com/ipfs/go-cid"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-routing"
 	"time"
 )
 

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -1,0 +1,231 @@
+package provider
+
+import (
+	"context"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/namespace"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/query"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Entry allows for the durability in the queue. When a cid is dequeued it is
+// not removed from the datastore until you call Complete() on the entry you
+// receive.
+type Entry struct {
+	cid cid.Cid
+	key ds.Key
+    queue *Queue
+}
+
+func (e *Entry) Complete() error {
+	return e.queue.remove(e.key)
+}
+
+// Queue provides a durable, FIFO interface to the datastore for storing cids
+//
+// Durability just means that cids in the process of being provided when a
+// crash or shutdown occurs will still be in the queue when the node is
+// brought back online.
+type Queue struct {
+	// used to differentiate queues in datastore
+	// e.g. provider vs reprovider
+	name string
+
+	ctx context.Context
+
+	tail uint64
+	head uint64
+
+	lock sync.Mutex
+	datastore ds.Datastore
+
+	dequeue chan *Entry
+	notEmpty chan struct{}
+}
+
+func NewQueue(name string, ctx context.Context, datastore ds.Datastore) (*Queue, error) {
+	namespaced := namespace.Wrap(datastore, ds.NewKey("/" + name + "/queue/"))
+	head, tail, err := getQueueHeadTail(name, ctx, namespaced)
+	if err != nil {
+		return nil, err
+	}
+	q := &Queue{
+		name: name,
+		ctx: ctx,
+		head: head,
+		tail: tail,
+		lock: sync.Mutex{},
+		datastore: namespaced,
+		dequeue: make(chan *Entry),
+		notEmpty: make(chan struct{}),
+	}
+	q.run()
+	return q, nil
+}
+
+// Put a cid in the queue
+func (q *Queue) Enqueue(cid cid.Cid) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	wasEmpty := q.IsEmpty()
+
+	nextKey := q.queueKey(q.tail)
+
+	if err := q.datastore.Put(nextKey, cid.Bytes()); err != nil {
+		return err
+	}
+
+	q.tail++
+
+	if wasEmpty {
+		select {
+		case q.notEmpty <- struct{}{}:
+		case <-q.ctx.Done():
+		}
+	}
+
+	return nil
+}
+
+// Remove an entry from the queue.
+func (q *Queue) Dequeue() <-chan *Entry {
+	return q.dequeue
+}
+
+func (q *Queue) IsEmpty() bool {
+	return (q.tail - q.head) == 0
+}
+
+func (q *Queue) remove(key ds.Key) error {
+	return q.datastore.Delete(key)
+}
+
+// dequeue items when the dequeue channel is available to
+// be written to
+func (q *Queue) run() {
+	go func() {
+		for {
+			select {
+			case <-q.ctx.Done():
+				return
+			default:
+			}
+			if q.IsEmpty() {
+				select {
+				case <-q.ctx.Done():
+					return
+				// wait for a notEmpty message
+				case <-q.notEmpty:
+				}
+			}
+
+			entry, err := q.next()
+			if err != nil {
+				log.Warningf("Error Dequeue()-ing: %s, %s", entry, err)
+				continue
+			}
+
+			select {
+			case <-q.ctx.Done():
+				return
+			case q.dequeue <- entry:
+			}
+		}
+	}()
+}
+
+// Find the next item in the queue, crawl forward if an entry is not
+// found in the next spot.
+func (q *Queue) next() (*Entry, error) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	var nextKey ds.Key
+	var value []byte
+	var err error
+	for {
+		if q.head >= q.tail {
+			return nil, errors.New("no more entries in queue")
+		}
+		select {
+		case <-q.ctx.Done():
+			return nil, nil
+		default:
+		}
+		nextKey = q.queueKey(q.head)
+		value, err = q.datastore.Get(nextKey)
+		if err == ds.ErrNotFound {
+			q.head++
+			continue
+		} else if err != nil {
+			return nil, err
+		} else {
+			break
+		}
+	}
+
+	id, err := cid.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &Entry {
+		cid: id,
+		key: nextKey,
+		queue: q,
+	}
+
+	q.head++
+
+	return entry, nil
+}
+
+func (q *Queue) queueKey(id uint64) ds.Key {
+	return ds.NewKey(strconv.FormatUint(id, 10))
+}
+
+// crawl over the queue entries to find the head and tail
+func getQueueHeadTail(name string, ctx context.Context, datastore ds.Datastore) (uint64, uint64, error) {
+	query := query.Query{}
+	results, err := datastore.Query(query)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var tail uint64 = 0
+	var head uint64 = math.MaxUint64
+	for entry := range results.Next() {
+		select {
+		case <-ctx.Done():
+			return 0, 0, nil
+		default:
+		}
+		trimmed := strings.TrimPrefix(entry.Key, "/")
+		id, err := strconv.ParseUint(trimmed, 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if id < head {
+			head = id
+		}
+
+		if (id+1) > tail {
+			tail = (id+1)
+		}
+	}
+	if err := results.Close(); err != nil {
+		return 0, 0, err
+	}
+	if head == math.MaxUint64 {
+		head = 0
+	}
+
+	return head, tail, nil
+}

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -2,10 +2,10 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
 	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
+	namespace "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
+	query "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
 	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 	"math"
 	"strconv"

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
 	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
-	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/namespace"
-	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/query"
 	"math"
 	"strconv"
 	"strings"

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -2,15 +2,15 @@ package provider
 
 import (
 	"context"
-	cid "gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	namespace "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
-	query "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
-	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+	"errors"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
+	cid "github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	namespace "github.com/ipfs/go-datastore/namespace"
+	query "github.com/ipfs/go-datastore/query"
 )
 
 // Entry allows for the durability in the queue. When a cid is dequeued it is

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
+	"gx/ipfs/QmZBH87CAPFHcc7cYmBqeSQ98zQ3SX9KUxiYgzPmLWNVKz/go-libp2p-routing"
+	"time"
+)
+
+var (
+	reprovideOutgoingWorkerLimit = 8
+)
+
+type doneFunc func(error)
+
+type Reprovider struct {
+	ctx context.Context
+	queue *Queue
+	tracker *Tracker
+	tick time.Duration
+	blockstore blockstore.Blockstore
+	contentRouting routing.ContentRouting
+	trigger chan doneFunc
+}
+
+// Reprovider periodically re-announces the cids that have been provided. These
+// reprovides can be run on an interval and/or manually. Reprovider also untracks
+// cids that are no longer in the blockstore.
+func NewReprovider(ctx context.Context, queue *Queue, tracker *Tracker, tick time.Duration, blockstore blockstore.Blockstore, contentRouting routing.ContentRouting) *Reprovider {
+	return &Reprovider{
+		ctx: ctx,
+		queue: queue,
+		tracker: tracker,
+		tick: tick,
+		blockstore: blockstore,
+		contentRouting: contentRouting,
+		trigger: make(chan doneFunc),
+	}
+}
+
+// Begin listening for triggers and reprovide whatever is
+// in the reprovider queue.
+func (rp *Reprovider) Run() {
+	go rp.handleTriggers()
+	go rp.handleAnnouncements()
+}
+
+// Add all the cids in the tracker to the reprovide queue
+func (rp *Reprovider) Reprovide() error {
+	cids, err := rp.tracker.Tracking(rp.ctx)
+	if err != nil {
+		return err
+	}
+	for c := range cids {
+		if err := rp.queue.Enqueue(c); err != nil {
+			log.Warningf("unable to enqueue cid: %s, %s", c, err)
+			continue
+		}
+	}
+	return nil
+}
+
+// Trigger causes a reprovide
+func (rp *Reprovider) Trigger(ctx context.Context) error {
+	pctx, cancel := context.WithTimeout(ctx, time.Minute)
+	var err error
+	done := func(e error) {
+		err = e
+		cancel()
+	}
+
+	select {
+	case <-rp.ctx.Done():
+		return rp.ctx.Err()
+	case <-pctx.Done():
+		return pctx.Err()
+	case rp.trigger <- done:
+		select {
+		case <-pctx.Done():
+			if err != nil || pctx.Err() == context.Canceled {
+				return err
+			} else {
+				return pctx.Err()
+			}
+		case <-rp.ctx.Done():
+			return rp.ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (rp *Reprovider) handleTriggers() {
+	// dont reprovide immediately.
+	// may have just started the daemon and shutting it down immediately.
+	// probability( up another minute | uptime ) increases with uptime.
+	after := time.After(time.Minute)
+	var done doneFunc
+	for {
+		if rp.tick == 0 {
+			after = nil
+		}
+
+		select {
+		case <-rp.ctx.Done():
+			return
+		case done = <-rp.trigger:
+		case <-after:
+		}
+
+		err := rp.Reprovide()
+		if err != nil {
+			log.Debug(err)
+		}
+
+		if done != nil {
+			done(err)
+		}
+
+		after = time.After(rp.tick)
+	}
+}
+
+func (rp *Reprovider) handleAnnouncements() {
+	for workers := 0; workers < reprovideOutgoingWorkerLimit; workers++ {
+		go func() {
+			for {
+				select {
+				case <-rp.ctx.Done():
+					return
+				case entry := <-rp.queue.Dequeue():
+					if err := doProvide(rp.ctx, rp.tracker, rp.blockstore, rp.contentRouting, entry.cid); err != nil {
+						log.Warningf("Unable to reprovide entry: %s, %s", entry.cid, err)
+					}
+					if err := entry.Complete(); err != nil {
+						log.Warningf("Unable to complete queue entry when reproviding: %s, %s", entry.cid, err)
+					}
+				}
+			}
+		}()
+	}
+}

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -2,8 +2,8 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
-	"gx/ipfs/QmZBH87CAPFHcc7cYmBqeSQ98zQ3SX9KUxiYgzPmLWNVKz/go-libp2p-routing"
+	"gx/ipfs/QmXjKkjMDTtXAiLBwstVexofB8LeruZmE2eBd85GwGFFLA/go-ipfs-blockstore"
+	"gx/ipfs/QmcxZXMqFu4vjLQRfG2tAcg6DPQNurgZ2SQ5iQVk6dXQjn/go-libp2p-routing"
 	"time"
 )
 

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -2,8 +2,8 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmXjKkjMDTtXAiLBwstVexofB8LeruZmE2eBd85GwGFFLA/go-ipfs-blockstore"
-	"gx/ipfs/QmcxZXMqFu4vjLQRfG2tAcg6DPQNurgZ2SQ5iQVk6dXQjn/go-libp2p-routing"
+	"github.com/ipfs/go-ipfs-blockstore"
+	"github.com/libp2p/go-libp2p-routing"
 	"time"
 )
 

--- a/provider/strategy.go
+++ b/provider/strategy.go
@@ -1,0 +1,34 @@
+package provider
+
+// TODO: The strategy module is going to change so that it just
+// calls Provide on a given provider instead of returning a channel.
+
+import (
+	"context"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
+	"gx/ipfs/QmdURv6Sbob8TVW2tFFve9vcEWrSUgwPqeqnXyvYhLrkyd/go-merkledag"
+)
+
+func NewProvideAllStrategy(dag ipld.DAGService) Strategy {
+	return func(ctx context.Context, root cid.Cid) <-chan cid.Cid {
+		cids := make(chan cid.Cid)
+		go func() {
+			select {
+			case <-ctx.Done():
+				return
+			case cids <- root:
+			}
+			merkledag.EnumerateChildren(ctx, merkledag.GetLinksWithDAG(dag), root, func(cid cid.Cid) bool {
+				select {
+				case <-ctx.Done():
+					return false
+				case cids <- root:
+				}
+				return true
+			})
+			close(cids)
+		}()
+		return cids
+	}
+}

--- a/provider/strategy.go
+++ b/provider/strategy.go
@@ -5,9 +5,9 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
-	"gx/ipfs/QmdURv6Sbob8TVW2tFFve9vcEWrSUgwPqeqnXyvYhLrkyd/go-merkledag"
+	"gx/ipfs/QmScf5hnTEK8fDpRJAbcdMnKXpKUp1ytdymzXUbXDCFssp/go-merkledag"
+	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	ipld "gx/ipfs/QmZ6nzCLwGLVfRzYLpD7pW6UNuBDKEcA2imJtVpbEx2rxy/go-ipld-format"
 )
 
 func NewProvideAllStrategy(dag ipld.DAGService) Strategy {

--- a/provider/strategy.go
+++ b/provider/strategy.go
@@ -5,9 +5,9 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmScf5hnTEK8fDpRJAbcdMnKXpKUp1ytdymzXUbXDCFssp/go-merkledag"
-	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	ipld "gx/ipfs/QmZ6nzCLwGLVfRzYLpD7pW6UNuBDKEcA2imJtVpbEx2rxy/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 )
 
 func NewProvideAllStrategy(dag ipld.DAGService) Strategy {

--- a/provider/tracker.go
+++ b/provider/tracker.go
@@ -2,10 +2,10 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/namespace"
-	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/query"
-	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
+	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
+	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
+	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
 )
 
 const providerTrackingPrefix = "/provider/tracking/"

--- a/provider/tracker.go
+++ b/provider/tracker.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/namespace"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/query"
+	ds "gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
+)
+
+const providerTrackingPrefix = "/provider/tracking/"
+
+// Keeps track of which cids are being provided.
+type Tracker struct {
+	datastore ds.Datastore
+}
+
+func NewTracker(datastore ds.Datastore) *Tracker {
+	return &Tracker{
+		datastore: namespace.Wrap(datastore, ds.NewKey(providerTrackingPrefix)),
+	}
+}
+
+func (t *Tracker) IsTracking(cid cid.Cid) (bool, error) {
+	return t.datastore.Has(providerTrackingKey(cid))
+}
+
+func (t *Tracker) Track(cid cid.Cid) error {
+	return t.datastore.Put(providerTrackingKey(cid), cid.Bytes())
+}
+
+func (t *Tracker) Untrack(cid cid.Cid) error {
+	return t.datastore.Delete(providerTrackingKey(cid))
+}
+
+// Returns all the cids that are being tracked.
+func (t *Tracker) Tracking(ctx context.Context) (<-chan cid.Cid, error) {
+	q := query.Query{}
+	results, err := t.datastore.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	cids := make(chan cid.Cid)
+	go func() {
+		defer close(cids);
+		for result := range results.Next() {
+			key, err := cid.Parse(result.Value)
+			if err != nil {
+				log.Warningf("unable to parse tracked cid: %s", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case cids <- key:
+			}
+		}
+	}()
+	return cids, nil
+}
+
+func providerTrackingKey(cid cid.Cid) ds.Key {
+	return ds.NewKey(cid.String())
+}

--- a/provider/tracker.go
+++ b/provider/tracker.go
@@ -42,7 +42,7 @@ func (t *Tracker) Tracking(ctx context.Context) (<-chan cid.Cid, error) {
 	}
 	cids := make(chan cid.Cid)
 	go func() {
-		defer close(cids);
+		defer close(cids)
 		for result := range results.Next() {
 			key, err := cid.Parse(result.Value)
 			if err != nil {

--- a/provider/tracker.go
+++ b/provider/tracker.go
@@ -2,10 +2,10 @@ package provider
 
 import (
 	"context"
-	"gx/ipfs/QmTbxNB1NwDesLmKTscr4udL2tVP7MaxvXnD1D9yX7g3PN/go-cid"
-	ds "gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/namespace"
-	"gx/ipfs/QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9/go-datastore/query"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
 )
 
 const providerTrackingPrefix = "/provider/tracking/"


### PR DESCRIPTION
This is a follow up to https://github.com/ipfs/go-ipfs/pull/5840

My goal is to get some feedback on my progress towards reworking providing strategies and to offer a possible solution to https://github.com/ipfs/go-ipfs/issues/5822.

## Overview
What is in this PR:

### Provider
- Use a strategy to decide which CIDs below a CID to provide
- Queue CIDs to provide on disk, using the datastore (the "provide queue")
    - only if we haven't already provided this CID
- Have workers work through the provide queue announcing each CID
- When a CID is successfully announced, track it so that we know not to provide it again
- Call `IpfsNode.Provider.Provide(cid)` all over the place
    - it's possible I've missed some places, I should triple check

### Reprovider
- Queue the list of all currently provided CIDs
- Have workers work through the reprovide queue

What is **NOT** in this PR:
- A robust provide strategy

## TODO
- [x] reprovider based on tracker data and provider module
- [x] rebase
- [x] move `ipfs bitswap reprovide` to `ipfs provider reprovide`
- [ ] move to core api
- [ ] timestamp provider entries?
- [ ] caller configured provider strategies
- [ ] migrating data when nodes get upgraded to this new system
- [ ] tests

## Known Things
- duplicates can be added to the provide/reprovide queues but no duplicate providing work will be done in terms of content routing
