### PR TITLE
content-type to allowedHeadersArr

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -190,6 +190,7 @@ func (i *gatewayHandler) getOrHeadHandler(ctx context.Context, w http.ResponseWr
 		"Content-Range",
 		"X-Chunked-Output",
 		"X-Stream-Output",
+		"content-type"
 	}
 
 	var allowedHeaders = strings.Join(allowedHeadersArr, ", ")


### PR DESCRIPTION
When using browser(chrow, firefox) to request a resource from IPFS, browser uses a preflight request with content-type header. So without content-type in the allowed list, the request will fail.