### PR TITLE
CoreAPI: Don't panic when testing incomplete implementions

### DIFF
--- a/core/coreapi/interface/tests/api.go
+++ b/core/coreapi/interface/tests/api.go
@@ -2,11 +2,14 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	coreiface "github.com/ipfs/go-ipfs/core/coreapi/interface"
 )
+
+var apiNotImplemented = errors.New("api not implemented")
 
 func (tp *provider) makeAPI(ctx context.Context) (coreiface.CoreAPI, error) {
 	api, err := tp.MakeAPISwarm(ctx, false, 1)
@@ -74,5 +77,18 @@ func TestApi(p Provider) func(t *testing.T) {
 				t.Errorf("%d test swarms(s) not closed", running)
 			}
 		})
+	}
+}
+
+func (tp *provider) hasApi(t *testing.T, tf func(coreiface.CoreAPI) error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	api, err := tp.makeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tf(api); err != nil {
+		t.Fatal(api)
 	}
 }

--- a/core/coreapi/interface/tests/block.go
+++ b/core/coreapi/interface/tests/block.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (tp *provider) TestBlock(t *testing.T) {
+	tp.hasApi(t, func(api coreiface.CoreAPI) error {
+		if api.Block() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestBlockPut", tp.TestBlockPut)
 	t.Run("TestBlockPutFormat", tp.TestBlockPutFormat)
 	t.Run("TestBlockPutHash", tp.TestBlockPutHash)

--- a/core/coreapi/interface/tests/dag.go
+++ b/core/coreapi/interface/tests/dag.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (tp *provider) TestDag(t *testing.T) {
+	tp.hasApi(t, func(api coreiface.CoreAPI) error {
+		if api.Dag() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestPut", tp.TestPut)
 	t.Run("TestPutWithHash", tp.TestPutWithHash)
 	t.Run("TestPath", tp.TestDagPath)

--- a/core/coreapi/interface/tests/dht.go
+++ b/core/coreapi/interface/tests/dht.go
@@ -5,10 +5,18 @@ import (
 	"io"
 	"testing"
 
+	"github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 )
 
 func (tp *provider) TestDht(t *testing.T) {
+	tp.hasApi(t, func(api iface.CoreAPI) error {
+		if api.Dht() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestDhtFindPeer", tp.TestDhtFindPeer)
 	t.Run("TestDhtFindProviders", tp.TestDhtFindProviders)
 	t.Run("TestDhtProvide", tp.TestDhtProvide)

--- a/core/coreapi/interface/tests/key.go
+++ b/core/coreapi/interface/tests/key.go
@@ -5,10 +5,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/go-ipfs/core/coreapi/interface"
 	opt "github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 )
 
 func (tp *provider) TestKey(t *testing.T) {
+	tp.hasApi(t, func(api iface.CoreAPI) error {
+		if api.Key() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestListSelf", tp.TestListSelf)
 	t.Run("TestRenameSelf", tp.TestRenameSelf)
 	t.Run("TestRemoveSelf", tp.TestRemoveSelf)

--- a/core/coreapi/interface/tests/name.go
+++ b/core/coreapi/interface/tests/name.go
@@ -16,6 +16,13 @@ import (
 )
 
 func (tp *provider) TestName(t *testing.T) {
+	tp.hasApi(t, func(api coreiface.CoreAPI) error {
+		if api.Name() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestPublishResolve", tp.TestPublishResolve)
 	t.Run("TestBasicPublishResolveKey", tp.TestBasicPublishResolveKey)
 	t.Run("TestBasicPublishResolveTimeout", tp.TestBasicPublishResolveTimeout)

--- a/core/coreapi/interface/tests/object.go
+++ b/core/coreapi/interface/tests/object.go
@@ -13,6 +13,13 @@ import (
 )
 
 func (tp *provider) TestObject(t *testing.T) {
+	tp.hasApi(t, func(api iface.CoreAPI) error {
+		if api.Object() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestNew", tp.TestNew)
 	t.Run("TestObjectPut", tp.TestObjectPut)
 	t.Run("TestObjectGet", tp.TestObjectGet)

--- a/core/coreapi/interface/tests/path.go
+++ b/core/coreapi/interface/tests/path.go
@@ -26,7 +26,20 @@ func (tp *provider) TestMutablePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	blk, err := api.Block().Put(ctx, strings.NewReader(`foo`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if blk.Path().Mutable() {
+		t.Error("expected /ipld path to be immutable")
+	}
+
 	// get self /ipns path
+	if api.Key() == nil {
+		t.Fatal(".Key not implemented")
+	}
+
 	keys, err := api.Key().List(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -34,15 +47,6 @@ func (tp *provider) TestMutablePath(t *testing.T) {
 
 	if !keys[0].Path().Mutable() {
 		t.Error("expected self /ipns path to be mutable")
-	}
-
-	blk, err := api.Block().Put(ctx, strings.NewReader(`foo`))
-	if err != nil {
-		t.Error(err)
-	}
-
-	if blk.Path().Mutable() {
-		t.Error("expected /ipld path to be immutable")
 	}
 }
 
@@ -52,6 +56,10 @@ func (tp *provider) TestPathRemainder(t *testing.T) {
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if api.Dag() == nil {
+		t.Fatal(".Dag not implemented")
 	}
 
 	obj, err := api.Dag().Put(ctx, strings.NewReader(`{"foo": {"bar": "baz"}}`))
@@ -80,6 +88,10 @@ func (tp *provider) TestEmptyPathRemainder(t *testing.T) {
 	api, err := tp.makeAPI(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if api.Dag() == nil {
+		t.Fatal(".Dag not implemented")
 	}
 
 	obj, err := api.Dag().Put(ctx, strings.NewReader(`{"foo": {"bar": "baz"}}`))
@@ -114,6 +126,10 @@ func (tp *provider) TestInvalidPathRemainder(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if api.Dag() == nil {
+		t.Fatal(".Dag not implemented")
+	}
+
 	obj, err := api.Dag().Put(ctx, strings.NewReader(`{"foo": {"bar": "baz"}}`))
 	if err != nil {
 		t.Fatal(err)
@@ -138,9 +154,17 @@ func (tp *provider) TestPathRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if api.Block() == nil {
+		t.Fatal(".Block not implemented")
+	}
+
 	blk, err := api.Block().Put(ctx, strings.NewReader(`foo`), options.Block.Format("raw"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+
+	if api.Dag() == nil {
+		t.Fatal(".Dag not implemented")
 	}
 
 	obj, err := api.Dag().Put(ctx, strings.NewReader(`{"foo": {"/": "`+blk.Path().Cid().String()+`"}}`))

--- a/core/coreapi/interface/tests/pin.go
+++ b/core/coreapi/interface/tests/pin.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"strings"
 	"testing"
 
@@ -9,6 +10,13 @@ import (
 )
 
 func (tp *provider) TestPin(t *testing.T) {
+	tp.hasApi(t, func(api iface.CoreAPI) error {
+		if api.Pin() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestPinAdd", tp.TestPinAdd)
 	t.Run("TestPinSimple", tp.TestPinSimple)
 	t.Run("TestPinRecursive", tp.TestPinRecursive)

--- a/core/coreapi/interface/tests/pubsub.go
+++ b/core/coreapi/interface/tests/pubsub.go
@@ -2,12 +2,20 @@ package tests
 
 import (
 	"context"
+	"github.com/ipfs/go-ipfs/core/coreapi/interface"
 	"github.com/ipfs/go-ipfs/core/coreapi/interface/options"
 	"testing"
 	"time"
 )
 
 func (tp *provider) TestPubSub(t *testing.T) {
+	tp.hasApi(t, func(api iface.CoreAPI) error {
+		if api.PubSub() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestBasicPubSub", tp.TestBasicPubSub)
 }
 

--- a/core/coreapi/interface/tests/unixfs.go
+++ b/core/coreapi/interface/tests/unixfs.go
@@ -24,6 +24,13 @@ import (
 )
 
 func (tp *provider) TestUnixfs(t *testing.T) {
+	tp.hasApi(t, func(api coreiface.CoreAPI) error {
+		if api.Unixfs() == nil {
+			return apiNotImplemented
+		}
+		return nil
+	})
+
 	t.Run("TestAdd", tp.TestAdd)
 	t.Run("TestAddPinned", tp.TestAddPinned)
 	t.Run("TestAddHashOnly", tp.TestAddHashOnly)


### PR DESCRIPTION
It makes it much easier to start implementing `go-ipfs-http-api`