### PR TITLE
reduce verbosity of daemon start

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -200,12 +200,8 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	managefd, _ := req.Options[adjustFDLimitKwd].(bool)
 	if managefd {
-		if changedFds, newFdsLimit, err := utilmain.ManageFdLimit(); err != nil {
+		if _, _, err := utilmain.ManageFdLimit(); err != nil {
 			log.Errorf("setting file descriptor limit: %s", err)
-		} else {
-			if changedFds {
-				fmt.Printf("Successfully raised file descriptor limit to %d.\n", newFdsLimit)
-			}
 		}
 	}
 

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -211,12 +211,6 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	cctx := env.(*oldcmds.Context)
 
-	go func() {
-		<-req.Context.Done()
-		fmt.Println("Received interrupt signal, shutting down...")
-		fmt.Println("(Hit ctrl-c again to force-shutdown the daemon.)")
-	}()
-
 	// check transport encryption flag.
 	unencrypted, _ := req.Options[unencryptTransportKwd].(bool)
 	if unencrypted {
@@ -393,6 +387,14 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})
 
 	fmt.Printf("Daemon is ready\n")
+
+	// Give the user some immediate feedback when they hit C-c
+	go func() {
+		<-req.Context.Done()
+		fmt.Println("Received interrupt signal, shutting down...")
+		fmt.Println("(Hit ctrl-c again to force-shutdown the daemon.)")
+	}()
+
 	// collect long-running errors and block for shutdown
 	// TODO(cryptix): our fuse currently doesnt follow this pattern for graceful shutdown
 	for err := range merge(apiErrc, gwErrc, gcErrc) {

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -133,7 +133,7 @@ TEST_ULIMIT_PRESET=1
 test_launch_ipfs_daemon
 
 test_expect_success "daemon raised its fd limit" '
-  grep "raised file descriptor limit to 2048." actual_daemon > /dev/null
+  grep -v "setting file descriptor limit" actual_daemon > /dev/null
 '
 
 test_expect_success "daemon actually can handle 2048 file descriptors" '


### PR DESCRIPTION
Also, avoid printing C-c message unless we *actually* start the daemon:

Now `ipfs daemon` with no repo prints:

```
Initializing daemon...
go-ipfs version: 0.4.19-dev-7a9b1716f
Repo version: 7
System version: amd64/linux
Golang version: go1.11.4
Error: no IPFS repo found in /tmp/xyz.
please run: 'ipfs init'
```

work towards: #5903