### PR TITLE
Improve the Filestore document

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -183,7 +183,10 @@ Modify your ipfs config:
 ipfs config --json Experimental.FilestoreEnabled true
 ```
 
-And then pass the `--nocopy` flag when running `ipfs add`
+Then restart your IPFS node to reload your config.
+
+Finally, when adding files with ipfs add, pass the --nocopy flag to use the
+filestore instead of copying the files into your local IPFS repo.
 
 ### Road to being a real feature
 - [ ] Needs more people to use and report on how well it works.


### PR DESCRIPTION
Fix for the #5746. Switch to Filestore need to restart the ipfs node.

License: MIT
Signed-off-by: Bamvor Zhang <jian.zhang@ipfsbit.com>