### PR TITLE
coreapi: few more error check fixes

### DIFF
--- a/core/coreapi/interface/tests/dag.go
+++ b/core/coreapi/interface/tests/dag.go
@@ -185,7 +185,7 @@ func (tp *provider) TestBatch(t *testing.T) {
 	}
 
 	_, err = api.Dag().Get(ctx, nds[0].Cid())
-	if err == nil || err.Error() != "merkledag: not found" {
+	if err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Error(err)
 	}
 

--- a/core/coreapi/interface/tests/path.go
+++ b/core/coreapi/interface/tests/path.go
@@ -151,7 +151,7 @@ func (tp *provider) TestInvalidPathRemainder(t *testing.T) {
 	}
 
 	_, err = api.ResolvePath(ctx, p1)
-	if err == nil || err.Error() != "no such link found" {
+	if err == nil || !strings.Contains(err.Error(), "no such link found") {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/core/coreapi/interface/tests/unixfs.go
+++ b/core/coreapi/interface/tests/unixfs.go
@@ -587,7 +587,7 @@ func (tp *provider) TestAddHashOnly(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if err.Error() != "blockservice: key not found" {
+	if !strings.Contains(err.Error(), "blockservice: key not found") {
 		t.Errorf("unxepected error: %s", err.Error())
 	}
 }


### PR DESCRIPTION
With this https://github.com/ipfs/go-ipfs-http-client/pull/1 is passing all interface tests!