### PR TITLE
 Fix the PUT-existing bug in writable gateway API

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -427,32 +427,38 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rnode, err := i.node.DAG.Get(ctx, c)
-	if err != nil {
-		webError(w, "putHandler: Could not create DAG from request", err, http.StatusInternalServerError)
-		return
-	}
+	var newcid *cid.Cid
+	if newPath == "" {
+		// not inserting anything: directory tree is unchanged
+		newcid = c
+	} else {
+		rnode, err := i.node.DAG.Get(ctx, c)
+		if err != nil {
+			webError(w, "putHandler: Could not create DAG from request", err, http.StatusInternalServerError)
+			return
+		}
 
-	pbnd, ok := rnode.(*dag.ProtoNode)
-	if !ok {
-		webError(w, "Cannot read non protobuf nodes through gateway", dag.ErrNotProtobuf, http.StatusBadRequest)
-		return
-	}
+		pbnd, ok := rnode.(*dag.ProtoNode)
+		if !ok {
+			webError(w, "Cannot read non protobuf nodes through gateway", dag.ErrNotProtobuf, http.StatusBadRequest)
+			return
+		}
 
-	e := dagutils.NewDagEditor(pbnd, i.node.DAG)
-	err = e.InsertNodeAtPath(ctx, newPath, newnode, ft.EmptyDirNode)
-	if err != nil {
-		webError(w, "putHandler: InsertNodeAtPath failed", err, http.StatusInternalServerError)
-		return
-	}
+		e := dagutils.NewDagEditor(pbnd, i.node.DAG)
+		err = e.InsertNodeAtPath(ctx, newPath, newnode, ft.EmptyDirNode)
+		if err != nil {
+			webError(w, "putHandler: InsertNodeAtPath failed", err, http.StatusInternalServerError)
+			return
+		}
 
-	nnode, err := e.Finalize(ctx, i.node.DAG)
-	if err != nil {
-		webError(w, "putHandler: could not get node", err, http.StatusInternalServerError)
-		return
-	}
+		nnode, err := e.Finalize(ctx, i.node.DAG)
+		if err != nil {
+			webError(w, "putHandler: could not get node", err, http.StatusInternalServerError)
+			return
+		}
 
-	newcid := nnode.Cid()
+		newcid = nnode.Cid()
+	}
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("IPFS-Hash", newcid.String())

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -105,6 +105,23 @@ test_expect_success "We can HTTP GET file just updated" '
   test_cmp infile2 outfile2
 '
 
+test_expect_success "Replacing a file with PUT gives us the hash of the new tree" '
+  echo "$RANDOM" >infile3 &&
+  URL="http://localhost:$port/ipfs/$HASH/test/test.txt" &&
+  echo "PUT $URL" &&
+  curl -svX PUT --data-binary @infile3 "$URL" 2>curl_putExisting.out &&
+  grep "HTTP/1.1 201 Created" curl_putExisting.out &&
+  LOCATION=$(grep Location curl_putExisting.out) &&
+  HASH=$(expr "$LOCATION" : "< Location: /ipfs/\(.*\)/test/test.txt")
+'
+
+test_expect_success "We can HTTP GET file just replaced" '
+  URL="http://localhost:$port/ipfs/$HASH/test/test.txt" &&
+  echo "GET $URL" &&
+  curl -svo outfile3 "$URL" 2>curl_getExisting.out &&
+  test_cmp infile3 outfile3
+'
+
 test_kill_ipfs_daemon
 
 test_done

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -102,12 +102,15 @@ test_expect_success "We can HTTP GET file just updated" '
   test_cmp infile2 outfile2
 '
 
-test_expect_success "Replacing a file with PUT gives us the hash of the new tree" '
+test_expect_success "We can replace a file with PUT" '
   echo "$RANDOM" >infile3 &&
   URL="http://localhost:$port/ipfs/$HASH/test/test.txt" &&
   echo "PUT $URL" &&
   curl -svX PUT --data-binary @infile3 "$URL" 2>curl_putExisting.out &&
-  grep "HTTP/1.1 201 Created" curl_putExisting.out &&
+  grep "HTTP/1.1 201 Created" curl_putExisting.out
+'
+
+test_expect_success "Put gives us the hash of the new tree" '
   LOCATION_HEADER=$(grep Location curl_putExisting.out) &&
   IPFS_HASH_HEADER=$(grep Ipfs-Hash curl_putExisting.out) &&
   HASH1=$(expr "$LOCATION_HEADER" : "< Location: /ipfs/\(.*\)/test/test.txt") &&

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -108,11 +108,11 @@ test_expect_success "Replacing a file with PUT gives us the hash of the new tree
   echo "PUT $URL" &&
   curl -svX PUT --data-binary @infile3 "$URL" 2>curl_putExisting.out &&
   grep "HTTP/1.1 201 Created" curl_putExisting.out &&
-  LOCATION=$(grep Location curl_putExisting.out) &&
-  IPFS_HASH=$(grep Ipfs-Hash curl_putExisting.out) &&
-  HASH=$(expr "$LOCATION" : "< Location: /ipfs/\(.*\)/test/test.txt") &&
-  IPFS_HASH=$(expr "$IPFS_HASH" : "< Ipfs-Hash: \(\w*\)") &&
-  [ "$HASH" = "$IPFS_HASH" ]
+  LOCATION_HEADER=$(grep Location curl_putExisting.out) &&
+  IPFS_HASH_HEADER=$(grep Ipfs-Hash curl_putExisting.out) &&
+  HASH1=$(expr "$LOCATION_HEADER" : "< Location: /ipfs/\(.*\)/test/test.txt") &&
+  HASH2=$(expr "$IPFS_HASH_HEADER" : "< Ipfs-Hash: \(\w*\)") &&
+  [ "$HASH2" = "$HASH1" ]
 '
 
 test_expect_success "We can HTTP GET file just replaced" '

--- a/test/sharness/t0111-gateway-writeable.sh
+++ b/test/sharness/t0111-gateway-writeable.sh
@@ -112,7 +112,6 @@ test_expect_success "Replacing a file with PUT gives us the hash of the new tree
   IPFS_HASH=$(grep Ipfs-Hash curl_putExisting.out) &&
   HASH=$(expr "$LOCATION" : "< Location: /ipfs/\(.*\)/test/test.txt") &&
   IPFS_HASH=$(expr "$IPFS_HASH" : "< Ipfs-Hash: \(\w*\)") &&
-  echo "$HASH -vs- $IPFS_HASH" > /home/jes/foo.log &&
   [ "$HASH" = "$IPFS_HASH" ]
 '
 


### PR DESCRIPTION
MOVED FROM: https://github.com/ipfs/go-ipfs/pull/3931

@jes wrote:

> See on https://discuss.ipfs.io/t/writeable-http-gateways/210
> 
> Previously, a PUT to a filename that already exists would return the hash
> of the newly-inserted file instead of the hash of the new tree. This is not
> useful, and it makes much more sense for the API to be consistent.
> 
> Furthermore, anybody who knows about the bug is already DELETE-ing the filename
> before PUT-ing the new content, so the fix doesn't trample over that behaviour
> either.
> 
> With this fix, every conceivable usage of the API is either unaffected or
> improved.
> 
> It could do with a unit test.
> 
> ----
> 
> All I did was remove the special-case for the "file already exists" case, and it works correctly. It's easier to see this if you view ```git diff -w```.