### PR TITLE
Only perform DNSLink lookups on fully qualified domain names (FQDN)

### DIFF
--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -45,6 +45,7 @@ type lookupRes struct {
 // TXT records for a given domain name should contain a b58
 // encoded multihash.
 func (r *DNSResolver) resolveOnceAsync(ctx context.Context, name string, options opts.ResolveOpts) <-chan onceResult {
+	var fqdn string
 	out := make(chan onceResult, 1)
 	segments := strings.SplitN(name, "/", 2)
 	domain := segments[0]
@@ -56,11 +57,17 @@ func (r *DNSResolver) resolveOnceAsync(ctx context.Context, name string, options
 	}
 	log.Debugf("DNSResolver resolving %s", domain)
 
+	if strings.HasSuffix(domain, ".") {
+		fqdn = domain
+	} else {
+		fqdn = domain + "."
+	}
+
 	rootChan := make(chan lookupRes, 1)
-	go workDomain(r, domain, rootChan)
+	go workDomain(r, fqdn, rootChan)
 
 	subChan := make(chan lookupRes, 1)
-	go workDomain(r, "_dnslink."+domain, subChan)
+	go workDomain(r, "_dnslink."+fqdn, subChan)
 
 	appendPath := func(p path.Path) (path.Path, error) {
 		if len(segments) > 1 {

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -61,66 +61,66 @@ func TestDnsEntryParsing(t *testing.T) {
 func newMockDNS() *mockDNS {
 	return &mockDNS{
 		entries: map[string][]string{
-			"multihash.example.com": []string{
+			"multihash.example.com.": []string{
 				"dnslink=QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"ipfs.example.com": []string{
+			"ipfs.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"_dnslink.dipfs.example.com": []string{
+			"_dnslink.dipfs.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"dns1.example.com": []string{
+			"dns1.example.com.": []string{
 				"dnslink=/ipns/ipfs.example.com",
 			},
-			"dns2.example.com": []string{
+			"dns2.example.com.": []string{
 				"dnslink=/ipns/dns1.example.com",
 			},
-			"multi.example.com": []string{
+			"multi.example.com.": []string{
 				"some stuff",
 				"dnslink=/ipns/dns1.example.com",
 				"masked dnslink=/ipns/example.invalid",
 			},
-			"equals.example.com": []string{
+			"equals.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/=equals",
 			},
-			"loop1.example.com": []string{
+			"loop1.example.com.": []string{
 				"dnslink=/ipns/loop2.example.com",
 			},
-			"loop2.example.com": []string{
+			"loop2.example.com.": []string{
 				"dnslink=/ipns/loop1.example.com",
 			},
-			"_dnslink.dloop1.example.com": []string{
+			"_dnslink.dloop1.example.com.": []string{
 				"dnslink=/ipns/loop2.example.com",
 			},
-			"_dnslink.dloop2.example.com": []string{
+			"_dnslink.dloop2.example.com.": []string{
 				"dnslink=/ipns/loop1.example.com",
 			},
-			"bad.example.com": []string{
+			"bad.example.com.": []string{
 				"dnslink=",
 			},
-			"withsegment.example.com": []string{
+			"withsegment.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment",
 			},
-			"withrecsegment.example.com": []string{
+			"withrecsegment.example.com.": []string{
 				"dnslink=/ipns/withsegment.example.com/subsub",
 			},
-			"withtrailing.example.com": []string{
+			"withtrailing.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/",
 			},
-			"withtrailingrec.example.com": []string{
+			"withtrailingrec.example.com.": []string{
 				"dnslink=/ipns/withtrailing.example.com/segment/",
 			},
-			"double.example.com": []string{
+			"double.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"_dnslink.double.example.com": []string{
+			"_dnslink.double.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"double.conflict.com": []string{
+			"double.conflict.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD",
 			},
-			"_dnslink.conflict.example.com": []string{
+			"_dnslink.conflict.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjE",
 			},
 		},

--- a/namesys/dns_test.go
+++ b/namesys/dns_test.go
@@ -123,6 +123,9 @@ func newMockDNS() *mockDNS {
 			"_dnslink.conflict.example.com.": []string{
 				"dnslink=/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjE",
 			},
+			"fqdn.example.com.": []string{
+				"dnslink=/ipfs/QmYvMB9yrsSf7RKBghkfwmHJkzJhW2ZgVwq3LxBXXPasFr",
+			},
 		},
 	}
 }
@@ -159,4 +162,5 @@ func TestDNSResolution(t *testing.T) {
 	testResolution(t, r, "withtrailingrec.example.com", opts.DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD/sub/segment/", nil)
 	testResolution(t, r, "double.example.com", opts.DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjD", nil)
 	testResolution(t, r, "conflict.example.com", opts.DefaultDepthLimit, "/ipfs/QmY3hE8xgFCjGcz6PHgnvJz5HZi1BaKRfPkn1ghZUcYMjE", nil)
+	testResolution(t, r, "fqdn.example.com.", opts.DefaultDepthLimit, "/ipfs/QmYvMB9yrsSf7RKBghkfwmHJkzJhW2ZgVwq3LxBXXPasFr", nil)
 }


### PR DESCRIPTION
This change **halves the number of DNS queries required** to lookup DNSLink information for "example.com" by forcing the use of a FQDN (e.g. `example.com.`).

* example.com
* example.com.local (removed)
* _dnslink.example.com
* _dnslink.example.com.local (removed)

Where .local is the local system's organization/domain name.

License: MIT
Signed-off-by: Daniel Aleksandersen