### PR TITLE
docker: recursively fix permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ EXPOSE 8081
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
   && adduser -D -h $IPFS_PATH -u 1000 -G users ipfs \
-  && chown ipfs:users $IPFS_PATH
+  && chown -R ipfs:users $IPFS_PATH
 
 # Switch to a non-privileged user
 USER ipfs

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -57,7 +57,7 @@ EXPOSE 8081
 ENV IPFS_PATH /data/ipfs
 RUN mkdir -p $IPFS_PATH \
   && useradd -s /usr/sbin/nologin -d $IPFS_PATH -u 1000 -G users ipfs \
-  && chown ipfs:users $IPFS_PATH
+  && chown -R ipfs:users $IPFS_PATH
 
 # Switch to a non-privileged user
 USER ipfs


### PR DESCRIPTION
The docker tests tend to fail on Travis so I figured this might be related.