### PR TITLE
docs: duplicate default helptext in `name publish`

### DIFF
--- a/core/commands/name/publish.go
+++ b/core/commands/name/publish.go
@@ -79,7 +79,7 @@ Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by
     "ns", "us" (or "µs"), "ms", "s", "m", "h".`).WithDefault("24h"),
 		cmdkit.BoolOption(allowOfflineOptionName, "When offline, save the IPNS record to the the local datastore without broadcasting to the network instead of simply failing."),
 		cmdkit.StringOption(ttlOptionName, "Time duration this record should be cached for (caution: experimental)."),
-		cmdkit.StringOption(keyOptionName, "k", "Name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'. Default: <<default>>.").WithDefault("self"),
+		cmdkit.StringOption(keyOptionName, "k", "Name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'.").WithDefault("self"),
 		cmdkit.BoolOption(quieterOptionName, "Q", "Write only final hash."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {


### PR DESCRIPTION
> -k,            --key      string - Name of the key to be used or a valid PeerID, as listed by 'ipfs key list -l'. Default: Default: self..