### PR TITLE
fix HAMT bookmark ln

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -24,7 +24,7 @@ the above issue.
 - [p2p http proxy](#p2p-http-proxy)
 - [Circuit Relay](#circuit-relay)
 - [Plugins](#plugins)
-- [Directory Sharding / HAMT](#directory-sharding-hamt)
+- [Directory Sharding / HAMT](#directory-sharding--hamt)
 - [IPNS PubSub](#ipns-pubsub)
 - [QUIC](#quic)
 - [AutoRelay](#autorelay)


### PR DESCRIPTION
link was broken due to `/` in title. using `--` fixes.