### PR TITLE
fix: show interactive output from install.sh

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -13,11 +13,11 @@ binpaths="/usr/local/bin /usr/bin"
 is_write_perm_missing=""
 
 for binpath in $binpaths; do
-  if mv "$bin" "$binpath/$bin" 2> /dev/null; then
+  if mv "$bin" "$binpath/$bin" ; then
     echo "Moved $bin to $binpath"
     exit 0
   else
-    if [ -d "$binpath" -a ! -w "$binpath" ]; then
+    if [ -d "$binpath" ] && [ ! -w "$binpath" ]; then
       is_write_perm_missing=1
     fi
   fi


### PR DESCRIPTION
When trying out the latest rc, i used the `./install.sh`
It hung, with no output. I removed the 2> /dev/null and
it turned out mv was waiting for user input to confirm
the change of file permssions from 555 to 755.

```console
override r-xr-xr-x  oli/staff for /usr/local/bin/./ipfs? (y/n [n])
```

This PR removes piping the output from mv to /dev/null
as it seems like the safest fix.

An alternative would be to just add -f but i've err'd
on the side of caution.

If also tweaked the second condition based on the
recommendations of shellcheck
see: https://github.com/koalaman/shellcheck/wiki/SC2166

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>