### PR TITLE
yamux: increase yamux window size to 8MiB.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -418,7 +418,7 @@ func makeSmuxTransportOption(mplexExp bool) libp2p.Option {
 		ConnectionWriteTimeout: time.Second * 10,
 		KeepAliveInterval:      time.Second * 30,
 		EnableKeepAlive:        true,
-		MaxStreamWindowSize:    uint32(1024 * 512),
+		MaxStreamWindowSize:    uint32(16 * 1024 * 1024), // 16MiB
 		LogOutput:              ioutil.Discard,
 	}
 


### PR DESCRIPTION
This _should_ be variable. But, until we can get around to fixing that, 8MiB means a max speed of 40MiB given a 200ms RTT. The current limit gives us a 2.5MiB max rate which _really_ hurts.

Note: We now auto-shrink this buffer as needed (using a buffer pool) so this
shouldn't leak memory.