### PR TITLE
mk: change git-hash command to include information about modifications

### DIFF
--- a/mk/git.mk
+++ b/mk/git.mk
@@ -1,1 +1,2 @@
-git-hash:=$(shell git rev-parse --short HEAD 2>/dev/null)
+git-hash:=$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null)
+


### PR DESCRIPTION
With this command we will get hash information as well as information if
build was made using uncommited files.

The difference is `0.4.20-dev-c8c0c48e2` vs `0.4.20-dev-c8c0c48e2-dirty`.