### PR TITLE
Provide root node immediately on add and pin add

### DIFF
--- a/core/builder.go
+++ b/core/builder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"github.com/ipfs/go-ipfs/provider"
 	"os"
 	"syscall"
 	"time"
@@ -274,6 +275,13 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 		n.Pinning = pin.NewPinner(n.Repo.Datastore(), n.DAG, internalDag)
 	}
 	n.Resolver = resolver.NewBasicResolver(n.DAG)
+
+	// Provider
+	queue, err := provider.NewQueue("provider-v1", ctx, n.Repo.Datastore())
+	if err != nil {
+		return err
+	}
+	n.Provider = provider.NewProvider(ctx, queue, n.Routing)
 
 	if cfg.Online {
 		if err := n.startLateOnlineServices(ctx); err != nil {

--- a/core/builder.go
+++ b/core/builder.go
@@ -277,7 +277,7 @@ func setupNode(ctx context.Context, n *IpfsNode, cfg *BuildCfg) error {
 	n.Resolver = resolver.NewBasicResolver(n.DAG)
 
 	// Provider
-	queue, err := provider.NewQueue("provider-v1", ctx, n.Repo.Datastore())
+	queue, err := provider.NewQueue(ctx, "provider-v1", n.Repo.Datastore())
 	if err != nil {
 		return err
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ipfs/go-ipfs/provider"
 	"io"
 	"io/ioutil"
 	"os"
@@ -29,6 +28,7 @@ import (
 	ipnsrp "github.com/ipfs/go-ipfs/namesys/republisher"
 	p2p "github.com/ipfs/go-ipfs/p2p"
 	pin "github.com/ipfs/go-ipfs/pin"
+	provider "github.com/ipfs/go-ipfs/provider"
 	repo "github.com/ipfs/go-ipfs/repo"
 
 	bitswap "github.com/ipfs/go-bitswap"

--- a/core/core.go
+++ b/core/core.go
@@ -125,7 +125,7 @@ type IpfsNode struct {
 	Routing      routing.IpfsRouting // the routing system. recommend ipfs-dht
 	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
 	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
-	Provider     *provider.Provider  // the value provider system
+	Provider     provider.Provider  // the value provider system
 	Reprovider   *rp.Reprovider      // the value reprovider system
 	IpnsRepub    *ipnsrp.Republisher
 

--- a/core/core.go
+++ b/core/core.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ipfs/go-ipfs/provider"
 	"io"
 	"io/ioutil"
 	"os"
@@ -124,6 +125,7 @@ type IpfsNode struct {
 	Routing      routing.IpfsRouting // the routing system. recommend ipfs-dht
 	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
 	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
+	Provider     *provider.Provider  // the value provider system
 	Reprovider   *rp.Reprovider      // the value reprovider system
 	IpnsRepub    *ipnsrp.Republisher
 
@@ -323,6 +325,12 @@ func (n *IpfsNode) startLateOnlineServices(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Provider
+
+	n.Provider.Run()
+
+	// Reprovider
 
 	var keyProvider rp.KeyChanFunc
 

--- a/core/core.go
+++ b/core/core.go
@@ -125,7 +125,7 @@ type IpfsNode struct {
 	Routing      routing.IpfsRouting // the routing system. recommend ipfs-dht
 	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
 	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
-	Provider     provider.Provider  // the value provider system
+	Provider     provider.Provider   // the value provider system
 	Reprovider   *rp.Reprovider      // the value reprovider system
 	IpnsRepub    *ipnsrp.Republisher
 

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -67,7 +67,7 @@ type CoreAPI struct {
 	namesys namesys.NameSystem
 	routing routing.IpfsRouting
 
-	provider *provider.Provider
+	provider provider.Provider
 
 	pubSub *pubsub.PubSub
 
@@ -215,6 +215,7 @@ func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, e
 
 		subApi.routing = offlineroute.NewOfflineRouter(subApi.repo.Datastore(), subApi.recordValidator)
 		subApi.namesys = namesys.NewNameSystem(subApi.routing, subApi.repo.Datastore(), cs)
+		subApi.provider = provider.NewOfflineProvider()
 
 		subApi.peerstore = nil
 		subApi.peerHost = nil

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/namesys"
+	"github.com/ipfs/go-ipfs/provider"
 	"github.com/ipfs/go-ipfs/pin"
 	"github.com/ipfs/go-ipfs/repo"
 
@@ -65,6 +66,8 @@ type CoreAPI struct {
 
 	namesys namesys.NameSystem
 	routing routing.IpfsRouting
+
+	provider *provider.Provider
 
 	pubSub *pubsub.PubSub
 
@@ -173,6 +176,8 @@ func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, e
 		recordValidator: n.RecordValidator,
 		exchange:        n.Exchange,
 		routing:         n.Routing,
+
+		provider: n.Provider,
 
 		pubSub: n.PubSub,
 

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/namesys"
-	"github.com/ipfs/go-ipfs/provider"
 	"github.com/ipfs/go-ipfs/pin"
+	"github.com/ipfs/go-ipfs/provider"
 	"github.com/ipfs/go-ipfs/repo"
 
 	bserv "github.com/ipfs/go-blockservice"

--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -32,6 +32,10 @@ func (api *PinAPI) Add(ctx context.Context, p coreiface.Path, opts ...caopts.Pin
 		return fmt.Errorf("pin: %s", err)
 	}
 
+	if err := api.provider.Provide(dagNode.Cid()); err != nil {
+		return err
+	}
+
 	return api.pinning.Flush()
 }
 

--- a/core/coreapi/provider.go
+++ b/core/coreapi/provider.go
@@ -4,8 +4,10 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
+// ProviderAPI brings Provider behavior to CoreAPI
 type ProviderAPI CoreAPI
 
-func (api *ProviderAPI) Provide(root cid.Cid) error {
-	return api.provider.Provide(root)
+// Provide the given cid using the current provider
+func (api *ProviderAPI) Provide(cid cid.Cid) error {
+	return api.provider.Provide(cid)
 }

--- a/core/coreapi/provider.go
+++ b/core/coreapi/provider.go
@@ -1,0 +1,11 @@
+package coreapi
+
+import (
+	cid "github.com/ipfs/go-cid"
+)
+
+type ProviderAPI CoreAPI
+
+func (api *ProviderAPI) Provide(root cid.Cid) error {
+	return api.provider.Provide(root)
+}

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -129,6 +129,11 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 	if err != nil {
 		return nil, err
 	}
+
+	if err := api.provider.Provide(nd.Cid()); err != nil {
+		return nil, err
+	}
+
 	return coreiface.IpfsPath(nd.Cid()), nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/ipfs/go-fs-lock v0.0.1
 	github.com/ipfs/go-ipfs-addr v0.0.1
 	github.com/ipfs/go-ipfs-blockstore v0.0.1
+	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.1
 	github.com/ipfs/go-ipfs-cmdkit v0.0.1
 	github.com/ipfs/go-ipfs-cmds v0.0.1

--- a/provider/offline.go
+++ b/provider/offline.go
@@ -1,0 +1,15 @@
+package provider
+
+import "github.com/ipfs/go-cid"
+
+type offlineProvider struct {}
+
+func NewOfflineProvider() Provider {
+	return &offlineProvider{}
+}
+
+func (op *offlineProvider) Run() {}
+
+func (op *offlineProvider) Provide(cid cid.Cid) error {
+	return nil
+}

--- a/provider/offline.go
+++ b/provider/offline.go
@@ -2,8 +2,9 @@ package provider
 
 import "github.com/ipfs/go-cid"
 
-type offlineProvider struct {}
+type offlineProvider struct{}
 
+// NewOfflineProvider creates a Provider that does nothing
 func NewOfflineProvider() Provider {
 	return &offlineProvider{}
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-routing"
-	"time"
 )
 
 var (
@@ -17,7 +16,6 @@ var (
 
 const (
 	provideOutgoingWorkerLimit = 8
-	provideOutgoingTimeout     = 15 * time.Second
 )
 
 // Provider announces blocks to the network, tracks which blocks are
@@ -75,14 +73,11 @@ func (p *Provider) handleAnnouncements() {
 func doProvide(ctx context.Context, contentRouting routing.ContentRouting, key cid.Cid) error {
 	// announce
 	log.Info("announce - start - ", key)
-	ctx, cancel := context.WithTimeout(ctx, provideOutgoingTimeout)
 	if err := contentRouting.Provide(ctx, key, true); err != nil {
 		log.Warningf("Failed to provide cid: %s", err)
 		// TODO: Maybe put these failures onto a failures queue?
-		cancel()
 		return err
 	}
-	cancel()
 	log.Info("announce - end - ", key)
 	return nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,13 +11,9 @@ import (
 	routing "github.com/libp2p/go-libp2p-routing"
 )
 
-var (
-	log = logging.Logger("provider")
-)
+var	log = logging.Logger("provider")
 
-const (
-	provideOutgoingWorkerLimit = 8
-)
+const provideOutgoingWorkerLimit = 8
 
 // Provider announces blocks to the network
 type Provider interface {
@@ -44,13 +40,13 @@ func NewProvider(ctx context.Context, queue *Queue, contentRouting routing.Conte
 
 // Start workers to handle provide requests.
 func (p *provider) Run() {
-	p.queue.Run()
 	p.handleAnnouncements()
 }
 
 // Provide the given cid using specified strategy.
 func (p *provider) Provide(root cid.Cid) error {
-	return p.queue.Enqueue(root)
+	p.queue.Enqueue(root)
+	return nil
 }
 
 // Handle all outgoing cids by providing (announcing) them
@@ -61,12 +57,12 @@ func (p *provider) handleAnnouncements() {
 				select {
 				case <-p.ctx.Done():
 					return
-				case entry := <-p.queue.Dequeue():
-					log.Info("announce - start - ", entry.cid)
-					if err := p.contentRouting.Provide(p.ctx, entry.cid, true); err != nil {
-						log.Warningf("Unable to provide entry: %s, %s", entry.cid, err)
+				case c := <-p.queue.Dequeue():
+					log.Info("announce - start - ", c)
+					if err := p.contentRouting.Provide(p.ctx, c, true); err != nil {
+						log.Warningf("Unable to provide entry: %s, %s", c, err)
 					}
-					log.Info("announce - end - ", entry.cid)
+					log.Info("announce - end - ", c)
 				}
 			}
 		}()

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,88 @@
+// Package provider implements structures and methods to provide blocks,
+// keep track of which blocks are provided, and to allow those blocks to
+// be reprovided.
+package provider
+
+import (
+	"context"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-routing"
+	"time"
+)
+
+var (
+	log = logging.Logger("provider")
+)
+
+const (
+	provideOutgoingWorkerLimit = 8
+	provideOutgoingTimeout     = 15 * time.Second
+)
+
+// Provider announces blocks to the network, tracks which blocks are
+// being provided, and untracks blocks when they're no longer in the blockstore.
+type Provider struct {
+	ctx context.Context
+	// the CIDs for which provide announcements should be made
+	queue *Queue
+	// used to announce providing to the network
+	contentRouting routing.ContentRouting
+}
+
+func NewProvider(ctx context.Context, queue *Queue, contentRouting routing.ContentRouting) *Provider {
+	return &Provider{
+		ctx:            ctx,
+		queue:          queue,
+		contentRouting: contentRouting,
+	}
+}
+
+// Start workers to handle provide requests.
+func (p *Provider) Run() {
+	p.queue.Run()
+	p.handleAnnouncements()
+}
+
+// Provide the given cid using specified strategy.
+func (p *Provider) Provide(root cid.Cid) error {
+	return p.queue.Enqueue(root)
+}
+
+// Handle all outgoing cids by providing (announcing) them
+func (p *Provider) handleAnnouncements() {
+	for workers := 0; workers < provideOutgoingWorkerLimit; workers++ {
+		go func() {
+			for {
+				select {
+				case <-p.ctx.Done():
+					return
+				case entry := <-p.queue.Dequeue():
+					if err := doProvide(p.ctx, p.contentRouting, entry.cid); err != nil {
+						log.Warningf("Unable to provide entry: %s, %s", entry.cid, err)
+					}
+
+					if err := entry.Complete(); err != nil {
+						log.Warningf("Unable to complete queue entry when providing: %s, %s", entry.cid, err)
+					}
+				}
+			}
+		}()
+	}
+}
+
+// TODO: better document this provide logic
+func doProvide(ctx context.Context, contentRouting routing.ContentRouting, key cid.Cid) error {
+	// announce
+	log.Info("announce - start - ", key)
+	ctx, cancel := context.WithTimeout(ctx, provideOutgoingTimeout)
+	if err := contentRouting.Provide(ctx, key, true); err != nil {
+		log.Warningf("Failed to provide cid: %s", err)
+		// TODO: Maybe put these failures onto a failures queue?
+		cancel()
+		return err
+	}
+	cancel()
+	log.Info("announce - end - ", key)
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -5,9 +5,10 @@ package provider
 
 import (
 	"context"
-	"github.com/ipfs/go-cid"
+
+	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
-	"github.com/libp2p/go-libp2p-routing"
+	routing "github.com/libp2p/go-libp2p-routing"
 )
 
 var (

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -5,10 +5,9 @@ package provider
 
 import (
 	"context"
-
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
-	routing "github.com/libp2p/go-libp2p-routing"
+	"github.com/libp2p/go-libp2p-routing"
 )
 
 var log = logging.Logger("provider")
@@ -17,7 +16,9 @@ const provideOutgoingWorkerLimit = 8
 
 // Provider announces blocks to the network
 type Provider interface {
+	// Run is used to begin processing the provider work
 	Run()
+	// Provide takes a cid and makes an attempt to announce it to the network
 	Provide(cid.Cid) error
 }
 
@@ -53,7 +54,7 @@ func (p *provider) Provide(root cid.Cid) error {
 func (p *provider) handleAnnouncements() {
 	for workers := 0; workers < provideOutgoingWorkerLimit; workers++ {
 		go func() {
-			for {
+			for p.ctx.Err() == nil {
 				select {
 				case <-p.ctx.Done():
 					return

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,7 +11,7 @@ import (
 	routing "github.com/libp2p/go-libp2p-routing"
 )
 
-var	log = logging.Logger("provider")
+var log = logging.Logger("provider")
 
 const provideOutgoingWorkerLimit = 8
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,13 +18,12 @@ const (
 	provideOutgoingWorkerLimit = 8
 )
 
+// Provider announces blocks to the network
 type Provider interface {
 	Run()
 	Provide(cid.Cid) error
 }
 
-// Provider announces blocks to the network, tracks which blocks are
-// being provided, and untracks blocks when they're no longer in the blockstore.
 type provider struct {
 	ctx context.Context
 	// the CIDs for which provide announcements should be made
@@ -33,6 +32,7 @@ type provider struct {
 	contentRouting routing.ContentRouting
 }
 
+// NewProvider creates a provider that announces blocks to the network using a content router
 func NewProvider(ctx context.Context, queue *Queue, contentRouting routing.ContentRouting) Provider {
 	return &provider{
 		ctx:            ctx,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -62,28 +62,13 @@ func (p *provider) handleAnnouncements() {
 				case <-p.ctx.Done():
 					return
 				case entry := <-p.queue.Dequeue():
-					if err := doProvide(p.ctx, p.contentRouting, entry.cid); err != nil {
+					log.Info("announce - start - ", entry.cid)
+					if err := p.contentRouting.Provide(p.ctx, entry.cid, true); err != nil {
 						log.Warningf("Unable to provide entry: %s, %s", entry.cid, err)
 					}
-
-					if err := entry.Complete(); err != nil {
-						log.Warningf("Unable to complete queue entry when providing: %s, %s", entry.cid, err)
-					}
+					log.Info("announce - end - ", entry.cid)
 				}
 			}
 		}()
 	}
-}
-
-// TODO: better document this provide logic
-func doProvide(ctx context.Context, contentRouting routing.ContentRouting, key cid.Cid) error {
-	// announce
-	log.Info("announce - start - ", key)
-	if err := contentRouting.Provide(ctx, key, true); err != nil {
-		log.Warningf("Failed to provide cid: %s", err)
-		// TODO: Maybe put these failures onto a failures queue?
-		return err
-	}
-	log.Info("announce - end - ", key)
-	return nil
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -19,6 +19,15 @@ type mockRouting struct {
 	provided chan cid.Cid
 }
 
+func (r *mockRouting) Provide(ctx context.Context, cid cid.Cid, recursive bool) error {
+	r.provided <- cid
+	return nil
+}
+
+func (r *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, timeout int) <-chan pstore.PeerInfo {
+	return nil
+}
+
 func mockContentRouting() *mockRouting {
 	r := mockRouting{}
 	r.provided = make(chan cid.Cid)
@@ -67,14 +76,4 @@ func TestAnnouncement(t *testing.T) {
 			t.Fatal("Timeout waiting for cids to be provided.")
 		}
 	}
-}
-
-func (r *mockRouting) Provide(ctx context.Context, cid cid.Cid, recursive bool) error {
-	r.provided <- cid
-	return nil
-}
-
-// Search for peers who are able to provide a given key
-func (r *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, timeout int) <-chan pstore.PeerInfo {
-	return nil
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	cid "github.com/ipfs/go-cid"
 	datastore "github.com/ipfs/go-datastore"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	sync "github.com/ipfs/go-datastore/sync"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
 var blockGenerator = blocksutil.NewBlockGenerator()
@@ -58,13 +58,13 @@ func TestAnnouncement(t *testing.T) {
 
 	for cids.Len() > 0 {
 		select {
-			case cp := <-r.provided:
-				if !cids.Has(cp) {
-					t.Fatal("Wrong CID provided")
-				}
-				cids.Remove(cp)
-			case <-time.After(time.Second * 5):
-				t.Fatal("Timeout waiting for cids to be provided.")
+		case cp := <-r.provided:
+			if !cids.Has(cp) {
+				t.Fatal("Wrong CID provided")
+			}
+			cids.Remove(cp)
+		case <-time.After(time.Second * 5):
+			t.Fatal("Timeout waiting for cids to be provided.")
 		}
 	}
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -42,7 +42,7 @@ func TestAnnouncement(t *testing.T) {
 
 	cids := cid.NewSet()
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000; i++ {
 		c := blockGenerator.Next().Cid()
 		cids.Add(c)
 	}
@@ -63,7 +63,7 @@ func TestAnnouncement(t *testing.T) {
 					t.Fatal("Wrong CID provided")
 				}
 				cids.Remove(cp)
-			case <-time.After(time.Second * 1):
+			case <-time.After(time.Second * 5):
 				t.Fatal("Timeout waiting for cids to be provided.")
 		}
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -42,7 +42,7 @@ func TestAnnouncement(t *testing.T) {
 
 	cids := cid.NewSet()
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		c := blockGenerator.Next().Cid()
 		cids.Add(c)
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -2,13 +2,15 @@ package provider
 
 import (
 	"context"
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-ipfs-blocksutil"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
 	"math/rand"
 	"testing"
 	"time"
+
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	cid "github.com/ipfs/go-cid"
+	datastore "github.com/ipfs/go-datastore"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	sync "github.com/ipfs/go-datastore/sync"
 )
 
 var blockGenerator = blocksutil.NewBlockGenerator()
@@ -25,11 +27,10 @@ func mockContentRouting() *mockRouting {
 
 func TestAnnouncement(t *testing.T) {
 	ctx := context.Background()
-	defer func() {
-		ctx.Done()
-	}()
+	defer ctx.Done()
 
-	queue, err := NewQueue(ctx, "test", datastore.NewMapDatastore())
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	queue, err := NewQueue(ctx, "test", ds)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-ipfs-blocksutil"
+	pstore "github.com/libp2p/go-libp2p-peerstore"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+
+type mockRouting struct {
+	provided chan cid.Cid
+}
+
+func mockContentRouting() *mockRouting {
+	r := mockRouting{}
+	r.provided = make(chan cid.Cid)
+	return &r
+}
+
+func TestAnnouncement(t *testing.T) {
+	ctx := context.Background()
+	defer func() {
+		ctx.Done()
+	}()
+
+	queue, err := NewQueue(ctx, "test", datastore.NewMapDatastore())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := mockContentRouting()
+
+	provider := NewProvider(ctx, queue, r)
+	provider.Run()
+
+	cids := cid.NewSet()
+
+	for i := 0; i < 100; i++ {
+		c := blockGenerator.Next().Cid()
+		cids.Add(c)
+	}
+
+	go func() {
+		for _, c := range cids.Keys() {
+			err = provider.Provide(c)
+			// A little goroutine stirring to exercise some different states
+			r := rand.Intn(10)
+			time.Sleep(time.Microsecond * time.Duration(r))
+		}
+	}()
+
+	for cids.Len() > 0 {
+		select {
+			case cp := <-r.provided:
+				if !cids.Has(cp) {
+					t.Fatal("Wrong CID provided")
+				}
+				cids.Remove(cp)
+			case <-time.After(time.Second * 1):
+				t.Fatal("Timeout waiting for cids to be provided.")
+		}
+	}
+}
+
+func (r *mockRouting) Provide(ctx context.Context, cid cid.Cid, recursive bool) error {
+	r.provided <- cid
+	return nil
+}
+
+// Search for peers who are able to provide a given key
+func (r *mockRouting) FindProvidersAsync(ctx context.Context, cid cid.Cid, timeout int) <-chan pstore.PeerInfo {
+	return nil
+}

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -19,14 +19,11 @@ import (
 type Queue struct {
 	// used to differentiate queues in datastore
 	// e.g. provider vs reprovider
-	name string
-	ctx context.Context
-
-	tail uint64
-	head uint64
-
-	ds          datastore.Datastore // Must be threadsafe
-
+	name    string
+	ctx     context.Context
+	tail    uint64
+	head    uint64
+	ds      datastore.Datastore // Must be threadsafe
 	dequeue chan cid.Cid
 	enqueue chan cid.Cid
 }
@@ -39,13 +36,13 @@ func NewQueue(ctx context.Context, name string, ds datastore.Datastore) (*Queue,
 		return nil, err
 	}
 	q := &Queue{
-		name:        name,
-		ctx:         ctx,
-		head:        head,
-		tail:        tail,
-		ds:          namespaced,
-		dequeue:     make(chan cid.Cid),
-		enqueue:     make(chan cid.Cid),
+		name:    name,
+		ctx:     ctx,
+		head:    head,
+		tail:    tail,
+		ds:      namespaced,
+		dequeue: make(chan cid.Cid),
+		enqueue: make(chan cid.Cid),
 	}
 	q.work()
 	return q, nil
@@ -54,8 +51,8 @@ func NewQueue(ctx context.Context, name string, ds datastore.Datastore) (*Queue,
 // Enqueue puts a cid in the queue
 func (q *Queue) Enqueue(cid cid.Cid) {
 	select {
-		case q.enqueue <- cid:
-		case <-q.ctx.Done():
+	case q.enqueue <- cid:
+	case <-q.ctx.Done():
 	}
 }
 

--- a/provider/queue.go
+++ b/provider/queue.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Entry allows for the durability in the queue. When a cid is dequeued it is
+// not removed from the datastore until you call Complete() on the entry you
+// receive.
+type Entry struct {
+	cid cid.Cid
+	key ds.Key
+	queue *Queue
+}
+
+func (e *Entry) Complete() error {
+	return e.queue.remove(e.key)
+}
+
+// Queue provides a durable, FIFO interface to the datastore for storing cids
+//
+// Durability just means that cids in the process of being provided when a
+// crash or shutdown occurs will still be in the queue when the node is
+// brought back online.
+type Queue struct {
+	// used to differentiate queues in datastore
+	// e.g. provider vs reprovider
+	name string
+
+	ctx context.Context
+
+	tail uint64
+	head uint64
+
+	lock sync.Mutex
+	datastore ds.Datastore
+
+	dequeue chan *Entry
+	notEmpty chan struct{}
+
+	isRunning bool
+}
+
+func NewQueue(name string, ctx context.Context, datastore ds.Datastore) (*Queue, error) {
+	namespaced := namespace.Wrap(datastore, ds.NewKey("/" + name + "/queue/"))
+	head, tail, err := getQueueHeadTail(name, ctx, namespaced)
+	if err != nil {
+		return nil, err
+	}
+	q := &Queue{
+		name: name,
+		ctx: ctx,
+		head: head,
+		tail: tail,
+		lock: sync.Mutex{},
+		datastore: namespaced,
+		dequeue: make(chan *Entry),
+		notEmpty: make(chan struct{}),
+		isRunning: false,
+	}
+	return q, nil
+}
+
+// Put a cid in the queue
+func (q *Queue) Enqueue(cid cid.Cid) error {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	wasEmpty := q.IsEmpty()
+
+	nextKey := q.queueKey(q.tail)
+
+	if err := q.datastore.Put(nextKey, cid.Bytes()); err != nil {
+		return err
+	}
+
+	q.tail++
+
+	if q.isRunning && wasEmpty {
+		select {
+		case q.notEmpty <- struct{}{}:
+		case <-q.ctx.Done():
+		}
+	}
+
+	return nil
+}
+
+// Remove an entry from the queue.
+func (q *Queue) Dequeue() <-chan *Entry {
+	return q.dequeue
+}
+
+func (q *Queue) IsEmpty() bool {
+	return (q.tail - q.head) == 0
+}
+
+func (q *Queue) remove(key ds.Key) error {
+	return q.datastore.Delete(key)
+}
+
+// dequeue items when the dequeue channel is available to
+// be written to
+func (q *Queue) Run() {
+	q.isRunning = true
+	go func() {
+		for {
+			select {
+			case <-q.ctx.Done():
+				return
+			default:
+			}
+			if q.IsEmpty() {
+				select {
+				case <-q.ctx.Done():
+					return
+					// wait for a notEmpty message
+				case <-q.notEmpty:
+				}
+			}
+
+			entry, err := q.next()
+			if err != nil {
+				log.Warningf("Error Dequeue()-ing: %s, %s", entry, err)
+				continue
+			}
+
+			select {
+			case <-q.ctx.Done():
+				return
+			case q.dequeue <- entry:
+			}
+		}
+	}()
+}
+
+// Find the next item in the queue, crawl forward if an entry is not
+// found in the next spot.
+func (q *Queue) next() (*Entry, error) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	var nextKey ds.Key
+	var value []byte
+	var err error
+	for {
+		if q.head >= q.tail {
+			return nil, errors.New("no more entries in queue")
+		}
+		select {
+		case <-q.ctx.Done():
+			return nil, nil
+		default:
+		}
+		nextKey = q.queueKey(q.head)
+		value, err = q.datastore.Get(nextKey)
+		if err == ds.ErrNotFound {
+			q.head++
+			continue
+		} else if err != nil {
+			return nil, err
+		} else {
+			break
+		}
+	}
+
+	id, err := cid.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &Entry {
+		cid: id,
+		key: nextKey,
+		queue: q,
+	}
+
+	q.head++
+
+	return entry, nil
+}
+
+func (q *Queue) queueKey(id uint64) ds.Key {
+	return ds.NewKey(strconv.FormatUint(id, 10))
+}
+
+// crawl over the queue entries to find the head and tail
+func getQueueHeadTail(name string, ctx context.Context, datastore ds.Datastore) (uint64, uint64, error) {
+	query := query.Query{}
+	results, err := datastore.Query(query)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var tail uint64 = 0
+	var head uint64 = math.MaxUint64
+	for entry := range results.Next() {
+		select {
+		case <-ctx.Done():
+			return 0, 0, nil
+		default:
+		}
+		trimmed := strings.TrimPrefix(entry.Key, "/")
+		id, err := strconv.ParseUint(trimmed, 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if id < head {
+			head = id
+		}
+
+		if (id+1) > tail {
+			tail = (id+1)
+		}
+	}
+	if err := results.Close(); err != nil {
+		return 0, 0, err
+	}
+	if head == math.MaxUint64 {
+		head = 0
+	}
+
+	return head, tail, nil
+}
+

--- a/provider/queue_test.go
+++ b/provider/queue_test.go
@@ -22,7 +22,7 @@ func makeCids(n int) []cid.Cid {
 func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 	for _, c := range cids {
 		select {
-		case dequeued := <- q.dequeue:
+		case dequeued := <-q.dequeue:
 			if c != dequeued {
 				t.Fatalf("Error in ordering of CIDs retrieved from queue. Expected: %s, got: %s", c, dequeued)
 			}

--- a/provider/queue_test.go
+++ b/provider/queue_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func makeCids(n int) []cid.Cid {
-	cids := make([]cid.Cid, 0, 10)
+	cids := make([]cid.Cid, 0, n)
 	for i := 0; i < 10; i++ {
 		c := blockGenerator.Next().Cid()
 		cids = append(cids, c)
@@ -23,8 +23,8 @@ func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
 	for _, c := range cids {
 		select {
 		case dequeued := <- q.dequeue:
-			if c != dequeued.cid {
-				t.Fatalf("Error in ordering of CIDs retrieved from queue. Expected: %s, got: %s", c, dequeued.cid)
+			if c != dequeued {
+				t.Fatalf("Error in ordering of CIDs retrieved from queue. Expected: %s, got: %s", c, dequeued)
 			}
 
 		case <-time.After(time.Second * 1):
@@ -42,15 +42,11 @@ func TestBasicOperation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	queue.Run()
 
 	cids := makeCids(10)
 
 	for _, c := range cids {
-		err = queue.Enqueue(c)
-		if err != nil {
-			t.Fatal("Failed to enqueue CID")
-		}
+		queue.Enqueue(c)
 	}
 
 	assertOrdered(cids, queue, t)
@@ -65,15 +61,11 @@ func TestInitialization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	queue.Run()
 
 	cids := makeCids(10)
 
 	for _, c := range cids {
-		err = queue.Enqueue(c)
-		if err != nil {
-			t.Fatal("Failed to enqueue CID")
-		}
+		queue.Enqueue(c)
 	}
 
 	assertOrdered(cids[:5], queue, t)
@@ -83,7 +75,6 @@ func TestInitialization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	queue.Run()
 
 	assertOrdered(cids[5:], queue, t)
 }

--- a/provider/queue_test.go
+++ b/provider/queue_test.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cid "github.com/ipfs/go-cid"
+	datastore "github.com/ipfs/go-datastore"
+	sync "github.com/ipfs/go-datastore/sync"
+)
+
+func makeCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, 10)
+	for i := 0; i < 10; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}
+
+func assertOrdered(cids []cid.Cid, q *Queue, t *testing.T) {
+	for _, c := range cids {
+		select {
+		case dequeued := <- q.dequeue:
+			if c != dequeued.cid {
+				t.Fatalf("Error in ordering of CIDs retrieved from queue. Expected: %s, got: %s", c, dequeued.cid)
+			}
+
+		case <-time.After(time.Second * 1):
+			t.Fatal("Timeout waiting for cids to be provided.")
+		}
+	}
+}
+
+func TestBasicOperation(t *testing.T) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	queue, err := NewQueue(ctx, "test", ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue.Run()
+
+	cids := makeCids(10)
+
+	for _, c := range cids {
+		err = queue.Enqueue(c)
+		if err != nil {
+			t.Fatal("Failed to enqueue CID")
+		}
+	}
+
+	assertOrdered(cids, queue, t)
+}
+
+func TestInitialization(t *testing.T) {
+	ctx := context.Background()
+	defer ctx.Done()
+
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	queue, err := NewQueue(ctx, "test", ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue.Run()
+
+	cids := makeCids(10)
+
+	for _, c := range cids {
+		err = queue.Enqueue(c)
+		if err != nil {
+			t.Fatal("Failed to enqueue CID")
+		}
+	}
+
+	assertOrdered(cids[:5], queue, t)
+
+	// make a new queue, same data
+	queue, err = NewQueue(ctx, "test", ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queue.Run()
+
+	assertOrdered(cids[5:], queue, t)
+}


### PR DESCRIPTION
Provide root node immediately when `ipfs add <cid>` and `ipfs pin add <cid>`.

This PR introduces part of the new provider subsystem from the rest of the ongoing provider work so it's more extensive than it might otherwise have been. This seemed like a good way to merge some of that work and begin using it. And he work to get this PR mergeable will get folded back into #5870 

Addresses: https://github.com/ipfs/go-ipfs/issues/6067