### PR TITLE
CoreAPI: Files API

### DIFF
--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -72,7 +72,7 @@ type CoreAPI struct {
 	checkPublishAllowed func() error
 	checkOnline         func(allowOffline bool) error
 
-	filesRoot       *mfs.Root // TODO: option filtering
+	filesRoot *mfs.Root // TODO: option filtering
 
 	// ONLY for re-applying options in WithOptions, DO NOT USE ANYWHERE ELSE
 	nd         *core.IpfsNode

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ipfs/go-mfs"
 
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/namesys"
@@ -71,6 +72,8 @@ type CoreAPI struct {
 	checkPublishAllowed func() error
 	checkOnline         func(allowOffline bool) error
 
+	filesRoot       *mfs.Root // TODO: option filtering
+
 	// ONLY for re-applying options in WithOptions, DO NOT USE ANYWHERE ELSE
 	nd         *core.IpfsNode
 	parentOpts options.ApiSettings
@@ -117,6 +120,10 @@ func (api *CoreAPI) Key() coreiface.KeyAPI {
 // Object returns the ObjectAPI interface implementation backed by the go-ipfs node
 func (api *CoreAPI) Object() coreiface.ObjectAPI {
 	return (*ObjectAPI)(api)
+}
+
+func (api *CoreAPI) Mfs() coreiface.MfsAPI {
+	return (*MfsAPI)(api)
 }
 
 // Pin returns the PinAPI interface implementation backed by the go-ipfs node

--- a/core/coreapi/mfs.go
+++ b/core/coreapi/mfs.go
@@ -1,0 +1,170 @@
+package coreapi
+
+import (
+	"context"
+	"fmt"
+	"github.com/ipfs/go-mfs"
+	"github.com/pkg/errors"
+	"os"
+	gopath "path"
+	"time"
+
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+)
+
+const defaultFilePerm = 0644
+const defaultDirPerm = 0755
+
+type MfsAPI CoreAPI
+
+type fileNodeInfo struct{
+	l mfs.NodeListing
+}
+
+func (i *fileNodeInfo) Name() string {
+	return i.l.Name //TODO: check what is really returned here
+}
+
+func (i *fileNodeInfo) Size() int64 {
+	return i.l.Size
+}
+
+func (i *fileNodeInfo) Mode() os.FileMode {
+	return defaultFilePerm
+}
+
+func (i *fileNodeInfo) ModTime() time.Time {
+	return time.Unix(0, 0)
+}
+
+func (i *fileNodeInfo) IsDir() bool {
+	return mfs.NodeType(i.l.Type) == mfs.TDir
+}
+
+func (i *fileNodeInfo) Sys() interface{} {
+	return i.l
+}
+
+func (api *MfsAPI) Create(ctx context.Context, path coreiface.MfsPath) (coreiface.File, error) {
+	return api.OpenFile(ctx, path, os.O_CREATE | os.O_WRONLY, defaultFilePerm)
+}
+
+func (api *MfsAPI) Open(ctx context.Context, path coreiface.MfsPath) (coreiface.File, error) {
+	return api.OpenFile(ctx, path, os.O_RDWR, defaultFilePerm)
+}
+
+func (api *MfsAPI) OpenFile(ctx context.Context, path coreiface.MfsPath, flag int, perm os.FileMode) (coreiface.File, error) {
+	panic("implement me")
+}
+
+func (api *MfsAPI) Stat(ctx context.Context, path coreiface.MfsPath) (os.FileInfo, error) {
+	fsn, err := mfs.Lookup(api.filesRoot, path.String())
+	if err != nil {
+		return nil, err
+	}
+
+	nd, err := fsn.GetNode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &fileNodeInfo{
+		l: mfs.NodeListing{
+			Name: path.String(),
+			Type: int(fsn.Type()),
+			Size: -1, //TODO
+			Hash: nd.Cid().String(),
+		},
+	}, nil
+}
+
+func (api *MfsAPI) Rename(ctx context.Context, oldpath, newpath coreiface.MfsPath) error {
+	flush := false //TODO
+	err := mfs.Mv(api.filesRoot, oldpath.String(), newpath.String())
+	if err == nil && flush {
+		err = mfs.FlushPath(api.filesRoot, "/")
+	}
+	return err
+}
+
+func (api *MfsAPI) Remove(ctx context.Context, path coreiface.MfsPath) error {
+	if path.String() == "/" {
+		return fmt.Errorf("cannot delete root")
+	}
+
+	dir, name := gopath.Split(path.String())
+	parent, err := mfs.Lookup(api.filesRoot, dir)
+	if err != nil {
+		return fmt.Errorf("parent lookup: %s", err)
+	}
+
+	pdir, ok := parent.(*mfs.Directory)
+	if !ok {
+		return fmt.Errorf("no such file or directory: %s", path)
+	}
+
+	// TODO: force
+
+	// get child node by name, when the node is corrupted and nonexistent,
+	// it will return specific error.
+	child, err := pdir.Child(name)
+	if err != nil {
+		return err
+	}
+
+	dashr := true // TODO: make into an option
+
+	switch child.(type) {
+	case *mfs.Directory:
+		if !dashr {
+			return fmt.Errorf("%s is a directory, use -r to remove directories", path)
+		}
+	}
+
+	err = pdir.Unlink(name)
+	if err != nil {
+		return err
+	}
+
+	return pdir.Flush() //TODO: setting for flush
+}
+
+func (api *MfsAPI) ReadDir(ctx context.Context, path coreiface.MfsPath) ([]os.FileInfo, error) {
+	fsn, err := mfs.Lookup(api.filesRoot, path.String())
+	if err != nil {
+		return nil, err
+	}
+
+	switch fsn := fsn.(type) {
+	case *mfs.Directory:
+		lst, err := fsn.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		out := make([]os.FileInfo, len(lst))
+		for i, v := range lst {
+			out[i] = &fileNodeInfo{
+				l: v,
+			}
+		}
+
+		return out, nil
+	default:
+		return nil, errors.New("readdir: unsupported node type")
+	}
+}
+
+func (api *MfsAPI) MkdirAll(path coreiface.MfsPath, perm os.FileMode) error {
+	return mfs.Mkdir(api.filesRoot, path.String(), mfs.MkdirOpts{
+		Mkparents:  true,
+		Flush:      false,
+		//CidBuilder: prefix, TODO
+	})
+}
+
+func (api *MfsAPI) core() coreiface.CoreAPI {
+	return (*CoreAPI)(api)
+}
+
+var _ os.FileInfo = &fileNodeInfo{}


### PR DESCRIPTION
Interface PR: https://github.com/ipfs/interface-go-ipfs-core/pull/19

Depends on:
* [ ] Interface reviewed
* [ ] `ReadAt` in go-mfs (not really blocking, but really nice to have)
* [ ] Tests