### PR TITLE
resolve: fix recursion

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -71,10 +71,7 @@ The resolver can recursively resolve:
 		}
 
 		output, err := resolver.Resolve(req.Context, name, ropts...)
-		if err == namesys.ErrResolveFailed {
-			return err
-		}
-		if err != nil {
+		if err != nil && (recursive || err != namesys.ErrResolveRecursion) {
 			return err
 		}
 		return cmds.EmitOnce(res, &ncmd.ResolvedPath{Path: output})

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -58,7 +58,7 @@ The resolver can recursively resolve:
 		cmdkit.StringArg("domain-name", true, false, "The domain-name name to resolve.").EnableStdin(),
 	},
 	Options: []cmdkit.Option{
-		cmdkit.BoolOption(dnsRecursiveOptionName, "r", "Resolve until the result is not a DNS link."),
+		cmdkit.BoolOption(dnsRecursiveOptionName, "r", "Resolve until the result is not a DNS link.").WithDefault(true),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		recursive, _ := req.Options[dnsRecursiveOptionName].(bool)

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
+	namesys "github.com/ipfs/go-ipfs/namesys"
 
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -130,7 +131,7 @@ Resolve the value of a dnslink:
 
 		if !stream {
 			output, err := api.Name().Resolve(req.Context, name, opts...)
-			if err != nil {
+			if err != nil && (recursive || err != namesys.ErrResolveRecursion) {
 				return err
 			}
 
@@ -143,8 +144,8 @@ Resolve the value of a dnslink:
 		}
 
 		for v := range output {
-			if v.Err != nil {
-				return err
+			if v.Err != nil && (recursive || v.Err != namesys.ErrResolveRecursion) {
+				return v.Err
 			}
 			if err := res.Emit(&ResolvedPath{path.FromString(v.Path.String())}); err != nil {
 				return err

--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -73,7 +73,7 @@ Resolve the value of a dnslink:
 		cmdkit.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID."),
 	},
 	Options: []cmdkit.Option{
-		cmdkit.BoolOption(recursiveOptionName, "r", "Resolve until the result is not an IPNS name."),
+		cmdkit.BoolOption(recursiveOptionName, "r", "Resolve until the result is not an IPNS name.").WithDefault(true),
 		cmdkit.BoolOption(nocacheOptionName, "n", "Do not use cached entries."),
 		cmdkit.UintOption(dhtRecordCountOptionName, "dhtrc", "Number of records to request for DHT resolution."),
 		cmdkit.StringOption(dhtTimeoutOptionName, "dhtt", "Max time to collect values during DHT resolution eg \"30s\". Pass 0 for no timeout."),

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -70,7 +70,7 @@ Resolve the value of an IPFS DAG path:
 		cmdkit.StringArg("name", true, false, "The name to resolve.").EnableStdin(),
 	},
 	Options: []cmdkit.Option{
-		cmdkit.BoolOption(resolveRecursiveOptionName, "r", "Resolve until the result is an IPFS name."),
+		cmdkit.BoolOption(resolveRecursiveOptionName, "r", "Resolve until the result is an IPFS name.").WithDefault(true),
 		cmdkit.IntOption(resolveDhtRecordCountOptionName, "dhtrc", "Number of records to request for DHT resolution."),
 		cmdkit.StringOption(resolveDhtTimeoutOptionName, "dhtt", "Max time to collect values during DHT resolution eg \"30s\". Pass 0 for no timeout."),
 	},


### PR DESCRIPTION
1. Recurse by default. This is what users expect and it should only un-break
applications. We have a default limit of 32.
2. When recursion is turned off, return the partial result. Otherwise, these
commands are pretty much useless

fixes #5635
fixes #5585
fixes #4181
fixes #4293
fixes #6086