### PR TITLE
build: add ipget in dist_get

### DIFF
--- a/bin/dist_get
+++ b/bin/dist_get
@@ -43,6 +43,7 @@ download() {
 		die "download error: cannot write to $dl_output"
 	fi
 
+	try_download "$dl_url" "$dl_output" "ipget '$dl_url' -o '$dl_output'" && return
 	try_download "$dl_url" "$dl_output" "wget '$dl_url' -O '$dl_output'" && return
 	try_download "$dl_url" "$dl_output" "curl --silent --fail --output '$dl_output' '$dl_url'" && return
 	try_download "$dl_url" "$dl_output" "fetch '$dl_url' -o '$dl_output'" && return


### PR DESCRIPTION
Because dogfood (and it's faster to fetch through my LAN with existing nodes than through the gateway usually).