### PR TITLE
Fuse fixes

### DIFF
--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -80,7 +80,7 @@ func Bootstrap(n *IpfsNode, cfg BootstrapConfig) (io.Closer, error) {
 	if len(cfg.BootstrapPeers()) == 0 {
 		// We *need* to bootstrap but we have no bootstrap peers
 		// configured *at all*, inform the user.
-		log.Error("no bootstrap nodes configured: go-ipfs may have difficulty connecting to the network")
+		log.Warning("no bootstrap nodes configured: go-ipfs may have difficulty connecting to the network")
 	}
 
 	// the periodic bootstrap function -- the connection supervisor

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"testing"
 
+	"bazil.org/fuse"
+
 	core "github.com/ipfs/go-ipfs/core"
 
 	fstest "bazil.org/fuse/fs/fstestutil"
@@ -106,6 +108,7 @@ func (m *mountWrap) Close() error {
 }
 
 func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *mountWrap) {
+	t.Helper()
 	maybeSkipFuseTests(t)
 
 	var err error
@@ -126,8 +129,11 @@ func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *mountWra
 		t.Fatal(err)
 	}
 	mnt, err := fstest.MountedT(t, fs, nil)
+	if err == fuse.ErrOSXFUSENotFound {
+		t.Skip(err)
+	}
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("error mounting at temporary directory: %v", err)
 	}
 
 	return node, &mountWrap{

--- a/fuse/node/mount_darwin.go
+++ b/fuse/node/mount_darwin.go
@@ -5,7 +5,6 @@ package node
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"

--- a/fuse/node/mount_darwin.go
+++ b/fuse/node/mount_darwin.go
@@ -5,6 +5,7 @@ package node
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -22,10 +23,10 @@ func init() {
 
 // dontCheckOSXFUSEConfigKey is a key used to let the user tell us to
 // skip fuse checks.
-var dontCheckOSXFUSEConfigKey = "DontCheckOSXFUSE"
+const dontCheckOSXFUSEConfigKey = "DontCheckOSXFUSE"
 
 // fuseVersionPkg is the go pkg url for fuse-version
-var fuseVersionPkg = "github.com/jbenet/go-fuse-version/fuse-version"
+const fuseVersionPkg = "github.com/jbenet/go-fuse-version/fuse-version"
 
 // errStrFuseRequired is returned when we're sure the user does not have fuse.
 var errStrFuseRequired = `OSXFUSE not found.
@@ -58,7 +59,12 @@ For more help, see:
 	https://github.com/ipfs/go-ipfs/issues/177
 `
 
-var errStrNeedFuseVersion = `unable to check fuse version.
+type errNeedFuseVersion struct {
+	cause string
+}
+
+func (me errNeedFuseVersion) Error() string {
+	return fmt.Sprintf(`unable to check fuse version.
 
 Dear User,
 
@@ -79,7 +85,8 @@ version you have by running:
 [1]: https://github.com/ipfs/go-ipfs/issues/177
 [2]: https://github.com/ipfs/go-ipfs/pull/533
 [3]: %s
-`
+`, fuseVersionPkg, dontCheckOSXFUSEConfigKey, me.cause)
+}
 
 var errStrFailedToRunFuseVersion = `unable to check fuse version.
 
@@ -211,13 +218,13 @@ func ensureFuseVersionIsInstalled() error {
 
 		log.Debug("fuse-version: failed to install.")
 		s := err.Error() + "\n" + cmdoutstr
-		return fmt.Errorf(errStrNeedFuseVersion, fuseVersionPkg, dontCheckOSXFUSEConfigKey, s)
+		return errNeedFuseVersion{s}
 	}
 
 	// ok, try again...
 	if _, err := exec.LookPath("fuse-version"); err != nil {
 		log.Debug("fuse-version: failed to install?")
-		return fmt.Errorf(errStrNeedFuseVersion, fuseVersionPkg, dontCheckOSXFUSEConfigKey, err)
+		return errNeedFuseVersion{err.Error()}
 	}
 
 	log.Debug("fuse-version: install success")

--- a/fuse/node/mount_darwin.go
+++ b/fuse/node/mount_darwin.go
@@ -204,7 +204,7 @@ func ensureFuseVersionIsInstalled() error {
 
 	// try installing it...
 	log.Debug("fuse-version: no fuse-version. attempting to install.")
-	cmd := exec.Command("go", "get", "github.com/jbenet/go-fuse-version/fuse-version")
+	cmd := exec.Command("go", "install", "github.com/jbenet/go-fuse-version/fuse-version")
 	cmdout := new(bytes.Buffer)
 	cmd.Stdout = cmdout
 	cmd.Stderr = cmdout

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"bazil.org/fuse"
+
 	"context"
 
 	core "github.com/ipfs/go-ipfs/core"
@@ -61,8 +63,11 @@ func TestExternalUnmount(t *testing.T) {
 	mkdir(t, ipnsDir)
 
 	err = Mount(node, ipfsDir, ipnsDir)
+	if _, ok := err.(errNeedFuseVersion); ok || err == fuse.ErrOSXFUSENotFound {
+		t.Skip(err)
+	}
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("error mounting: %v", err)
 	}
 
 	// Run shell command to externally unmount the directory

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"testing"
 
+	"bazil.org/fuse"
+
 	core "github.com/ipfs/go-ipfs/core"
 	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
 	coremock "github.com/ipfs/go-ipfs/core/mock"
@@ -50,6 +52,7 @@ func randObj(t *testing.T, nd *core.IpfsNode, size int64) (ipld.Node, []byte) {
 }
 
 func setupIpfsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *fstest.Mount) {
+	t.Helper()
 	maybeSkipFuseTests(t)
 
 	var err error
@@ -62,8 +65,11 @@ func setupIpfsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *fstest.M
 
 	fs := NewFileSystem(node)
 	mnt, err := fstest.MountedT(t, fs, nil)
+	if err == fuse.ErrOSXFUSENotFound {
+		t.Skip(err)
+	}
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("error mounting temporary directory: %v", err)
 	}
 
 	return node, mnt


### PR DESCRIPTION
- Skip errors due to fuse missing on OSX
- Downgrade bootstrap node error: It's very noisy in the test logs, and probably indicates user error (which may be a warning), rather than an actual, unexpected error.
- Fix automatic installation of go-fuse-version with go modules
- Misc uses of testing.T.Helper