### PR TITLE
docs/experimental-features.md: link to ipfs-ds-convert

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -550,7 +550,7 @@ See [Plugin docs](./plugins.md)
  ```
  $ ipfs init --profile=badgerds
  ```
- or
+ or install https://github.com/ipfs/ipfs-ds-convert/ and
  ```
  [BACKUP ~/.ipfs]
  $ ipfs config profile apply badgerds


### PR DESCRIPTION
I was confused by ipfs-ds-convert returning command not found and
attempted to "ipfs ds-convert" and similar commands in case it was
typoed until I found out it was in a separate repo.