### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# Please see https://help.github.com/articles/about-codeowners/ for more information
-
-# Global owner
-*		@Kubuxu
-
-# Subsystem specific owners
-
-


### PR DESCRIPTION
IMO, this is just confusing new contributors because they always see @Kubuxu tagged for review but that doesn't actually mean anyone's going to review the PR.

It _also_ means _I_ can't ask @Kubuxu to review the PR.