### PR TITLE
test: remove version/deps from ro commands test

### DIFF
--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -38,7 +38,6 @@ func TestROCommands(t *testing.T) {
 		"/refs",
 		"/resolve",
 		"/version",
-		"/version/deps",
 	}
 
 	cmdSet := make(map[string]struct{})


### PR DESCRIPTION
Because steb did a bad thing and pushed to master. Not sure _why_ my pre-commit hook didn't catch this but...