### PR TITLE
Dockerfile: Remove 2 year old deprecation warning

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -26,22 +26,4 @@ else
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi
 
-# if the first argument is daemon
-if [ "$1" = "daemon" ]; then
-  # filter the first argument until
-  # https://github.com/ipfs/go-ipfs/pull/3573
-  # has been resolved
-  shift
-else
-  # print deprecation warning
-  # go-ipfs used to hardcode "ipfs daemon" in it's entrypoint
-  # this workaround supports the new syntax so people start setting daemon explicitly
-  # when overwriting CMD
-  echo "DEPRECATED: arguments have been set but the first argument isn't 'daemon'" >&2
-  echo "DEPRECATED: run 'docker run ipfs/go-ipfs daemon $@' instead" >&2
-  echo "DEPRECATED: see the following PRs for more information:" >&2
-  echo "DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3573" >&2
-  echo "DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3685" >&2
-fi
-
-exec ipfs daemon "$@"
+exec ipfs "$@"


### PR DESCRIPTION
This finally removes support for the implicit daemon argument and unlocks full access to all subcommands.