### PR TITLE
align output for the command ipfs object stat

### DIFF
--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -347,8 +347,10 @@ var ObjectStatCmd = &cmds.Command{
 	Type: ipld.NodeStat{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *ipld.NodeStat) error {
+			wtr := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+			defer wtr.Flush()
 			fw := func(s string, n int) {
-				fmt.Fprintf(w, "%s: %d\n", s, n)
+				fmt.Fprintf(wtr, "%s:\t%d\n", s, n)
 			}
 			fw("NumLinks", out.NumLinks)
 			fw("BlockSize", out.BlockSize)

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -69,10 +69,10 @@ test_object_cmd() {
   '
 
   test_expect_success "'ipfs object get' output looks good" '
-    echo "NumLinks: 0" > expected_stat &&
-    echo "BlockSize: 18" >> expected_stat &&
-    echo "LinksSize: 2" >> expected_stat &&
-    echo "DataSize: 16" >> expected_stat &&
+    echo "NumLinks:       0" > expected_stat &&
+    echo "BlockSize:      18" >> expected_stat &&
+    echo "LinksSize:      2" >> expected_stat &&
+    echo "DataSize:       16" >> expected_stat &&
     echo "CumulativeSize: 18" >> expected_stat &&
     test_cmp expected_stat actual_stat
   '
@@ -276,11 +276,11 @@ test_object_cmd() {
   '
 
   test_expect_success "ipfs object stat output looks good" '
-    echo NumLinks: 1 > obj_stat_exp &&
-    echo BlockSize: 47 >> obj_stat_exp &&
-    echo LinksSize: 45 >> obj_stat_exp &&
-    echo DataSize: 2 >> obj_stat_exp &&
-    echo CumulativeSize: 114 >> obj_stat_exp &&
+    echo "NumLinks:       1" > obj_stat_exp &&
+    echo "BlockSize:      47" >> obj_stat_exp &&
+    echo "LinksSize:      45" >> obj_stat_exp &&
+    echo "DataSize:       2" >> obj_stat_exp &&
+    echo "CumulativeSize: 114" >> obj_stat_exp &&
 
     test_cmp obj_stat_exp obj_stat_out
   '


### PR DESCRIPTION
License: MIT
Signed-off-by: Eric Wu <myself659@163.com>

# before align 

```
root@IA:~/ipfs-demo# ipfs object stat QmchMzwpT2c8qWn8JL3bfjTm3hFa45QDRe4DAUBTseitCD
NumLinks: 4
BlockSize: 200
LinksSize: 178
DataSize: 22
CumulativeSize: 947747
```
# after  align 
```
root@IA:~/ipfs-demo# ipfs object stat QmchMzwpT2c8qWn8JL3bfjTm3hFa45QDRe4DAUBTseitCD
NumLinks:       4
BlockSize:      200
LinksSize:      178
DataSize:       22
CumulativeSize: 947747
```
