### PR TITLE
gitattributes: default to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
+# Default to text
+* text eol=lf
+
+# True text
+*.md text eol=auto
+LICENSE text eol=auto
+
+# Binary assets
 assets/init-doc/*          binary
 core/coreunix/test_data/** binary


### PR DESCRIPTION
1. Default to LF line endings. Windows users should use a real text editor when coding.
2. Allow markdown/license files to be autoconverted so they're readable everywhere.

fixes #6195