### PR TITLE
fix the wrong path configuration in root redirection

### DIFF
--- a/core/corehttp/redirect.go
+++ b/core/corehttp/redirect.go
@@ -10,7 +10,11 @@ import (
 func RedirectOption(path string, redirect string) ServeOption {
 	handler := &redirectHandler{redirect}
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
-		mux.Handle("/"+path+"/", handler)
+		if len(path) > 0 {
+			mux.Handle("/"+path+"/", handler)
+		} else {
+			mux.Handle("/", handler)
+		}
 		return mux, nil
 	}
 }


### PR DESCRIPTION
### What is included
- tiny bug fix for the configuration of root redirection

### As before
when you setup root redirection for the gateway or endpoint, you can configure RootRedirect in your configuration file as

```
  "Gateway": {
   .... // omitted ...
    "NoFetch": false,
    "PathPrefixes": [],
    "RootRedirect": "PATH_TO_REDIRECTION",
    "Writable": false
  },
```

currently the configuration doesn't seem to work well, because

```daemon.go
	if len(cfg.Gateway.RootRedirect) > 0 {
		opts = append(opts, corehttp.RedirectOption("", cfg.Gateway.RootRedirect))
	}
```

and when path = "" Handler for redirection will be set to "//"

```redirect.go
	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
		mux.Handle("/"+path+"/", handler)
		return mux, nil
	}
```

in local

```
curl localhost:5001 # returns 404
```


### fix
as I fixed in the diff, handle correctly the case for root redirection.

