### PR TITLE
test(coreapi): use a thread-safe datastore everywhere

### DIFF
--- a/core/coreapi/test/api_test.go
+++ b/core/coreapi/test/api_test.go
@@ -71,10 +71,10 @@ func (NodeProvider) MakeAPISwarm(ctx context.Context, fullIdentity bool, n int) 
 		c.Identity = ident
 		c.Experimental.FilestoreEnabled = true
 
-		ds := datastore.NewMapDatastore()
+		ds := syncds.MutexWrap(datastore.NewMapDatastore())
 		r := &repo.Mock{
 			C: c,
-			D: syncds.MutexWrap(ds),
+			D: ds,
 			K: keystore.NewMemKeystore(),
 			F: filestore.NewFileManager(ds, filepath.Dir(os.TempDir())),
 		}


### PR DESCRIPTION
fixes https://github.com/libp2p/go-libp2p-kad-dht/issues/321

cc @anacrolix