### PR TITLE
commands(feat): use the coreapi in the urlstore command

### DIFF
--- a/core/commands/urlstore.go
+++ b/core/commands/urlstore.go
@@ -27,7 +27,7 @@ var urlAdd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Add URL via urlstore.",
 		LongDescription: `
-DEPRECATED: Use 'ipfs add --nocopy URL'.
+DEPRECATED: Use 'ipfs add --nocopy --cid-version=1 URL'.
 
 Add URLs to ipfs without storing the data locally.
 
@@ -48,6 +48,8 @@ settings for 'ipfs add'.
 	Type: &BlockStat{},
 
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		log.Error("The 'ipfs urlstore' command is deprecated, please use 'ipfs add --nocopy --cid-version=1")
+
 		urlString := req.Arguments[0]
 		if !filestore.IsURL(req.Arguments[0]) {
 			return fmt.Errorf("unsupported url syntax: %s", urlString)

--- a/core/commands/urlstore.go
+++ b/core/commands/urlstore.go
@@ -27,6 +27,8 @@ var urlAdd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Add URL via urlstore.",
 		LongDescription: `
+DEPRECATED: Use 'ipfs add --nocopy URL'.
+
 Add URLs to ipfs without storing the data locally.
 
 The URL provided must be stable and ideally on a web server under your
@@ -34,10 +36,6 @@ control.
 
 The file is added using raw-leaves but otherwise using the default
 settings for 'ipfs add'.
-
-This command is considered temporary until a better solution can be
-found.  It may disappear or the semantics can change at any
-time.
 `,
 	},
 	Options: []cmdkit.Option{

--- a/core/commands/urlstore.go
+++ b/core/commands/urlstore.go
@@ -3,20 +3,15 @@ package commands
 import (
 	"fmt"
 	"io"
-	"net/http"
+	"net/url"
 
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	filestore "github.com/ipfs/go-ipfs/filestore"
-	pin "github.com/ipfs/go-ipfs/pin"
 
-	cid "github.com/ipfs/go-cid"
-	chunk "github.com/ipfs/go-ipfs-chunker"
 	cmdkit "github.com/ipfs/go-ipfs-cmdkit"
 	cmds "github.com/ipfs/go-ipfs-cmds"
-	balanced "github.com/ipfs/go-unixfs/importer/balanced"
-	ihelper "github.com/ipfs/go-unixfs/importer/helpers"
-	trickle "github.com/ipfs/go-unixfs/importer/trickle"
-	mh "github.com/multiformats/go-multihash"
+	files "github.com/ipfs/go-ipfs-files"
+	"github.com/ipfs/interface-go-ipfs-core/options"
 )
 
 var urlStoreCmd = &cmds.Command{
@@ -55,17 +50,17 @@ time.
 	Type: &BlockStat{},
 
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		url := req.Arguments[0]
-		n, err := cmdenv.GetNode(env)
+		urlString := req.Arguments[0]
+		if !filestore.IsURL(req.Arguments[0]) {
+			return fmt.Errorf("unsupported url syntax: %s", urlString)
+		}
+
+		url, err := url.Parse(urlString)
 		if err != nil {
 			return err
 		}
 
-		if !filestore.IsURL(url) {
-			return fmt.Errorf("unsupported url syntax: %s", url)
-		}
-
-		cfg, err := n.Repo.Config()
+		cfg, err := cmdenv.GetConfig(env)
 		if err != nil {
 			return err
 		}
@@ -74,68 +69,40 @@ time.
 			return filestore.ErrUrlstoreNotEnabled
 		}
 
-		useTrickledag, _ := req.Options[trickleOptionName].(bool)
-		dopin, _ := req.Options[pinOptionName].(bool)
-
 		enc, err := cmdenv.GetCidEncoder(req)
 		if err != nil {
 			return err
 		}
 
-		hreq, err := http.NewRequest("GET", url, nil)
+		api, err := cmdenv.GetApi(env, req)
 		if err != nil {
 			return err
 		}
 
-		hres, err := http.DefaultClient.Do(hreq)
-		if err != nil {
-			return err
-		}
-		if hres.StatusCode != http.StatusOK {
-			return fmt.Errorf("expected code 200, got: %d", hres.StatusCode)
+		useTrickledag, _ := req.Options[trickleOptionName].(bool)
+		dopin, _ := req.Options[pinOptionName].(bool)
+
+		opts := []options.UnixfsAddOption{
+			options.Unixfs.Pin(dopin),
+			options.Unixfs.CidVersion(1),
+			options.Unixfs.RawLeaves(true),
+			options.Unixfs.Nocopy(true),
 		}
 
-		if dopin {
-			// Take the pinlock
-			defer n.Blockstore.PinLock().Unlock()
-		}
-
-		chk := chunk.NewSizeSplitter(hres.Body, chunk.DefaultBlockSize)
-		prefix := cid.NewPrefixV1(cid.DagProtobuf, mh.SHA2_256)
-		dbp := &ihelper.DagBuilderParams{
-			Dagserv:    n.DAG,
-			RawLeaves:  true,
-			Maxlinks:   ihelper.DefaultLinksPerBlock,
-			NoCopy:     true,
-			CidBuilder: &prefix,
-			URL:        url,
-		}
-
-		layout := balanced.Layout
 		if useTrickledag {
-			layout = trickle.Layout
+			opts = append(opts, options.Unixfs.Layout(options.TrickleLayout))
 		}
 
-		db, err := dbp.New(chk)
+		file := files.NewWebFile(url)
+
+		path, err := api.Unixfs().Add(req.Context, file, opts...)
 		if err != nil {
 			return err
 		}
-		root, err := layout(db)
-		if err != nil {
-			return err
-		}
-
-		c := root.Cid()
-		if dopin {
-			n.Pinning.PinWithMode(c, pin.Recursive)
-			if err := n.Pinning.Flush(); err != nil {
-				return err
-			}
-		}
-
+		size, _ := file.Size()
 		return cmds.EmitOnce(res, &BlockStat{
-			Key:  enc.Encode(c),
-			Size: int(hres.ContentLength),
+			Key:  enc.Encode(path.Cid()),
+			Size: int(size),
 		})
 	},
 	Encoders: cmds.EncoderMap{

--- a/core/commands/urlstore.go
+++ b/core/commands/urlstore.go
@@ -58,15 +58,6 @@ settings for 'ipfs add'.
 			return err
 		}
 
-		cfg, err := cmdenv.GetConfig(env)
-		if err != nil {
-			return err
-		}
-
-		if !cfg.Experimental.UrlstoreEnabled {
-			return filestore.ErrUrlstoreNotEnabled
-		}
-
 		enc, err := cmdenv.GetCidEncoder(req)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is the first step in deprecating this command and works towards fixing #6002.