### PR TITLE
gc: cancel context

### DIFF
--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -84,8 +84,6 @@ func BestEffortRoots(filesRoot *mfs.Root) ([]cid.Cid, error) {
 }
 
 func GarbageCollect(n *core.IpfsNode, ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel() // in case error occurs during operation
 	roots, err := BestEffortRoots(n.FilesRoot)
 	if err != nil {
 		return err

--- a/pin/gc/gc.go
+++ b/pin/gc/gc.go
@@ -39,6 +39,7 @@ type Result struct {
 // The routine then iterates over every block in the blockstore and
 // deletes any block that is not found in the marked set.
 func GC(ctx context.Context, bs bstore.GCBlockstore, dstor dstore.Datastore, pn pin.Pinner, bestEffortRoots []cid.Cid) <-chan Result {
+	ctx, cancel := context.WithCancel(ctx)
 
 	elock := log.EventBegin(ctx, "GC.lockWait")
 	unlocker := bs.GCLock()
@@ -52,6 +53,7 @@ func GC(ctx context.Context, bs bstore.GCBlockstore, dstor dstore.Datastore, pn 
 	output := make(chan Result, 128)
 
 	go func() {
+		defer cancel()
 		defer close(output)
 		defer unlocker.Unlock()
 		defer elock.Done()


### PR DESCRIPTION
We were canceling the context in `GarbageCollect` but some functions call `GC` directly. Move the context cancelation down to where we actually _need_ it.

I'm not sure _where_ we failed to cancel the context but I'm hoping https://github.com/ipfs/go-ipfs-cmds/pull/163 will help with that.