### PR TITLE
GOCC implementation & fix in make & build scripts

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -4,6 +4,7 @@ COVERAGE :=
 DISTCLEAN :=
 TEST :=
 TEST_SHORT :=
+GOCC ?= go
 
 all: help    # all has to be first defined target
 .PHONY: all
@@ -104,7 +105,7 @@ install_unsupported: install
 .PHONY: install_unsupported
 
 uninstall:
-	go clean -i ./cmd/ipfs
+	$(GOCC) clean -i ./cmd/ipfs
 .PHONY: uninstall
 
 help:

--- a/bin/check_go_version
+++ b/bin/check_go_version
@@ -31,12 +31,14 @@ PREFIX=$(expr "$0" : "\(.*\/\)") || PREFIX='./'
 
 # Check that the go binary exist and is in the path
 
-type go >/dev/null 2>&1 || die_upgrade "go is not installed or not in the PATH!"
+GOCC=${GOCC="go"}
+
+type ${GOCC} >/dev/null 2>&1 || die_upgrade "go is not installed or not in the PATH!"
 
 # Check the go binary version
 
-VERS_STR=$(go version 2>&1) || die "'go version' failed with output: $VERS_STR"
+VERS_STR=$(${GOCC} version 2>&1) || die "'go version' failed with output: $VERS_STR"
 
 GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
 
-check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "go"
+check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "${GOCC}"

--- a/bin/dist_get
+++ b/bin/dist_get
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+GOCC=${GOCC=go}
+
 die() {
 	echo "$@" >&2
 	exit 1
@@ -99,7 +101,7 @@ get_go_vars() {
 	if [ ! -z "$GOOS" ] && [ ! -z "$GOARCH" ]; then
 		printf "%s-%s" "$GOOS" "$GOARCH"
 	elif have_binary go; then
-		printf "%s-%s" "$(go env GOOS)" "$(go env GOARCH)"
+		printf "%s-%s" "$($GOCC env GOOS)" "$($GOCC env GOARCH)"
 	else
 		die "no way of determining system GOOS and GOARCH\nPlease manually set GOOS and GOARCH then retry."
 	fi

--- a/bin/maketarball.sh
+++ b/bin/maketarball.sh
@@ -11,11 +11,13 @@ if ! [[ "$OUTPUT" = /* ]]; then
   OUTPUT="$PWD/$OUTPUT"
 fi
 
+GOCC=${GOCC=go}
+
 TMPDIR="$(mktemp -d)"
 cp -r . "$TMPDIR"
 ( cd "$TMPDIR" &&
   echo $PWD &&
-  go mod vendor &&
+  $GOCC mod vendor &&
   (git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || true) > .tarball &&
   chmod -R u=rwX,go=rX "$TMPDIR" # normalize permissions
   tar -czf "$OUTPUT" --exclude="./.git" .

--- a/coverage/Rules.mk
+++ b/coverage/Rules.mk
@@ -1,5 +1,7 @@
 include mk/header.mk
 
+GOCC ?= go
+
 $(d)/coverage_deps: $$(DEPS_GO)
 	rm -rf $(@D)/unitcover && mkdir $(@D)/unitcover
 	rm -rf $(@D)/sharnesscover && mkdir $(@D)/sharnesscover
@@ -11,16 +13,16 @@ endif
 .PHONY: $(d)/coverage_deps
 
 # unit tests coverage
-UTESTS_$(d) := $(shell go list -f '{{if (len .TestGoFiles)}}{{.ImportPath}}{{end}}' $(go-flags-with-tags) ./...)
-UTESTS_$(d) += $(shell go list -f '{{if (len .XTestGoFiles)}}{{.ImportPath}}{{end}}' $(go-flags-with-tags) ./... | grep -v go-ipfs/vendor | grep -v go-ipfs/Godeps)
+UTESTS_$(d) := $(shell $(GOCC) list -f '{{if (len .TestGoFiles)}}{{.ImportPath}}{{end}}' $(go-flags-with-tags) ./...)
+UTESTS_$(d) += $(shell $(GOCC) list -f '{{if (len .XTestGoFiles)}}{{.ImportPath}}{{end}}' $(go-flags-with-tags) ./... | grep -v go-ipfs/vendor | grep -v go-ipfs/Godeps)
 
 UCOVER_$(d) := $(addsuffix .coverprofile,$(addprefix $(d)/unitcover/, $(subst /,_,$(UTESTS_$(d)))))
 
 $(UCOVER_$(d)): $(d)/coverage_deps ALWAYS
 	$(eval TMP_PKG := $(subst _,/,$(basename $(@F))))
-	$(eval TMP_DEPS := $(shell go list -f '{{range .Deps}}{{.}} {{end}}' $(go-flags-with-tags) $(TMP_PKG) | sed 's/ /\n/g' | grep ipfs/go-ipfs) $(TMP_PKG))
+	$(eval TMP_DEPS := $(shell $(GOCC) list -f '{{range .Deps}}{{.}} {{end}}' $(go-flags-with-tags) $(TMP_PKG) | sed 's/ /\n/g' | grep ipfs/go-ipfs) $(TMP_PKG))
 	$(eval TMP_DEPS_LIST := $(call join-with,$(comma),$(TMP_DEPS)))
-	go test $(go-flags-with-tags) $(GOTFLAGS) -v -covermode=atomic -json -coverpkg=$(TMP_DEPS_LIST) -coverprofile=$@ $(TMP_PKG) | tee -a test/unit/gotest.json
+	$(GOCC) test $(go-flags-with-tags) $(GOTFLAGS) -v -covermode=atomic -json -coverpkg=$(TMP_DEPS_LIST) -coverprofile=$@ $(TMP_PKG) | tee -a test/unit/gotest.json
 
 
 $(d)/unit_tests.coverprofile: $(UCOVER_$(d))

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -73,7 +73,7 @@ test_go_megacheck:
 test_go: $(TEST_GO)
 
 check_go_version:
-	@go version
+	@$(GOCC) version
 	bin/check_go_version $(GO_MIN_VERSION)
 .PHONY: check_go_version
 DEPS_GO += check_go_version

--- a/mk/tarball.mk
+++ b/mk/tarball.mk
@@ -8,6 +8,7 @@ tarball-is:=1
 git-hash:=$(shell cat .tarball)
 endif
 
+GOCC ?= go
 
 go-ipfs-source.tar.gz: distclean
-	bin/maketarball.sh $@
+	GOCC=$(GOCC) bin/maketarball.sh $@


### PR DESCRIPTION
The usage of a native 'go' command has been replaced with a make &
environment variable $GOCC. This enables building with multiple go
versions on a single machine as documented:
  * https://golang.org/doc/install#extra_versions

This enables the usage of:
```bash
$ make install
$ # OR
$ GOCC=go1.12.3 make install
$ # OR
$ GOCC=go1.12.4 make install
```
And the build and test tools now pick up on this change

 On branch go-version-check
 Changes to be committed:
	modified:   Rules.mk
	modified:   bin/check_go_version
	modified:   bin/dist_get
	modified:   bin/maketarball.sh
	modified:   coverage/Rules.mk
	modified:   mk/golang.mk
	modified:   mk/tarball.mk
License: MIT
Signed-off-by: Chris Buesser <christopher.buesser@gmail.com>