### PR TITLE
Go test fix

### DIFF
--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -104,7 +104,7 @@ func setupIpnsTest(t *testing.T, node *core.IpfsNode) (*core.IpfsNode, *mountWra
 
 	var err error
 	if node == nil {
-		node, err = core.NewNode(context.Background(), nil)
+		node, err = core.NewNode(context.Background(), &core.BuildCfg{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -64,9 +64,12 @@ func TestExternalUnmount(t *testing.T) {
 	mkdir(t, ipnsDir)
 
 	err = Mount(node, ipfsDir, ipnsDir)
-	if strings.Contains(err.Error(), "unable to check fuse version") || err == fuse.ErrOSXFUSENotFound {
-		t.Skip(err)
+	if err != nil {
+		if strings.Contains(err.Error(), "unable to check fuse version") || err == fuse.ErrOSXFUSENotFound {
+			t.Skip(err)
+		}
 	}
+
 	if err != nil {
 		t.Fatalf("error mounting: %v", err)
 	}

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -42,7 +42,7 @@ func TestExternalUnmount(t *testing.T) {
 	// TODO: needed?
 	maybeSkipFuseTests(t)
 
-	node, err := core.NewNode(context.Background(), nil)
+	node, err := core.NewNode(context.Background(), &core.BuildCfg{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Problem
go test ./... was panicking.

### Issue
1. core.NewNode was called with a nil pointer to a core.BuildCfg object -- Fixed in: 9380660
1. Error() was called on nil error object -- Fixed in: 5ce2deb

### Result
go test ./... passes all tests.