### PR TITLE
License update to dual MIT and Apache 2

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,1 @@
+This library is dual-licensed under Apache 2.0 and MIT terms.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,5 @@
-This library is dual-licensed under Apache 2.0 and MIT terms.
+This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license. 
+Unless otherwise noted, all code contributed prior to 2019-05-06 and not contributed by 
+a user listed in [this signoff issue](https://github.com/ipfs/go-ipfs/issues/6302) is 
+licensed under MIT-only. All new contributions (and past contributions since 2019-05-06) 
+are licensed under a dual MIT/Apache-2.0 license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,0 @@
-This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license. 
-Unless otherwise noted, all code contributed prior to 2019-05-06 and not contributed by 
-a user listed in [this signoff issue](https://github.com/ipfs/go-ipfs/issues/6302) is 
-licensed under MIT-only. All new contributions (and past contributions since 2019-05-06) 
-are licensed under a dual MIT/Apache-2.0 license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+This project is transitioning from an MIT-only license to a dual MIT/Apache-2.0 license. 
+Unless otherwise noted, all code contributed prior to 2019-05-06 and not contributed by 
+a user listed in [this signoff issue](https://github.com/ipfs/go-ipfs/issues/6302) is 
+licensed under MIT-only. All new contributions (and past contributions since 2019-05-06) 
+are licensed under a dual MIT/Apache-2.0 license.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,5 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2016 Juan Batiz-Benet
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
This series of commits aims to update go-ipfs to follow a dual-licensing best practice based on research into open-source licensing by @ianjdarrow. He recommends a dual MIT and Apache 2.0 license -

> This has two major benefits:

> - There are concerns in the open source community about whether the MIT license leaves users vulnerable to patent infringement claims. We think the pure legal risk is small, but the way the open source community interacts with our project is really important. It makes sense to pick the license that makes the largest number of people comfortable.
- There's now no reason to adopt a separate DCO, since the Apache-2 license grant addresses the same issue.

> Why use a dual license, instead of just Apache-2? The Apache-2 license is incompatible with the GPLv2 license, which includes things like the Linux kernel. With a dual license, GPLv2 projects can just use the MIT license instead. Our goal is to make our software available to as many projects as possible, so we'd rather adopt a licensing scheme that doesn't exclude anyone.

In addition to these commits, we also need to get an explicit OK from current and past contributors to give their consent to relicensing - which will happen in an issue thread.