### PR TITLE
docs: fix Routing section

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -63,6 +63,7 @@ Available profiles:
 - [`Bootstrap`](#bootstrap)
 - [`Datastore`](#datastore)
 - [`Discovery`](#discovery)
+- [`Routing`](#routing)
 - [`Gateway`](#gateway)
 - [`Identity`](#identity)
 - [`Ipns`](#ipns)
@@ -214,12 +215,27 @@ Default: `true`
   -  `Interval`
 A number of seconds to wait between discovery checks.
 
-- `Routing`
+
+## `Routing`
+Contains options for content routing mechanisms.
+
+- `Type`
 Content routing mode. Can be overridden with daemon `--routing` flag.
 Valid modes are:
   - `dht` (default)
   - `dhtclient`
   - `none`
+  
+**Example:**
+
+```json
+{
+  "Routing": {
+    "Type": "dhtclient"
+  }
+}
+```  
+  
 
 ## `Gateway`
 Options for the HTTP gateway.


### PR DESCRIPTION
This PR fixes `docs/config.md` to reflect that `Routing` is not a child of `Discovery`.

`Discovery` section was confusing users as they tried to do 

```
ipfs config Discovery.Routing dhtclient
```

instead of 

```
ipfs config Routing.Type dhtclient
```

Ref. https://github.com/ipfs/go-ipfs-config/blob/664ccd976e969e78364720ec5f1d1544bc99305f/routing.go#L6

cc @Stebalien to speed up review, as it is a bug in docs only