### PR TITLE
Feat/config envs docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN chmod 4755 /usr/local/bin/fusermount
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
 COPY --from=0 /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 
+RUN wget -q -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && chmod +x /usr/local/bin/jq
+
 # Swarm TCP; should be exposed to the public
 EXPOSE 4001
 # Daemon API; must not be exposed publicly but to client services under you control

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,5 +1,38 @@
 #!/bin/sh
 set -e
+
+envToConfig() {
+  ipfsPrefix="IPFS_CONFIG"
+  configFile="$IPFS_PATH/config"
+  configFileTmp="$(mktemp)"
+
+  env |
+    while IFS='=' read -r name value
+    do
+      case "$name" in
+        "$ipfsPrefix"*)
+          parsedName=${name#$ipfsPrefix*}
+          jsonName=${parsedName//_/.}
+          case "$value" in
+            [*)
+               # encode as json array
+               arr=$(echo "$value" |tr -d '[]' | tr ', ' '\n')
+               jsonValue=$(jq -nr --arg value "$arr" '$value|split("\n")')
+               ;;
+             *)
+               # ensure value is json-quoted if needed
+               jsonValue=$(jq -nr --argjson value "${value}" '$value|tojson'  2>/dev/null || jq -nr --arg value "${value}" '$value|tojson' 2>/dev/null)
+               ;;
+          esac
+
+          jqStr="$(printf '%s = %s' "$jsonName" "$jsonValue")"
+          jq --arg jqStr "$jqStr" ".| $jqStr" < "$configFile" > "$configFileTmp" && mv "$configFileTmp" "$configFile"
+          ;;
+      esac
+    done
+}
+
+
 user=ipfs
 repo="$IPFS_PATH"
 
@@ -22,6 +55,7 @@ else
     *) INIT_ARGS="--profile=$IPFS_PROFILE" ;;
   esac
   ipfs init $INIT_ARGS
+  envToConfig
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 fi


### PR DESCRIPTION
Implements https://github.com/ipfs/go-ipfs/issues/251

Allows passing ENVs to the Docker container to update go-ipfs configuration in `/data/ipfs/config`:
The ENVs should being with `IPFS_CONFIG_` and are case sensitive. Nested properties are expressed via the `_` separator:
 ```
"Swarm": {
    "AddrFilters": null,
    "ConnMgr": {
      "LowWater": 200,`
    }
  }
```
can be set via `IPFS_CONFIG_Swarm_ConnMgr_LowWater=200`


Multiple ENVs:
```
docker run -it \
-e IPFS_CONFIG_Swarm_ConnMgr_LowWater=200 \
-e IPFS_CONFIG_Swarm_ConnMgr_GracePeriod=49s \
-e IPFS_CONFIG_Gateway_Writable=false \
-e IPFS_CONFIG_Swarm_ConnMgr_Type=basic \
-e IPFS_CONFIG_Bootstrap="["/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN","/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u]"" \
go-ipfs:latest
```