### PR TITLE
block cmd: allow adding multiple blocks at once

### DIFF
--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	files "github.com/ipfs/go-ipfs-files"
+
 	util "github.com/ipfs/go-ipfs/blocks/blockstoreutil"
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
@@ -129,7 +131,7 @@ than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.FileArg("data", true, false, "The data to be stored as an IPFS block.").EnableStdin(),
+		cmds.FileArg("data", true, true, "The data to be stored as an IPFS block.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.StringOption(blockFormatOptionName, "f", "cid format for blocks to be created with."),
@@ -139,11 +141,6 @@ than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
-		if err != nil {
-			return err
-		}
-
-		file, err := cmdenv.GetFileArg(req.Files.Entries())
 		if err != nil {
 			return err
 		}
@@ -170,18 +167,31 @@ than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
 
 		pin, _ := req.Options[pinOptionName].(bool)
 
-		p, err := api.Block().Put(req.Context, file,
-			options.Block.Hash(mhtval, mhlen),
-			options.Block.Format(format),
-			options.Block.Pin(pin))
-		if err != nil {
-			return err
+		it := req.Files.Entries()
+		for it.Next() {
+			file := files.FileFromEntry(it)
+			if file == nil {
+				return errors.New("expected a file")
+			}
+
+			p, err := api.Block().Put(req.Context, file,
+				options.Block.Hash(mhtval, mhlen),
+				options.Block.Format(format),
+				options.Block.Pin(pin))
+			if err != nil {
+				return err
+			}
+
+			err = res.Emit(&BlockStat{
+				Key:  p.Path().Cid().String(),
+				Size: p.Size(),
+			})
+			if err != nil {
+				return err
+			}
 		}
 
-		return cmds.EmitOnce(res, &BlockStat{
-			Key:  p.Path().Cid().String(),
-			Size: p.Size(),
-		})
+		return it.Err()
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, bs *BlockStat) error {

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -11,6 +11,7 @@ test_description="Test block command"
 test_init_ipfs
 
 HASH="QmRKqGMAM6EZngbpjSqrvYzq5Qd8b1bSWymjSUY9zQSNDk"
+HASHB="QmdnpnsaEj69isdw5sNzp3h3HkaDz7xKq7BmvFFBzNr5e7"
 
 #
 # "block put tests"
@@ -23,6 +24,18 @@ test_expect_success "'ipfs block put' succeeds" '
 
 test_expect_success "'ipfs block put' output looks good" '
   echo "$HASH" >expected_out &&
+  test_cmp expected_out actual_out
+'
+
+test_expect_success "'ipfs block put' with 2 files succeeds" '
+  echo "Hello Mars!" > a &&
+  echo "Hello Venus!" > b &&
+  ipfs block put a b >actual_out
+'
+
+test_expect_success "'ipfs block put' output looks good" '
+  echo "$HASH" >expected_out &&
+  echo "$HASHB" >>expected_out &&
   test_cmp expected_out actual_out
 '
 


### PR DESCRIPTION
This makes `block put` consistent with `dag put` (Addressing https://github.com/ipfs/go-ipfs/issues/4721)

This will be a minor breaking change for js, cc @vmx