### PR TITLE
fix vendoring dependencies when building the source tarball

### DIFF
--- a/bin/maketarball.sh
+++ b/bin/maketarball.sh
@@ -13,14 +13,14 @@ fi
 
 GOCC=${GOCC=go}
 
-TMPDIR="$(mktemp -d)"
-cp -r . "$TMPDIR"
-( cd "$TMPDIR" &&
+TEMP="$(mktemp -d)"
+cp -r . "$TEMP"
+( cd "$TEMP" &&
   echo $PWD &&
   $GOCC mod vendor &&
   (git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || true) > .tarball &&
-  chmod -R u=rwX,go=rX "$TMPDIR" # normalize permissions
+  chmod -R u=rwX,go=rX "$TEMP" # normalize permissions
   tar -czf "$OUTPUT" --exclude="./.git" .
   )
 
-rm -rf "$TMPDIR"
+rm -rf "$TEMP"


### PR DESCRIPTION
TMPDIR is a special variable indicating the _system_ temporary directory root. Unfortunately, go refuses to honor `go.mod` files in this directory to prevent random `/tmp/go.mod` files from messing with modules cloned into `/tmp`.

The fix is simple: rename TMPDIR to TEMP.

Note: this is only an issue when TMPDIR is exported (e.g., you're like me and you put your temporary directory somewhere else).