### PR TITLE
core: Use correct default for connmgr lowWater

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -41,7 +41,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	// parse ConnMgr config
 
 	grace := config.DefaultConnMgrGracePeriod
-	low := config.DefaultConnMgrHighWater
+	low := config.DefaultConnMgrLowWater
 	high := config.DefaultConnMgrHighWater
 
 	connmgr := fx.Options()


### PR DESCRIPTION
Most people weren't affected by this as those values are set in config at init, but for others it would be rather hard to debug.