### PR TITLE
release: go-ipfs 0.4.21-rc2

### DIFF
--- a/version.go
+++ b/version.go
@@ -4,6 +4,6 @@ package ipfs
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.4.21-rc1"
+const CurrentVersionNumber = "0.4.21-rc2"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"


### PR DESCRIPTION
Still no release notes but I want to throw this up on the gateways. It has some important fixes that affect the connection manager.