### PR TITLE
fix shutdown data race and tie the process to the app

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"io"
 
-	"go.uber.org/fx"
-
 	version "github.com/ipfs/go-ipfs"
 	"github.com/ipfs/go-ipfs/core/bootstrap"
 	"github.com/ipfs/go-ipfs/core/node"
@@ -107,8 +105,6 @@ type IpfsNode struct {
 	Process goprocess.Process
 	ctx     context.Context
 
-	app *fx.App
-
 	// Flags
 	IsOnline bool `optional:"true"` // Online is set when networking is enabled.
 	IsDaemon bool `optional:"true"` // Daemon is set when running on a long-running daemon.
@@ -124,7 +120,7 @@ type Mounts struct {
 
 // Close calls Close() on the App object
 func (n *IpfsNode) Close() error {
-	return n.app.Stop(n.ctx)
+	return n.Process.Close()
 }
 
 // Context returns the IpfsNode context

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go4.org v0.0.0-20190313082347-94abd6928b1d // indirect
 	golang.org/x/sys v0.0.0-20190522044717-8097e1b27ff5
+	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gotest.tools/gotestsum v0.3.4
 )


### PR DESCRIPTION
This:

1. Ensures the process/app shutdown each-other.
2. Uses the process to handle context cancellation to deal with any
   thread-safety issues.