### PR TITLE
fix: use http.Error for sending errors

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -102,14 +102,15 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	errmsg := "Method " + r.Method + " not allowed: "
+	var status int
 	if !i.config.Writable {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		status = http.StatusMethodNotAllowed
 		errmsg = errmsg + "read only access"
 	} else {
-		w.WriteHeader(http.StatusBadRequest)
+		status = http.StatusBadRequest
 		errmsg = errmsg + "bad request for " + r.URL.Path
 	}
-	fmt.Fprint(w, errmsg)
+	http.Error(w, errmsg, status)
 }
 
 func (i *gatewayHandler) optionsHandler(w http.ResponseWriter, r *http.Request) {
@@ -600,9 +601,7 @@ func webError(w http.ResponseWriter, message string, err error, defaultCode int)
 }
 
 func webErrorWithCode(w http.ResponseWriter, message string, err error, code int) {
-	w.WriteHeader(code)
-
-	fmt.Fprintf(w, "%s: %s\n", message, err)
+	http.Error(w, fmt.Sprintf("%s: %s", message, err), code)
 	if code >= 500 {
 		log.Warningf("server error: %s: %s", err)
 	}

--- a/core/corehttp/mutex_profile.go
+++ b/core/corehttp/mutex_profile.go
@@ -15,25 +15,23 @@ func MutexFractionOption(path string) ServeOption {
 	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
-				w.WriteHeader(http.StatusMethodNotAllowed)
+				http.Error(w, "only POST allowed", http.StatusMethodNotAllowed)
 				return
 			}
 			if err := r.ParseForm(); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(err.Error()))
+				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 
 			asfr := r.Form.Get("fraction")
 			if len(asfr) == 0 {
-				w.WriteHeader(http.StatusBadRequest)
+				http.Error(w, "parameter 'fraction' must be set", http.StatusBadRequest)
 				return
 			}
 
 			fr, err := strconv.Atoi(asfr)
 			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(err.Error()))
+				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 			log.Infof("Setting MutexProfileFraction to %d", fr)

--- a/core/corehttp/proxy.go
+++ b/core/corehttp/proxy.go
@@ -73,7 +73,5 @@ func parseRequest(request *http.Request) (*proxyRequest, error) {
 }
 
 func handleError(w http.ResponseWriter, msg string, err error, code int) {
-	w.WriteHeader(code)
-	fmt.Fprintf(w, "%s: %s\n", msg, err)
-	log.Warningf("http proxy error: %s: %s", err)
+	http.Error(w, fmt.Sprintf("%s: %s", msg, err), code)
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v0.0.1
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-chunker v0.0.1
-	github.com/ipfs/go-ipfs-cmds v0.0.7
+	github.com/ipfs/go-ipfs-cmds v0.0.8
 	github.com/ipfs/go-ipfs-config v0.0.3
 	github.com/ipfs/go-ipfs-ds-help v0.0.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
 github.com/ipfs/go-ipfs-chunker v0.0.1 h1:cHUUxKFQ99pozdahi+uSC/3Y6HeRpi9oTeUHbE27SEw=
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
-github.com/ipfs/go-ipfs-cmds v0.0.7 h1:0N2NXxYAZn1kHpHrZMHZYRcVGJSxQogDD89oKc0GZMg=
-github.com/ipfs/go-ipfs-cmds v0.0.7/go.mod h1:E5ou2OpwkAtR8LdneNdq4w1vPcrTWvh/6WPhjxGaX/Y=
+github.com/ipfs/go-ipfs-cmds v0.0.8 h1:ZMo0ZeQOr10ZKY4yxYA3lRHUbnF/ZYcV9cpU0IrlGFI=
+github.com/ipfs/go-ipfs-cmds v0.0.8/go.mod h1:TiK4e7/V31tuEb8YWDF8lN3qrnDH+BS7ZqWIeYJlAs8=
 github.com/ipfs/go-ipfs-config v0.0.1 h1:6ED08emzI1imdsAjixFi2pEyZxTVD5ECKtCOxLBx+Uc=
 github.com/ipfs/go-ipfs-config v0.0.1/go.mod h1:KDbHjNyg4e6LLQSQpkgQMBz6Jf4LXiWAcmnkcwmH0DU=
 github.com/ipfs/go-ipfs-config v0.0.3 h1:Ep4tRdP1iVK76BgOprD9B/qtOEdpno+1Xb57BqydgGk=


### PR DESCRIPTION
This sets a few headers that prevent browsers from misinterpreting the error text.