### PR TITLE
core/commands/pin: add verbose pin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,3 +115,5 @@ require (
 )
 
 go 1.12
+
+replace github.com/ipfs/go-merkledag => github.com/reinerRubin/go-merkledag v0.0.4-0.20190605083217-3ff70c5ac497

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.0-20190519111021-9935e8e0588d h1:Z5QMcUKnQw7ouB1wDuyZM6TL/rm+brJcNk6Ai8ut3zM=
 github.com/prometheus/procfs v0.0.0-20190519111021-9935e8e0588d/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/reinerRubin/go-merkledag v0.0.4-0.20190605083217-3ff70c5ac497 h1:yfIpS84RJHaKdr7T+QDMHo6+wdbidIF16naYwWxmnMo=
+github.com/reinerRubin/go-merkledag v0.0.4-0.20190605083217-3ff70c5ac497/go.mod h1:Oc5kIXLHokkE1hWGMBHw+oxehkAaTOqtEb7Zbh6BhLA=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=

--- a/test/sharness/t0085-pins.sh
+++ b/test/sharness/t0085-pins.sh
@@ -160,6 +160,20 @@ test_pin_progress() {
   '
 }
 
+test_pin_verbose_progress() {
+  test_pin_dag_init
+
+  test_expect_success "'ipfs pin add --progress --verbose' file" '
+    ipfs pin add --progress --verbose $HASH 2> test_pin_verbose_progress_err
+  '
+
+  test_expect_success "pin verbose progress reported correctly" '
+    cat test_pin_verbose_progress_err
+    grep -q "Pinning $HASH" test_pin_verbose_progress_err
+  '
+}
+
+
 test_init_ipfs
 
 test_pins
@@ -187,6 +201,9 @@ test_pin_dag
 test_pin_dag --raw-leaves
 
 test_pin_progress
+
+test_pin_dag
+test_pin_verbose_progress
 
 test_kill_ipfs_daemon
 


### PR DESCRIPTION
Hello,
I have tried to add a verbose argument to the pinning command. It add output like this:
```
Pinning QmQZ1WVkddYPpRPm6vPpemhNacjwhupzSMzFEcYMisVpuY                                               
Pinning QmQeYwtLpXuEmvG9vWfRhoeyNgXYw5KExozDTHyp3vBQzc                                              
```
Currently this PR is more like a demo for the PR to go-merkledag [1].  

@michaelavila 

1 - https://github.com/ipfs/go-merkledag/pull/38
https://github.com/ipfs/go-ipfs/issues/6042