### PR TITLE
build: strip GOPATH from build paths

### DIFF
--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -10,6 +10,9 @@ unexport GOFLAGS
 GOFLAGS ?=
 GOTFLAGS ?=
 
+# Try to make building as reproducible as possible by stripping the go path.
+GOFLAGS += -asmflags=all=-trimpath="$(GOPATH)" -gcflags=all=-trimpath="$(GOPATH)"
+
 ifeq ($(tarball-is),1)
 	GOFLAGS += -mod=vendor
 endif


### PR DESCRIPTION
This should help fix some of our problems using plugins with go-ipfs.