### PR TITLE
libp2p: moves discovery after host listen

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -94,11 +94,11 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		BaseLibP2P,
 
 		fx.Provide(libp2p.AddrFilters(cfg.Swarm.AddrFilters)),
-		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled, cfg.Discovery.MDNS.Interval)),
 		fx.Provide(libp2p.AddrsFactory(cfg.Addresses.Announce, cfg.Addresses.NoAnnounce)),
 		fx.Provide(libp2p.SmuxTransport(bcfg.getOpt("mplex"))),
 		fx.Provide(libp2p.Relay(cfg.Swarm.DisableRelay, cfg.Swarm.EnableRelayHop)),
 		fx.Invoke(libp2p.StartListening(cfg.Addresses.Swarm)),
+		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled, cfg.Discovery.MDNS.Interval)),
 
 		fx.Provide(libp2p.Security(!bcfg.DisableEncryptedConnections, cfg.Experimental.PreferTLS)),
 


### PR DESCRIPTION
Prevents the MDNS server from starting when the host has zero addresses.

Re: https://github.com/libp2p/go-libp2p/issues/652