### PR TITLE
docs: fix install guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If the issue is a protocol weakness that cannot be immediately exploited or some
 
 ## Install
 
-The canonical download instructions for IPFS are over at: https://docs.ipfs.io/introduction/install/. It is **highly suggested** you follow those instructions if you are not interested in working on IPFS development.
+The canonical download instructions for IPFS are over at: https://docs.ipfs.io/guides/guides/install/. It is **highly suggested** you follow those instructions if you are not interested in working on IPFS development.
 
 ### System Requirements
 


### PR DESCRIPTION
https://docs.ipfs.io/introduction/install/ -> https://docs.ipfs.io/guides/guides/install/

although (a) can we do redirects on docs.ipfs.io for dead links? and (b) what's with /guides/guides/?