### PR TITLE
install.sh: Fix wrong destination path for ipfs binary

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -13,7 +13,7 @@ binpaths="/usr/local/bin /usr/bin"
 is_write_perm_missing=""
 
 for binpath in $binpaths; do
-  if mv "$bin" "$binpath/$bin" ; then
+  if mv "$bin" "$binpath/ipfs" ; then
     echo "Moved $bin to $binpath"
     exit 0
   else


### PR DESCRIPTION
Installation script fails if current directory is not the directory where script is located:

```
$ ./go-ipfs/install.sh 
mv: cannot move './go-ipfs/ipfs' to '/usr/local/bin/./go-ipfs/ipfs': No such file or directory

$ /tmp/go-ipfs/install.sh 
mv: cannot move '/tmp/go-ipfs/ipfs' to '/usr/local/bin//tmp/go-ipfs/ipfs': No such file or directory
```