### PR TITLE
Close started plugins when one of them fails to start.

### DIFF
--- a/plugin/loader/loader.go
+++ b/plugin/loader/loader.go
@@ -115,7 +115,7 @@ func (loader *PluginLoader) Start(iface coreiface.CoreAPI) error {
 		if pl, ok := pl.(plugin.PluginDaemon); ok {
 			err := pl.Start(iface)
 			if err != nil {
-				_ = closePlugins(loader.plugins[i:])
+				_ = closePlugins(loader.plugins[:i])
 				return err
 			}
 		}


### PR DESCRIPTION
See: https://github.com/ipfs/go-ipfs/pull/5955#discussion_r292395838