### PR TITLE
Load plugins on darwin/macOS

### DIFF
--- a/plugin/loader/load_unix.go
+++ b/plugin/loader/load_unix.go
@@ -1,4 +1,5 @@
 // +build !noplugin
+// +build linux,cgo darwin,cgo
 
 package loader
 


### PR DESCRIPTION
Previously plugins were only loaded on linux. Darwin also supports plugins. The build constraint matches that of the standard library `plugin` package ([see](https://github.com/golang/go/blob/f2a4c139c1e0cff35f89e4b5a531d5dedc5ed8e0/src/plugin/plugin_dlopen.go#L5)).

**Note:** The `plugin` package requires cgo. So builds for darwin should be build on darwin to support plugins.