### PR TITLE
Fix: ensure pin rm takes a lock

### DIFF
--- a/core/coreapi/pin.go
+++ b/core/coreapi/pin.go
@@ -67,6 +67,10 @@ func (api *PinAPI) Rm(ctx context.Context, p path.Path, opts ...caopts.PinRmOpti
 		return err
 	}
 
+	// Note: after unpin the pin sets are flushed to the blockstore, so we need
+	// to take a lock to prevent a concurrent garbage collection
+	defer api.blockstore.PinLock().Unlock()
+
 	if err = api.pinning.Unpin(ctx, rp.Cid(), settings.Recursive); err != nil {
 		return err
 	}


### PR DESCRIPTION
See https://github.com/ipfs/go-ipfs/issues/6428