### PR TITLE
Include the git blob id of the dir-index bundle in the ETag

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -54,6 +54,8 @@ include $(dir)/Rules.mk
 dir := filestore/pb
 include $(dir)/Rules.mk
 
+dir := assets
+include $(dir)/Rules.mk
 
 # -------------------- #
 #   universal rules    #

--- a/assets/Rules.mk
+++ b/assets/Rules.mk
@@ -1,0 +1,1 @@
+assets-bindata-blob:=$(shell git hash-object $(dir)/bindata.go)

--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -13,7 +13,7 @@ PATH := $(realpath $(d)):$(PATH)
 # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
 # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
 
-$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs".CurrentCommit=$(git-hash)"
+$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs".CurrentCommit=$(git-hash) -X "github.com/ipfs/go-ipfs/core/corehttp".AssetsBindataBlob=$(assets-bindata-blob)"
 
 $(d)-try-build $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -32,7 +32,7 @@ import (
 	"github.com/multiformats/go-multibase"
 )
 
-// This is set to the git object id of github.com/ipfs/go-ipfs/assets/bindata.go
+// AssetsBindataBlob is set to the git object id of github.com/ipfs/go-ipfs/assets/bindata.go
 // during build time and is critical during directory-view ETag construction
 var AssetsBindataBlob string
 
@@ -182,26 +182,26 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 
 	defer dr.Close()
 
-	var response_etag string
+	var responseEtag string
 
 	// we need to figure out whether this is a directory before doing most of the heavy lifting below
 	_, ok := dr.(files.Directory)
 
 	if ok && AssetsBindataBlob != "" {
-		response_etag = "\"DirIndex-" + AssetsBindataBlob + "_CID-" + resolvedPath.Cid().String() + "\""
+		responseEtag = "\"DirIndex-" + AssetsBindataBlob + "_CID-" + resolvedPath.Cid().String() + "\""
 	} else {
-		response_etag = "\"" + resolvedPath.Cid().String() + "\""
+		responseEtag = "\"" + resolvedPath.Cid().String() + "\""
 	}
 
 	// Check etag sent back to us
-	if r.Header.Get("If-None-Match") == response_etag || r.Header.Get("If-None-Match") == "W/"+response_etag {
+	if r.Header.Get("If-None-Match") == responseEtag || r.Header.Get("If-None-Match") == "W/"+responseEtag {
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
 
 	i.addUserHeaders(w) // ok, _now_ write user's headers.
 	w.Header().Set("X-IPFS-Path", urlPath)
-	w.Header().Set("Etag", response_etag)
+	w.Header().Set("Etag", responseEtag)
 
 	// Suborigin header, sandboxes apps from each other in the browser (even
 	// though they are served from the same gateway domain).


### PR DESCRIPTION
While the content of raw files retrieved via the gateway should never
change, the look and feel of the directory index can and will change
between versions of go-ipfs.

Incorporate the hash of assets/bindata.go into the ETag when appropriate

License: MIT
Signed-off-by: Mib Kd743naq <mib.kd743naq@gmail.com>