### PR TITLE
feat: add ability to use existing config during init

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -212,12 +212,12 @@ test_set_address_vars() {
 
 test_launch_ipfs_daemon() {
 
-  args="$@"
+  args=("$@")
 
   test "$TEST_ULIMIT_PRESET" != 1 && ulimit -n 2048
 
   test_expect_success "'ipfs daemon' succeeds" '
-    ipfs daemon $args >actual_daemon 2>daemon_err &
+    ipfs daemon "${args[@]}" >actual_daemon 2>daemon_err &
     IPFS_PID=$!
   '
 

--- a/test/sharness/t0020-init.sh
+++ b/test/sharness/t0020-init.sh
@@ -163,6 +163,20 @@ test_expect_success "'ipfs config Addresses.API' looks good" '
   test $(cat actual_config) = "/ip4/127.0.0.1/tcp/0"
 '
 
+test_expect_success "ipfs init from existing config succeeds" '
+  export ORIG_PATH=$IPFS_PATH
+  export IPFS_PATH=$(pwd)/.ipfs-clone
+
+  ipfs init "$ORIG_PATH/config" &&
+  ipfs config Addresses.API > actual_config &&
+  test $(cat actual_config) = "/ip4/127.0.0.1/tcp/0"
+'
+
+test_expect_success "clean up ipfs clone dir and reset IPFS_PATH" '
+  rm -rf "$IPFS_PATH" &&
+  export IPFS_PATH=$ORIG_PATH
+'
+
 test_expect_success "clean up ipfs dir" '
   rm -rf "$IPFS_PATH"
 '

--- a/test/sharness/t0060-daemon.sh
+++ b/test/sharness/t0060-daemon.sh
@@ -8,6 +8,43 @@ test_description="Test daemon command"
 
 . lib/test-lib.sh
 
+test_expect_success "test environment initialized" '
+  export ORIG_IPFS_PATH="$IPFS_PATH"
+
+  export ORIG_PATH="$(pwd)/.ipfs"
+  export IPFS_PATH="$ORIG_PATH"
+  export CLONE_PATH="$(pwd)/.ipfs-clone"
+  ipfs init --profile=badgerds > /dev/null
+'
+
+export IPFS_PATH=$CLONE_PATH
+test_launch_ipfs_daemon --init --init-config="$ORIG_PATH/config"
+test_kill_ipfs_daemon
+
+test_expect_success "daemon initialization with existing config works" '
+  ipfs config "Datastore.Spec.child.path" >actual &&
+  test $(cat actual) = "badgerds"
+'
+
+test_expect_success "clean up daemon clone" '
+  rm -rf "$CLONE_PATH"
+'
+test_launch_ipfs_daemon --init --init-config="$ORIG_PATH/config" --init-profile=randomports
+test_kill_ipfs_daemon
+
+test_expect_failure "daemon initialization with existing config + profiles works" '
+  ipfs config Addresses >clone_conf &&
+  IPFS_PATH=$ORIG_PATH &&
+  ipfs config Addresses >orig_conf &&
+  test_cmp clone_conf orig_conf
+'
+
+test_expect_success "clean up test environment" '
+  rm -rf "$CLONE_PATH"
+  rm -rf "$ORIG_PATH"
+
+  export IPFS_PATH=$ORIG_IPFS_PATH
+'
 
 test_init_ipfs
 test_launch_ipfs_daemon


### PR DESCRIPTION
Related to:
https://github.com/ipfs/go-ipfs/issues/6262

This patch adds
`ipfs daemon --init --init-config-file=${PATH}`
and
`ipfs init --config-file=${PATH}`
allowing users to specify existing configuration files instead of (re)generating them.

Does not deal with merging of existing configs and/or profiles (yet?).