### PR TITLE
Docker initscript: allow changing API and Gateway config addresses

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,31 +1,31 @@
 #!/bin/sh
 set -e
 user=ipfs
-repo="$IPFS_PATH"
+repo="${IPFS_PATH}"
 : ${addr_api:=/ip4/0.0.0.0/tcp/5001}
 : ${addr_gw:=/ip4/0.0.0.0/tcp/8080}
 
 if [ `id -u` -eq 0 ]; then
-  echo "Changing user to $user"
+  echo "Changing user to ${user}"
   # ensure folder is writable
-  su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
+  su-exec "${user}" test -w "${repo}" || chown -R -- "${user}" "${repo}"
   # restart script with new privileges
-  exec su-exec "$user" "$0" "$@"
+  exec su-exec "${user}" "${0}" "${@}"
 fi
 
 # 2nd invocation with regular user
 ipfs version
 
-if [ -e "$repo/config" ]; then
-  echo "Found IPFS fs-repo at $repo"
+if [ -e "${repo}/config" ]; then
+  echo "Found IPFS fs-repo at ${repo}"
 else
-  case "$IPFS_PROFILE" in
+  case "${IPFS_PROFILE}" in
     "") INIT_ARGS="" ;;
-    *) INIT_ARGS="--profile=$IPFS_PROFILE" ;;
+    *) INIT_ARGS="--profile=${IPFS_PROFILE}" ;;
   esac
-  ipfs init $INIT_ARGS
-  ipfs config Addresses.API $addr_api
-  ipfs config Addresses.Gateway $addr_gw
+  ipfs init ${INIT_ARGS}
+  ipfs config Addresses.API ${addr_api}
+  ipfs config Addresses.Gateway ${addr_gw}
 fi
 
 exec ipfs "$@"

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -2,6 +2,8 @@
 set -e
 user=ipfs
 repo="$IPFS_PATH"
+: ${addr_api:=/ip4/0.0.0.0/tcp/5001}
+: ${addr_gw:=/ip4/0.0.0.0/tcp/8080}
 
 if [ `id -u` -eq 0 ]; then
   echo "Changing user to $user"
@@ -22,8 +24,8 @@ else
     *) INIT_ARGS="--profile=$IPFS_PROFILE" ;;
   esac
   ipfs init $INIT_ARGS
-  ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
-  ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+  ipfs config Addresses.API $addr_api
+  ipfs config Addresses.Gateway $addr_gw
 fi
 
 exec ipfs "$@"


### PR DESCRIPTION
Allows easier tinkering with networking configuration, but using previous values as defaults to not break anything.
Minor syntax best practices for safety.
Also, would be worth considering changing `set -e` by `set -euo pipefail` as a best practice. `u` being break on unset vars, and `-o pipefail` to do not hide piped command failures (aka fail loud).