### PR TITLE
Fix automatic labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,8 +1,7 @@
 ---
 name: 'Bug Report'
 about: 'Report a bug in go-ipfs.'
-labels:
-  - bug
+labels: bug
 ---
 
 #### Version information:

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,8 +1,7 @@
 ---
 name: 'Documentation Issue'
 about: 'Report missing/erroneous documentation, propose new documentation, report broken links, etc.'
-labels:
-  - documentation
+labels: documentation
 ---
 
 #### Location

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,8 +1,7 @@
 ---
 name: 'Enhancement'
 about: 'Suggest an improvement to an existing go-ipfs feature.'
-labels:
-  - enhancement
+labels: enhancement
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,8 +1,7 @@
 ---
 name: 'Feature'
 about: 'Suggest a new feature in go-ipfs.'
-labels:
-  - feature
+labels: feature
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,7 @@
 ---
 name: 'Question/Support'
 about: 'Ask a question about go-ipfs or request support.'
-labels:
-  - question
-  - invalid
+labels: question, invalid
 ---
 
 This bug tracker is only for actionable bug reports and feature requests. Please direct any questions to https://discuss.ipfs.io or to our Matrix (#ipfs:matrix.org) or IRC (#ipfs on freenode) channels.


### PR DESCRIPTION
Label list should be a comma separated string instead of a yaml array.

Noticed when opening https://github.com/ipfs/go-ipfs/issues/6502 via the enhancement template didn't automatically add the label.