### PR TITLE
Adds Siderus in early testers

### DIFF
--- a/docs/EARLY_TESTERS.md
+++ b/docs/EARLY_TESTERS.md
@@ -27,6 +27,7 @@ We will ask early testers to participate at two points in the process:
 - [ ] Pinata (@obo20)
 - [ ] RTrade (@postables)
 - [ ] QRI (@b5)
+- [ ] Siderus (@koalalorenzo)
 
 ## How to sign up?
 


### PR DESCRIPTION
Adds Siderus as Early tester to help with [Siderus Orion](https://orion.siderus.io/) as well as on the gateway