### PR TITLE
feat: add --long as alias for -l in files.ls

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -379,7 +379,7 @@ type filesLsOutput struct {
 }
 
 const (
-	longOptionName     = "l"
+	longOptionName     = "long"
 	dontSortOptionName = "U"
 )
 
@@ -408,7 +408,7 @@ Examples:
 		cmds.StringArg("path", false, false, "Path to show listing for. Defaults to '/'."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption(longOptionName, "Use long listing format."),
+		cmds.BoolOption(longOptionName, "l", "Use long listing format."),
 		cmds.BoolOption(dontSortOptionName, "Do not sort; list entries in directory order."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -202,6 +202,12 @@ test_files_api() {
     test_cmp ls_l_expected ls_l_actual
   '
 
+  test_expect_success "file has correct hash and size listed with --long" '
+    echo "file1	$FILE1	4" > ls_l_expected &&
+    ipfs files ls --long /cats/file1 > ls_l_actual &&
+    test_cmp ls_l_expected ls_l_actual
+  '
+
   test_expect_success "file has correct hash and size listed with -l --cid-base=base32" '
     echo "file1	`cid-fmt -v 1 -b base32 %s $FILE1`	4" > ls_l_expected &&
     ipfs files ls --cid-base=base32 -l /cats/file1 > ls_l_actual &&
@@ -436,7 +442,7 @@ test_files_api() {
   test_expect_success "file hash correct $EXTRA" '
     echo $FILE_HASH > filehash_expected &&
     ipfs files stat --hash /cats/ipfs > filehash &&
-    test_cmp filehash_expected filehash 
+    test_cmp filehash_expected filehash
   '
 
   test_expect_success "cant write to negative offset $EXTRA" '


### PR DESCRIPTION
Allow passing --long or ?long=true as a more descriptive option name than "l".

refs https://github.com/ipfs/go-ipfs/issues/5026#issuecomment-392477565
refs https://github.com/ipfs/interface-js-ipfs-core/pull/426
refs https://github.com/ipfs/js-ipfs-http-client/issues/1049