### PR TITLE
feat: allow /ipns/webui.ipfs.io on api port

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -23,6 +23,7 @@ var WebUIPaths = []string{
 	"/ipfs/QmRyWyKWmphamkMRnJVjUTzSFSAAZowYP4rnbgnfMXC9Mr",
 	"/ipfs/QmU3o9bvfenhTKhxUakbYrLDnZU7HezAVxPM6Ehjw9Xjqy",
 	"/ipfs/QmPhnvn747LqwPYMJmQVorMaGbMSgA7mRRoyyZYz3DoZRQ",
+	"/ipns/webui.ipfs.io",
 }
 
 var WebUIOption = RedirectOption("webui", WebUIPath)


### PR DESCRIPTION
We want to allow user to try out the latest versions of the webui before they are officially released with go-ipfs. 

With this change in place, a user will be able to visit http://localhost:5001/ipns/webui.ipfs.io
and have it fetch the latest version of the webui. go-ipfs can and should continue to ship with a hardcoded CID for a stable release of webui that it has been tested with, but including the ipns address in the list allows us to test out newer versions.

Right now ipfs-companion includes a workaround to strip the origin header from blessed, new versions of webui, to allow this, but it causes other issues, so we'd like to replace that hack, with this feature.

see: https://github.com/ipfs-shipyard/ipfs-companion/issues/736