### PR TITLE
mk: handle stripping paths when GOPATH contains whitespace

### DIFF
--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -11,7 +11,7 @@ GOFLAGS ?=
 GOTFLAGS ?=
 
 # Try to make building as reproducible as possible by stripping the go path.
-GOFLAGS += -asmflags=all=-trimpath="$(GOPATH)" -gcflags=all=-trimpath="$(GOPATH)"
+GOFLAGS += "-asmflags=all='-trimpath=$(GOPATH)'" "-gcflags=all='-trimpath=$(GOPATH)'"
 
 ifeq ($(tarball-is),1)
 	GOFLAGS += -mod=vendor


### PR DESCRIPTION
Arguments where not being properly passed to `go` when `$GOPATH` contained whitespace.
Introduced in https://github.com/ipfs/go-ipfs/pull/6412
See also:
https://github.com/golang/go/issues/33223