### PR TITLE
feat(docker): /container-init.d for advanced initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,10 @@ RUN mkdir -p $IPFS_PATH \
 RUN mkdir /ipfs /ipns \
   && chown ipfs:users /ipfs /ipns
 
+# Create the init scripts directory
+RUN mkdir /container-init.d \
+  && chown ipfs:users /container-init.d
+
 # Expose the fs-repo as a volume.
 # start_ipfs initializes an fs-repo if none is mounted.
 # Important this happens after the USER directive so permissions are correct.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ LABEL maintainer="Steven Allen <steven@stebalien.com>"
 ENV SRC_DIR /go-ipfs
 COPY --from=0 $SRC_DIR/cmd/ipfs/ipfs /usr/local/bin/ipfs
 COPY --from=0 $SRC_DIR/bin/container_daemon /usr/local/bin/start_ipfs
+COPY --from=0 $SRC_DIR/bin/container_init_run /usr/local/bin/container_init_run
 COPY --from=0 /tmp/su-exec/su-exec-static /sbin/su-exec
 COPY --from=0 /tmp/tini /sbin/tini
 COPY --from=0 /bin/fusermount /usr/local/bin/fusermount

--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Basic proof of 'ipfs working' locally:
     # QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o
     ipfs cat <that hash>
 
+To perform a custom initialization and configuration step, one can create or mount a `/container-init.d` directory containing `.sh` scripts. These scripts are executed if they have `+x` permission, otherwise they are just sourced. The scripts may also depend on environment variables set by the `docker run` command or in `docker-compose.yml`. The custom initialization step is **only** performed during IPFS initialization and is executed **after** the swarm key is copied to the IPFS data directory.
+
 ### Troubleshooting
 
 If you have previously installed IPFS before and you are running into problems getting a newer version to work, try deleting (or backing up somewhere else) your IPFS config directory (~/.ipfs by default) and rerunning `ipfs init`. This will reinitialize the config file to its defaults and clear out the local datastore of any bad entries.

--- a/README.md
+++ b/README.md
@@ -366,48 +366,6 @@ Basic proof of 'ipfs working' locally:
     # QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o
     ipfs cat <that hash>
 
-To perform a custom initialization and configuration step, one can mount `.sh` scripts to a `/container-init.d` directory, or mount the entire directory. These scripts are executed if they have `+x` permission, otherwise they are just sourced. Executed scripts can exit with error and abort the initialization process. The scripts may also depend on environment variables set by the `docker run` command or in `docker-compose.yml`. The custom initialization step is **only** performed during IPFS initialization, **after** `ipfs init`, **after** after the swarm key is copied to the IPFS data directory, and **before** the daemon is started. This also enables custom containers to layer extra initialization steps to the base image by adding more scripts to `/container-init.d`.
-
-This example initializes a peer in a private network, without any communication with the default bootstrap nodes because it is performed before the daemon starts:
-
-```bash
-
-# This is the initialization script
-TEST_NAME=00-test.sh
-TEST_SCRIPT=`pwd`/$TEST_NAME
-
-# The script will add this node when creating the container
-PRIV_PEER_IP=127.0.0.1
-PRIV_PEER_ID=QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
-
-# For instructional purposes, create the initialization script here,
-# but this may be part of a suite of scripts maintained by the IT team,
-# or created inside a custom Dockerfile.
-cat >$TEST_SCRIPT <<EOF
-echo Removing boostraps...
-ipfs bootstrap rm all || exit 1
-echo Adding custom boostrap from environment...
-MULTIADDR=/ip4/\$PRIV_PEER_IP/tcp/4001/ipfs/\$PRIV_PEER_ID
-ipfs bootstrap add \$MULTIADDR || exit 1
-exit 0
-EOF
-
-# Set the script as executable
-chmod +x $TEST_SCRIPT
-
-# Initialize the container with the custom scripted mounted.
-# It is also possible to mount the entire /container-init.d
-# rather than a single script, if needed
-docker run -d --name ipfs_host \
-    -e PRIV_PEER_IP=$PRIV_PEER_IP \
-    -e PRIV_PEER_ID=$PRIV_PEER_ID \
-    -v $TEST_SCRIPT:/container-init.d/$TEST_NAME \
-    -p 4001:4001 \
-    -p 127.0.0.1:8080:8080 \
-    -p 127.0.0.1:5001:5001 \
-    ipfs/go-ipfs:latest
-```
-
 ### Troubleshooting
 
 If you have previously installed IPFS before and you are running into problems getting a newer version to work, try deleting (or backing up somewhere else) your IPFS config directory (~/.ipfs by default) and rerunning `ipfs init`. This will reinitialize the config file to its defaults and clear out the local datastore of any bad entries.

--- a/README.md
+++ b/README.md
@@ -370,40 +370,43 @@ To perform a custom initialization and configuration step, one can mount `.sh` s
 
 This example initializes a peer in a private network, without any communication with the default bootstrap nodes because it is performed before the daemon starts:
 
-    # This is the initialization script
-    TEST_NAME=00-test.sh
-    TEST_SCRIPT=`pwd`/$TEST_NAME
+```bash
 
-    # The script will add this node when creating the container
-    MY_PEER_IP=127.0.0.1
-    MY_PEER_HASH=QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+# This is the initialization script
+TEST_NAME=00-test.sh
+TEST_SCRIPT=`pwd`/$TEST_NAME
 
-    # For instructional purposes, create the initialization script here,
-    # but this may be part of a suite of scripts maintained by the IT team,
-    # or created inside a custom Dockerfile.
-    cat >$TEST_SCRIPT <<EOF
-    echo Removing boostraps...
-    ipfs bootstrap rm all || exit 1
-    echo Adding custom boostrap from environment...
-    MULTIADDR=/ip4/\$MY_PEER_IP/tcp/4001/ipfs/\$MY_PEER_HASH
-    ipfs bootstrap add \$MULTIADDR || exit 1
-    exit 0
-    EOF
+# The script will add this node when creating the container
+PRIV_PEER_IP=127.0.0.1
+PRIV_PEER_ID=QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
 
-    # Set the script as executable
-    chmod +x $TEST_SCRIPT
+# For instructional purposes, create the initialization script here,
+# but this may be part of a suite of scripts maintained by the IT team,
+# or created inside a custom Dockerfile.
+cat >$TEST_SCRIPT <<EOF
+echo Removing boostraps...
+ipfs bootstrap rm all || exit 1
+echo Adding custom boostrap from environment...
+MULTIADDR=/ip4/\$PRIV_PEER_IP/tcp/4001/ipfs/\$PRIV_PEER_ID
+ipfs bootstrap add \$MULTIADDR || exit 1
+exit 0
+EOF
 
-    # Initialize the container with the custom scripted mounted.
-    # It is also possible to mount the entire /container-init.d
-    # rather than a single
-    docker run -d --name ipfs_host \
-        -e MY_PEER_IP=$MY_PEER_IP \
-        -e MY_PEER_HASH=$MY_PEER_HASH \
-        -v $TEST_SCRIPT:/container-init.d/$TEST_NAME \
-        -p 4001:4001 \
-        -p 127.0.0.1:8080:8080 \
-        -p 127.0.0.1:5001:5001 \
-        ipfs/go-ipfs:latest
+# Set the script as executable
+chmod +x $TEST_SCRIPT
+
+# Initialize the container with the custom scripted mounted.
+# It is also possible to mount the entire /container-init.d
+# rather than a single script, if needed
+docker run -d --name ipfs_host \
+    -e PRIV_PEER_IP=$PRIV_PEER_IP \
+    -e PRIV_PEER_ID=$PRIV_PEER_ID \
+    -v $TEST_SCRIPT:/container-init.d/$TEST_NAME \
+    -p 4001:4001 \
+    -p 127.0.0.1:8080:8080 \
+    -p 127.0.0.1:5001:5001 \
+    ipfs/go-ipfs:latest
+```
 
 ### Troubleshooting
 

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -63,7 +63,7 @@ else
       # source the others
       if [ -x "$script" ] ; then
         echo "-Executing '$script'..."
-        $script
+        $script || exit 1
       else
         echo "-Sourcing '$script'..."
         source $script

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -58,7 +58,7 @@ else
   if [ -d "$IPFS_INIT_SCRIPTS_DIR" ] ; then
     echo "Configuring IPFS using init scripts..."
     # Check for any *.sh scripts
-    for script in "$IPFS_INIT_SCRIPTS_DIR/"*.sh ; do
+    for script in $(find $IPFS_INIT_SCRIPTS_DIR -type f \( -iname \*.sh \)) ; do
       # Execute the scripts with +x permission and
       # source the others
       if [ -x "$script" ] ; then

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -51,6 +51,26 @@ else
   # Unset the swarm key file variable
   unset IPFS_SWARM_KEY_FILE
 
+  # Initialization directory
+  IPFS_INIT_SCRIPTS_DIR="/container-init.d"
+
+  # Check if initialization directory exists
+  if [ -d "$IPFS_INIT_SCRIPTS_DIR" ] ; then
+    echo "Configuring IPFS using init scripts..."
+    # Check for any *.sh scripts
+    for script in "$IPFS_INIT_SCRIPTS_DIR/"*.sh ; do
+      # Execute the scripts with +x permission and
+      # source the others
+      if [ -x "$script" ] ; then
+        echo "-Executing '$script'..."
+        $script
+      else
+        echo "-Sourcing '$script'..."
+        source $script
+      fi
+    done
+  fi
+
 fi
 
 exec ipfs "$@"

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,9 +1,10 @@
 #!/bin/sh
 set -e
+
 user=ipfs
 repo="$IPFS_PATH"
 
-if [ `id -u` -eq 0 ]; then
+if [ "$(id -u)" -eq 0 ]; then
   echo "Changing user to $user"
   # ensure folder is writable
   su-exec "$user" test -w "$repo" || chown -R -- "$user" "$repo"
@@ -14,14 +15,11 @@ fi
 # 2nd invocation with regular user
 ipfs version
 
+
 if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
-  case "$IPFS_PROFILE" in
-    "") INIT_ARGS="" ;;
-    *) INIT_ARGS="--profile=$IPFS_PROFILE" ;;
-  esac
-  ipfs init $INIT_ARGS
+  ipfs init ${IPFS_PROFILE:+"--profile=$IPFS_PROFILE"}
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 
@@ -31,9 +29,9 @@ else
   SWARM_KEY_PERM=0400
 
   # Create a swarm key from a given environment variable
-  if [ ! -z "$IPFS_SWARM_KEY" ] ; then
+  if [ -n "$IPFS_SWARM_KEY" ] ; then
     echo "Copying swarm key from variable..."
-    echo -e "$IPFS_SWARM_KEY" >"$SWARM_KEY_FILE" || exit 1
+    printf "%s\n" "$IPFS_SWARM_KEY" >"$SWARM_KEY_FILE" || exit 1
     chmod $SWARM_KEY_PERM "$SWARM_KEY_FILE"
   fi
 
@@ -43,34 +41,15 @@ else
   # Check during initialization if a swarm key was provided and
   # copy it to the ipfs directory with the right permissions
   # WARNING: This will replace the swarm key if it exists
-  if [ ! -z "$IPFS_SWARM_KEY_FILE" ] ; then
+  if [ -n "$IPFS_SWARM_KEY_FILE" ] ; then
     echo "Copying swarm key from file..."
     install -m $SWARM_KEY_PERM "$IPFS_SWARM_KEY_FILE" "$SWARM_KEY_FILE" || exit 1
   fi
 
   # Unset the swarm key file variable
   unset IPFS_SWARM_KEY_FILE
-
-  # Initialization directory
-  IPFS_INIT_SCRIPTS_DIR="/container-init.d"
-
-  # Check if initialization directory exists
-  if [ -d "$IPFS_INIT_SCRIPTS_DIR" ] ; then
-    echo "Configuring IPFS using init scripts..."
-    # Check for any *.sh scripts
-    for script in $(find $IPFS_INIT_SCRIPTS_DIR -type f \( -iname \*.sh \)) ; do
-      # Execute the scripts with +x permission and
-      # source the others
-      if [ -x "$script" ] ; then
-        echo "-Executing '$script'..."
-        $script || exit 1
-      else
-        echo "-Sourcing '$script'..."
-        source $script
-      fi
-    done
-  fi
-
 fi
+
+find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 
 exec ipfs "$@"

--- a/bin/container_init_run
+++ b/bin/container_init_run
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# used by the container startup script for running initialization scripts
+
+script="$1"
+if [ -x "$script" ] ; then
+    printf "Executing '%s'...\n" "$script"
+    "$script"
+else
+    printf "Sourcing '%s'...\n" "$script"
+    . "$script"
+fi

--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -70,6 +70,16 @@ docker_stop() {
     docker stop "$1"
 }
 
+# This takes a docker ID as argument
+docker_rm() {
+    docker rm -f -v "$1" > /dev/null
+}
+
+# This takes a docker image name as argument
+docker_rmi() {
+    docker rmi -f "$1" > /dev/null
+}
+
 # Test whether all the expected lines are included in a file. The file
 # can have extra lines.
 #

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -99,5 +99,7 @@ test_expect_success "stop docker container" '
   docker_stop "$DOC_ID"
 '
 
+docker_rm "$DOC_ID"
+docker_rmi "$IMAGE_ID"
 test_done
 

--- a/test/sharness/t0300-docker-image.sh
+++ b/test/sharness/t0300-docker-image.sh
@@ -29,7 +29,7 @@ TEST_TESTS_DIR=$(dirname "$TEST_SCRIPTS_DIR")
 APP_ROOT_DIR=$(dirname "$TEST_TESTS_DIR")
 
 test_expect_success "docker image build succeeds" '
-  docker_build "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR" >build-actual ||
+  docker_build "$TEST_TESTS_DIR/../Dockerfile" "$APP_ROOT_DIR" | tee build-actual ||
   test_fsh echo "TEST_TESTS_DIR: $TEST_TESTS_DIR" ||
   test_fsh echo "APP_ROOT_DIR : $APP_ROOT_DIR" ||
   test_fsh cat build-actual
@@ -41,8 +41,18 @@ test_expect_success "docker image build output looks good" '
   test_fsh cat build-actual
 '
 
+test_expect_success "write init scripts" '
+  echo "ipfs config Foo Bar" > 001.sh &&
+  echo "ipfs config Baz Qux" > 002.sh &&
+  chmod +x 002.sh
+'
+
 test_expect_success "docker image runs" '
-  DOC_ID=$(docker run -d -p 127.0.0.1:5001:5001 -p 127.0.0.1:8080:8080 "$IMAGE_ID")
+  DOC_ID=$(docker run -d \
+                  -p 127.0.0.1:5001:5001 -p 127.0.0.1:8080:8080 \
+                  -v "$PWD/001.sh":/container-init.d/001.sh \
+                  -v "$PWD/002.sh":/container-init.d/002.sh \
+                  "$IMAGE_ID")
 '
 
 test_expect_success "docker container gateway is up" '
@@ -51,6 +61,21 @@ test_expect_success "docker container gateway is up" '
 
 test_expect_success "docker container API is up" '
   pollEndpoint -host=/ip4/127.0.0.1/tcp/5001 -http-url http://localhost:5001/version -v -tries 30 -tout 1s
+'
+
+test_expect_success "check that init scripts were run correctly and in the correct order" "
+  echo -e \"Sourcing '/container-init.d/001.sh'...\nExecuting '/container-init.d/002.sh'...\" > expected &&
+  docker logs $DOC_ID 2>/dev/null | grep -e 001.sh -e 002.sh > actual &&
+  test_cmp actual expected
+"
+
+test_expect_success "check that init script configs were applied" '
+  echo Bar > expected &&
+  docker exec "$DOC_ID" ipfs config Foo > actual &&
+  test_cmp actual expected &&
+  echo Qux > expected &&
+  docker exec "$DOC_ID" ipfs config Baz > actual &&
+  test_cmp actual expected
 '
 
 test_expect_success "simple ipfs add/cat can be run in docker container" '

--- a/test/sharness/t0301-docker-migrate.sh
+++ b/test/sharness/t0301-docker-migrate.sh
@@ -77,5 +77,7 @@ test_expect_success "correct version was requested" '
   grep "/fs-repo-6-to-7/v1.1.1/fs-repo-6-to-7_v1.1.1_linux-amd64.tar.gz" dist_serv_out > /dev/null
 '
 
+docker_rm "$DOC_ID"
+docker_rmi "$IMAGE_ID"
 test_done
 


### PR DESCRIPTION
This is a proposal to help solve advanced initialization in container environments being discussed in several issues. It follows the model used by postgres container: https://hub.docker.com/_/postgres

This PR adds support for an optional `/container-init.d` directory in the container that can be mounted with custom configuration scripts. These scripts are executed if they have +x permission, otherwise they are just sourced.

This model also allows passing environment variables to the custom scripts when launching the container.

This grants flexibility to and delegates the responsability of bulding complex initializations to the users and administrators.

-----------

License: MIT
Signed-off-by: Caian Benedicto <caianbene@gmail.com>