### PR TITLE
github: update question template to avoid click throughs

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,10 @@
 ---
 name: 'Question/Support'
-about: 'Ask a question about go-ipfs or request support.'
-labels: question, invalid
+about: 'DO NOT SELECT THIS OPTION: Ask questions on discuss.ipfs.io.'
+labels: question
 ---
+
+DO NOT ASK QUESTIONS HERE
 
 This bug tracker is only for actionable bug reports and feature requests. Please direct any questions to https://discuss.ipfs.io or to our Matrix (#ipfs:matrix.org) or IRC (#ipfs on freenode) channels.
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: 'Question/Support'
-about: 'DO NOT SELECT THIS OPTION: Ask questions on discuss.ipfs.io.'
+about: 'DO NOT SELECT THIS OPTION: Ask questions on discuss.ipfs.io, IRC (#ipfs on freenode), or Matrix (#ipfs:matrix.org)'
 labels: question
 ---
 


### PR DESCRIPTION
People tend not to read templates (I'm also guilty of this) unless something jumps out. Let's make this jump out (this template _exists_ to tell users not to ask questions here).