### PR TITLE
docker: update the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.12-stretch
-MAINTAINER Lars Gierth <lgierth@ipfs.io>
+FROM golang:1.12.9-buster
+MAINTAINER Steven Allen <steven@stebalien.com>
 
 ENV SRC_DIR /go-ipfs
 
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y ca-certificates
 RUN apt-get update && apt-get install -y fuse
 
 # Now comes the actual target image, which aims to be as small as possible.
-FROM busybox:1-glibc
-MAINTAINER Lars Gierth <lgierth@ipfs.io>
+FROM busybox:1.31.0-glibc
+MAINTAINER Steven Allen <stven@stebalien.com>
 
 # Get the ipfs binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go-ipfs


### PR DESCRIPTION
* Explicitly switch to buster.
* Explicitly set the golang version (and use the latest patch release).
* Explicitly set the busybox version.
* Update the maintainer