### PR TITLE
docs: add ship date and next release issue opening time

### DIFF
--- a/docs/RELEASE_ISSUE_TEMPLATE.md
+++ b/docs/RELEASE_ISSUE_TEMPLATE.md
@@ -8,6 +8,10 @@ We're happy to announce go-ipfs X.Y.Z, bla bla...
 
 <List of items with PRs and/or Issues to be considered for this release>
 
+# 🚢 Estimated shipping date
+
+<Date this release will ship on if everything goes to plan (week beginning...)>
+
 ## 🔦 Highlights
 
 < top highlights for this release notes >
@@ -103,4 +107,3 @@ Would you like to contribute to the IPFS project and don't know how? Well, there
 ## ⁉️ Do you have questions?
 
 The best place to ask your questions about IPFS, how it works and what you can do with it is at [discuss.ipfs.io](http://discuss.ipfs.io). We are also available at the `#ipfs` channel on Freenode, which is also [accessible through our Matrix bridge](https://riot.im/app/#/room/#freenode_#ipfs:matrix.org).
-

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -85,7 +85,9 @@ Some patch releases, especially ones fixing one or more complex bugs, may underg
 
 ## Performing a Release
 
-The release is managed by the `Lead Maintainer` for `go-ipfs`. It starts with the opening of an issue containing the content available on the [RELEASE_ISSUE_TEMPLATE](./RELEASE_ISSUE_TEMPLATE.md). This issue will be pinned and labeled with the ["release"](https://github.com/ipfs/go-ipfs/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Arelease) tag. Then, the 5 stages will be followed until the release is done.
+The release is managed by the `Lead Maintainer` for `go-ipfs`. It starts with the opening of an issue containing the content available on the [RELEASE_ISSUE_TEMPLATE](./RELEASE_ISSUE_TEMPLATE.md) not more than **48 hours** after the previous release.
+
+This issue is pinned and labeled ["release"](https://github.com/ipfs/go-ipfs/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Arelease). When the cycle is due to begin the 5 stages will be followed until the release is done.
 
 ## Release Version Numbers (aka semver)
 


### PR DESCRIPTION
Adds estimated shipping date (can be fuzzy) to the release issue template and clarifies the time before which the next release issue should be opened. This communicates expectations for when the new release is due and will help with planning of included features. The community could even suggest inclusions.

@Stebalien you had the idea of adding estimates for each of the stages - do you want me to add them? I think I might leave these out of the js-ipfs release process for now unless requested as I think the actual release date is most important and we do already clarify that it should take around 3 weeks in the releases documentation.