### PR TITLE
docker: libdl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 RUN chmod 4755 /usr/local/bin/fusermount
 
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
-COPY --from=0 /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
+COPY --from=0 /lib/x86_64-linux-gnu/libdl.so.2 /lib/libdl.so.2
 
 # Swarm TCP; should be exposed to the public
 EXPOSE 4001


### PR DESCRIPTION
Docker build is currently broken due to an updated version of libdl.
```
Step 23/34 : COPY --from=0 /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
COPY failed: stat /var/lib/docker/overlay2/86ed53025341b07961f14ed4d63a25317be51264a0555b6f8a768cc9e749e8ca/merged/lib/x86_64-linux-gnu/libdl-2.24.so: no such file or directory
```
This copies the symlinked libdl.so.2 instead of specific version. 