### PR TITLE
build: fix build when we don't have a full git tree

### DIFF
--- a/mk/git.mk
+++ b/mk/git.mk
@@ -1,2 +1,4 @@
-git-hash:=$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null)
-
+# First try to "describe" the state. This tells us if the state is dirty.
+# If that fails (e.g., we're building a docker image and have an empty objects
+# directory), assume the source isn't dirty and build anyways.
+git-hash:=$(shell git describe --always --match=NeVeRmAtCh --dirty 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)


### PR DESCRIPTION
When building with docker, we don't have a _full_ git repo.