### PR TITLE
cmd: ipfs handle GUI environment on Windows

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -22,10 +22,10 @@ import (
 	repo "github.com/ipfs/go-ipfs/repo"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 
-	"github.com/ipfs/go-ipfs-cmds"
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs-cmds/cli"
 	cmdhttp "github.com/ipfs/go-ipfs-cmds/http"
-	"github.com/ipfs/go-ipfs-config"
+	config "github.com/ipfs/go-ipfs-config"
 	u "github.com/ipfs/go-ipfs-util"
 	logging "github.com/ipfs/go-log"
 	loggables "github.com/libp2p/go-libp2p-loggables"
@@ -113,6 +113,9 @@ func mainRet() int {
 				os.Args[1] = "--help"
 			}
 		}
+	} else if insideGUI() { // if no args were passed, and we're in a GUI environment
+		// launch the daemon instead of launching a ghost window
+		os.Args = append(os.Args, "daemon", "--init")
 	}
 
 	// output depends on executable name passed in os.Args
@@ -170,6 +173,10 @@ func mainRet() int {
 
 	// everything went better than expected :)
 	return 0
+}
+
+func insideGUI() bool {
+	return util.InsideGUI()
 }
 
 func checkDebug(req *cmds.Request) {

--- a/cmd/ipfs/util/ui.go
+++ b/cmd/ipfs/util/ui.go
@@ -1,0 +1,7 @@
+//+build !windows
+
+package util
+
+func InsideGUI() bool {
+	return false
+}

--- a/cmd/ipfs/util/ui_windows.go
+++ b/cmd/ipfs/util/ui_windows.go
@@ -1,0 +1,18 @@
+package util
+
+import "golang.org/x/sys/windows"
+
+func InsideGUI() bool {
+	conhostInfo := &windows.ConsoleScreenBufferInfo{}
+	if err := windows.GetConsoleScreenBufferInfo(windows.Stdout, conhostInfo); err != nil {
+		return false
+	}
+
+	if (conhostInfo.CursorPosition.X | conhostInfo.CursorPosition.Y) == 0 {
+		// console cursor has not moved prior to our execution
+		// high probability that we're not in a terminal
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Resolves: https://github.com/ipfs/go-ipfs/issues/6633

Hacky but maybe acceptable.


If we're not launched from a terminal, we launch the daemon by default.
If we're inside of a terminal, we print help.

https://youtu.be/diam0dQaBdw
(for some reason my cursor didn't get recorded)