### PR TITLE
pin: fix pin update X Y where X==Y

### DIFF
--- a/pin/pin.go
+++ b/pin/pin.go
@@ -516,6 +516,14 @@ func (p *pinner) RecursiveKeys() []cid.Cid {
 // this is more efficient than simply pinning the new one and unpinning the
 // old one
 func (p *pinner) Update(ctx context.Context, from, to cid.Cid, unpin bool) error {
+	if from == to {
+		// Nothing to do. Don't remove this check or we'll end up
+		// _removing_ the pin.
+		//
+		// See #6648
+		return nil
+	}
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
 

--- a/test/sharness/t0085-pins.sh
+++ b/test/sharness/t0085-pins.sh
@@ -101,6 +101,9 @@ test_pins() {
     ipfs pin ls $LS_ARGS $BASE_ARGS > after_update &&
     test_must_fail grep -q "$HASH_A" after_update &&
     test_should_contain "$HASH_B" after_update &&
+    ipfs pin update --unpin=true "$HASH_B" "$HASH_B" &&
+    ipfs pin ls $LS_ARGS $BASE_ARGS > after_idempotent_update &&
+    test_should_contain "$HASH_B" after_idempotent_update &&
     ipfs pin rm "$HASH_B"
   '
 }


### PR DESCRIPTION
We were pining Y then removing the pin for X. When X == Y, we'd remove the new pin.

fixes #6648