### PR TITLE
plugins: support Close() for Tracer plugins as well

### DIFF
--- a/plugin/daemon.go
+++ b/plugin/daemon.go
@@ -10,5 +10,4 @@ type PluginDaemon interface {
 	Plugin
 
 	Start(coreiface.CoreAPI) error
-	Close() error
 }

--- a/plugin/loader/loader.go
+++ b/plugin/loader/loader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -266,8 +267,8 @@ func (loader *PluginLoader) Close() error {
 	started := loader.started
 	loader.started = nil
 	for _, pl := range started {
-		if pl, ok := pl.(plugin.PluginDaemon); ok {
-			err := pl.Close()
+		if closer, ok := pl.(io.Closer); ok {
+			err := closer.Close()
 			if err != nil {
 				errs = append(errs, fmt.Sprintf(
 					"error closing plugin %s: %s",

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -9,8 +9,11 @@ type Environment struct {
 	Config interface{}
 }
 
-// Plugin is base interface for all kinds of go-ipfs plugins
+// Plugin is the base interface for all kinds of go-ipfs plugins
 // It will be included in interfaces of different Plugins
+//
+// Optionally, Plugins can implement io.Closer if they want to
+// have a termination step when unloading.
 type Plugin interface {
 	// Name should return unique name of the plugin
 	Name() string

--- a/plugin/tracer.go
+++ b/plugin/tracer.go
@@ -7,5 +7,6 @@ import (
 // PluginTracer is an interface that can be implemented to add a tracer
 type PluginTracer interface {
 	Plugin
+
 	InitTracer() (opentracing.Tracer, error)
 }


### PR DESCRIPTION
Most of the tracers available need to properly close to send the remaining traces before the process exit.