### PR TITLE
fix: make collect-profiles.sh work on mac

### DIFF
--- a/bin/collect-profiles.sh
+++ b/bin/collect-profiles.sh
@@ -3,7 +3,7 @@ set -x
 set -euo pipefail
 IFS=$'\n\t'
 
-HTTP_API="${1:-localhost:5001}"
+HTTP_API="${1:-127.0.0.1:5001}"
 tmpdir=$(mktemp -d)
 export PPROF_TMPDIR="$tmpdir"
 pushd "$tmpdir"

--- a/bin/collect-profiles.sh
+++ b/bin/collect-profiles.sh
@@ -36,9 +36,5 @@ echo "Disabling mutex profiling"
 curl -X POST -v "http://$HTTP_API"'/debug/pprof-mutex/?fraction=0'
 
 popd
-tar cvzf "./ipfs-profile-$(uname -n)-$(date -Iseconds).tar.gz" -C "$tmpdir" .
+tar cvzf "./ipfs-profile-$(uname -n)-$(date +'%Y-%m-%dT%H:%M:%S%z').tar.gz" -C "$tmpdir" .
 rm -rf "$tmpdir"
-
-
-
-


### PR DESCRIPTION
The version of `date` that ships with darwin does not support the `-Iseconds` flag.

Use a pattern with `date` to achieve the same thing but should have better cross platform support.

Also, makes collect-profiles.sh executable.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>