### PR TITLE
feat: add ipfs version info to prometheus metrics

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -33,7 +33,8 @@ import (
 	goprocess "github.com/jbenet/goprocess"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
-	"github.com/prometheus/client_golang/prometheus"
+	prometheus "github.com/prometheus/client_golang/prometheus"
+	promauto "github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -413,6 +414,18 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 			return err
 		}
 	}
+
+	// Add ipfs version info to prometheous metrics
+	var ipfsInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ipfs_info",
+		Help: "IPFS version information.",
+	}, []string{"version", "commit"})
+
+	// Setting to 1 lets us multiply it with other stats to add the version labels
+	ipfsInfoMetric.With(prometheus.Labels{
+		"version": version.CurrentVersionNumber,
+		"commit": version.CurrentCommit,
+	}).Set(1)
 
 	// initialize metrics collector
 	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})


### PR DESCRIPTION
Adds `ipfs_info` prometheus metric with version and commit info to http://localhost:5001/debug/metrics/prometheus output...

```console
# HELP ipfs_info IPFS version information.
# TYPE ipfs_info gauge
ipfs_info{commit="9ea7c6a11-dirty",version="0.5.0-dev"} 1
```

This follows the same pattern as go and other systems, adding a gauge metric that is set to 1, with the version info added as labels.

This is a common pattern for prometheus. It lets operators merge version info into other prometheus metrics by multiplying it with the other stat. As the value is always 1, it simply adds the labels to the aggregated info but does not change the other stats value... as described in https://www.robustperception.io/exposing-the-software-version-to-prometheus

For example, we already expose the go version info as

```console
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.12.9"} 1
```

Part of #5604 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>