### PR TITLE
docs: fix broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ SUBCOMMANDS
 
 ## Getting Started
 
-See also: http://ipfs.io/docs/getting-started/
+See also: https://docs.ipfs.io/guides/guides/install
 
 To start using IPFS, you must first initialize IPFS's config files on your
 system, this is done with `ipfs init`. See `ipfs init --help` for information on


### PR DESCRIPTION
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/1211152/65948236-86ad7580-e442-11e9-8246-9e8ad619cebc.png">

Not sure if pointing to https://docs.ipfs.io/guides/guides/install/ is the "getting started guide" we want (or that we had). @ipfs/docs what is the best/new getting started guide now that the previous url is broken?