### PR TITLE
introduce IpfsNode Plugin

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -19,7 +19,6 @@ import (
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	commands "github.com/ipfs/go-ipfs/core/commands"
-	coreapi "github.com/ipfs/go-ipfs/core/coreapi"
 	corehttp "github.com/ipfs/go-ipfs/core/corehttp"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	libp2p "github.com/ipfs/go-ipfs/core/node/libp2p"
@@ -368,11 +367,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// Start "core" plugins. We want to do this *before* starting the HTTP
 	// API as the user may be relying on these plugins.
-	api, err := coreapi.NewCoreAPI(node)
-	if err != nil {
-		return err
-	}
-	err = cctx.Plugins.Start(api)
+	err = cctx.Plugins.Start(node)
 	if err != nil {
 		return err
 	}

--- a/plugin/daemoninternal.go
+++ b/plugin/daemoninternal.go
@@ -1,0 +1,14 @@
+package plugin
+
+import "github.com/ipfs/go-ipfs/core"
+
+// PluginDaemonInternal is an interface for daemon plugins. These plugins will be run on
+// the daemon and will be given a direct access to the IpfsNode.
+//
+// Note: PluginDaemonInternal is considered internal and no guarantee is made concerning
+// the stability of its API. If you can, use PluginAPI instead.
+type PluginDaemonInternal interface {
+	Plugin
+
+	Start(*core.IpfsNode) error
+}


### PR DESCRIPTION
This PR introduce a new kind of plugin able to directly use `IpfsNode`. As `IpfsNode` is considered internal, no guarantee is made about API stability. This is useful when a plugin needs a direct access to the internal and using `CoreApi` is not enough.

As introducing `PluginNode` make the naming a little akward, this PR also introduce a copy of `PluginDaemon` named `PluginApi` and deprecate `PluginDaemon`. As it is a separate commit, we can remove that easily if you don't like it.

