### PR TITLE
add prometheus/common/version pkg to export more version info about go-ipfs

### DIFF
--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -13,7 +13,20 @@ PATH := $(realpath $(d)):$(PATH)
 # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
 # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
 
-$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs".CurrentCommit=$(git-hash)"
+DATE := $(shell date +%FT%T%z)
+USER := $(shell whoami)
+GIT_VERSION := $(shell git --no-pager describe --tags --always --dirty)
+GIT_REVISION := $(shell git rev-parse HEAD)
+BRANCH := $(shell git branch | grep "*" | cut -d ' ' -f2)
+
+$(d)_flags =-ldflags "
+$(d)_flags := $($(d)_flags)-X github.com/ipfs/go-ipfs.CurrentCommit=$(git-hash) 
+$(d)_flags := $($(d)_flags)-X github.com/prometheus/common/version.Version=$(GIT_VERSION) 
+$(d)_flags := $($(d)_flags)-X github.com/prometheus/common/version.BuildDate=$(DATE) 
+$(d)_flags := $($(d)_flags)-X github.com/prometheus/common/version.Branch=$(BRANCH) 
+$(d)_flags := $($(d)_flags)-X github.com/prometheus/common/version.Revision=$(GIT_REVISION) 
+$(d)_flags := $($(d)_flags)-X github.com/prometheus/common/version.BuildUser=$(USER) 
+$(d)_flags := $($(d)_flags)"
 
 $(d)-try-build $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
 

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -36,6 +36,7 @@ import (
 	manet "github.com/multiformats/go-multiaddr-net"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	promauto "github.com/prometheus/client_golang/prometheus/promauto"
+	promversion "github.com/prometheus/common/version"
 )
 
 const (
@@ -421,6 +422,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// initialize metrics collector
 	prometheus.MustRegister(&corehttp.IpfsNodeCollector{Node: node})
+	prometheus.MustRegister(promversion.NewCollector("go_ipfs"))
 
 	// The daemon is *finally* ready.
 	fmt.Printf("Daemon is ready\n")

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
+	github.com/prometheus/common v0.6.0
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1


### PR DESCRIPTION
This extends the current setup and offloads it to a very [nice little package](https://github.com/prometheus/common/tree/master/version). I have kept the exported information around so as to not break any prometheus queries or dashboards that anyone has.