### PR TITLE
fix(coreapi/add): close the fake repo used when adding with hash-only

### DIFF
--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -69,6 +69,7 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		if err != nil {
 			return nil, err
 		}
+		defer nilnode.Close()
 		addblockstore = nilnode.Blockstore
 		exch = nilnode.Exchange
 		pinning = nilnode.Pinning


### PR DESCRIPTION
fixes #6744