### PR TITLE
fix bug 6748

### DIFF
--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -127,8 +127,10 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 		return nil, err
 	}
 
-	if err := api.provider.Provide(nd.Cid()); err != nil {
-		return nil, err
+	if !settings.OnlyHash {
+		if err := api.provider.Provide(nd.Cid()); err != nil {
+			return nil, err
+		}
 	}
 
 	return path.IpfsPath(nd.Cid()), nil


### PR DESCRIPTION
ipfs add with only hash, don't need to announce cid to other peer，because unable to get this file from IPFS network. And waste memery to store the useless cid.

when i modified this code, and close the mock repo(issue 6744)，no memery grow with large calls.