### PR TITLE
fix issue 6760, adding with hash-only, high CPU usage.

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -354,7 +354,6 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		// We wait for the node to close first, as the node has children
 		// that it will wait for before closing, such as the API server.
 		node.Close()
-		_ = coreapi.CloseFakeRepo()
 
 		select {
 		case <-req.Context.Done():

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -354,6 +354,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		// We wait for the node to close first, as the node has children
 		// that it will wait for before closing, such as the API server.
 		node.Close()
+		coreapi.CloseFakeRepo()
 
 		select {
 		case <-req.Context.Done():

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -354,7 +354,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		// We wait for the node to close first, as the node has children
 		// that it will wait for before closing, such as the API server.
 		node.Close()
-		coreapi.CloseFakeRepo()
+		_ = coreapi.CloseFakeRepo()
 
 		select {
 		case <-req.Context.Done():

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -3,6 +3,7 @@ package coreapi
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ipfs/go-ipfs/core"
 
@@ -27,6 +28,43 @@ import (
 )
 
 type UnixfsAPI CoreAPI
+var nilNode *core.IpfsNode
+var lock sync.Mutex
+
+func getOrCreateNilNode() (*core.IpfsNode,error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if nilNode != nil {
+		return nilNode,nil
+	}
+
+	node,err := core.NewNode(context.Background(),  &core.BuildCfg{
+		//TODO: need this to be true or all files
+		// hashed will be stored in memory!
+		NilRepo: true,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	nilNode = node
+	return nilNode,nil
+}
+
+func CloseFakeRepo() error {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if nilNode != nil {
+		if err := nilNode.Close(); err != nil {
+			return err
+		}
+		nilNode = nil
+	}
+	return nil
+}
 
 // Add builds a merkledag node from a reader, adds it to the blockstore,
 // and returns the key representing that node.
@@ -61,18 +99,13 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 	pinning := api.pinning
 
 	if settings.OnlyHash {
-		nilnode, err := core.NewNode(ctx, &core.BuildCfg{
-			//TODO: need this to be true or all files
-			// hashed will be stored in memory!
-			NilRepo: true,
-		})
+		node, err := getOrCreateNilNode()
 		if err != nil {
 			return nil, err
 		}
-		defer nilnode.Close()
-		addblockstore = nilnode.Blockstore
-		exch = nilnode.Exchange
-		pinning = nilnode.Pinning
+		addblockstore = node.Blockstore
+		exch = node.Exchange
+		pinning = node.Pinning
 	}
 
 	bserv := blockservice.New(addblockstore, exch) // hash security 001


### PR DESCRIPTION
IPFS daemon will create a IDENTITY for repo through function GenerateKeyPairWithReader. This action cost so much CPU resource. And IPFS daemon creates a fake repo for each `ipfs add -n xxx`.
So, i create a global fake node,  all the calls `ipfs add -n xxx` can use this fake node to avoid GenerateKeyPairWithReader.