### PR TITLE
fix: ignore nonexistant when force rm

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -1005,11 +1005,8 @@ Remove files or directories.
 
 		pdir, err := getParentDir(nd.FilesRoot, dir)
 		if err != nil {
-			if force {
-				switch err {
-				case os.ErrNotExist:
-					return nil
-				}
+			if force && err == os.ErrNotExist {
+				return nil
 			}
 			return fmt.Errorf("parent lookup: %s", err)
 		}
@@ -1017,12 +1014,10 @@ Remove files or directories.
 		if force {
 			err := pdir.Unlink(name)
 			if err != nil {
-				switch err {
-				case os.ErrNotExist:
+				if err == os.ErrNotExist {
 					return nil
-				default:
-					return err
 				}
+				return err
 			}
 			return pdir.Flush()
 		}

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -683,6 +683,14 @@ test_files_api() {
     ipfs files rm --force /forcibly-dir &&
     verify_dir_contents /
   '
+
+  test_expect_success "remove nonexistant path forcibly" '
+    ipfs files rm --force /nonexistant
+  '
+
+  test_expect_success "remove deeply nonexistant path forcibly" '
+    ipfs files rm --force /deeply/nonexistant
+  '
 }
 
 # test offline and online


### PR DESCRIPTION
- Make `ipfs files rm --force /nonexistant` succeed when the path does not exist.
- Add shaness test for removing nonexistant paths
- Refactor duplicated code to find a parent dir into a function

I've been writing scripts against the files api, and having to stat things before removing them is a pain. So this PR aims to make --force do what I'd expect it to.


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>