### PR TITLE
feat: files (mfs) api implementation

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -1,30 +1,23 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 
-	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	"github.com/ipfs/go-ipfs/core/fileshelpers"
 
 	"github.com/dustin/go-humanize"
 	cid "github.com/ipfs/go-cid"
 	cmds "github.com/ipfs/go-ipfs-cmds"
-	ipld "github.com/ipfs/go-ipld-format"
-	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
 	"github.com/ipfs/go-mfs"
 	iface "github.com/ipfs/interface-go-ipfs-core"
-	path "github.com/ipfs/interface-go-ipfs-core/path"
 	mh "github.com/multiformats/go-multihash"
 )
-
-var flog = logging.Logger("cmds/files")
 
 // FilesCmd is the 'ipfs files' command
 var FilesCmd = &cmds.Command{
@@ -213,20 +206,6 @@ var filesCpCmd = &cmds.Command{
 	},
 }
 
-func getNodeFromPath(ctx context.Context, node *core.IpfsNode, api iface.CoreAPI, p string) (ipld.Node, error) {
-	switch {
-	case strings.HasPrefix(p, "/ipfs/"):
-		return api.ResolveNode(ctx, path.New(p))
-	default:
-		fsn, err := mfs.Lookup(node.FilesRoot, p)
-		if err != nil {
-			return nil, err
-		}
-
-		return fsn.GetNode()
-	}
-}
-
 type filesLsOutput struct {
 	Entries []mfs.NodeListing
 }
@@ -369,19 +348,6 @@ Examples:
 
 		return res.Emit(rc)
 	},
-}
-
-type contextReader interface {
-	CtxReadFull(context.Context, []byte) (int, error)
-}
-
-type contextReaderWrapper struct {
-	R   contextReader
-	ctx context.Context
-}
-
-func (crw *contextReaderWrapper) Read(b []byte) (int, error) {
-	return crw.R.CtxReadFull(crw.ctx, b)
 }
 
 var filesMvCmd = &cmds.Command{

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -19,15 +19,16 @@ import (
 	"fmt"
 
 	bserv "github.com/ipfs/go-blockservice"
-	"github.com/ipfs/go-ipfs-blockstore"
-	"github.com/ipfs/go-ipfs-exchange-interface"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	offlinexch "github.com/ipfs/go-ipfs-exchange-offline"
-	"github.com/ipfs/go-ipfs-pinner"
-	"github.com/ipfs/go-ipfs-provider"
+	pin "github.com/ipfs/go-ipfs-pinner"
+	provider "github.com/ipfs/go-ipfs-provider"
 	offlineroute "github.com/ipfs/go-ipfs-routing/offline"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-mfs"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/ipfs/interface-go-ipfs-core/options"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
@@ -56,6 +57,7 @@ type CoreAPI struct {
 	blockstore blockstore.GCBlockstore
 	baseBlocks blockstore.Blockstore
 	pinning    pin.Pinner
+	filesRoot  *mfs.Root
 
 	blocks bserv.BlockService
 	dag    ipld.DAGService
@@ -143,6 +145,11 @@ func (api *CoreAPI) PubSub() coreiface.PubSubAPI {
 	return (*PubSubAPI)(api)
 }
 
+// Files returns the FilesAPI interface implementation backed by the go-ipfs node
+func (api *CoreAPI) Files() coreiface.FilesAPI {
+	return (*FilesAPI)(api)
+}
+
 // WithOptions returns api with global options applied
 func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, error) {
 	settings := api.parentOpts // make sure to copy
@@ -167,6 +174,7 @@ func (api *CoreAPI) WithOptions(opts ...options.ApiOption) (coreiface.CoreAPI, e
 		blockstore: n.Blockstore,
 		baseBlocks: n.BaseBlocks,
 		pinning:    n.Pinning,
+		filesRoot:  n.FilesRoot,
 
 		blocks: n.Blocks,
 		dag:    n.DAG,

--- a/core/coreapi/files.go
+++ b/core/coreapi/files.go
@@ -1,0 +1,56 @@
+package coreapi
+
+import (
+	"context"
+	"io"
+
+	"github.com/ipfs/go-ipfs/core/fileshelpers"
+	"github.com/ipfs/go-mfs"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+)
+
+type FilesAPI CoreAPI
+
+func (api *FilesAPI) Copy(ctx context.Context, src, dst string, opts *coreiface.FilesCopyOptions) error {
+	return fileshelpers.Copy(ctx, api.filesRoot, (*CoreAPI)(api), src, dst, opts)
+}
+
+func (api *FilesAPI) Move(ctx context.Context, src, dst string, opts *coreiface.FilesMoveOptions) error {
+	return fileshelpers.Move(ctx, api.filesRoot, src, dst, opts)
+}
+
+func (api *FilesAPI) List(ctx context.Context, path string, opts *coreiface.FilesListOptions) ([]mfs.NodeListing, error) {
+	return fileshelpers.List(ctx, api.filesRoot, path, opts)
+}
+
+func (api *FilesAPI) Mkdir(ctx context.Context, path string, opts *coreiface.FilesMkdirOptions) error {
+	return fileshelpers.Mkdir(ctx, api.filesRoot, path, opts)
+}
+
+func (api *FilesAPI) Read(ctx context.Context, path string, opts *coreiface.FilesReadOptions) (io.ReadCloser, error) {
+	return fileshelpers.Read(ctx, api.filesRoot, path, opts)
+}
+
+func (api *FilesAPI) Remove(ctx context.Context, path string, opts *coreiface.FilesRemoveOptions) error {
+	return fileshelpers.Remove(ctx, api.filesRoot, path, opts)
+}
+
+func (api *FilesAPI) Stat(ctx context.Context, path string, opts *coreiface.FilesStatOptions) (*coreiface.FileInfo, error) {
+	return fileshelpers.Stat(
+		ctx,
+		api.filesRoot,
+		(*CoreAPI)(api),
+		api.blockstore,
+		api.dag,
+		path,
+		opts,
+	)
+}
+
+func (api *FilesAPI) Write(ctx context.Context, path string, r io.Reader, opts *coreiface.FilesWriteOptions) error {
+	return fileshelpers.Write(ctx, api.filesRoot, path, r, opts)
+}
+
+func (api *FilesAPI) ChangeCid(ctx context.Context, path string, opts *coreiface.FilesChangeCidOptions) error {
+	return fileshelpers.ChangeCid(ctx, api.filesRoot, path, opts)
+}

--- a/core/coreapi/files.go
+++ b/core/coreapi/files.go
@@ -54,3 +54,8 @@ func (api *FilesAPI) Write(ctx context.Context, path string, r io.Reader, opts *
 func (api *FilesAPI) ChangeCid(ctx context.Context, path string, opts *coreiface.FilesChangeCidOptions) error {
 	return fileshelpers.ChangeCid(ctx, api.filesRoot, path, opts)
 }
+
+func (api *FilesAPI) Flush(ctx context.Context, path string) error {
+	_, err := mfs.FlushPath(ctx, api.filesRoot, path)
+	return err
+}

--- a/core/fileshelpers/fileshelpers.go
+++ b/core/fileshelpers/fileshelpers.go
@@ -1,0 +1,646 @@
+package fileshelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	gopath "path"
+	"strings"
+
+	bservice "github.com/ipfs/go-blockservice"
+	"github.com/ipfs/go-cid"
+	cidenc "github.com/ipfs/go-cidutil/cidenc"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	offline "github.com/ipfs/go-ipfs-exchange-offline"
+	ipld "github.com/ipfs/go-ipld-format"
+	logging "github.com/ipfs/go-log"
+	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-mfs"
+	ft "github.com/ipfs/go-unixfs"
+	iface "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipfs/interface-go-ipfs-core/path"
+)
+
+var log = logging.Logger("core/fileshelpers")
+var defaultMoveOptions = &iface.FilesMoveOptions{Flush: true}
+
+func Move(ctx context.Context, root *mfs.Root, src, dst string, opts *iface.FilesMoveOptions) error {
+	if opts == nil {
+		opts = defaultMoveOptions
+	}
+
+	src, err := checkPath(src)
+	if err != nil {
+		return err
+	}
+	dst, err = checkPath(dst)
+	if err != nil {
+		return err
+	}
+
+	err = mfs.Mv(root, src, dst)
+	if err == nil && opts.Flush {
+		_, err = mfs.FlushPath(ctx, root, "/")
+	}
+	return err
+}
+
+var defaultCopyOptions = &iface.FilesCopyOptions{Flush: true}
+
+func Copy(ctx context.Context, root *mfs.Root, api iface.CoreAPI, src, dst string, opts *iface.FilesCopyOptions) error {
+	if opts == nil {
+		opts = defaultCopyOptions
+	}
+
+	src, err := checkPath(src)
+	if err != nil {
+		return err
+	}
+
+	dst, err = checkPath(dst)
+	if err != nil {
+		return err
+	}
+
+	if dst[len(dst)-1] == '/' {
+		dst += gopath.Base(src)
+	}
+
+	node, err := getNodeFromPath(ctx, root, api, src)
+	if err != nil {
+		return fmt.Errorf("cp: cannot get node from path %s: %s", src, err)
+	}
+
+	err = mfs.PutNode(root, dst, node)
+	if err != nil {
+		return fmt.Errorf("cp: cannot put node in path %s: %s", dst, err)
+	}
+
+	if opts.Flush {
+		_, err = mfs.FlushPath(ctx, root, dst)
+		if err != nil {
+			return fmt.Errorf("cp: cannot flush the created file %s: %s", dst, err)
+		}
+	}
+
+	return nil
+}
+
+func Remove(ctx context.Context, root *mfs.Root, path string, opts *iface.FilesRemoveOptions) error {
+	if opts == nil {
+		opts = &iface.FilesRemoveOptions{}
+	}
+
+	path, err := checkPath(path)
+	if err != nil {
+		return err
+	}
+
+	if path == "/" {
+		return fmt.Errorf("cannot delete root")
+	}
+
+	// 'rm a/b/c/' will fail unless we trim the slash at the end
+	if path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
+	}
+
+	dir, name := gopath.Split(path)
+
+	pdir, err := getParentDir(root, dir)
+	if err != nil {
+		if opts.Force && err == os.ErrNotExist {
+			return nil
+		}
+		return fmt.Errorf("parent lookup: %s", err)
+	}
+
+	// if 'force' specified, it will remove anything else,
+	// including file, directory, corrupted node, etc
+	if opts.Force {
+		err := pdir.Unlink(name)
+		if err != nil {
+			if err == os.ErrNotExist {
+				return nil
+			}
+			return err
+		}
+		return pdir.Flush()
+	}
+
+	// get child node by name, when the node is corrupted and nonexistent,
+	// it will return specific error.
+	child, err := pdir.Child(name)
+	if err != nil {
+		return err
+	}
+
+	switch child.(type) {
+	case *mfs.Directory:
+		if !opts.Recursive {
+			return fmt.Errorf("%s is a directory, use -r to remove directories", path)
+		}
+	}
+
+	err = pdir.Unlink(name)
+	if err != nil {
+		return err
+	}
+
+	return pdir.Flush()
+}
+
+func List(ctx context.Context, root *mfs.Root, path string, opts *iface.FilesListOptions) ([]mfs.NodeListing, error) {
+	if opts == nil {
+		opts = &iface.FilesListOptions{
+			CidEncoder: cidenc.Default(),
+		}
+	}
+
+	path, err := checkPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fsn, err := mfs.Lookup(root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	switch fsn := fsn.(type) {
+	case *mfs.Directory:
+		if !opts.Long {
+			var output []mfs.NodeListing
+			names, err := fsn.ListNames(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, name := range names {
+				output = append(output, mfs.NodeListing{
+					Name: name,
+				})
+			}
+			return output, nil
+		}
+		return fsn.List(ctx)
+	case *mfs.File:
+		_, name := gopath.Split(path)
+		out := []mfs.NodeListing{{Name: name}}
+		if opts.Long {
+			out[0].Type = int(fsn.Type())
+
+			size, err := fsn.Size()
+			if err != nil {
+				return nil, err
+			}
+			out[0].Size = size
+
+			nd, err := fsn.GetNode()
+			if err != nil {
+				return nil, err
+			}
+			out[0].Hash = opts.CidEncoder.Encode(nd.Cid())
+		}
+		return out, nil
+	default:
+		return nil, errors.New("unrecognized type")
+	}
+}
+
+func Write(ctx context.Context, root *mfs.Root, path string, r io.Reader, opts *iface.FilesWriteOptions) (retErr error) {
+	if opts == nil {
+		opts = &iface.FilesWriteOptions{}
+	}
+
+	path, err := checkPath(path)
+	if err != nil {
+		return err
+	}
+
+	if opts.Offset < 0 {
+		return fmt.Errorf("cannot have negative write offset")
+	}
+
+	if opts.MakeParents {
+		err := ensureContainingDirectoryExists(root, path, opts.CidBuilder)
+		if err != nil {
+			return err
+		}
+	}
+
+	fi, err := getFileHandle(root, path, opts.Create, opts.CidBuilder)
+	if err != nil {
+		return err
+	}
+
+	if opts.RawLeavesOverride {
+		fi.RawLeaves = opts.RawLeaves
+	}
+
+	wfd, err := fi.Open(mfs.Flags{Write: true, Sync: opts.Flush})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err := wfd.Close()
+		if err != nil {
+			if retErr == nil {
+				retErr = err
+			} else {
+				log.Error("files: error closing file mfs file descriptor", err)
+			}
+		}
+	}()
+
+	if opts.Truncate {
+		if err := wfd.Truncate(0); err != nil {
+			return err
+		}
+	}
+
+	if opts.Count < 0 {
+		return fmt.Errorf("cannot have negative byte count")
+	}
+
+	_, err = wfd.Seek(int64(opts.Offset), io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	if opts.Count > 0 {
+		r = io.LimitReader(r, int64(opts.Count))
+	}
+
+	_, err = io.Copy(wfd, r)
+	return err
+}
+
+func ChangeCid(ctx context.Context, root *mfs.Root, path string, opts *iface.FilesChangeCidOptions) error {
+	if opts == nil {
+		opts = &iface.FilesChangeCidOptions{}
+	}
+
+	if opts.CidBuilder == nil {
+		return nil
+	}
+
+	nd, err := mfs.Lookup(root, path)
+	if err != nil {
+		return err
+	}
+
+	switch n := nd.(type) {
+	case *mfs.Directory:
+		n.SetCidBuilder(opts.CidBuilder)
+	default:
+		return fmt.Errorf("can only update directories")
+	}
+
+	if opts.Flush {
+		_, err = mfs.FlushPath(ctx, root, path)
+	}
+
+	return err
+}
+
+func Mkdir(ctx context.Context, root *mfs.Root, path string, opts *iface.FilesMkdirOptions) error {
+	if opts == nil {
+		opts = &iface.FilesMkdirOptions{}
+	}
+
+	dirtomake, err := checkPath(path)
+	if err != nil {
+		return err
+	}
+
+	err = mfs.Mkdir(root, dirtomake, mfs.MkdirOpts{
+		Mkparents:  opts.MakeParents,
+		Flush:      opts.Flush,
+		CidBuilder: opts.CidBuilder,
+	})
+
+	return err
+}
+
+func ensureContainingDirectoryExists(r *mfs.Root, path string, builder cid.Builder) error {
+	dirtomake := gopath.Dir(path)
+
+	if dirtomake == "/" {
+		return nil
+	}
+
+	return mfs.Mkdir(r, dirtomake, mfs.MkdirOpts{
+		Mkparents:  true,
+		CidBuilder: builder,
+	})
+}
+
+func getFileHandle(r *mfs.Root, path string, create bool, builder cid.Builder) (*mfs.File, error) {
+	target, err := mfs.Lookup(r, path)
+	switch err {
+	case nil:
+		fi, ok := target.(*mfs.File)
+		if !ok {
+			return nil, fmt.Errorf("%s was not a file", path)
+		}
+		return fi, nil
+
+	case os.ErrNotExist:
+		if !create {
+			return nil, err
+		}
+
+		// if create is specified and the file doesnt exist, we create the file
+		dirname, fname := gopath.Split(path)
+		pdir, err := getParentDir(r, dirname)
+		if err != nil {
+			return nil, err
+		}
+
+		if builder == nil {
+			builder = pdir.GetCidBuilder()
+		}
+
+		nd := dag.NodeWithData(ft.FilePBData(nil, 0))
+		nd.SetCidBuilder(builder)
+		err = pdir.AddChild(fname, nd)
+		if err != nil {
+			return nil, err
+		}
+
+		fsn, err := pdir.Child(fname)
+		if err != nil {
+			return nil, err
+		}
+
+		fi, ok := fsn.(*mfs.File)
+		if !ok {
+			return nil, errors.New("expected *mfs.File, didnt get it. This is likely a race condition")
+		}
+		return fi, nil
+
+	default:
+		return nil, err
+	}
+}
+
+func Read(ctx context.Context, root *mfs.Root, path string, opts *iface.FilesReadOptions) (io.ReadCloser, error) {
+	if opts == nil {
+		opts = &iface.FilesReadOptions{}
+	}
+
+	path, err := checkPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fsn, err := mfs.Lookup(root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, ok := fsn.(*mfs.File)
+	if !ok {
+		return nil, fmt.Errorf("%s was not a file", path)
+	}
+
+	rfd, err := fi.Open(mfs.Flags{Read: true})
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Offset < 0 {
+		return nil, fmt.Errorf("cannot specify negative offset")
+	}
+
+	filen, err := rfd.Size()
+	if err != nil {
+		return nil, err
+	}
+
+	if int64(opts.Offset) > filen {
+		return nil, fmt.Errorf("offset was past end of file (%d > %d)", opts.Offset, filen)
+	}
+
+	_, err = rfd.Seek(int64(opts.Offset), io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+
+	var r io.ReadCloser = &contextReaderWrapper{
+		R:   rfd,
+		ctx: ctx,
+	}
+
+	if opts.Count < 0 {
+		return nil, fmt.Errorf("cannot specify negative 'count'")
+	}
+
+	if opts.Count > 0 {
+		r = &limitReaderCloserWrapper{
+			Reader: io.LimitReader(r, int64(opts.Count)),
+			F:      rfd,
+		}
+	}
+
+	return r, nil
+}
+
+type contextReadCloser interface {
+	CtxReadFull(context.Context, []byte) (int, error)
+	Close() error
+}
+
+type contextReaderWrapper struct {
+	R   contextReadCloser
+	ctx context.Context
+}
+
+func (crw *contextReaderWrapper) Read(b []byte) (int, error) {
+	return crw.R.CtxReadFull(crw.ctx, b)
+}
+
+func (crw *contextReaderWrapper) Close() error {
+	return crw.R.Close()
+}
+
+type limitReaderCloserWrapper struct {
+	io.Reader
+	F mfs.FileDescriptor
+}
+
+func (lrcw *limitReaderCloserWrapper) Close() error {
+	return lrcw.F.Close()
+}
+
+func Stat(ctx context.Context, root *mfs.Root, api iface.CoreAPI, bs blockstore.GCBlockstore, ds ipld.DAGService, path string, opts *iface.FilesStatOptions) (*iface.FileInfo, error) {
+	if opts == nil {
+		opts = &iface.FilesStatOptions{
+			CidEncoder: cidenc.Default(),
+		}
+	}
+
+	path, err := checkPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var dagserv ipld.DAGService
+	if opts.WithLocality {
+		// an offline DAGService will not fetch from the network
+		dagserv = dag.NewDAGService(bservice.New(
+			bs,
+			offline.Exchange(bs),
+		))
+	} else {
+		dagserv = ds
+	}
+
+	nd, err := getNodeFromPath(ctx, root, api, path)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := statNode(nd, opts.CidEncoder)
+	if err != nil {
+		return nil, err
+	}
+
+	if !opts.WithLocality {
+		return o, nil
+	}
+
+	local, sizeLocal, err := walkBlock(ctx, dagserv, nd)
+	if err != nil {
+		return nil, err
+	}
+
+	o.WithLocality = true
+	o.Local = local
+	o.SizeLocal = sizeLocal
+	return o, nil
+}
+
+func walkBlock(ctx context.Context, dagserv ipld.DAGService, nd ipld.Node) (bool, uint64, error) {
+	// Start with the block data size
+	sizeLocal := uint64(len(nd.RawData()))
+
+	local := true
+
+	for _, link := range nd.Links() {
+		child, err := dagserv.Get(ctx, link.Cid)
+
+		if err == ipld.ErrNotFound {
+			local = false
+			continue
+		}
+
+		if err != nil {
+			return local, sizeLocal, err
+		}
+
+		childLocal, childLocalSize, err := walkBlock(ctx, dagserv, child)
+
+		if err != nil {
+			return local, sizeLocal, err
+		}
+
+		// Recursively add the child size
+		local = local && childLocal
+		sizeLocal += childLocalSize
+	}
+
+	return local, sizeLocal, nil
+}
+
+func getNodeFromPath(ctx context.Context, root *mfs.Root, api iface.CoreAPI, p string) (ipld.Node, error) {
+	switch {
+	case strings.HasPrefix(p, "/ipfs/"):
+		return api.ResolveNode(ctx, path.New(p))
+	default:
+		fsn, err := mfs.Lookup(root, p)
+		if err != nil {
+			return nil, err
+		}
+
+		return fsn.GetNode()
+	}
+}
+
+func getParentDir(root *mfs.Root, dir string) (*mfs.Directory, error) {
+	parent, err := mfs.Lookup(root, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	pdir, ok := parent.(*mfs.Directory)
+	if !ok {
+		return nil, errors.New("expected *mfs.Directory, didnt get it. This is likely a race condition")
+	}
+	return pdir, nil
+}
+
+func checkPath(p string) (string, error) {
+	if len(p) == 0 {
+		return "", fmt.Errorf("paths must not be empty")
+	}
+
+	if p[0] != '/' {
+		return "", fmt.Errorf("paths must start with a leading slash")
+	}
+
+	cleaned := gopath.Clean(p)
+	if p[len(p)-1] == '/' && p != "/" {
+		cleaned += "/"
+	}
+	return cleaned, nil
+}
+
+func statNode(nd ipld.Node, enc cidenc.Encoder) (*iface.FileInfo, error) {
+	c := nd.Cid()
+
+	cumulsize, err := nd.Size()
+	if err != nil {
+		return nil, err
+	}
+
+	switch n := nd.(type) {
+	case *dag.ProtoNode:
+		d, err := ft.FSNodeFromBytes(n.Data())
+		if err != nil {
+			return nil, err
+		}
+
+		var ndtype string
+		switch d.Type() {
+		case ft.TDirectory, ft.THAMTShard:
+			ndtype = "directory"
+		case ft.TFile, ft.TMetadata, ft.TRaw:
+			ndtype = "file"
+		default:
+			return nil, fmt.Errorf("unrecognized node type: %s", d.Type())
+		}
+
+		return &iface.FileInfo{
+			Hash:           enc.Encode(c),
+			Blocks:         len(nd.Links()),
+			Size:           d.FileSize(),
+			CumulativeSize: cumulsize,
+			Type:           ndtype,
+		}, nil
+	case *dag.RawNode:
+		return &iface.FileInfo{
+			Hash:           enc.Encode(c),
+			Blocks:         0,
+			Size:           cumulsize,
+			CumulativeSize: cumulsize,
+			Type:           "file",
+		}, nil
+	default:
+		return nil, fmt.Errorf("not unixfs node (proto or raw)")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/ipfs/go-ipfs
 
-replace github.com/ipfs/interface-go-ipfs-core v0.2.5 => ../interface-go-ipfs-core
-
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
 	github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33 // indirect
@@ -113,3 +111,5 @@ require (
 )
 
 go 1.12
+
+replace github.com/ipfs/interface-go-ipfs-core => github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/ipfs/go-ipfs
 
+replace github.com/ipfs/interface-go-ipfs-core v0.2.5 => ../interface-go-ipfs-core
+
 require (
 	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
 	github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33 // indirect
@@ -12,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/gogo/protobuf v1.3.1
+	github.com/google/martian v2.1.0+incompatible
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-bitswap v0.1.10
@@ -53,6 +56,7 @@ require (
 	github.com/ipfs/go-unixfs v0.2.1
 	github.com/ipfs/go-verifcid v0.0.1
 	github.com/ipfs/interface-go-ipfs-core v0.2.5
+	github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 // indirect
 	github.com/jbenet/go-is-domain v1.0.3
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2

--- a/go.mod
+++ b/go.mod
@@ -112,4 +112,4 @@ require (
 
 go 1.12
 
-replace github.com/ipfs/interface-go-ipfs-core => github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7
+replace github.com/ipfs/interface-go-ipfs-core => github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207124604-39489ae2bff1

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
+github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7 h1:WsOo9f0a04ehGkh/Cgmkwum7DKwRF9dFyxl1fOppb9k=
+github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7/go.mod h1:AGHzFaPhV4nYLymAuuZPkp+hAMXRb3fjLLxWFYql2Ck=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
+github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -287,6 +289,8 @@ github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+
 github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec/go.mod h1:rGaEvXB4uRSZMmzKNLoXvTu1sfx+1kv/DojUlPrSZGs=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
+github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253 h1:+AUuGGAh/2X3wcomiZvjeTcx5OvGXsfdnIqk3KPM+HE=
+github.com/jbenet/go-fuse-version v0.0.0-20160322195114-6d4c97bcf253/go.mod h1:gWtF+3u3zVe5/+I44niTEcU/KmVo2oMyLh0WhxpBT28=
 github.com/jbenet/go-is-domain v1.0.3 h1:FuRBJ0h79p00eseyaLckJT5KnE8RyqI+HLopvNSyNE0=
 github.com/jbenet/go-is-domain v1.0.3/go.mod h1:xbRLRb0S7FgzDBTJlguhDVwLYM/5yNtvktxj2Ttfy7Q=
 github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmv
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
 github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7 h1:WsOo9f0a04ehGkh/Cgmkwum7DKwRF9dFyxl1fOppb9k=
 github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207123451-a1a93a6e33e7/go.mod h1:AGHzFaPhV4nYLymAuuZPkp+hAMXRb3fjLLxWFYql2Ck=
+github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207124604-39489ae2bff1 h1:VJ5pcUb5qVs+nxA2/XUDQI3Jv0QwEhhyj27elzreWRs=
+github.com/hacdias/interface-go-ipfs-core v0.2.6-0.20191207124604-39489ae2bff1/go.mod h1:AGHzFaPhV4nYLymAuuZPkp+hAMXRb3fjLLxWFYql2Ck=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=


### PR DESCRIPTION
This implements the Files (MFS) API

- [ ] Interface: https://github.com/ipfs/interface-go-ipfs-core/pull/54
- [x] Moves almost all `ipfs files <cmd>` related code to an helper package called `fileshelpers`
- [x] Implements the API for all interfaces
- [x] Keeps current functionality, but changes the meaning of `count=0` in `files write` and `files read`. To simplify, if count equals 0, then we want to write or read everything. It doesn't even make sense to not read or not write anything.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>