### PR TITLE
Fix Typos

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -402,7 +402,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		return err
 	}
 
-	// Add ipfs version info to prometheous metrics
+	// Add ipfs version info to prometheus metrics
 	var ipfsInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ipfs_info",
 		Help: "IPFS version information.",

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -35,7 +35,7 @@ You may have to create /ipfs and /ipns before using 'ipfs mount':
 `,
 		LongDescription: `
 Mount IPFS at a read-only mountpoint on the OS. The default, /ipfs and /ipns,
-are set in the configuration file, but can be overriden by the options.
+are set in the configuration file, but can be overridden by the options.
 All IPFS objects will be accessible under this directory. Note that the
 root will not be listable, as it is virtual. Access known paths directly.
 

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -34,7 +34,7 @@ type Object struct {
 	Links []Link `json:"Links,omitempty"`
 }
 
-var ErrDataEncoding = errors.New("unkown data field encoding")
+var ErrDataEncoding = errors.New("unknown data field encoding")
 
 const (
 	headersOptionName      = "headers"
@@ -197,7 +197,7 @@ This command outputs data in the following encodings:
   * "xml"
 (Specified by the "--encoding" or "--enc" flag)
 
-The encoding of the object's data field can be specifed by using the
+The encoding of the object's data field can be specified by using the
 --data-encoding flag
 
 Supported values are:

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -523,7 +523,7 @@ Efficiently pins a new object based on differences from an existing one and,
 by default, removes the old pin.
 
 This commands is useful when the new pin contains many similarities or is a
-derivate of an existing one, particuarly for large objects. This allows a more
+derivative of an existing one, particuarly for large objects. This allows a more
 efficient DAG-traversal which fully skips already-pinned branches from the old
 object. As a requirement, the old object needs to be an existing recursive
 pin.

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -338,7 +338,7 @@ func deserializeNode(nd *Node, dataFieldEncoding string) (*dag.ProtoNode, error)
 		}
 		dagnode.SetData(data)
 	default:
-		return nil, fmt.Errorf("unkown data field encoding")
+		return nil, fmt.Errorf("unknown data field encoding")
 	}
 
 	links := make([]*ipld.Link, len(nd.Links))

--- a/mk/util.mk
+++ b/mk/util.mk
@@ -34,10 +34,10 @@ space+=
 comma:=,
 join-with=$(subst $(space),$1,$(strip $2))
 
-# debug target, prints varaible. Example: `make print-GOFLAGS`
+# debug target, prints variable. Example: `make print-GOFLAGS`
 print-%:
 	@echo $*=$($*)
 
-# phony target that will mean that recipe is always exectued
+# phony target that will mean that recipe is always executed
 ALWAYS:
 .PHONY: ALWAYS

--- a/test/sharness/README.md
+++ b/test/sharness/README.md
@@ -52,7 +52,7 @@ directory.
 Please do not change anything in the "lib/sharness" directory.
 
 If you really need some changes in sharness, please fork it from
-[its cannonical repo](https://github.com/mlafeldt/sharness/) and
+[its canonical repo](https://github.com/mlafeldt/sharness/) and
 send pull requests there.
 
 ## Writing Tests

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -193,7 +193,7 @@ test_add_cat_file() {
     test_expect_code 1 ipfs add -Q --chunker rabin-12-512-1024 mountdir/hello.txt
   '
 
-  test_expect_success "ipfs add --chunker buzhash suceeds" '
+  test_expect_success "ipfs add --chunker buzhash succeeds" '
     ipfs add --chunker buzhash mountdir/hello.txt >actual
   '
 
@@ -787,11 +787,11 @@ test_add_cat_5MB '--cid-version=1 --raw-leaves=false' "bafybeieyifrgpjn3yengthr7
 
 # note: --hash=blake2b-256 implies --cid-version=1 which implies --raw-leaves=true
 # the specified hash represents the leaf nodes stored as raw leaves and
-# encoded with the blake2b-256 hash funtion
+# encoded with the blake2b-256 hash function
 test_add_cat_5MB '--hash=blake2b-256' "bafykbzacebnmjcl4sn37b3ehtibvf263oun2w6idghenrvlpehq5w5jqyvhjo"
 
 # the specified hash represents the leaf nodes stored as protoful nodes and
-# encoded with the blake2b-256 hash funtion
+# encoded with the blake2b-256 hash function
 test_add_cat_5MB '--hash=blake2b-256 --raw-leaves=false' "bafykbzaceaxiiykzgpbhnzlecffqm3zbuvhujyvxe5scltksyafagkyw4rjn2"
 
 test_add_cat_expensive "" "QmU9SWAPPmNEKZB8umYMmjYvN7VyHqABNvdA6GUi4MMEz3"
@@ -802,7 +802,7 @@ test_add_cat_expensive "--cid-version=1" "bafybeidkj5ecbhrqmzrcee2rw7qwsx24z3364
 
 # note: --hash=blake2b-256 implies --cid-version=1 which implies --raw-leaves=true
 # the specified hash represents the leaf nodes stored as raw leaves and
-# encoded with the blake2b-256 hash funtion
+# encoded with the blake2b-256 hash function
 test_add_cat_expensive '--hash=blake2b-256' "bafykbzaceb26fnq5hz5iopzamcb4yqykya5x6a4nvzdmcyuu4rj2akzs3z7r6"
 
 test_add_named_pipe

--- a/test/sharness/t0175-reprovider.sh
+++ b/test/sharness/t0175-reprovider.sh
@@ -16,7 +16,7 @@ init_strategy() {
     PEERID_1=$(iptb attr get 1 id)
   '
 
-  test_expect_success 'use pinning startegy for reprovider' '
+  test_expect_success 'use pinning strategy for reprovider' '
     ipfsi 0 config Reprovider.Strategy '$1'
   '
 

--- a/test/sharness/t0184-http-proxy-over-p2p.sh
+++ b/test/sharness/t0184-http-proxy-over-p2p.sh
@@ -169,7 +169,7 @@ test_expect_success 'start http server' '
     start_http_server
 '
 
-test_expect_success 'handle proxy http request propogates error response from remote' '
+test_expect_success 'handle proxy http request propagates error response from remote' '
     serve_content "SORRY GUYS, I LOST IT" "404 Not Found" &&
     curl_send_proxy_request_and_check_response 404 "SORRY GUYS, I LOST IT"
 '

--- a/test/sharness/t0272-urlstore.sh
+++ b/test/sharness/t0272-urlstore.sh
@@ -28,7 +28,7 @@ test_urlstore() {
   
   test_launch_ipfs_daemon --offline
   
-  test_expect_success "make sure files can be retrived via the gateway" '
+  test_expect_success "make sure files can be retrieved via the gateway" '
     curl http://127.0.0.1:$GWAY_PORT/ipfs/$HASH1a -o file1.actual &&
     test_cmp file1 file1.actual &&
     curl http://127.0.0.1:$GWAY_PORT/ipfs/$HASH2a -o file2.actual &&


### PR DESCRIPTION
```
go-ipfs/cmd/ipfs/daemon.go:405:29: "prometheous" is a misspelling of "prometheus"
go-ipfs/core/commands/mount_unix.go:38:46: "overriden" is a misspelling of "overridden"
go-ipfs/core/commands/object/object.go:37:34: "unkown" is a misspelling of "unknown"
go-ipfs/core/commands/object/object.go:200:47: "specifed" is a misspelling of "specified"
go-ipfs/core/commands/pin.go:526:0: "derivate" is a misspelling of "derivative"
go-ipfs/core/coreapi/object.go:341:26: "unkown" is a misspelling of "unknown"
go-ipfs/mk/util.mk:37:23: "varaible" is a misspelling of "variable"
go-ipfs/mk/util.mk:41:52: "exectued" is a misspelling of "executed"
go-ipfs/test/sharness/README.md:55:5: "cannonical" is a misspelling of "canonical"
go-ipfs/test/sharness/t0040-add-and-cat.sh:196:50: "suceeds" is a misspelling of "succeeds"
go-ipfs/test/sharness/t0040-add-and-cat.sh:790:36: "funtion" is a misspelling of "function"
go-ipfs/test/sharness/t0040-add-and-cat.sh:794:36: "funtion" is a misspelling of "function"
go-ipfs/test/sharness/t0040-add-and-cat.sh:805:36: "funtion" is a misspelling of "function"
go-ipfs/test/sharness/t0175-reprovider.sh:19:35: "startegy" is a misspelling of "strategy"
go-ipfs/test/sharness/t0184-http-proxy-over-p2p.sh:172:47: "propogates" is a misspelling of "propagates"
go-ipfs/test/sharness/t0272-urlstore.sh:31:46: "retrived" is a misspelling of "retrieved"
```