### PR TITLE
add support for detecting window close events (on Windows)

### DIFF
--- a/cmd/ipfs/util/signal_windows.go
+++ b/cmd/ipfs/util/signal_windows.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+type (
+	DWORD    = uint32
+	MSVCBOOL = uintptr
+)
+
+const (
+	processed = iota
+	notProcessed
+)
+
+func init() {
+	nativeNotifier = windowEventHandler
+}
+
+// windowEventHandler creates and registers a WINAPI `HandlerRoutine` callback
+// which receives window events and relays them as interrupt signals to the provided channel
+func windowEventHandler(ih *IntrHandler, sigChan chan os.Signal, sigs ...os.Signal) {
+	// we don't want to relay the events `signal` is already listening for
+	// otherwise the channel will receive them twice
+	var goIsHandlingIntterupts bool
+	for _, sig := range sigs {
+		if sig == os.Interrupt {
+			goIsHandlingIntterupts = true
+		}
+	}
+
+	fp := func(ctrlType DWORD) MSVCBOOL {
+		switch ctrlType {
+		case windows.CTRL_CLOSE_EVENT:
+			//NOTE: the OS will terminate our process after receiving this event
+			// either after `SPI_GETHUNGAPPTIMEOUT` or immediately after we return non-0
+			// (whichever is first)
+			sigChan <- os.Interrupt
+			ih.wg.Wait()
+			return processed
+		case windows.CTRL_C_EVENT, windows.CTRL_BREAK_EVENT:
+			if !goIsHandlingIntterupts {
+				sigChan <- os.Interrupt
+			}
+			return processed
+
+		default:
+			// we didn't expect this event
+			// send it to the next handler
+			return notProcessed
+		}
+	}
+
+	// register the callback with the OS
+	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	setConsoleCtrlHandler := kernel32.NewProc("SetConsoleCtrlHandler")
+
+	setConsoleCtrlHandler.Call(windows.NewCallback(fp), 1)
+}


### PR DESCRIPTION
WIP fix for https://github.com/ipfs/go-ipfs/issues/1897

We add a shim `nativeNotifier` who's responsibility is to notify a channel of events/signals not covered by the `signal` pkg.
In this case, we implement this to add support for Windows' window events.

When the window receives a `CTRL+C`, `CTRL+BREAK`, or `WM_CLOSE` event, we will notify the interrupt channel and tell the OS we proccessed the event successfully.
This in turn will cancel the node's context for the first event and exit outright upon subsequent interrupts.

**Current problem**:
When processing `CTRL_C_EVENT` and `CTRL_BREAK_EVENT` events, nothing special has to be considered. But `WM_CLOSE` breaks down to a `CTRL_CLOSE_EVENT` which has special implications in this context.
https://docs.microsoft.com/en-us/windows/console/handlerroutine

When we receive this message, the system will terminate us in either 5 seconds, or when we return from our event handler (whichever is first).
Meaning we can initiate graceful shutdown from any signal, but need a way to wait for shutdown to be completed before returning from the handler, specifically when handling the `CTRL_CLOSE_EVENT` event.

i.e. the node has to...
```Go
case windows.CTRL_CLOSE_EVENT:
	// start shutting down here
	...
	// and block here until shutdown is finished
	return processed // this is the moment the process dies 👀
```

Commands like `shutdown` have direct access to the node and can just call its `Close` method, blocking until the node is finished shutting down.
We're a background thread that gets called at some arbitrary point by the user/OS, and don't have access to the node object so we can't just do the same.

This needs to be taken care of before this can progress out of a draft.

Edit:
[video showing the signal getting caught](https://www.youtube.com/watch?v=atWnbhnqWDI)