### PR TITLE
feat: update go-ds-badger to use async writes by default.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v0.1.1
 	github.com/ipfs/go-ipfs-chunker v0.0.3
 	github.com/ipfs/go-ipfs-cmds v0.1.1
-	github.com/ipfs/go-ipfs-config v0.1.0
+	github.com/ipfs/go-ipfs-config v0.2.0
 	github.com/ipfs/go-ipfs-ds-help v0.0.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.3 h1:UuXhKoxvxl/vGhie+WXFRZYCwpZjbKF2SzD1Tv
 github.com/ipfs/go-ipfs-chunker v0.0.3/go.mod h1:RkGJorerOQNTDPgmX7HtJ5YzVQqaIYdzI/hrCHty5Kc=
 github.com/ipfs/go-ipfs-cmds v0.1.1 h1:H9/BLf5rcsULHMj/x8gC0e5o+raYhqk1OQsfzbGMNM4=
 github.com/ipfs/go-ipfs-cmds v0.1.1/go.mod h1:k1zMXcOLtljA9iAnZHddbH69yVm5+weRL0snmMD/rK0=
-github.com/ipfs/go-ipfs-config v0.1.0 h1:swjuXF30jL4nH7r63JucMaIfyC97Y0JTWSSwZMTiv64=
-github.com/ipfs/go-ipfs-config v0.1.0/go.mod h1:vEXbHHFPMCGCVhgv8oye4QF75kQ/gyZ3/tBdMMZFAps=
+github.com/ipfs/go-ipfs-config v0.2.0 h1:c5UtyIRVdeSYRP2I1ZR167e9XJs5x8vepeo2w4I4+KU=
+github.com/ipfs/go-ipfs-config v0.2.0/go.mod h1:vEXbHHFPMCGCVhgv8oye4QF75kQ/gyZ3/tBdMMZFAps=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=


### PR DESCRIPTION
Go-ipfs now manually calls "sync" on the underlying datastore after adding data.
We can now write asynchronously and sync once at the end.