### PR TITLE
feat(repo): bump repo version

### DIFF
--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -36,7 +36,7 @@ const LockFile = "repo.lock"
 var log = logging.Logger("fsrepo")
 
 // version number that we are currently expecting to see
-var RepoVersion = 7
+var RepoVersion = 8
 
 var migrationInstructions = `See https://github.com/ipfs/fs-repo-migrations/blob/master/run.md
 Sorry for the inconvenience. In the future, these will run automatically.`


### PR DESCRIPTION
We're bumping to version 8 to migrate bootstrappers:

1. Switch from /ipfs to /p2p. This isn't necessary but it's still "nice".
2. Add new bootstrappers to old nodes that don't have them.

part of #6797