### PR TITLE
make it possible to change the codec with the `ipfs cid` subcommand

### DIFF
--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -169,10 +169,7 @@ func emitCids(req *cmds.Request, resp cmds.ResponseEmitter, opts cidFormatOpts) 
 			emitErr = resp.Emit(res)
 			continue
 		}
-		base := opts.newBase
-		if base == -1 {
-			base, _ = cid.ExtractEncoding(cidStr)
-		}
+
 		if opts.verConv != nil {
 			c, err = opts.verConv(c)
 			if err != nil {
@@ -181,6 +178,16 @@ func emitCids(req *cmds.Request, resp cmds.ResponseEmitter, opts cidFormatOpts) 
 				continue
 			}
 		}
+
+		base := opts.newBase
+		if base == -1 {
+			if c.Version() == 0 {
+				base = mbase.Base58BTC
+			} else {
+				base, _ = cid.ExtractEncoding(cidStr)
+			}
+		}
+
 		str, err := cidutil.Format(opts.fmtStr, base, c)
 		if _, ok := err.(cidutil.FormatStringError); ok {
 			// no point in continuing if there is a problem with the format string

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -10,6 +10,10 @@ CIDv0="QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
 CIDv1="zdj7WZAAFKPvYPPzyJLso2hhxo8a7ZACFQ4DvvfrNXTHidofr"
 CIDb32="bafybeibxm2nsadl3fnxv2sxcxmxaco2jl53wpeorjdzidjwf5aqdg7wa6u"
 
+CIDbase="QmYNmQKp6SuaVrpgWRsPTgCQCnpxUYGq76YEKBXuj2N4H6"
+CIDb32pb="bafybeievd6mwe6vcwnkwo3eizs3h7w3a34opszbyfxziqdxguhjw7imdve"
+CIDb32raw="bafkreievd6mwe6vcwnkwo3eizs3h7w3a34opszbyfxziqdxguhjw7imdve"
+
 test_expect_success "cid base32 works" '
   echo $CIDb32 > expected &&
   ipfs cid base32 $CIDv0 > actual1 &&
@@ -233,5 +237,18 @@ test_expect_success "cid hashes --numeric" '
   ipfs cid hashes --numeric > actual &&
   test_cmp hashes_expect actual
 '
+
+test_expect_success "cid format -c raw" '
+  echo $CIDb32raw > expected &&
+  ipfs cid format --codec raw -b base32 $CIDb32pb > actual &&
+  test_cmp actual expected
+'
+
+test_expect_success "cid format -c protobuf -v 0" '
+  echo $CIDbase > expected &&
+  ipfs cid format --codec protobuf -v 0 $CIDb32raw > actual &&
+  test_cmp actual expected
+'
+
 
 test_done

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -26,6 +26,12 @@ test_expect_success "cid format -v 1 -b base58btc" '
   test_cmp expected actual2
 '
 
+test_expect_success "cid format -v 0" '
+  echo $CIDv0 > expected &&
+  ipfs cid format -v 0 $CIDb32 > actual &&
+  test_cmp expected actual
+'
+
 cat <<EOF > various_cids
 QmZZRTyhDpL5Jgift1cHbAhexeE1m2Hw8x8g7rTcPahDvo
  QmPhk6cJkRcFfZCdYam4c9MKYjFG9V29LswUnbrFNhtk2S


### PR DESCRIPTION
This will be useful when testing `refs local, `repo gc`, and `repo verify` commands once we store blocks by multihash instead of by CID. At that point, these commands will return raw v1 CIDs as the blockstore won't actually remember the codec used to store the block.

Flags choice:

* Ideally, we'd use the `-f, --format` flags like every other command but we're already using `-f` (format) for the format string.
* Alternatively, I'd like to use `-c`. However, we're using _that_ for a global `--config` flag (bit of a waste given that it doesn't work...).

`--codec` will have to do for now.

Note: this patch also fixes `ipfs cid format -v 0 SOME_BASE32_CID` by implicitly converting to base58 (likely what the user intended).