### PR TITLE
fix(badgerds): turn off sync writes by default

### DIFF
--- a/plugin/plugins/badgerds/badgerds.go
+++ b/plugin/plugins/badgerds/badgerds.go
@@ -60,7 +60,7 @@ func (*badgerdsPlugin) DatastoreConfigParser() fsrepo.ConfigFromMap {
 
 		sw, ok := params["syncWrites"]
 		if !ok {
-			c.syncWrites = true
+			c.syncWrites = false
 		} else {
 			if swb, ok := sw.(bool); ok {
 				c.syncWrites = swb


### PR DESCRIPTION
We already do this in the datastore _profile_, but we should do this in the
plugin as well. I'm pretty sure this makes absolutely no difference.