### PR TITLE
test: E2E tests against ipfs-webui HEAD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
       <<: *default_environment
   node-browsers:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,16 @@ executors:
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
+  node-browsers:
+    docker:
+      - image: circleci/node:10-browsers
+    working_directory: ~/ipfs/go-ipfs
+    environment:
+      <<: *default_environment
+      NO_SANDBOX: true
+      IPFS_REUSEPORT: false
+      LIBP2P_ALLOW_WEAK_RSA_KEYS: 1
+      E2E_IPFSD_TYPE: go
 
 jobs:
   gobuild:
@@ -188,7 +198,7 @@ jobs:
           working_directory: ~/ipfs/go-ipfs/interop
           environment:
             IPFS_REUSEPORT: false
-            LIBP2P_ALLOW_WEAK_RSA_KEYS: true
+            LIBP2P_ALLOW_WEAK_RSA_KEYS: 1
             IPFS_GO_EXEC: /tmp/circleci-workspace/bin/ipfs
       - store_test_results:
           path: /tmp/test-results
@@ -255,6 +265,41 @@ jobs:
           paths:
             - ~/go/pkg/mod
             - ~/.cache/go-build/
+  ipfs-webui:
+    executor: node-browsers
+    steps:
+      - *make_out_dirs
+      - attach_workspace:
+          at: /tmp/circleci-workspace
+      - run:
+          name: Cloning
+          command: |
+            git clone https://github.com/ipfs-shipyard/ipfs-webui.git
+            git -C ipfs-webui log -1
+      - restore_cache:
+          keys:
+            - v1-ipfs-webui-{{ checksum "~/ipfs/go-ipfs/ipfs-webui/package-lock.json" }}
+            - v1-ipfs-webui-
+      - run:
+          name: Installing dependencies
+          command: |
+            npm install
+          working_directory: ~/ipfs/go-ipfs/ipfs-webui
+      - run:
+          name: Running upstream tests (finish early if they fail)
+          command: |
+            npm test || circleci-agent step halt
+          working_directory: ~/ipfs/go-ipfs/ipfs-webui
+      - run:
+          name: Running tests with go-ipfs built from current commit
+          command: npm test
+          working_directory: ~/ipfs/go-ipfs/ipfs-webui
+          environment:
+            IPFS_GO_EXEC: /tmp/circleci-workspace/bin/ipfs
+      - save_cache:
+          key: v1-ipfs-webui-{{ checksum "~/ipfs/go-ipfs/ipfs-webui/package-lock.json" }}
+          paths:
+            - ~/ipfs/go-ipfs/ipfs-webui/node_modules
 workflows:
   version: 2
   test:
@@ -271,5 +316,8 @@ workflows:
         requires:
           - build
     - go-ipfs-http-client:
+        requires:
+          - build
+    - ipfs-webui:
         requires:
           - build


### PR DESCRIPTION
> Parent: https://github.com/ipfs-shipyard/ipfs-webui/issues/1164

This PR adds CircleCI config for running ipfs-webui's end to end tests against `ipfs` binary produced by this repo.

It does not increase CI time, as its runs in parallel to interop tests, and those take much longer:

> ![times](https://user-images.githubusercontent.com/157609/72531440-c2ddd800-3871-11ea-8785-df2873b24a04.png)

The goal is to catch regressions in go-ipfs+ipfs-webui interop, such as this one (hardened go-ipfs was unable to connect to peer that used weak key size):

> ![Screenshot_2020-01-15 ipfs-webui (23414) - ipfs go-ipfs](https://user-images.githubusercontent.com/157609/72459462-1d702900-37cb-11ea-81b4-693533fd9c47.png)

When everything works as expected, it looks like this:

> ![green](https://user-images.githubusercontent.com/157609/72523499-3c6cca80-3860-11ea-83ea-e1c448bef973.png)



## TODO

- [x] use custom executor capable of running Chrome in headless mode
- [x] fix ipfsd-ctl error with latest go-ipfs master
   - error:  `[test:e2e  ] SyntaxError: Unexpected end of JSON input`
   - reason: `ipfs init` failed because `ipfsd-ctl` uses 1024 bit keys in `test` mode
   - fix: set `LIBP2P_ALLOW_WEAK_RSA_KEYS: true` in test env
- [x] confirm version from `IPFS_GO_EXEC` is used
   - confirmed: `[test:e2e  ] E2E using /go-ipfs/0.5.0-dev/28a9a6501 (/tmp/circleci-workspace/bin/ipfs) with Peer ID QmXcHQoM2SFTAaxE2khR4WpPDCnouYNMPPEkqxZxKNk6oa`
- [x] confirm CI works and added time is acceptable
  - we should be good: it takes ~6m and finishes long before `interop` tests suite (both run  in parallel) 
- [x] consider: if test time is low enough, run original tests first to confirm ipfs-webui's HEAD is green, then run again with `ipfs` from this repo's `HEAD` 
  - decision: running tests second time take less than a minute, sounds feasible
  - note: if upstream tests fail, we dont break the build, but exit with code `0` (skipping, as there is no way to test for regression if upstream webui is broken)
- [x] fix [`failed to negotiate security protocol: MAC verification failed`](https://user-images.githubusercontent.com/157609/72459462-1d702900-37cb-11ea-81b4-693533fd9c47.png))
  - note: it is super cool that the moment we've set up E2E regression test, we've found a regression :ok_hand: 
  - reason: `LIBP2P_ALLOW_WEAK_RSA_KEYS=true` did not decrease minimal key size limit everywhere
  - fix: changing to `LIBP2P_ALLOW_WEAK_RSA_KEYS=1` fixed the "MAC verification failed" error. I updated `true` → `1` everywhere.
- [x] switch to ipfs-webui's `master` 
  - remove checkout of "fix/test-external" (requires https://github.com/ipfs-shipyard/ipfs-webui/pull/1377 to land first)