### PR TITLE
docs: define Gateway.PathPrefixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -294,7 +294,27 @@ A boolean to configure whether the gateway is writeable or not.
 Default: `false`
 
 - `PathPrefixes`
-TODO
+Array of acceptable url paths that a client can specify in X-Ipfs-Path-Prefix header. 
+
+The X-Ipfs-Path-Prefix header is used to specify a base path to prepend to links in directory listings and for trailing-slash redirects. It is intended to be set by a frontend http proxy like nginx.
+
+Example: We mount `blog.ipfs.io` (a dnslink page) at `ipfs.io/blog`.
+
+**.ipfs/config**
+```json
+"Gateway": {
+  "PathPrefixes": ["/blog"],
+```
+
+**nginx_ipfs.conf**
+```nginx
+location /blog/ {
+  rewrite "^/blog(/.*)$" $1 break;
+  proxy_set_header Host blog.ipfs.io;
+  proxy_set_header X-Ipfs-Gateway-Prefix /blog;
+  proxy_pass http://127.0.0.1:8080;
+}
+```
 
 Default: `[]`
 


### PR DESCRIPTION
adds docs for Gateway.PathPrefixes. Taken from great commit notes by @lgierth (thank you!) https://github.com/ipfs/go-ipfs/commit/09937f84b64212896e1d80147f828d86ebc19d68