### PR TITLE
update dockerfile and use openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-buster
+FROM golang:1.13.6-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 ENV SRC_DIR /go-ipfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 # Add suid bit on fusermount so it will run properly
 RUN chmod 4755 /usr/local/bin/fusermount
 
+# Fix permissions on start_ipfs (ignore the build machine's permissions)
+RUN chmod 0755 /usr/local/bin/start_ipfs
+
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
 COPY --from=0 /lib/x86_64-linux-gnu/libdl.so.2 /lib/libdl.so.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cd $SRC_DIR \
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers
 ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.16.1
+ENV TINI_VERSION v0.18.0
 RUN set -x \
   && cd /tmp \
   && git clone https://github.com/ncopa/su-exec.git \


### PR DESCRIPTION
This PR:

* Updates docker deps (go -> 1.13.5, tini -> 0.18.0)
* Builds go-ipfs using openssl. We don't distribute go-ipfs with OpenSSL support by default to avoid depending on external libraries. However, we completely control the docker environment so there's no reason not to build with OpenSSL support. This significantly reduces CPU usage.
* Explicitly set the permissions on start_ipfs so we don't inherit the defaults set by the host OS.