### PR TITLE
fix: dont fail to collect profiles if no ipfs bin

### DIFF
--- a/bin/collect-profiles.sh
+++ b/bin/collect-profiles.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-HTTP_API="${1:-127.0.0.1:5001}"
+SOURCE_URL="${1:-http://127.0.0.1:5001}"
 tmpdir=$(mktemp -d)
 export PPROF_TMPDIR="$tmpdir"
 pushd "$tmpdir" > /dev/null
@@ -22,27 +22,27 @@ if command -v ipfs > /dev/null 2>&1; then
 fi
 
 echo Collecting goroutine stacks
-curl -s -o goroutines.stacks "http://$HTTP_API"'/debug/pprof/goroutine?debug=2'
+curl -s -o goroutines.stacks "$SOURCE_URL"'/debug/pprof/goroutine?debug=2'
 
 echo Collecting goroutine profile
-go tool pprof -symbolize=remote -svg -output goroutine.svg "http://$HTTP_API/debug/pprof/goroutine"
+go tool pprof -symbolize=remote -svg -output goroutine.svg "$SOURCE_URL/debug/pprof/goroutine"
 
 echo Collecting heap profile
-go tool pprof -symbolize=remote -svg -output heap.svg "http://$HTTP_API/debug/pprof/heap"
+go tool pprof -symbolize=remote -svg -output heap.svg "$SOURCE_URL/debug/pprof/heap"
 
 echo "Collecting cpu profile (~30s)"
-go tool pprof -symbolize=remote -svg -output cpu.svg "http://$HTTP_API/debug/pprof/profile"
+go tool pprof -symbolize=remote -svg -output cpu.svg "$SOURCE_URL/debug/pprof/profile"
 
 echo "Enabling mutex profiling"
-curl -X POST "http://$HTTP_API"'/debug/pprof-mutex/?fraction=4'
+curl -X POST "$SOURCE_URL"'/debug/pprof-mutex/?fraction=4'
 
 echo "Waiting for mutex data to be updated (30s)"
 sleep 30
-curl -s -o mutex.txt "http://$HTTP_API"'/debug/pprof/mutex?debug=2'
-go tool pprof -symbolize=remote -svg -output mutex.svg "http://$HTTP_API/debug/pprof/mutex"
+curl -s -o mutex.txt "$SOURCE_URL"'/debug/pprof/mutex?debug=2'
+go tool pprof -symbolize=remote -svg -output mutex.svg "$SOURCE_URL/debug/pprof/mutex"
 
 echo "Disabling mutex profiling"
-curl -X POST "http://$HTTP_API"'/debug/pprof-mutex/?fraction=0'
+curl -X POST "$SOURCE_URL"'/debug/pprof-mutex/?fraction=0'
 
 OUTPUT_NAME=ipfs-profile-$(uname -n)-$(date +'%Y-%m-%dT%H:%M:%S%z').tar.gz
 echo "Creating $OUTPUT_NAME"

--- a/bin/collect-profiles.sh
+++ b/bin/collect-profiles.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
-set -x
+
+# collect-profiles.sh
+#
+# Collects go profile information from a running `ipfs` daemon.
+# Creates an archive including the profiles, profile graph svgs,
+# ...and where available, a copy of the `ipfs` binary on the PATH.
+#
+# Please run this script and attach the profile archive it creates
+# when reporting bugs at https://github.com/ipfs/go-ipfs/issues
+
 set -euo pipefail
 IFS=$'\n\t'
 
 HTTP_API="${1:-127.0.0.1:5001}"
 tmpdir=$(mktemp -d)
 export PPROF_TMPDIR="$tmpdir"
-pushd "$tmpdir"
+pushd "$tmpdir" > /dev/null
 
-IPFS_BIN=$(which ipfs)
-if [[ -e "$IPFS_BIN" ]]; then
-    cp "$IPFS_BIN" ipfs
+if command -v ipfs > /dev/null 2>&1; then
+  cp "$(command -v ipfs)" ipfs
 fi
 
 echo Collecting goroutine stacks
-curl -o goroutines.stacks "http://$HTTP_API"'/debug/pprof/goroutine?debug=2'
+curl -s -o goroutines.stacks "http://$HTTP_API"'/debug/pprof/goroutine?debug=2'
 
 echo Collecting goroutine profile
 go tool pprof -symbolize=remote -svg -output goroutine.svg "http://$HTTP_API/debug/pprof/goroutine"
@@ -26,15 +34,18 @@ echo "Collecting cpu profile (~30s)"
 go tool pprof -symbolize=remote -svg -output cpu.svg "http://$HTTP_API/debug/pprof/profile"
 
 echo "Enabling mutex profiling"
-curl -X POST -v "http://$HTTP_API"'/debug/pprof-mutex/?fraction=4'
+curl -X POST "http://$HTTP_API"'/debug/pprof-mutex/?fraction=4'
 
 echo "Waiting for mutex data to be updated (30s)"
 sleep 30
-curl -o mutex.txt "http://$HTTP_API"'/debug/pprof/mutex?debug=2'
+curl -s -o mutex.txt "http://$HTTP_API"'/debug/pprof/mutex?debug=2'
 go tool pprof -symbolize=remote -svg -output mutex.svg "http://$HTTP_API/debug/pprof/mutex"
-echo "Disabling mutex profiling"
-curl -X POST -v "http://$HTTP_API"'/debug/pprof-mutex/?fraction=0'
 
-popd
-tar cvzf "./ipfs-profile-$(uname -n)-$(date +'%Y-%m-%dT%H:%M:%S%z').tar.gz" -C "$tmpdir" .
+echo "Disabling mutex profiling"
+curl -X POST "http://$HTTP_API"'/debug/pprof-mutex/?fraction=0'
+
+OUTPUT_NAME=ipfs-profile-$(uname -n)-$(date +'%Y-%m-%dT%H:%M:%S%z').tar.gz
+echo "Creating $OUTPUT_NAME"
+popd > /dev/null
+tar czf "./$OUTPUT_NAME" -C "$tmpdir" .
 rm -rf "$tmpdir"


### PR DESCRIPTION
Due to the bash args used, collect-profiles.sh would fail if `which ipfs` failed to find an ipfs binary on the path, like when running ipfs in docker. Fixes that by using a check for the command that wont error if it's not found.

Also
- adds a comment to explain when to use the script and what it does.
- be less chatty. Simplify the output so it's clearer what it's doing. Experts can read the script or set the -x flag themselves.
- allow profiling of remote nodes via https.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>