### PR TITLE
doc(release): move WebUI from manual tests to automated tests section

### DIFF
--- a/docs/RELEASE_ISSUE_TEMPLATE.md
+++ b/docs/RELEASE_ISSUE_TEMPLATE.md
@@ -43,6 +43,7 @@ Checklist:
     - [ ] [interop](https://github.com/ipfs/interop#test-with-a-non-yet-released-version-of-go-ipfs)
     - [ ] [go-ipfs-api](https://github.com/ipfs/go-ipfs-api)
     - [ ] [go-ipfs-http-client](https://github.com/ipfs/go-ipfs-http-client)
+    - [ ] [WebUI](https://github.com/ipfs-shipyard/ipfs-webui)
 - [ ] **Stage 1 - Internal Testing**
   - [ ] CHANGELOG.md has been updated
     - use [`./bin/mkreleaselog`](https://github.com/ipfs/go-ipfs/tree/master/bin/mkreleaselog) to generate a nice starter list
@@ -54,7 +55,6 @@ Checklist:
     - [ ] Deploy new version to a subset of Preload nodes
     - [ ] Collect metrics every day. Work with the Infrastructure team to learn of any hiccup
   - [ ] IPFS Application Testing -  Run the tests of the following applications:
-    - [ ] [WebUI](https://github.com/ipfs-shipyard/ipfs-webui) - @olizilla
     - [ ] [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop) - @hacdias
     - [ ] [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion) - @lidel
     - [ ] [NPM on IPFS](https://github.com/ipfs-shipyard/npm-on-ipfs) - @achingbrain


### PR DESCRIPTION
We no longer need to manually test the webui on release.