### PR TITLE
fix(build): instruct users to use GOTAGS, not GOFLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -425,7 +425,7 @@ receiving multiple inbound connections per second.
 To enable openssl support, rebuild go-ipfs with:
 
 ```bash
-> make build GOFLAGS=-tags=openssl
+> make build GOTAGS=openssl
 ```
 
 ### CoreAPI

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
 
 # Now comes the actual target image, which aims to be as small as possible.
 FROM busybox:1.31.0-glibc
-LABEL maintainer="Steven Allen <stven@stebalien.com>"
+LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Get the ipfs binary, entrypoint script, and TLS CAs from the build container.
 ENV SRC_DIR /go-ipfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . $SRC_DIR
 # Also: fix getting HEAD commit hash via git rev-parse.
 RUN cd $SRC_DIR \
   && mkdir .git/objects \
-  && make build GOFLAGS=-tags=openssl
+  && make build GOTAGS=openssl
 
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ IPFS can run on most Linux, macOS, and Windows systems. We recommend running it 
 
 If your system is resource constrained, we recommend:
 
-1. Installing OpenSSL and rebuilding go-ipfs manually with `make build GOFLAGS=-tags=openssl`. See the [download and compile](#download-and-compile-ipfs) section for more information on compiling go-ipfs.
+1. Installing OpenSSL and rebuilding go-ipfs manually with `make build GOTAGS=openssl`. See the [download and compile](#download-and-compile-ipfs) section for more information on compiling go-ipfs.
 2. Initializing your daemon with `ipfs init --profile=lowpower`
 
 ### Install prebuilt packages
@@ -204,7 +204,7 @@ make build GOOS=myTargetOS GOARCH=myTargetArchitecture
 
 ##### OpenSSL
 
-To build go-ipfs with OpenSSL support, append `GOFLAGS=-tags=openssl` to your `make` invocation. Building with OpenSSL should significantly reduce the background CPU usage on nodes that frequently make or receive new connections.
+To build go-ipfs with OpenSSL support, append `GOTAGS=openssl` to your `make` invocation. Building with OpenSSL should significantly reduce the background CPU usage on nodes that frequently make or receive new connections.
 
 Note: OpenSSL requires CGO support and, by default, CGO is disabled when cross compiling. To cross compile with OpenSSL support, you must:
 


### PR DESCRIPTION
GOFLAGS will _override_ all the flags. If we just want to set a tag e.g., enable OpenSSL, we should set GOTAGS=openssl.

fixes https://github.com/ipfs/go-ipfs/issues/6622#issuecomment-576713181