### PR TITLE
fix: make rsa the default key type

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -63,7 +63,7 @@ var keyGenCmd = &cmds.Command{
 		Tagline: "Create a new keypair",
 	},
 	Options: []cmds.Option{
-		cmds.StringOption(keyStoreTypeOptionName, "t", "type of the key to create [rsa, ed25519]"),
+		cmds.StringOption(keyStoreTypeOptionName, "t", "type of the key to create [rsa, ed25519]").WithDefault("rsa"),
 		cmds.IntOption(keyStoreSizeOptionName, "s", "size of the key to generate"),
 	},
 	Arguments: []cmds.Argument{


### PR DESCRIPTION
It's already the default when initializing the node, we might as well make it the default when creating new keys.

fixes #6861