### PR TITLE
fix: fix id addr format

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -14,6 +14,7 @@ import (
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	ic "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	pstore "github.com/libp2p/go-libp2p-core/peerstore"
 	kb "github.com/libp2p/go-libp2p-kbucket"
@@ -184,9 +185,12 @@ func printSelf(node *core.IpfsNode) (interface{}, error) {
 	info.PublicKey = base64.StdEncoding.EncodeToString(pkb)
 
 	if node.PeerHost != nil {
-		for _, a := range node.PeerHost.Addrs() {
-			s := a.String() + "/ipfs/" + info.ID
-			info.Addresses = append(info.Addresses, s)
+		addrs, err := peer.AddrInfoToP2pAddrs(host.InfoFromHost(node.PeerHost))
+		if err != nil {
+			return nil, err
+		}
+		for _, a := range addrs {
+			info.Addresses = append(info.Addresses, a.String())
 		}
 	}
 	info.ProtocolVersion = identify.LibP2PVersion

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -298,10 +298,11 @@ var swarmAddrsLocalCmd = &cmds.Command{
 		}
 
 		var addrs []string
+		p2pProtocolName := ma.ProtocolWithCode(ma.P_P2P).Name
 		for _, addr := range maddrs {
 			saddr := addr.String()
 			if showid {
-				saddr = path.Join(saddr, "ipfs", self.ID().Pretty())
+				saddr = path.Join(saddr, p2pProtocolName, self.ID().Pretty())
 			}
 			addrs = append(addrs, saddr)
 		}


### PR DESCRIPTION
Instead of manually creating multiaddr strings, use the multiaddr logic to format them. We were still using `/ipfs` multiaddrs instead of `/p2p` multiaddrs.