### PR TITLE
feat: pass IPFS_PLUGINS to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,15 @@ RUN cd $SRC_DIR \
 
 COPY . $SRC_DIR
 
+# Preload an in-tree but disabled-by-default plugin by adding it to the IPFS_PLUGINS variable
+# e.g. docker build --build-arg IPFS_PLUGINS="foo bar baz"
+ARG IPFS_PLUGINS
+
 # Build the thing.
 # Also: fix getting HEAD commit hash via git rev-parse.
 RUN cd $SRC_DIR \
   && mkdir .git/objects \
-  && make build GOTAGS=openssl
+  && make build GOTAGS=openssl IPFS_PLUGINS=$IPFS_PLUGINS
 
 # Get su-exec, a very minimal tool for dropping privileges,
 # and tini, a very minimal init daemon for containers

--- a/plugin/plugins/peerlog/peerlog.go
+++ b/plugin/plugins/peerlog/peerlog.go
@@ -40,7 +40,6 @@ func (*peerLogPlugin) Version() string {
 
 // Init initializes plugin
 func (*peerLogPlugin) Init(*plugin.Environment) error {
-	fmt.Println("peerLogPlugin enabled - PeerIDs will be logged")
 	return nil
 }
 


### PR DESCRIPTION
- allow IPFS_PLUGINS build-arg to be passed to docker build command
- remove annoying logging from peerlog plugin that appears multiple times in docker logs

usage:
```console
$ docker build --build-arg IPFS_PLUGINS="foo bar baz"
```
License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>