### PR TITLE
remove expired GPG key from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Before opening an issue, consider using one of the following locations to ensure
 
 The IPFS protocol and its implementations are still in heavy development. This means that there may be problems in our protocols, or there may be mistakes in our implementations. And -- though IPFS is not production-ready yet -- many people are already running nodes in their machines. So we take security vulnerabilities very seriously. If you discover a security issue, please bring it to our attention right away!
 
-If you find a vulnerability that may affect live deployments -- for example, by exposing a remote execution exploit -- please send your report privately to security@ipfs.io. Please DO NOT file a public issue. The GPG key for security@ipfs.io is [4B9665FB 92636D17 7C7A86D3 50AAE8A9 59B13AF3](https://pgp.mit.edu/pks/lookup?op=get&search=0x50AAE8A959B13AF3).
+If you find a vulnerability that may affect live deployments -- for example, by exposing a remote execution exploit -- please send your report privately to security@ipfs.io. Please DO NOT file a public issue.
 
 If the issue is a protocol weakness that cannot be immediately exploited or something not yet deployed, just discuss it openly.
 


### PR DESCRIPTION
Encourage initial bug reports to security@ to be unencrypted for faster triage