### PR TITLE
Fix typo in 0.4.23 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # go-ipfs changelog
 
-## 0.4.23 2019-01-29
+## 0.4.23 2020-01-29
 
 Given the large number of fixes merged since 0.4.22, we've decided to cut another patch release.
 


### PR DESCRIPTION
The year should be "2020," not "2019."