### PR TITLE
Introducing EncodedFSKeystore with base32 encoding (#5947)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
           name: Cloning
           command: |
             git clone https://github.com/ipfs/interop.git
+            git -C interop checkout "fix/disable-repo-interop-test"
             git -C interop log -1
       - restore_cache:
           keys:

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -271,3 +271,92 @@ func assertDirContents(dir string, exp []string) error {
 	}
 	return nil
 }
+
+func TestEncodedKeystoreBasics(t *testing.T) {
+	tdir, err := ioutil.TempDir("", "encoded-keystore-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ks, err := NewEncodedFSKeystore(tdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := ks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(l) != 0 {
+		t.Fatal("expected no keys")
+	}
+
+	k1 := privKeyOrFatal(t)
+	k1Name, err := encode("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k2 := privKeyOrFatal(t)
+	k2Name, err := encode("bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ks.Put("foo", k1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ks.Put("bar", k2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l, err = ks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(l)
+	if l[0] != "bar" || l[1] != "foo" {
+		t.Fatal("wrong entries listed")
+	}
+
+	if err := assertDirContents(tdir, []string{k1Name, k2Name}); err != nil {
+		t.Fatal(err)
+	}
+
+	exist, err := ks.Has("foo")
+	if !exist {
+		t.Fatal("should know it has a key named foo")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ks.Delete("bar"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assertDirContents(tdir, []string{k1Name}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := assertGetKey(ks, "foo", k1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ks.Put("..///foo/", k1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ks.Put("", k1); err == nil {
+		t.Fatal("shouldnt be able to put a key with no name")
+	}
+
+	if err := ks.Put(".foo", k1); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/keystore/memkeystore.go
+++ b/keystore/memkeystore.go
@@ -1,6 +1,10 @@
 package keystore
 
-import ci "github.com/libp2p/go-libp2p-core/crypto"
+import (
+	"errors"
+
+	ci "github.com/libp2p/go-libp2p-core/crypto"
+)
 
 // MemKeystore is an in memory keystore implementation that is not persisted to
 // any backing storage.
@@ -8,6 +12,7 @@ type MemKeystore struct {
 	keys map[string]ci.PrivKey
 }
 
+// NewMemKeystore creates a MemKeystore.
 func NewMemKeystore() *MemKeystore {
 	return &MemKeystore{make(map[string]ci.PrivKey)}
 }
@@ -20,8 +25,8 @@ func (mk *MemKeystore) Has(name string) (bool, error) {
 
 // Put store a key in the Keystore
 func (mk *MemKeystore) Put(name string, k ci.PrivKey) error {
-	if err := validateName(name); err != nil {
-		return err
+	if name == "" {
+		return errors.New("key name must be at least one character")
 	}
 
 	_, ok := mk.keys[name]
@@ -35,10 +40,6 @@ func (mk *MemKeystore) Put(name string, k ci.PrivKey) error {
 
 // Get retrieve a key from the Keystore
 func (mk *MemKeystore) Get(name string) (ci.PrivKey, error) {
-	if err := validateName(name); err != nil {
-		return nil, err
-	}
-
 	k, ok := mk.keys[name]
 	if !ok {
 		return nil, ErrNoSuchKey
@@ -49,10 +50,6 @@ func (mk *MemKeystore) Get(name string) (ci.PrivKey, error) {
 
 // Delete remove a key from the Keystore
 func (mk *MemKeystore) Delete(name string) error {
-	if err := validateName(name); err != nil {
-		return err
-	}
-
 	delete(mk.keys, name)
 	return nil
 }

--- a/keystore/memkeystore_test.go
+++ b/keystore/memkeystore_test.go
@@ -85,15 +85,15 @@ func TestMemKeyStoreBasics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ks.Put("..///foo/", k1); err == nil {
-		t.Fatal("shouldnt be able to put a poorly named key")
+	if err := ks.Put("..///foo/", k1); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := ks.Put("", k1); err == nil {
 		t.Fatal("shouldnt be able to put a key with no name")
 	}
 
-	if err := ks.Put(".foo", k1); err == nil {
-		t.Fatal("shouldnt be able to put a key with a 'hidden' name")
+	if err := ks.Put(".foo", k1); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -36,7 +36,7 @@ const LockFile = "repo.lock"
 var log = logging.Logger("fsrepo")
 
 // version number that we are currently expecting to see
-var RepoVersion = 7
+var RepoVersion = 8
 
 var migrationInstructions = `See https://github.com/ipfs/fs-repo-migrations/blob/master/run.md
 Sorry for the inconvenience. In the future, these will run automatically.`
@@ -385,7 +385,7 @@ func (r *FSRepo) openConfig() error {
 
 func (r *FSRepo) openKeystore() error {
 	ksp := filepath.Join(r.path, "keystore")
-	ks, err := keystore.NewFSKeystore(ksp)
+	ks, err := keystore.NewKeystore(ksp)
 	if err != nil {
 		return err
 	}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -36,7 +36,7 @@ const LockFile = "repo.lock"
 var log = logging.Logger("fsrepo")
 
 // version number that we are currently expecting to see
-var RepoVersion = 8
+var RepoVersion = 9
 
 var migrationInstructions = `See https://github.com/ipfs/fs-repo-migrations/blob/master/run.md
 Sorry for the inconvenience. In the future, these will run automatically.`
@@ -385,7 +385,7 @@ func (r *FSRepo) openConfig() error {
 
 func (r *FSRepo) openKeystore() error {
 	ksp := filepath.Join(r.path, "keystore")
-	ks, err := keystore.NewKeystore(ksp)
+	ks, err := keystore.NewFSKeystore(ksp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ported from https://github.com/ipfs/go-ipfs/pull/6012

---

Encoding the key's filename with base32 introduces coherent behaviour
across different platforms and their case-sensitive/case-insensitive
file-systems. Moreover it allows wider character set to be used for the
name of the keys as the original restriction for special FS's characters
(e.g. '/', '.') will not apply.

License: MIT
Signed-off-by: Adam Uhlir <uhlir.a@gmail.com>