### PR TITLE
feat: dockerhub post push hook

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -21,12 +21,12 @@ set -euo pipefail
 # env vars set by docker hub https://docs.docker.com/docker-hub/builds/advanced/#environment-variables-for-building-and-testing
 DOCKER_REPO=${1:-$DOCKER_REPO}       # e.g. "ipfs/go-ipfs"
 DOCKER_TAG=${2:-$DOCKER_TAG}         # e.g. "bifrost-latest"
-SOURCE_BRANCH=${3:-$SOURCE_BRANCH}    # e.g. "feat/stabilize-dh"
-SOURCE_COMMIT=${4:-$SOURCE_COMMIT}    # e.g. "a44c610c6cf4d2a878b1b16f5add8280bed423c0"
+SOURCE_BRANCH=${3:-$SOURCE_BRANCH}   # e.g. "feat/stabilize-dh"
+SOURCE_COMMIT=${4:-$SOURCE_COMMIT}   # e.g. "a44c610c6cf4d2a878b1b16f5add8280bed423c0"
 
 # custom vars
-DRY_RUN=${5:-false}                    # e.g. "dryrun".
-BUILD_DATE=$(date -u +%F)             # e.g. "2020-03-05"
+DRY_RUN=${5:-false}                  # e.g. "dryrun".
+BUILD_DATE=$(date -u +%F)            # e.g. "2020-03-05"
 GIT_SHA_SHORT=$(echo "$SOURCE_COMMIT" | cut -c 1-7)
 
 # Use me to create and push a new tag.
@@ -39,7 +39,7 @@ pushTag () {
   else 
     echo "hooks/post_push - pushing tag: '$DOCKER_REPO:$NEW_TAG' for branch: '$SOURCE_BRANCH'"
     docker tag "$DOCKER_REPO:$DOCKER_TAG" "$DOCKER_REPO:$NEW_TAG"
-    # docker push "$DOCKER_REPO:$NEW_TAG"
+    docker push "$DOCKER_REPO:$NEW_TAG"
   fi
 }
 

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+# post_push - a dockerhub autobuild hook
+#
+# A hook, run on dockerhub after an autobuild completes and the configured tag has been pushed.
+# Use me to publish additional tag names.
+#
+# see: https://docs.docker.com/docker-hub/builds/advanced
+#
+# Usage:
+#   DOCKER_REPO="ipfs/go-ipfs" \
+#   DOCKER_TAG="bifrost-latest" \ 
+#   SOURCE_BRANCH="feat/stabilize-dh" \
+#   SOURCE_COMMIT="a44c610c6cf4d2a878b1b16f5add8280bed423c0" \
+#   ./post_push
+#
+#   # for testing you can pass the env vars as params, and flag it as a dry run, so nothing gets dockered.
+#   ./post_push "ipfs/go-ipfs" "bifrost-latest" "feat/stabilize-dh" "a44c610c6cf4d2a878b1b16f5add8280bed423c0" "dryrun"
+
+# env vars set by docker hub https://docs.docker.com/docker-hub/builds/advanced/#environment-variables-for-building-and-testing
+DOCKER_REPO=${1:-$DOCKER_REPO}       # e.g. "ipfs/go-ipfs"
+DOCKER_TAG=${2:-$DOCKER_TAG}         # e.g. "bifrost-latest"
+SOURCE_BRANCH=${3:-$SOURCE_BRANCH}    # e.g. "feat/stabilize-dh"
+SOURCE_COMMIT=${4:-$SOURCE_COMMIT}    # e.g. "a44c610c6cf4d2a878b1b16f5add8280bed423c0"
+
+# custom vars
+DRY_RUN=${5:-false}                    # e.g. "dryrun".
+BUILD_DATE=$(date -u +%F)             # e.g. "2020-03-05"
+GIT_SHA_SHORT=$(echo "$SOURCE_COMMIT" | cut -c 1-7)
+
+# Use me to create and push a new tag.
+pushTag () {
+  local NEW_TAG=$1
+  if [ "$DRY_RUN" != false ]; then
+    echo "hooks/post_push - DRY RUN! would push tag: '$DOCKER_REPO:$NEW_TAG' for branch: '$SOURCE_BRANCH'"
+    echo docker tag "$DOCKER_REPO:$DOCKER_TAG" "$DOCKER_REPO:$NEW_TAG"
+    echo docker push "$DOCKER_REPO:$NEW_TAG"
+  else 
+    echo "hooks/post_push - pushing tag: '$DOCKER_REPO:$NEW_TAG' for branch: '$SOURCE_BRANCH'"
+    docker tag "$DOCKER_REPO:$DOCKER_TAG" "$DOCKER_REPO:$NEW_TAG"
+    # docker push "$DOCKER_REPO:$NEW_TAG"
+  fi
+}
+
+# Add conditions where you'd like to publish an additional docker tag here
+if [ "$SOURCE_BRANCH" = "feat/stabilize-dht" ]; then
+  pushTag "bifrost-${BUILD_DATE}-${GIT_SHA_SHORT}"
+
+elif [ "$SOURCE_BRANCH" = "master" ]; then
+  pushTag "master-${BUILD_DATE}-${GIT_SHA_SHORT}"
+
+else
+  echo "hooks/post_push - nothing to do for image: '$DOCKER_REPO:$DOCKER_TAG', branch: '$SOURCE_BRANCH', commit: '$SOURCE_COMMIT'"
+fi


### PR DESCRIPTION
Dockerhub allows us to add scripts to a hooks directory in our repo, that allow us to alter the steps of an autobuild!

This PR adds a post_push dockerhub hook that adds additional tags for the stabilize-dht and master branch in the form 
- `<branch>-<short date>-<short commit sha>`
- `bifrost-2020-02-26-a44c610`
- `master-2020-03-01-18ca5ab`

This is an alternative to #6949 that requires no credentials in CI, but does not ensure our published docker tags are tested.

See #6949 for details.


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>