### PR TITLE
fix(subdomain-gw): curl on localhost (Option A: HTTP301+payload)

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -101,8 +101,24 @@ func HostnameOption() ServeOption {
 						// Yes, redirect if applicable
 						// Example: dweb.link/ipfs/{cid} → {cid}.ipfs.dweb.link
 						if newURL, ok := toSubdomainURL(r.Host, r.URL.Path, r); ok {
-							http.Redirect(w, r, newURL, http.StatusMovedPermanently)
-							return
+							// Just to be sure single Origin can't be abused in
+							// web browsers that ignored the redirect for some
+							// reason, Clear-Site-Data header clears browsing
+							// data (cookies, storage etc) associated with
+							// hostname's root Origin
+							// Note: we can't use "*" due to bug in Chromium:
+							// https://bugs.chromium.org/p/chromium/issues/detail?id=898503
+							w.Header().Set("Clear-Site-Data", "\"cookies\", \"storage\"")
+
+							// Set "Location" header with redirect destination.
+							// It is ignored by curl in default mode, but will
+							// be respected by user agents that follow
+							// redirects by default, namely web browsers
+							w.Header().Set("Location", newURL)
+
+							// Note: we continue regular gateway processing:
+							// HTTP Status Code http.StatusMovedPermanently
+							// will be set later, in statusResponseWriter
 						}
 					}
 

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -141,9 +141,30 @@ test_localhost_gateway_response_should_contain \
 #  payload directly, but redirect to URL with proper origin isolation
 
 test_localhost_gateway_response_should_contain \
-  "request for localhost/ipfs/{CIDv1} redirects to subdomain" \
+  "request for localhost/ipfs/{CIDv1} returns status code HTTP 301" \
+  "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
+  "301 Moved Permanently"
+
+test_localhost_gateway_response_should_contain \
+  "request for localhost/ipfs/{CIDv1} returns Location HTTP header for subdomain redirect in browsers" \
   "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
   "Location: http://$CIDv1.ipfs.localhost:$GWAY_PORT/"
+
+# Responses to the root domain of subdomain gateway hostname should Clear-Site-Data
+# https://github.com/ipfs/go-ipfs/issues/6975#issuecomment-597472477
+test_localhost_gateway_response_should_contain \
+  "request for localhost/ipfs/{CIDv1} returns Clear-Site-Data header to purge Origin cookies and storage" \
+  "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
+  'Clear-Site-Data: \"cookies\", \"storage\"'
+
+# We return body with HTTP 301 so existing cli scripts that use path-based
+# gateway do not break (curl doesn't auto-redirect without passing -L; wget
+# does not span across hostnames by default)
+# Context: https://github.com/ipfs/go-ipfs/issues/6975
+test_localhost_gateway_response_should_contain \
+  "request for localhost/ipfs/{CIDv1} includes valid payload in body for CLI tools like curl" \
+  "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
+  "$CID_VAL"
 
 test_localhost_gateway_response_should_contain \
   "request for localhost/ipfs/{CIDv0} redirects to CIDv1 representation in subdomain" \


### PR DESCRIPTION
> This is a PR against [`feat/gateway-subdomains` branch](https://github.com/ipfs/go-ipfs/pull/6096) to resolve concerns from https://github.com/ipfs/go-ipfs/issues/6975

### TL;DR

Return payload with HTTP 301 response:
- curl returns exit code 0 on 301, so no script will fail
- web browsers close connection after reading HTTP 301 and `Location` header, so there should not be any bandwidth wasted
  - just to be sure browsers don't store anything we return `Clear-Site-Data` header with such response

### Description 
When request is sent to `http://localhost:8080/ipfs/$cid` HTTP 301 status code with  "Location" header redirect client to subdomain destination at `$cid.ipfs.localhost:8080`

Redirects are not followed by `curl` in default mode, but will be respected by user agents that follow redirects by default, namely web browsers.

To fix curl, we return correct payload in body of HTTP 301 response, but set `Clear-Site-Data` header to ensure Origin sandbox can't be abused.

### Caveat

<del>This comes with side effect of prometeus client making redundant `WriteHeader` call, which produces warning in logs:</del>

> <del>`2020/03/11 14:57:06 http: superfluous response.WriteHeader call from github.com/prometheus/client_golang/prometheus/promhttp.(*responseWriterDelegator).WriteHeader (delegator.go:58)`</del>

<del>
I attempted to fix prometeus and avoid redundant call in https://github.com/prometheus/client_golang/pull/724 but am not sure if that approach will be approved upstream.</del>


**Update:** `superfluous response.WriteHeader call` fixed in https://github.com/ipfs/go-ipfs/commit/e705f023bbfb00530f73cc60e763d4705c2d4613