### PR TITLE
fix: revert changes to the user agent

### DIFF
--- a/test/sharness/t0026-id.sh
+++ b/test/sharness/t0026-id.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+test_description="Test to make sure our identity information looks sane"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_id_compute_agent() {
+    AGENT_VERSION="$(ipfs version --number)" || return 1
+    AGENT_COMMIT="$(ipfs version --number --commit)" || return 1
+    if test "$AGENT_COMMIT" = "$AGENT_VERSION"; then
+        AGENT_COMMIT=""
+    else
+        AGENT_COMMIT="${AGENT_COMMIT##$AGENT_VERSION-}"
+    fi
+    echo "go-ipfs/$AGENT_VERSION/$AGENT_COMMIT"
+}
+
+test_expect_success "checking AgentVersion" '
+  test_id_compute_agent > expected-agent-version &&
+  ipfs id -f "<aver>\n" > actual-agent-version &&
+  test_cmp expected-agent-version actual-agent-version
+'
+
+test_expect_success "checking ProtocolVersion" '
+  echo "ipfs/0.1.0" > expected-protocol-version &&
+  ipfs id -f "<pver>\n" > actual-protocol-version &&
+  test_cmp expected-protocol-version actual-protocol-version
+'
+
+test_expect_success "checking ID" '
+  ipfs config Identity.PeerID > expected-id &&
+  ipfs id -f "<id>\n" > actual-id &&
+  test_cmp expected-id actual-id
+'
+
+test_done

--- a/version.go
+++ b/version.go
@@ -9,4 +9,6 @@ const CurrentVersionNumber = "0.5.0-dev"
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"
 
 // UserAgent is the libp2p user agent used by go-ipfs.
-var UserAgent = ApiVersion + CurrentCommit
+//
+// Note: This will end in `/` when no commit is available. This is expected.
+var UserAgent = "go-ipfs/" + CurrentVersionNumber + "/" + CurrentCommit


### PR DESCRIPTION
Go-ipfs user agents usually look like go-ipfs/VERSION/COMMIT_or_EMPTY. However,
we changed this to /go-ipfs/VERSION(/COMMIT)? on master for a while. This change
reverts this to make parsing the user agent simpler.