### PR TITLE
Support pipes when named on the cli explicitly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ipfs/go-graphsync v0.0.5
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-chunker v0.0.4
-	github.com/ipfs/go-ipfs-cmds v0.1.1
+	github.com/ipfs/go-ipfs-cmds v0.1.2
 	github.com/ipfs/go-ipfs-config v0.2.1
 	github.com/ipfs/go-ipfs-ds-help v0.1.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,10 @@ github.com/ipfs/go-ipfs-chunker v0.0.4 h1:nb2ZIgtOk0TxJ5KDBEk+sv6iqJTF/PHg6owN2x
 github.com/ipfs/go-ipfs-chunker v0.0.4/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.1.1 h1:H9/BLf5rcsULHMj/x8gC0e5o+raYhqk1OQsfzbGMNM4=
 github.com/ipfs/go-ipfs-cmds v0.1.1/go.mod h1:k1zMXcOLtljA9iAnZHddbH69yVm5+weRL0snmMD/rK0=
+github.com/ipfs/go-ipfs-cmds v0.1.2-0.20200316211807-0c2a21b0dacc h1:HIG2l6XUnov+M6UwcUKKrwGc8Q+n9AYGbiGM4pK21SM=
+github.com/ipfs/go-ipfs-cmds v0.1.2-0.20200316211807-0c2a21b0dacc/go.mod h1:a9LyFOtQCnVc3BvbAgW+GrMXEuN29aLCNi3Wk0IM8wo=
+github.com/ipfs/go-ipfs-cmds v0.1.2 h1:02FLzTA9jYRle/xdMWYwGwxu3gzC3GhPUaz35dH+FrY=
+github.com/ipfs/go-ipfs-cmds v0.1.2/go.mod h1:a9LyFOtQCnVc3BvbAgW+GrMXEuN29aLCNi3Wk0IM8wo=
 github.com/ipfs/go-ipfs-config v0.2.1 h1:Mpyvdf9Zc8k3jg+sRe8e9iylYXHYXqFMuePUjAZQvsE=
 github.com/ipfs/go-ipfs-config v0.2.1/go.mod h1:zCKH1uf1XIvf67589BnQ5IAv/Pld2J3gQoQYvG8TK8w=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -504,14 +504,15 @@ test_add_cat_expensive() {
 }
 
 test_add_named_pipe() {
-  test_expect_success "useful error message when adding a named pipe" '
-    mkfifo named-pipe &&
-    test_expect_code 1 ipfs add named-pipe 2>actual &&
-    STAT=$(generic_stat named-pipe) &&
-    rm named-pipe &&
-    grep "Error: unrecognized file type for named-pipe: $STAT" actual &&
-    grep USAGE actual &&
-    grep "ipfs add" actual
+  test_expect_success "Adding named pipes explicitly works" '
+    mkfifo named-pipe1 &&
+    ( echo foo > named-pipe1 & echo "added $( echo foo | ipfs add -nq ) named-pipe1" > expected_named_pipes_add ) &&
+    mkfifo named-pipe2 &&
+    ( echo bar > named-pipe2 & echo "added $( echo bar | ipfs add -nq ) named-pipe2" >> expected_named_pipes_add ) &&
+    ipfs add -n named-pipe1 named-pipe2 >actual_pipe_add &&
+    rm named-pipe1 &&
+    rm named-pipe2 &&
+    test_cmp expected_named_pipes_add actual_pipe_add
   '
 
   test_expect_success "useful error message when recursively adding a named pipe" '


### PR DESCRIPTION
Still throws an error when a pipe is encountered during directory recursion.

~**WILL NOT** pass CI without https://github.com/ipfs/go-ipfs-cmds/pull/184~