### PR TITLE
Keystore: minor maintenance

### DIFF
--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -81,7 +81,7 @@ func (ks *FSKeystore) Put(name string, k ci.PrivKey) error {
 		return err
 	}
 
-	b, err := k.Bytes()
+	b, err := ci.MarshalPrivateKey(k)
 	if err != nil {
 		return err
 	}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -88,7 +88,7 @@ func (ks *FSKeystore) Put(name string, k ci.PrivKey) error {
 
 	kp := filepath.Join(ks.dir, name)
 
-	fi, err := os.OpenFile(kp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	fi, err := os.OpenFile(kp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0400)
 	if err != nil {
 		if os.IsExist(err) {
 			err = ErrKeyExists


### PR DESCRIPTION
```
keystore: Switch from Bytes() to MarshalPrivateKey()

Bytes is deprecated.
```

```
keystore: create new keys with 0400 permissions (as spec'ed) 

Spec is pretty much out of date but specifies this.

https://github.com/ipfs/specs/blob/master/KEYSTORE.md
```