### PR TITLE
fix: remove internal relay discovery

### DIFF
--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -11,7 +11,7 @@ func Relay(disable, enableHop bool) func() (opts Libp2pOpts, err error) {
 			// Enabled by default.
 			opts.Opts = append(opts.Opts, libp2p.DisableRelay())
 		} else {
-			relayOpts := []relay.RelayOpt{relay.OptDiscovery}
+			relayOpts := []relay.RelayOpt{}
 			if enableHop {
 				relayOpts = append(relayOpts, relay.OptHop)
 			}

--- a/test/sharness/t0182-circuit-relay.sh
+++ b/test/sharness/t0182-circuit-relay.sh
@@ -44,7 +44,7 @@ test_expect_success 'peer ids' '
 '
 
 test_expect_success 'connect A <-Relay-> B' '
-  ipfsi 0 swarm connect /p2p-circuit/p2p/$PEERID_2 > peers_out
+  ipfsi 0 swarm connect /p2p/$PEERID_1/p2p-circuit/p2p/$PEERID_2 > peers_out
 '
 
 test_expect_success 'output looks good' '


### PR DESCRIPTION
This logic collects a list of known relays by testing every new connection.

It exists so we can dial /p2p-circuit/p2p/QmFoobar addresses (circuit addresses that don't specify the relay). However, this kind of address is useless outside of basic demos as a random relay is practically guaranteed to not be connected to the target peer. Picking a random relay to connect to some peer is almost _never_ the desired behavior.