### PR TITLE
chore: update flatfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.4
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-ds-badger v0.2.4
-	github.com/ipfs/go-ds-flatfs v0.4.2
+	github.com/ipfs/go-ds-flatfs v0.4.3
 	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-ds-measure v0.1.0
 	github.com/ipfs/go-filestore v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/ipfs/go-ds-badger v0.2.3 h1:J27YvAcpuA5IvZUbeBxOcQgqnYHUPxoygc6Qxxkod
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-badger v0.2.4 h1:UPGB0y7luFHk+mY/tUZrif/272M8o+hFsW+avLUeWrM=
 github.com/ipfs/go-ds-badger v0.2.4/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
-github.com/ipfs/go-ds-flatfs v0.4.2 h1:v8VwVkmO+XN7YlrDgpuHl/0bGgu3qD44MKhIlbcfcFY=
-github.com/ipfs/go-ds-flatfs v0.4.2/go.mod h1:KiZoBq31WFUR5LmDKPUHhsc0XZgjho+R/AzEPQpaN4U=
+github.com/ipfs/go-ds-flatfs v0.4.3 h1:7M8/xpLkJhFJYaLumo2RRgt/cOehetutGW5zigTa5qY=
+github.com/ipfs/go-ds-flatfs v0.4.3/go.mod h1:e4TesLyZoA8k1gV/yCuBTnt2PJtypn4XUlB5n8KQMZY=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0 h1:OsCuIIh1LMTk4WIQ1UJH7e3j01qlOP+KWVhNS6lBDZY=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=


### PR DESCRIPTION
And remove retry logic. This was flatfs specific and we've moved the logic down into flatfs itself.

This update:

* Retries in more cases when we run out of file descriptors.
* Ensures we don't leak temporary files on batch put.