### PR TITLE
fix: invalidate cache on failed publish

### DIFF
--- a/namesys/cache.go
+++ b/namesys/cache.go
@@ -49,6 +49,13 @@ func (ns *mpns) cacheSet(name string, val path.Path, ttl time.Duration) {
 	})
 }
 
+func (ns *mpns) cacheInvalidate(name string) {
+	if ns.cache == nil {
+		return
+	}
+	ns.cache.Remove(name)
+}
+
 type cacheEntry struct {
 	val path.Path
 	eol time.Time

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -218,6 +218,9 @@ func (ns *mpns) PublishWithEOL(ctx context.Context, name ci.PrivKey, value path.
 		return err
 	}
 	if err := ns.ipnsPublisher.PublishWithEOL(ctx, name, value, eol); err != nil {
+		// Invalidate the cache. Publishing may _partially_ succeed but
+		// still return an error.
+		ns.cacheInvalidate(peer.Encode(id))
 		return err
 	}
 	ttl := DefaultResolverCacheTTL

--- a/test/sharness/t0160-resolve.sh
+++ b/test/sharness/t0160-resolve.sh
@@ -153,17 +153,24 @@ test_resolve_cmd_fail() {
   test_resolve "/ipld/$dag_hash/i/j" "/ipld/$dag_hash/i/j"
   test_resolve "/ipld/$dag_hash/i" "/ipld/$dag_hash/i"
 
+  # At the moment, publishing _fails_ because we fail to put to the DHT.
+  # However, resolving succeeds because we resolve the record we put to our own
+  # node.
+  #
+  # We should find a nice way to truly support offline publishing. But this
+  # behavior isn't terrible.
+
   test_resolve_setup_name_fail "self" "/ipfs/$a_hash"
-  test_resolve_fail "/ipns/$self_hash" "/ipfs/$a_hash"
-  test_resolve_fail "/ipns/$self_hash/b" "/ipfs/$b_hash"
-  test_resolve_fail "/ipns/$self_hash/b/c" "/ipfs/$c_hash"
+  test_resolve "/ipns/$self_hash" "/ipfs/$a_hash"
+  test_resolve "/ipns/$self_hash/b" "/ipfs/$b_hash"
+  test_resolve "/ipns/$self_hash/b/c" "/ipfs/$c_hash"
 
   test_resolve_setup_name_fail "self" "/ipfs/$b_hash"
-  test_resolve_fail "/ipns/$self_hash" "/ipfs/$b_hash"
-  test_resolve_fail "/ipns/$self_hash/c" "/ipfs/$c_hash"
+  test_resolve "/ipns/$self_hash" "/ipfs/$b_hash"
+  test_resolve "/ipns/$self_hash/c" "/ipfs/$c_hash"
 
   test_resolve_setup_name_fail "self" "/ipfs/$c_hash"
-  test_resolve_fail "/ipns/$self_hash" "/ipfs/$c_hash"
+  test_resolve "/ipns/$self_hash" "/ipfs/$c_hash"
 }
 
 # should work offline


### PR DESCRIPTION
If we fail to publish, _invalidate_ our cache. The publish may have partially succeeded.

fixes #7117

All credit goes to @aschmahmann for tracking this down.