### PR TITLE
Chore/reintroduce fifo test

### DIFF
--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -11,6 +11,13 @@ set -o pipefail
 tar -C ../t0054-dag-car-import-export-data/ --strip-components=1 -Jxf ../t0054-dag-car-import-export-data/test_dataset_car_v0.tar.xz
 tab=$'\t'
 
+test_cmp_sorted() {
+  # use test_cmp to dump out the unsorted file contents as a diff
+  [[ "$( sort "$1" | sha256sum )" == "$( sort "$2" | sha256sum )" ]] \
+    || test_cmp "$1" "$2"
+}
+export -f test_cmp_sorted
+
 reset_blockstore() {
   node=$1
 
@@ -65,11 +72,11 @@ EOE
       ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
       ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car \
       ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car \
-    | sort > basic_import_actual
+    > basic_import_actual
   '
 
   test_expect_success "basic import output as expected" '
-    test_cmp basic_import_expected basic_import_actual
+    test_cmp_sorted basic_import_expected basic_import_actual
   '
 
   test_expect_success "basic fetch+export 1" '
@@ -92,11 +99,11 @@ EOE
 
   test_expect_success "import/pin naked roots only, relying on local blockstore having all the data" '
     ipfsi 1 dag import --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
-      | sort > naked_import_result_json_actual
+      > naked_import_result_json_actual
   '
 
   test_expect_success "naked import output as expected" '
-    test_cmp  naked_root_import_json_expected naked_import_result_json_actual
+    test_cmp_sorted naked_root_import_json_expected naked_import_result_json_actual
   '
 
   reset_blockstore 0
@@ -114,7 +121,7 @@ EOE
           pipe_testnet \
           pipe_devnet \
           ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
-        | sort > basic_fifo_import_actual
+        > basic_fifo_import_actual
         result=$?
 
         wait
@@ -127,7 +134,7 @@ EOE
   '
 
   test_expect_success "fifo-import output as expected" '
-    test_cmp basic_import_expected basic_fifo_import_actual
+    test_cmp_sorted basic_import_expected basic_fifo_import_actual
   '
 }
 
@@ -158,7 +165,7 @@ test_expect_success "basic offline export of nonexistent cid" '
   ! ipfs dag export QmYwAPJXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX 2> offline_fetch_error_actual >/dev/null
 '
 test_expect_success "correct error" '
-  test_cmp offline_fetch_error_expected offline_fetch_error_actual
+  test_cmp_sorted offline_fetch_error_expected offline_fetch_error_actual
 '
 
 
@@ -168,10 +175,10 @@ cat >multiroot_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
 EOE
 test_expect_success "multiroot import works" '
-  ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car | sort > multiroot_import_json_actual
+  ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
 '
 test_expect_success "multiroot import expected output" '
-  test_cmp multiroot_import_json_expected multiroot_import_json_actual
+  test_cmp_sorted multiroot_import_json_expected multiroot_import_json_actual
 '
 
 
@@ -188,10 +195,10 @@ test_expect_success "expected silence on --pin-roots=false" '
 
 test_expect_success "naked root import works" '
   ipfs dag import --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
-  | sort > naked_root_import_json_actual
+    > naked_root_import_json_actual
 '
 test_expect_success "naked root import expected output" '
-   test_cmp naked_root_import_json_expected naked_root_import_json_actual
+   test_cmp_sorted naked_root_import_json_expected naked_root_import_json_actual
 '
 
 test_done

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -41,7 +41,8 @@ do_import() {
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
 
-      ipfsi "$node" dag import "$@" 2>&1 && ipfsi "$node" repo verify &>/dev/null
+      ipfsi "$node" dag import "$@" 2>&1 \
+        && ipfsi "$node" repo verify &>/dev/null
       result=$?
 
       rm -f spin.gc &>/dev/null
@@ -114,8 +115,8 @@ EOE
 
   test_expect_success "basic fifo import" '
     (
-        cat ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car > pipe_testnet &
-        cat ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car > pipe_devnet &
+        timeout 30 cat ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car > pipe_testnet &
+        timeout 30 cat ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car > pipe_devnet &
 
         do_import 0 \
           pipe_testnet \
@@ -142,7 +143,7 @@ EOE
         # What is tested here is that by the time import 1 + roots finishes and the
         # pipes are deleted, the preexisting open file handles will carry through,
         # even though pipe_devnet is no longer on the filesystem
-        cat ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car > pipe_devnet &
+        timeout 30 cat ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car > pipe_devnet &
 
         # ipfs import starts and blocks on part 1
         ipfsi 0 dag import \
@@ -152,7 +153,7 @@ EOE
         2>&1 & ipfs_pid=$!
 
         # Flush part 1, unblock everything, delete pipes as soon as possible
-        cat ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car > pipe_testnet
+        timeout 30 cat ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car > pipe_testnet
         rm -f pipe_devnet pipe_testnet
 
         wait "$ipfs_pid"


### PR DESCRIPTION
Bring back the test removed in https://github.com/ipfs/go-ipfs/pull/7154, with better description and workflow.

This should no longer hang, while still tests the actual use case for dagger

I would still like to add the timeouts here and there, but there's no way to do that over a shell function (`ipfsi`) without `bash -c`