### PR TITLE
feat: webui v2.7.4

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,7 +1,7 @@
 package corehttp
 
 // TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeihpkhgv3jfnyx5qcexded7agjpwbgvtc3o6lnk6n3cs37fh4xx4fe"
+const WebUIPath = "/ipfs/bafybeigxqbvc6qxk2wkdyzpkh7mr7zh5pxbvpjb6a6mxdtpwhlqaf4qj5a"
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{


### PR DESCRIPTION
(supersedes v2.7.3, so no need to keep old one around)

Release notes: https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.7.4

@Stebalien can we include this in 0.5.0-rc2 ? (cc https://github.com/ipfs/go-ipfs/issues/7109, @jessicaschilling )