### PR TITLE
add autonat config options

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -90,6 +90,25 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		}
 	}
 
+	autonat := fx.Options()
+
+	switch cfg.AutoNAT.ServiceMode {
+	default:
+		panic("BUG: unhandled autonat service mode")
+	case config.AutoNATServiceDisabled:
+	case config.AutoNATServiceUnset:
+		// TODO
+		//
+		// We're enabling the AutoNAT service by default on _all_ nodes
+		// for the moment.
+		//
+		// We should consider disabling it by default if the dht is set
+		// to dhtclient.
+		fallthrough
+	case config.AutoNATServiceEnabled:
+		autonat = fx.Provide(libp2p.AutoNATService(cfg.AutoNAT.Throttle))
+	}
+
 	// Gather all the options
 
 	opts := fx.Options(
@@ -110,9 +129,9 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 
 		maybeProvide(libp2p.BandwidthCounter, !cfg.Swarm.DisableBandwidthMetrics),
 		maybeProvide(libp2p.NatPortMap, !cfg.Swarm.DisableNatPortMap),
-		maybeProvide(libp2p.AutoNATService, cfg.Swarm.EnableAutoNATService),
 		maybeProvide(libp2p.AutoRelay, cfg.Swarm.EnableAutoRelay),
 		maybeProvide(libp2p.QUIC, cfg.Experimental.QUIC),
+		autonat,
 		connmgr,
 		ps,
 		disc,

--- a/core/node/libp2p/nat.go
+++ b/core/node/libp2p/nat.go
@@ -1,8 +1,28 @@
 package libp2p
 
 import (
+	"time"
+
+	"github.com/ipfs/go-ipfs-config"
 	"github.com/libp2p/go-libp2p"
 )
 
 var NatPortMap = simpleOpt(libp2p.NATPortMap())
-var AutoNATService = simpleOpt(libp2p.EnableNATService())
+
+func AutoNATService(throttle *config.AutoNATThrottleConfig) func() Libp2pOpts {
+	return func() (opts Libp2pOpts) {
+		opts.Opts = append(opts.Opts, libp2p.EnableNATService())
+		if throttle != nil {
+			global := throttle.GlobalLimit
+			peer := throttle.PeerLimit
+			interval := time.Duration(throttle.Interval)
+			if interval == 0 {
+				interval = time.Minute
+			}
+			opts.Opts = append(opts.Opts,
+				libp2p.AutoNATServiceRateLimit(global, peer, interval),
+			)
+		}
+		return opts
+	}
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -192,6 +192,47 @@ Example:
 
 Default: `null`
 
+## `AutoNAT`
+
+Contains the configuration options for the AutoNAT service. The AutoNAT service
+helps other nodes on the network determine if they're publicly reachable from
+the rest of the internet.
+
+### `AutoNAT.ServiceMode`
+
+When unset (default), the AutoNAT service defaults to _enabled_. Otherwise, this
+field can take one of two values:
+
+* "enabled" - Enable the service (unless the node determines that it, itself,
+  isn't reachable by the public internet).
+* "disabled" - Disable the service.
+
+Additional modes may be added in the future.
+
+### `AutoNAT.Throttle`
+
+When set, this option configure's the AutoNAT services throttling behavior. By
+default, go-ipfs will rate-limit the number of NAT checks performed for other
+nodes to 30 per minute, and 3 per peer.
+
+### `AutoNAT.Throttle.GlobalLimit`
+
+Configures how many AutoNAT requests to service per `AutoNAT.Throttle.Interval`.
+
+Default: 30
+
+### `AutoNAT.Throttle.PeerLimit`
+
+Configures how many AutoNAT requests per-peer to service per `AutoNAT.Throttle.Interval`.
+
+Default: 3
+
+### `AutoNAT.Throttle.Interval`
+
+Configures the interval for the above limits.
+
+Default: 1 Minute
+
 ## `Bootstrap`
 
 Bootstrap is an array of multiaddrs of trusted nodes to connect to in order to
@@ -700,11 +741,9 @@ DHT and override its public address(es) with relay addresses.
 
 ### `Swarm.EnableAutoNATService`
 
-Enables the AutoNAT service for this node.
+**REMOVED**
 
-The service allows peers to discover their NAT situation by requesting dial
-backs to their public addresses. This should only be enabled on publicly
-reachable nodes.
+Please use [`AutoNAT.ServiceMode`][].
 
 ### `Swarm.ConnMgr`
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/ipfs/go-bitswap v0.2.9
+	github.com/ipfs/go-bitswap v0.2.10
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-cmds v0.2.2
-	github.com/ipfs/go-ipfs-config v0.4.0
+	github.com/ipfs/go-ipfs-config v0.5.2
 	github.com/ipfs/go-ipfs-ds-help v0.1.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
@@ -60,7 +60,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-eventbus v0.1.0
-	github.com/libp2p/go-libp2p v0.7.4
+	github.com/libp2p/go-libp2p v0.8.0
 	github.com/libp2p/go-libp2p-circuit v0.2.1
 	github.com/libp2p/go-libp2p-connmgr v0.2.1
 	github.com/libp2p/go-libp2p-core v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.2.2 h1:F2pro/Q3ifRUsdxEKIS8cg8lO4R6WiwAyERiaG8I9no=
 github.com/ipfs/go-ipfs-cmds v0.2.2/go.mod h1:kqlUrp6m2ceoaJe40cXpADCi5aS6NKRn0NIeuLp5CeM=
-github.com/ipfs/go-ipfs-config v0.4.0 h1:MOXdj8EYQG55v1y+5e1QcctDKPEGobdwnXaDVa0/cc0=
-github.com/ipfs/go-ipfs-config v0.4.0/go.mod h1:nSLCFtlaL+2rbl3F+9D4gQZQbT1LjRKx7TJg/IHz6oM=
+github.com/ipfs/go-ipfs-config v0.5.2 h1:SPWiMNo7IOW0k+meO3PIprggp/PbZGUiO57L7HQ/sOY=
+github.com/ipfs/go-ipfs-config v0.5.2/go.mod h1:nSLCFtlaL+2rbl3F+9D4gQZQbT1LjRKx7TJg/IHz6oM=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
@@ -484,6 +484,8 @@ github.com/libp2p/go-libp2p v0.7.0 h1:qWmciout2lJclKfRlxqdepsQB7JihcbRhgcRcssP4r
 github.com/libp2p/go-libp2p v0.7.0/go.mod h1:hZJf8txWeCduQRDC/WSqBGMxaTHCOYHt2xSU1ivxn0k=
 github.com/libp2p/go-libp2p v0.7.4 h1:xVj1oSlN0C+FlxqiLuHC8WruMvq24xxfeVxmNhTG0r0=
 github.com/libp2p/go-libp2p v0.7.4/go.mod h1:oXsBlTLF1q7pxr+9w6lqzS1ILpyHsaBPniVO7zIHGMw=
+github.com/libp2p/go-libp2p v0.8.0 h1:8t8kAJM+o4rR91bfwbgbtykbdqPJv819+CTSPkXDT1A=
+github.com/libp2p/go-libp2p v0.8.0/go.mod h1:QRNH9pwdbEBpx5DTJYg+qxcVaDMAz3Ee/qDKwXujH5o=
 github.com/libp2p/go-libp2p-autonat v0.0.2/go.mod h1:fs71q5Xk+pdnKU014o2iq1RhMs9/PMaG5zXRFNnIIT4=
 github.com/libp2p/go-libp2p-autonat v0.0.6/go.mod h1:uZneLdOkZHro35xIhpbtTzLlgYturpu4J5+0cZK3MqE=
 github.com/libp2p/go-libp2p-autonat v0.1.0 h1:aCWAu43Ri4nU0ZPO7NyLzUvvfqd0nE3dX0R/ZGYVgOU=
@@ -494,6 +496,8 @@ github.com/libp2p/go-libp2p-autonat v0.2.0 h1:Kok+0M/4jiz6TTmxtBqAa5tLyHb/U+G/7o
 github.com/libp2p/go-libp2p-autonat v0.2.0/go.mod h1:DX+9teU4pEEoZUqR1PiMlqliONQdNbfzE1C718tcViI=
 github.com/libp2p/go-libp2p-autonat v0.2.1 h1:T0CRQhrvTBKfBSYw6Xo2K3ixtNpAnRCraxof3AAfgQA=
 github.com/libp2p/go-libp2p-autonat v0.2.1/go.mod h1:MWtAhV5Ko1l6QBsHQNSuM6b1sRkXrpk0/LqCr+vCVxI=
+github.com/libp2p/go-libp2p-autonat v0.2.2 h1:4dlgcEEugTFWSvdG2UIFxhnOMpX76QaZSRAtXmYB8n4=
+github.com/libp2p/go-libp2p-autonat v0.2.2/go.mod h1:HsM62HkqZmHR2k1xgX34WuWDzk/nBwNHoeyyT4IWV6A=
 github.com/libp2p/go-libp2p-blankhost v0.0.1/go.mod h1:Ibpbw/7cPPYwFb7PACIWdvxxv0t0XCCI10t7czjAjTc=
 github.com/libp2p/go-libp2p-blankhost v0.1.1/go.mod h1:pf2fvdLJPsC1FsVrNP3DUUvMzUts2dsLLBEpo1vW1ro=
 github.com/libp2p/go-libp2p-blankhost v0.1.3/go.mod h1:KML1//wiKR8vuuJO0y3LUd1uLv+tlkGTAr3jC0S5cLg=

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSA
 github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiLzBpJQIs=
 github.com/ipfs/go-bitswap v0.1.3/go.mod h1:YEQlFy0kkxops5Vy+OxWdRSEZIoS7I7KDIwoa5Chkps=
 github.com/ipfs/go-bitswap v0.1.8/go.mod h1:TOWoxllhccevbWFUR2N7B1MTSVVge1s6XSMiCSA4MzM=
-github.com/ipfs/go-bitswap v0.2.9 h1:23xzQ5kWx9F3Q4PrBS9nbPwMsxdWHXeD9nZX1/ozTlI=
-github.com/ipfs/go-bitswap v0.2.9/go.mod h1:2Yjog0GMdH8+AsxkE0DI9D2mANaUTxbVVav0pPoZoug=
+github.com/ipfs/go-bitswap v0.2.10 h1:jO16YYZ7ZT0Utf61hM/pENcptl8BfxX29z4HtKNPJkA=
+github.com/ipfs/go-bitswap v0.2.10/go.mod h1:2Yjog0GMdH8+AsxkE0DI9D2mANaUTxbVVav0pPoZoug=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=

--- a/test/sharness/t0185-autonat.sh
+++ b/test/sharness/t0185-autonat.sh
@@ -11,7 +11,15 @@ test_description="Test autonat"
 test_init_ipfs
 
 test_expect_success "enable autonat" '
-  ipfs config --json Swarm.EnableAutoNATService true
+  ipfs config AutoNAT.ServiceMode enabled
+'
+
+test_launch_ipfs_daemon
+
+test_kill_ipfs_daemon
+
+test_expect_success "enable autonat" '
+  ipfs config AutoNAT.ServiceMode disabled
 '
 
 test_launch_ipfs_daemon


### PR DESCRIPTION
1. Enable AutoNATService on _all_ nodes by default. If it's an issue, we can disable it in RC3 but this will give us the best testing results.
2. Expose options to configure AutoNAT rate limiting.