### PR TITLE
fix: subdomain redirect for dir CIDs

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -342,6 +342,16 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		BackLink: backLink,
 		Hash:     hash,
 	}
+
+	// See statusResponseWriter.WriteHeader
+	// and https://github.com/ipfs/go-ipfs/issues/7164
+	// Note: this needs to occur before listingTemplate.Execute otherwise we get
+	// superfluous response.WriteHeader call from prometheus/client_golang
+	if w.Header().Get("Location") != "" {
+		w.WriteHeader(http.StatusMovedPermanently)
+		return
+	}
+
 	err = listingTemplate.Execute(w, tplData)
 	if err != nil {
 		internalWebError(w, err)

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -145,7 +145,7 @@ test_localhost_gateway_response_should_contain \
 #  payload directly, but redirect to URL with proper origin isolation
 
 test_localhost_gateway_response_should_contain \
-  "request for localhost/ipfs/{CIDv1} returns status code HTTP 301" \
+  "request for localhost/ipfs/{CIDv1} returns HTTP 301 Moved Permanently" \
   "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
   "301 Moved Permanently"
 
@@ -153,6 +153,16 @@ test_localhost_gateway_response_should_contain \
   "request for localhost/ipfs/{CIDv1} returns Location HTTP header for subdomain redirect in browsers" \
   "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
   "Location: http://$CIDv1.ipfs.localhost:$GWAY_PORT/"
+
+test_localhost_gateway_response_should_contain \
+  "request for localhost/ipfs/{DIR_CID} returns HTTP 301 Moved Permanently" \
+  "http://localhost:$GWAY_PORT/ipfs/$DIR_CID" \
+  "301 Moved Permanently"
+
+test_localhost_gateway_response_should_contain \
+  "request for localhost/ipfs/{DIR_CID} returns Location HTTP header for subdomain redirect in browsers" \
+  "http://localhost:$GWAY_PORT/ipfs/$DIR_CID/" \
+  "Location: http://$DIR_CID.ipfs.localhost:$GWAY_PORT/"
 
 # Responses to the root domain of subdomain gateway hostname should Clear-Site-Data
 # https://github.com/ipfs/go-ipfs/issues/6975#issuecomment-597472477


### PR DESCRIPTION
Closes #7164

Note: due to the way `http` in golang works, status code can be set only once. 
There is a known issue with `prometheus/client_golang`: it sometimes produces `superfluous response.WriteHeader call` and if it is executed first, the status code set in our code is ignored. 

In this PR I set the redirect status code before executing the template to avoid potential race condition, feels like the least invasive way of making this work reliably. 