### PR TITLE
Choose architecture when download tini into docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,19 @@ RUN cd $SRC_DIR \
 # and tini, a very minimal init daemon for containers
 ENV SUEXEC_VERSION v0.2
 ENV TINI_VERSION v0.18.0
-RUN set -x \
-  && cd /tmp \
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        "amd64" | "armhf" | "arm64") tiniArch="tini-$dpkgArch" ;;\
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+  cd /tmp \
   && git clone https://github.com/ncopa/su-exec.git \
   && cd su-exec \
   && git checkout -q $SUEXEC_VERSION \
   && make \
   && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
   && chmod +x tini
 
 # Now comes the actual target image, which aims to be as small as possible.


### PR DESCRIPTION
Currently docker container pulls default amd64 version of tini.
I add platform chooser for tini binary into docker building process