### PR TITLE
update log helptext to match actual levels

### DIFF
--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -24,7 +24,7 @@ output of a running daemon.
 
 There are also two environmental variables that direct the logging 
 system (not just for the daemon logs, but all commands):
-    IPFS_LOGGING - sets the level of verbosity of the logging. One of: debug, info, warning, error, critical
+    IPFS_LOGGING - sets the level of verbosity of the logging. One of: debug, info, warn, error, dpanic, panic, fatal
     IPFS_LOGGING_FMT - sets formatting of the log output. One of: color, nocolor
 `,
 	},
@@ -49,8 +49,8 @@ the event log.
 		// TODO use a different keyword for 'all' because all can theoretically
 		// clash with a subsystem name
 		cmds.StringArg("subsystem", true, false, fmt.Sprintf("The subsystem logging identifier. Use '%s' for all subsystems.", logAllKeyword)),
-		cmds.StringArg("level", true, false, `The log level, with 'debug' the most verbose and 'critical' the least verbose.
-			One of: debug, info, warning, error, critical.
+		cmds.StringArg("level", true, false, `The log level, with 'debug' the most verbose and 'fatal' the least verbose.
+			One of: debug, info, warn, error, dpanic, panic, fatal.
 		`),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -24,8 +24,10 @@ output of a running daemon.
 
 There are also two environmental variables that direct the logging 
 system (not just for the daemon logs, but all commands):
-    IPFS_LOGGING - sets the level of verbosity of the logging. One of: debug, info, warn, error, dpanic, panic, fatal
-    IPFS_LOGGING_FMT - sets formatting of the log output. One of: color, nocolor
+    IPFS_LOGGING - sets the level of verbosity of the logging.
+        One of: debug, info, warn, error, dpanic, panic, fatal
+    IPFS_LOGGING_FMT - sets formatting of the log output.
+        One of: color, nocolor
 `,
 	},
 


### PR DESCRIPTION
It looks like "warning" and "critical" levels were removed, but the help text wasn't updated to reflect this.
```
> ipfs.exe version --all
go-ipfs version: 0.5.0-rc3
Repo version: 9
System version: amd64/windows
Golang version: go1.13.10
> ipfs.exe log level all warning
Error: unrecognized level: "warning"
> ipfs.exe log level all critical
Error: unrecognized level: "critical"
```