### PR TITLE
docs: note that ShardingEnabled is a global flag

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -545,8 +545,11 @@ You can read more in the [datastore](./datastores.md#badgerds) documentation.
 ### State
 Experimental
 
-Allows creating directories with an unlimited number of entries - currently
-size of unixfs directories is limited by the maximum block size
+Allows creating directories with an unlimited number of entries.
+
+**Caveats:**
+1. right now it is a GLOBAL FLAG which will impact the final CID of all directories produced by `ipfs.add` (even the small ones)
+2. currently size of unixfs directories is limited by the maximum block size
 
 ### Basic Usage:
 


### PR DESCRIPTION
This PR adds a note about global side effect of setting `ShardingEnabled` to `true`

Right now it is a global setting  which will impact the final CID of all directories produced by `ipfs.add`

People may assume that HAMT sharding gets enabled only for directories over some arbitrary threshold. 

(I did. And took me a moment to understand why CID of WebUI is no longer reproducible. Embarrassingly long moment.. :grimacing:  )

cc https://github.com/ipfs/interface-go-ipfs-core/issues/48