### PR TITLE
Add additional documentation links to the new issue screen

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,15 @@ contact_links:
  - name: Getting Help on IPFS
    url: https://ipfs.io/help
    about: All information about how and where to get help on IPFS.
+ - name: Go-ipfs configuration reference
+   url: https://github.com/ipfs/go-ipfs/blob/master/docs/config.md
+   about: Documentation on the different configuration settings
+ - name: Go-ipfs experimental features docs
+   url: https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md
+   about: Documentation on Private Networks, Filestore and other experimental features.
+ - name: HTTP API Reference
+   url: https://docs-beta.ipfs.io/reference/http/api/#api-v0-add
+   about: Documentation of all go-ipfs HTTP API endpoints.
  - name: IPFS Official Forum
    url: https://discuss.ipfs.io
    about: Please post general questions, support requests, and discussions here.


### PR DESCRIPTION
I figured we can actually link specific go-ipfs docs when users want to open an issue. Particularly the Config reference, the Experimental Features and the API reference. My personal perception is these 3 are the most sought after and I'm not sure they are very well linked from the docs site.