### PR TITLE
docs: fix subdomain examples in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4997,7 +4997,7 @@ There have been no changes since the last release candidate 0.4.3-rc4. \o/
 ### 0.4.3-rc4 - 2016-09-09
 
 This release candidate fixes issues in Bitswap and the `ipfs add` command, and improves testing.
-We plan for this tohttp://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.localhost:8080 be the last release candidate before the release of go-ipfs v0.4.3.
+We plan for this to be the last release candidate before the release of go-ipfs v0.4.3.
 
 With this release candidate, we're also moving go-ipfs to Go 1.7, which we expect will yield improvements in runtime performance, memory usage, build time and size of the release binaries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,13 +226,13 @@ In addition to a bunch of bug fixes, we've made two improvements to the gateway.
 
 You can play with both of these features by visiting:
 
-> http://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.io/
+> http://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.localhost:8080
 
 ##### Subdomain Gateway
 
 First up, we've changed how URLs in the IPFS gateway work for better browser
 security. The gateway will now redirect from
-`http://localhost:5001/ipfs/CID/...` to `http://CID.ipfs.localhost:5001/...` by
+`http://localhost:8080/ipfs/CID/...` to `http://CID.ipfs.localhost:8080/...` by
 default. This:
 
 * Ensures that every dapp gets its own browser origin.
@@ -246,7 +246,7 @@ Note: cURL doesn't follow redirects by default. To avoid breaking cURL and other
 
 The second feature is a face-lift to the directory listing theme and color palette.
 
-> http://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.io/
+> http://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.localhost:8080
 
 #### IPNS
 
@@ -4997,7 +4997,7 @@ There have been no changes since the last release candidate 0.4.3-rc4. \o/
 ### 0.4.3-rc4 - 2016-09-09
 
 This release candidate fixes issues in Bitswap and the `ipfs add` command, and improves testing.
-We plan for this to be the last release candidate before the release of go-ipfs v0.4.3.
+We plan for this tohttp://bafybeia6po64b6tfqq73lckadrhpihg2oubaxgqaoushquhcek46y3zumm.ipfs.localhost:8080 be the last release candidate before the release of go-ipfs v0.4.3.
 
 With this release candidate, we're also moving go-ipfs to Go 1.7, which we expect will yield improvements in runtime performance, memory usage, build time and size of the release binaries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ This release includes several new IPNS and IPNS-related features.
 
 ##### ENS
 
-IPFS now resolves [ENS](https://ens.domains/) names (e.g., `/ipns/ipfs.eth`) via DNSLink.
+IPFS now resolves [ENS](https://ens.domains/) names (e.g., `/ipns/ipfs.eth`) via DNSLink provided by https://eth.link service.
 
 ##### IPNS over PubSub
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,7 @@ This release includes several new IPNS and IPNS-related features.
 
 ##### ENS
 
-IPFS now resolves [ENS](https://ens.domains/) names (e.g., [/ipns/ipfs.eth](https://ipfs.eth.dweb.link)) via DNSLink.
+IPFS now resolves [ENS](https://ens.domains/) names (e.g., `/ipns/ipfs.eth`) via DNSLink.
 
 ##### IPNS over PubSub
 


### PR DESCRIPTION
This PR 

- fixes invalid examples for subdomain gateway in CHANGELOG for v0.5.0
- fixes ENS example 

(I already fixed this in https://github.com/ipfs/go-ipfs/releases/tag/v0.5.0)

cc @raulk @Stebalien 
