### PR TITLE
fix: do not use hard coded IPNS Publish maximum timeout duration

### DIFF
--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -22,7 +22,6 @@ import (
 
 const ipnsPrefix = "/ipns/"
 
-const PublishPutValTimeout = time.Minute
 const DefaultRecordEOL = 24 * time.Hour
 
 // IpnsPublisher is capable of publishing and resolving names to the IPFS
@@ -269,15 +268,10 @@ func PublishPublicKey(ctx context.Context, r routing.ValueStore, k string, pubk 
 	}
 
 	// Store associated public key
-	timectx, cancel := context.WithTimeout(ctx, PublishPutValTimeout)
-	defer cancel()
-	return r.PutValue(timectx, k, pkbytes)
+	return r.PutValue(ctx, k, pkbytes)
 }
 
 func PublishEntry(ctx context.Context, r routing.ValueStore, ipnskey string, rec *pb.IpnsEntry) error {
-	timectx, cancel := context.WithTimeout(ctx, PublishPutValTimeout)
-	defer cancel()
-
 	data, err := proto.Marshal(rec)
 	if err != nil {
 		return err
@@ -285,7 +279,7 @@ func PublishEntry(ctx context.Context, r routing.ValueStore, ipnskey string, rec
 
 	log.Debugf("Storing ipns entry at: %s", ipnskey)
 	// Store ipns entry at "/ipns/"+h(pubkey)
-	return r.PutValue(timectx, ipnskey, data)
+	return r.PutValue(ctx, ipnskey, data)
 }
 
 // InitializeKeyspace sets the ipns record for the given key to


### PR DESCRIPTION
fixes #7244

Sometimes IPNS publishes can take longer than a minute. Since DHT lookups now terminate without needing to query a huge portion of the network (even if the lookups take a while until more of the network upgrades to v0.5.0+), we should allow the user's IPNS queries to go on until they're ready to cancel them.

Note: There's still a 30 second timeout on doing a record Get before Publishing, however this doesn't bother me too much since it both doesn't cause an error to be returned and the whole code path is a bit strange in general since it seems to only get called if either:
1) The IPNS key is first being used (in which case we expect the Get to return no info, so we might as well have a timeout)
2) The datastore (not the blocks section, but the rest of the datastore) has been cleaned out/restored from a backup (not really supported)
3) The IPNS key is being added to a new machine (also not supported)