### PR TITLE
docs: update experimental-features doc with IPNS over pubsub changes.

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -427,7 +427,9 @@ ipfs config --json Experimental.ShardingEnabled true
 
 ### In Version
 
-0.4.14
+Introduced: 0.4.14
+
+Latest Major Change: 0.5.0
 
 ### State
 
@@ -439,9 +441,13 @@ When it is enabled:
 - IPNS publishers push records to a name-specific pubsub topic,
   in addition to publishing to the DHT.
 - IPNS resolvers subscribe to the name-specific topic on first
-  resolution and receive subsequently published records through pubsub in real time. This makes subsequent resolutions instant, as they are resolved through the local cache. Note that the initial resolution still goes through the DHT, as there is no message history in pubsub.
+  resolution and receive subsequently published records through pubsub in real time.
+  This makes subsequent resolutions instant, as they are resolved through the local cache.
 
 Both the publisher and the resolver nodes need to have the feature enabled for it to work effectively.
+
+Note: While IPNS pubsub has been available since 0.4.14, it received major changes in 0.5.0.
+Users interested in this feature should upgrade to at least 0.5.0
 
 ### How to enable
 
@@ -450,9 +456,7 @@ run your daemon with the `--enable-namesys-pubsub` flag; enables pubsub.
 ### Road to being a real feature
 
 - [ ] Needs more people to use and report on how well it works
-- [ ] Add a mechanism for last record distribution on subscription,
-  so that we don't have to hit the DHT for the initial resolution.
-  Alternatively, we could republish the last record periodically.
+- [ ] Pubsub enabled as a real feature
 
 ## QUIC
 

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -427,9 +427,14 @@ ipfs config --json Experimental.ShardingEnabled true
 
 ### In Version
 
-Introduced: 0.4.14
+0.4.14 :
+  - Introduced
 
-Latest Major Change: 0.5.0
+0.5.0 : 
+   - No longer needs to use the DHT for the first resolution
+   - When discovering PubSub peers via the DHT, the DHT key is different from previous versions
+      - This leads to 0.5 IPNS pubsub peers and 0.4 IPNS pubsub peers not being able to find each other in the DHT
+   - Robustness improvements
 
 ### State
 


### PR DESCRIPTION
Updates the IPNS over PubSub experimental feature to encompass the latest changes to the feature.