### PR TITLE
feat: bootstrap in dht when the routing table is empty

### DIFF
--- a/core/node/libp2p/routingopt.go
+++ b/core/node/libp2p/routingopt.go
@@ -4,31 +4,61 @@ import (
 	"context"
 
 	"github.com/ipfs/go-datastore"
-	nilrouting "github.com/ipfs/go-ipfs-routing/none"
 	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
 	routing "github.com/libp2p/go-libp2p-core/routing"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dual "github.com/libp2p/go-libp2p-kad-dht/dual"
 	record "github.com/libp2p/go-libp2p-record"
+	routinghelpers "github.com/libp2p/go-libp2p-routing-helpers"
 )
 
-type RoutingOption func(context.Context, host.Host, datastore.Batching, record.Validator) (routing.Routing, error)
+type RoutingOption func(
+	context.Context,
+	host.Host,
+	datastore.Batching,
+	record.Validator,
+	...peer.AddrInfo,
+) (routing.Routing, error)
 
-func constructDHTRouting(mode dht.ModeOpt) func(ctx context.Context, host host.Host, dstore datastore.Batching, validator record.Validator) (routing.Routing, error) {
-	return func(ctx context.Context, host host.Host, dstore datastore.Batching, validator record.Validator) (routing.Routing, error) {
+func constructDHTRouting(mode dht.ModeOpt) func(
+	ctx context.Context,
+	host host.Host,
+	dstore datastore.Batching,
+	validator record.Validator,
+	bootstrapPeers ...peer.AddrInfo,
+) (routing.Routing, error) {
+	return func(
+		ctx context.Context,
+		host host.Host,
+		dstore datastore.Batching,
+		validator record.Validator,
+		bootstrapPeers ...peer.AddrInfo,
+	) (routing.Routing, error) {
 		return dual.New(
 			ctx, host,
 			dht.Concurrency(10),
 			dht.Mode(mode),
 			dht.Datastore(dstore),
 			dht.Validator(validator),
+			dht.BootstrapPeers(bootstrapPeers...),
 		)
 	}
+}
+
+func constructNilRouting(
+	ctx context.Context,
+	host host.Host,
+	dstore datastore.Batching,
+	validator record.Validator,
+	bootstrapPeers ...peer.AddrInfo,
+) (routing.Routing, error) {
+	return routinghelpers.Null{}, nil
 }
 
 var (
 	DHTOption       RoutingOption = constructDHTRouting(dht.ModeAuto)
 	DHTClientOption               = constructDHTRouting(dht.ModeClient)
 	DHTServerOption               = constructDHTRouting(dht.ModeServer)
-	NilRouterOption               = nilrouting.ConstructNilRouting
+	NilRouterOption               = constructNilRouting
 )

--- a/go.mod
+++ b/go.mod
@@ -66,8 +66,8 @@ require (
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/libp2p/go-libp2p-discovery v0.4.0
 	github.com/libp2p/go-libp2p-http v0.1.5
-	github.com/libp2p/go-libp2p-kad-dht v0.7.11
-	github.com/libp2p/go-libp2p-kbucket v0.4.1
+	github.com/libp2p/go-libp2p-kad-dht v0.8.0
+	github.com/libp2p/go-libp2p-kbucket v0.4.2
 	github.com/libp2p/go-libp2p-loggables v0.1.0
 	github.com/libp2p/go-libp2p-mplex v0.2.3
 	github.com/libp2p/go-libp2p-peerstore v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -592,10 +592,10 @@ github.com/libp2p/go-libp2p-interface-connmgr v0.0.1/go.mod h1:GarlRLH0LdeWcLnYM
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.4/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
 github.com/libp2p/go-libp2p-interface-connmgr v0.0.5/go.mod h1:GarlRLH0LdeWcLnYM/SaBykKFl9U5JFnbBGruAk/D5k=
 github.com/libp2p/go-libp2p-interface-pnet v0.0.1/go.mod h1:el9jHpQAXK5dnTpKA4yfCNBZXvrzdOU75zz+C6ryp3k=
-github.com/libp2p/go-libp2p-kad-dht v0.7.11 h1:MP0DEuxO/Blg1AklIVV1P4R5xtYX+ZyXBCtEN7f60yQ=
-github.com/libp2p/go-libp2p-kad-dht v0.7.11/go.mod h1:1ht6+bG3Or+fNNERWPYmLacs6TN0CxBkFB5IKIWWwOI=
-github.com/libp2p/go-libp2p-kbucket v0.4.1 h1:6FyzbQuGLPzbMv3HiD232zqscIz5iB8ppJwb380+OGI=
-github.com/libp2p/go-libp2p-kbucket v0.4.1/go.mod h1:7sCeZx2GkNK1S6lQnGUW5JYZCFPnXzAZCCBBS70lytY=
+github.com/libp2p/go-libp2p-kad-dht v0.8.0 h1:vfqDTa/dUlNVlK3nL1b9pTMV9/hhIr4sDjUVk0VEtFQ=
+github.com/libp2p/go-libp2p-kad-dht v0.8.0/go.mod h1:u3rbYbp3CSraAHD5s81CJ3hHozKTud/UOXfAgh93Gek=
+github.com/libp2p/go-libp2p-kbucket v0.4.2 h1:wg+VPpCtY61bCasGRexCuXOmEmdKjN+k1w+JtTwu9gA=
+github.com/libp2p/go-libp2p-kbucket v0.4.2/go.mod h1:7sCeZx2GkNK1S6lQnGUW5JYZCFPnXzAZCCBBS70lytY=
 github.com/libp2p/go-libp2p-loggables v0.0.1/go.mod h1:lDipDlBNYbpyqyPX/KcoO+eq0sJYEVR2JgOexcivchg=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=


### PR DESCRIPTION
Otherwise, we could end up with only DHT clients and never re-bootstrap.

I've left the default go-ipfs bootstrapping code in for now as it's technically possible to disable the DHT entirely.