### PR TITLE
feat: support long CIDs in subdomains by splitting at 63rd char

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -157,8 +157,8 @@ func HostnameOption() ServeOption {
 				// Check if rootID is a valid CID
 				if rootCID, err := cid.Decode(rootID); err == nil {
 					// Do we need to redirect CID to a canonical DNS representation?
-					canonicalPrefix := toDNSSafePrefix(rootID)
-					if !strings.HasPrefix(r.Host, canonicalPrefix) {
+					hostPrefix := toDNSPrefix(rootID)
+					if !strings.HasPrefix(r.Host, hostPrefix) {
 						if newURL, ok := toSubdomainURL(hostname, pathPrefix+r.URL.Path, r); ok {
 							// Redirect to CID split split at deterministic places
 							// to ensure CID always gets the same Origin on the web
@@ -291,7 +291,7 @@ func isPeerIDNamespace(ns string) bool {
 }
 
 // Converts an identifier to DNS-safe representation
-func toDNSSafePrefix(id string) (prefix string) {
+func toDNSPrefix(id string) (prefix string) {
 	s := strings.Replace(id, ".", "", -1) // remove separators if present
 
 	// Return if things fit after dot removal
@@ -395,7 +395,7 @@ func toSubdomainURL(hostname, path string, r *http.Request) (redirURL string, ok
 			// produce a subdomain URL
 			return "", false
 		}
-		rootID = toDNSSafePrefix(rootID)
+		rootID = toDNSPrefix(rootID)
 	}
 
 	return safeRedirectURL(fmt.Sprintf(

--- a/core/corehttp/hostname_test.go
+++ b/core/corehttp/hostname_test.go
@@ -77,7 +77,7 @@ func TestPortStripping(t *testing.T) {
 
 }
 
-func TestToDNSSafePrefix(t *testing.T) {
+func TestDNSPrefix(t *testing.T) {
 	for _, test := range []struct {
 		in  string
 		out string
@@ -91,7 +91,7 @@ func TestToDNSSafePrefix(t *testing.T) {
 		{"bafkrgqe3ohjcjplc6n4f3fwunlj6upltggn7xqujbsvnvyw764srszz4u4rshq6ztos4chl4plgg4ffyyxnayrtdi5oc4xb2332g645433aeg", "bafkrgqe3ohjcjplc6n4f3fwunlj6upltggn7xqujbsvnvy.w764srszz4u4rshq6ztos4chl4plgg4ffyyxnayrtdi5oc4xb2332g645433aeg"},
 		{"bafkrgqe3ohjcjplc6n4f3fw.unlj6upltggn7xqujbsvnvyw764srszz4u4rshq6ztos4chl4plgg4.ffyyxnayrtdi5oc4xb2332g645433aeg", "bafkrgqe3ohjcjplc6n4f3fwunlj6upltggn7xqujbsvnvy.w764srszz4u4rshq6ztos4chl4plgg4ffyyxnayrtdi5oc4xb2332g645433aeg"},
 	} {
-		out := toDNSSafePrefix(test.in)
+		out := toDNSPrefix(test.in)
 		if out != test.out {
 			t.Errorf("(%s): returned '%s', expected '%s'", test.in, out, test.out)
 		}
@@ -153,6 +153,8 @@ func TestKnownSubdomainDetails(t *testing.T) {
 		{"bafzbeihe35nmjqar22thmxsnlsgxppd66pseq6tscs4mo25y55juhh6bju.ipns.dweb.ipfs.pvt.k12.ma.us", "dweb.ipfs.pvt.k12.ma.us", "ipns", "bafzbeihe35nmjqar22thmxsnlsgxppd66pseq6tscs4mo25y55juhh6bju", true},
 		// edge case check: understand split CIDs (workaround for 63 character limit of a single DNS label https://github.com/ipfs/go-ipfs/issues/7318)
 		// Note: canonical split is at 63, but we support arbitrary splits for improved UX
+		// Short CID (eg. unnecessarily split by user)
+		{"baf.kreicysg23kiwv34eg2d7.qweipxwosdo2py4ldv4.2nbauguluen5v6am.ipfs.dweb.link", "dweb.link", "ipfs", "bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am", true},
 		// ED25519 libp2p-key
 		{"ba.fzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk.ipfs.dweb.link", "dweb.link", "ipfs", "bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk", true},
 		{"bafzaajaiaejca4syrpdu6gdx4wsdnok.xkprgzxf4wrstuc34gxw5k5jrag2so5gk.ipfs.dweb.link", "dweb.link", "ipfs", "bafzaajaiaejca4syrpdu6gdx4wsdnokxkprgzxf4wrstuc34gxw5k5jrag2so5gk", true},

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -95,6 +95,7 @@ test_expect_success "Add test text file" '
   CIDv1_LONG=$(echo $CID_VAL | ipfs add --cid-version 1 --hash sha2-512 -Q)
   CID_DNS_SPLIT_CANONICAL="bafkrgqhhyivzstcz3hhswshfjgy6ertgmnqeleynhwt4dl.fsthi4hn7zgh4uvlsb5xncykzapi3ocd4lzogukir6ksdy6wzrnz6ohnv4aglcs"
   CID_DNS_SPLIT_CUSTOM="baf.krgqhhyivzstcz3hhswshfjgy6ertgmnqeleynhwt4dl.fsthi4hn7zgh4uvlsb5xncykzapi3ocd4lzogukir.6ksdy6wzrnz6ohnv4aglcs"
+  CID_DNS_SPLIT_CUSTOM2=$(echo $CIDv1 | sed -r -e "s/^./&./")
   CIDv0=$(echo $CID_VAL | ipfs add --cid-version 0 -Q)
   CIDv0to1=$(echo "$CIDv0" | ipfs cid base32)
 '
@@ -526,6 +527,11 @@ test_localhost_gateway_response_should_contain \
   "http://${CID_DNS_SPLIT_CUSTOM}.ipfs.localhost:$GWAY_PORT/ipfs/$CIDv1" \
   "Location: http://${CID_DNS_SPLIT_CANONICAL}.ipfs.localhost:$GWAY_PORT/"
 
+test_localhost_gateway_response_should_contain \
+  "request for {unnecessary.split.of.short.CID}.ipfs.localhost should return redirect to a canonical Origin" \
+  "http://${CID_DNS_SPLIT_CUSTOM2}.ipfs.localhost:$GWAY_PORT/ipfs/$CIDv1" \
+  "Location: http://${CIDv1}.ipfs.localhost:$GWAY_PORT/"
+
 # public gateway: *.example.com
 
 test_hostname_gateway_response_should_contain \
@@ -545,6 +551,12 @@ test_hostname_gateway_response_should_contain \
   "${CID_DNS_SPLIT_CUSTOM}.ipfs.example.com" \
   "http://127.0.0.1:$GWAY_PORT" \
   "Location: http://${CID_DNS_SPLIT_CANONICAL}.ipfs.example.com"
+
+test_hostname_gateway_response_should_contain \
+  "request for {unnecessary.split.of.short.CID}.ipfs.example.com should return redirect to a canonical Origin" \
+  "${CID_DNS_SPLIT_CUSTOM2}.ipfs.example.com" \
+  "http://127.0.0.1:$GWAY_PORT" \
+  "Location: http://${CIDv1}.ipfs.example.com"
 
 ## ============================================================================
 ## Test path-based requests with a custom hostname config


### PR DESCRIPTION
> - This is a "generic" fix for #7318 that solves DNS problem for all CIDs
> - IPNS will get additional one in form of ED25519 libp2p-keys represented in Base36, but that will be a separate PR when https://github.com/ipfs/go-cid/pull/107 lands. 
> - **Note:** significant downside of this approach is no TLS (impossible to get a wildcard cart for more than one level of of subdomains)

This PR adds subdomain gateway support for CIDs longer than 63 characters:

- CID is split after reaching 63 character limit counting from right to left. 
- Requests made with random splits are redirected to canonical split version to ensure every CID gets exactly one Origin.
- go  and sharness tests document behavior for longer CIDs


"Splitting logic" is in `toDNSSafePrefix` – would love some eyes on it. 
I am unsure if I it is the most efficient way to split into chunks of 63 starting from right to left, suggestions welcome. 

Ref.
- https://tools.ietf.org/html/rfc1034#page-7
- https://github.com/ipfs/go-ipfs/issues/7318