### PR TITLE
Include the git blob id of the dir-index bundle in the ETag

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,6 +1,8 @@
 //go:generate git submodule update --init ./dir-index-html
 //go:generate go run github.com/go-bindata/go-bindata/go-bindata -pkg=assets init-doc dir-index-html/dir-index.html dir-index-html/knownIcons.txt
 //go:generate gofmt -w bindata.go
+//go:generate sh -c "sed -i \"s/.*BindataVersionHash.*/BindataVersionHash=\\\"$(git hash-object bindata.go)\\\"/\" bindata_version_hash.go"
+//go:generate gofmt -w bindata_version_hash.go
 package assets
 
 import (

--- a/assets/bindata_version_hash.go
+++ b/assets/bindata_version_hash.go
@@ -1,0 +1,5 @@
+package assets
+
+const (
+	BindataVersionHash = "c1aa0601ac3eac2c50b296cf618a6747eeba8579"
+)

--- a/assets/bindata_version_hash.go
+++ b/assets/bindata_version_hash.go
@@ -1,3 +1,4 @@
+// File generated together with 'bindata.go' when running `go generate .` DO NOT EDIT. (@generated)
 package assets
 
 const (


### PR DESCRIPTION
While the content of raw files retrieved via the gateway should never
change, the look and feel of the directory index can and will change
between versions of go-ipfs.

Incorporate the hash of assets/bindata.go into the ETag when appropriate

@Stebalien this is what we spoke about <gulp> last year @ camp. Goes with @jessicaschilling's recent changes.