### PR TITLE
Add custom dns server address support(partialy)

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -62,7 +62,7 @@ The resolver can recursively resolve:
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		recursive, _ := req.Options[dnsRecursiveOptionName].(bool)
 		name := req.Arguments[0]
-		resolver := namesys.NewDNSResolver()
+		resolver := namesys.NewDNSResolver("")
 
 		var routing []nsopts.ResolveOpt
 		if !recursive {

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -60,7 +60,7 @@ func NewNameSystem(r routing.ValueStore, ds ds.Datastore, cachesize int) NameSys
 	}
 
 	return &mpns{
-		dnsResolver:      NewDNSResolver(),
+		dnsResolver:      NewDNSResolver(""),
 		proquintResolver: new(ProquintResolver),
 		ipnsResolver:     NewIpnsResolver(r),
 		ipnsPublisher:    NewIpnsPublisher(r, ds),


### PR DESCRIPTION
This add an option of dns server address to `namesys.NewDNSResolver()` and `namesys.DNSResolver`.
I haven't add config of dns server now.
