### PR TITLE
fix: use bitswap sessions for ipfs refs

### DIFF
--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -13,6 +13,7 @@ import (
 	cidenc "github.com/ipfs/go-cidutil/cidenc"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	ipld "github.com/ipfs/go-ipld-format"
+	merkledag "github.com/ipfs/go-merkledag"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	path "github.com/ipfs/interface-go-ipfs-core/path"
 )
@@ -102,6 +103,7 @@ NOTE: List all references recursively by using the flag '-r'.
 			format = "<src> -> <dst>"
 		}
 
+		// TODO: use session for resolving as well.
 		objs, err := objectsForPaths(ctx, api, req.Arguments)
 		if err != nil {
 			return err
@@ -109,7 +111,7 @@ NOTE: List all references recursively by using the flag '-r'.
 
 		rw := RefWriter{
 			res:      res,
-			DAG:      api.Dag(),
+			DAG:      merkledag.NewSession(ctx, api.Dag()),
 			Ctx:      ctx,
 			Unique:   unique,
 			PrintFmt: format,
@@ -164,16 +166,16 @@ Displays the hashes of all local objects.
 	Type:     RefWrapper{},
 }
 
-func objectsForPaths(ctx context.Context, n iface.CoreAPI, paths []string) ([]ipld.Node, error) {
-	objects := make([]ipld.Node, len(paths))
+func objectsForPaths(ctx context.Context, n iface.CoreAPI, paths []string) ([]cid.Cid, error) {
+	roots := make([]cid.Cid, len(paths))
 	for i, sp := range paths {
-		o, err := n.ResolveNode(ctx, path.New(sp))
+		o, err := n.ResolvePath(ctx, path.New(sp))
 		if err != nil {
 			return nil, err
 		}
-		objects[i] = o
+		roots[i] = o.Cid()
 	}
-	return objects, nil
+	return roots, nil
 }
 
 type RefWrapper struct {
@@ -183,7 +185,7 @@ type RefWrapper struct {
 
 type RefWriter struct {
 	res cmds.ResponseEmitter
-	DAG ipld.DAGService
+	DAG ipld.NodeGetter
 	Ctx context.Context
 
 	Unique   bool
@@ -194,7 +196,11 @@ type RefWriter struct {
 }
 
 // WriteRefs writes refs of the given object to the underlying writer.
-func (rw *RefWriter) WriteRefs(n ipld.Node, enc cidenc.Encoder) (int, error) {
+func (rw *RefWriter) WriteRefs(c cid.Cid, enc cidenc.Encoder) (int, error) {
+	n, err := rw.DAG.Get(rw.Ctx, c)
+	if err != nil {
+		return 0, err
+	}
 	return rw.writeRefsRecursive(n, 0, enc)
 }
 

--- a/core/coreapi/dag.go
+++ b/core/coreapi/dag.go
@@ -6,6 +6,7 @@ import (
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-ipfs-pinner"
 	ipld "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/go-merkledag"
 )
 
 type dagAPI struct {
@@ -50,3 +51,12 @@ func (adder *pinningAdder) AddMany(ctx context.Context, nds []ipld.Node) error {
 func (api *dagAPI) Pinning() ipld.NodeAdder {
 	return (*pinningAdder)(api.core)
 }
+
+func (api *dagAPI) Session(ctx context.Context) ipld.NodeGetter {
+	return dag.NewSession(ctx, api.DAGService)
+}
+
+var (
+	_ ipld.DAGService  = (*dagAPI)(nil)
+	_ dag.SessionMaker = (*dagAPI)(nil)
+)


### PR DESCRIPTION
This isn't perfect (we only use sessions after resolving the root cid) but it's
better than what we have. The real solution is #7198 so we can use sessions
everywhere.