### PR TITLE
fix two pubsub issues.

### DIFF
--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -74,7 +74,7 @@ This command outputs data in the following encodings:
 		cmds.StringArg("topic", true, false, "String name of topic to subscribe to."),
 	},
 	Options: []cmds.Option{
-		cmds.BoolOption(pubsubDiscoverOptionName, "try to discover other peers subscribed to the same topic"),
+		cmds.BoolOption(pubsubDiscoverOptionName, "Deprecated option to instruct pubsub to discovery peers for the topic. Discovery is now built into pubsub."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -83,9 +83,7 @@ This command outputs data in the following encodings:
 		}
 
 		topic := req.Arguments[0]
-		discover, _ := req.Options[pubsubDiscoverOptionName].(bool)
-
-		sub, err := api.PubSub().Subscribe(req.Context, topic, options.PubSub.Discover(discover))
+		sub, err := api.PubSub().Subscribe(req.Context, topic)
 		if err != nil {
 			return err
 		}

--- a/core/coreapi/coreapi.go
+++ b/core/coreapi/coreapi.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ipfs/go-ipfs-provider"
 	offlineroute "github.com/ipfs/go-ipfs-routing/offline"
 	ipld "github.com/ipfs/go-ipld-format"
-	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	"github.com/ipfs/interface-go-ipfs-core/options"
@@ -43,8 +42,6 @@ import (
 	"github.com/ipfs/go-ipfs/namesys"
 	"github.com/ipfs/go-ipfs/repo"
 )
-
-var log = logging.Logger("core/coreapi")
 
 type CoreAPI struct {
 	nctx context.Context

--- a/core/node/libp2p/pubsub.go
+++ b/core/node/libp2p/pubsub.go
@@ -17,6 +17,10 @@ func FloodSub(pubsubOptions ...pubsub.Option) interface{} {
 
 func GossipSub(pubsubOptions ...pubsub.Option) interface{} {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host, disc discovery.Discovery) (service *pubsub.PubSub, err error) {
-		return pubsub.NewGossipSub(helpers.LifecycleCtx(mctx, lc), host, append(pubsubOptions, pubsub.WithDiscovery(disc))...)
+		return pubsub.NewGossipSub(helpers.LifecycleCtx(mctx, lc), host, append(
+			pubsubOptions,
+			pubsub.WithDiscovery(disc),
+			pubsub.WithFloodPublish(true))...,
+		)
 	}
 }


### PR DESCRIPTION
1. Flood for first pubsub hop to ensure the message gets broadcasted even if some of our peers are overloaded.
2. Remove discovery logic. This is now handled by pubsub internally.