### PR TITLE
fix(commands): print consistent addresses in ipfs id

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -154,7 +154,13 @@ func printPeer(ps pstore.Peerstore, p peer.ID) (interface{}, error) {
 		info.PublicKey = base64.StdEncoding.EncodeToString(pkb)
 	}
 
-	for _, a := range ps.Addrs(p) {
+	addrInfo := ps.PeerInfo(p)
+	addrs, err := peer.AddrInfoToP2pAddrs(&addrInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range addrs {
 		info.Addresses = append(info.Addresses, a.String())
 	}
 

--- a/test/sharness/t0140-swarm.sh
+++ b/test/sharness/t0140-swarm.sh
@@ -123,6 +123,17 @@ test_expect_success "/p2p addresses work" '
   [ $(ipfsi 0 swarm peers | wc -l) -eq 1 ]
 '
 
+test_expect_success "ipfs id is consistent for node 0" '
+  ipfsi 1 id "$(iptb attr get 0 id)" > 1see0 &&
+  ipfsi 0 id > 0see0 &&
+  test_cmp 1see0 0see0
+'
+test_expect_success "ipfs id is consistent for node 1" '
+  ipfsi 0 id "$(iptb attr get 1 id)" > 0see1 &&
+  ipfsi 1 id > 1see1 &&
+  test_cmp 0see1 1see1
+'
+
 test_expect_success "stopping cluster" '
   iptb stop
 '

--- a/test/sharness/t0140-swarm.sh
+++ b/test/sharness/t0140-swarm.sh
@@ -128,10 +128,18 @@ test_expect_success "ipfs id is consistent for node 0" '
   ipfsi 0 id > 0see0 &&
   test_cmp 1see0 0see0
 '
+
 test_expect_success "ipfs id is consistent for node 1" '
   ipfsi 0 id "$(iptb attr get 1 id)" > 0see1 &&
   ipfsi 1 id > 1see1 &&
   test_cmp 0see1 1see1
+'
+
+test_expect_success "addresses contain /p2p/..." '
+  test_should_contain "/p2p/$(iptb attr get 1 id)\"" 0see1 &&
+  test_should_contain "/p2p/$(iptb attr get 1 id)\"" 1see1 &&
+  test_should_contain "/p2p/$(iptb attr get 0 id)\"" 1see0 &&
+  test_should_contain "/p2p/$(iptb attr get 0 id)\"" 0see0
 '
 
 test_expect_success "stopping cluster" '


### PR DESCRIPTION
Consistently append `/p2p/QmMyId` to addresses when calling `ipfs id Me` and `ipfs id NotMe`.

Fixes https://github.com/ipfs/go-ipfs/issues/7378.