### PR TITLE
feat: support ED25519 at subdomain gw with TLS

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -41,12 +41,15 @@ var defaultKnownGateways = map[string]config.GatewaySpec{
 	"dweb.link":       subdomainGatewaySpec,
 }
 
+// Label's max length in DNS (https://tools.ietf.org/html/rfc1034#page-7)
+const dnsLabelMaxLength int = 63
+
 // HostnameOption rewrites an incoming request based on the Host header.
 func HostnameOption() ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		childMux := http.NewServeMux()
 
-		coreApi, err := coreapi.NewCoreAPI(n)
+		coreAPI, err := coreapi.NewCoreAPI(n)
 		if err != nil {
 			return nil, err
 		}
@@ -101,7 +104,12 @@ func HostnameOption() ServeOption {
 					if gw.UseSubdomains {
 						// Yes, redirect if applicable
 						// Example: dweb.link/ipfs/{cid} → {cid}.ipfs.dweb.link
-						if newURL, ok := toSubdomainURL(host, r.URL.Path, r); ok {
+						newURL, err := toSubdomainURL(host, r.URL.Path, r)
+						if err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						if newURL != "" {
 							// Just to be sure single Origin can't be abused in
 							// web browsers that ignored the redirect for some
 							// reason, Clear-Site-Data header clears browsing
@@ -131,7 +139,7 @@ func HostnameOption() ServeOption {
 				// Not a whitelisted path
 
 				// Try DNSLink, if it was not explicitly disabled for the hostname
-				if !gw.NoDNSLink && isDNSLinkRequest(r.Context(), coreApi, host) {
+				if !gw.NoDNSLink && isDNSLinkRequest(r.Context(), coreAPI, host) {
 					// rewrite path and handle as DNSLink
 					r.URL.Path = "/ipns/" + stripPort(host) + r.URL.Path
 					childMux.ServeHTTP(w, r)
@@ -158,14 +166,42 @@ func HostnameOption() ServeOption {
 					return
 				}
 
-				// Do we need to fix multicodec in PeerID represented as CIDv1?
-				if isPeerIDNamespace(ns) {
-					keyCid, err := cid.Decode(rootID)
-					if err == nil && keyCid.Type() != cid.Libp2pKey {
-						if newURL, ok := toSubdomainURL(hostname, pathPrefix+r.URL.Path, r); ok {
-							// Redirect to CID fixed inside of toSubdomainURL()
+				// Check if rootID is a valid CID
+				if rootCID, err := cid.Decode(rootID); err == nil {
+					// Do we need to redirect root CID to a canonical DNS representation?
+					dnsCID, err := toDNSPrefix(rootID, rootCID)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					if !strings.HasPrefix(r.Host, dnsCID) {
+						dnsPrefix := "/" + ns + "/" + dnsCID
+						newURL, err := toSubdomainURL(hostname, dnsPrefix+r.URL.Path, r)
+						if err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						if newURL != "" {
+							// Redirect to deterministic CID to ensure CID
+							// always gets the same Origin on the web
 							http.Redirect(w, r, newURL, http.StatusMovedPermanently)
 							return
+						}
+					}
+
+					// Do we need to fix multicodec in PeerID represented as CIDv1?
+					if isPeerIDNamespace(ns) {
+						if rootCID.Type() != cid.Libp2pKey {
+							newURL, err := toSubdomainURL(hostname, pathPrefix+r.URL.Path, r)
+							if err != nil {
+								http.Error(w, err.Error(), http.StatusBadRequest)
+								return
+							}
+							if newURL != "" {
+								// Redirect to CID fixed inside of toSubdomainURL()
+								http.Redirect(w, r, newURL, http.StatusMovedPermanently)
+								return
+							}
 						}
 					}
 				}
@@ -183,7 +219,7 @@ func HostnameOption() ServeOption {
 			// 1. is wildcard DNSLink enabled (Gateway.NoDNSLink=false)?
 			// 2. does Host header include a fully qualified domain name (FQDN)?
 			// 3. does DNSLink record exist in DNS?
-			if !cfg.Gateway.NoDNSLink && isDNSLinkRequest(r.Context(), coreApi, host) {
+			if !cfg.Gateway.NoDNSLink && isDNSLinkRequest(r.Context(), coreAPI, host) {
 				// rewrite path and handle as DNSLink
 				r.URL.Path = "/ipns/" + stripPort(host) + r.URL.Path
 				childMux.ServeHTTP(w, r)
@@ -273,18 +309,38 @@ func isPeerIDNamespace(ns string) bool {
 	}
 }
 
+// Converts an identifier to DNS-safe representation that fits in 63 characters
+func toDNSPrefix(rootID string, rootCID cid.Cid) (prefix string, err error) {
+	// Return as-is if things fit
+	if len(rootID) <= dnsLabelMaxLength {
+		return rootID, nil
+	}
+
+	// Convert to Base36 and see if that helped
+	rootID, err = cid.NewCidV1(rootCID.Type(), rootCID.Hash()).StringOfBase(mbase.Base36)
+	if err != nil {
+		return "", err
+	}
+	if len(rootID) <= dnsLabelMaxLength {
+		return rootID, nil
+	}
+
+	// Can't win with DNS at this point, return error
+	return "", fmt.Errorf("CID incompatible with DNS label length limit of 63: %s", rootID)
+}
+
 // Converts a hostname/path to a subdomain-based URL, if applicable.
-func toSubdomainURL(hostname, path string, r *http.Request) (redirURL string, ok bool) {
+func toSubdomainURL(hostname, path string, r *http.Request) (redirURL string, err error) {
 	var scheme, ns, rootID, rest string
 
 	query := r.URL.RawQuery
 	parts := strings.SplitN(path, "/", 4)
-	safeRedirectURL := func(in string) (out string, ok bool) {
+	safeRedirectURL := func(in string) (out string, err error) {
 		safeURI, err := url.ParseRequestURI(in)
 		if err != nil {
-			return "", false
+			return "", err
 		}
-		return safeURI.String(), true
+		return safeURI.String(), nil
 	}
 
 	// Support X-Forwarded-Proto if added by a reverse proxy
@@ -304,11 +360,11 @@ func toSubdomainURL(hostname, path string, r *http.Request) (redirURL string, ok
 		ns = parts[1]
 		rootID = parts[2]
 	default:
-		return "", false
+		return "", nil
 	}
 
 	if !isSubdomainNamespace(ns) {
-		return "", false
+		return "", nil
 	}
 
 	// add prefix if query is present
@@ -327,25 +383,42 @@ func toSubdomainURL(hostname, path string, r *http.Request) (redirURL string, ok
 	}
 
 	// If rootID is a CID, ensure it uses DNS-friendly text representation
-	if rootCid, err := cid.Decode(rootID); err == nil {
-		multicodec := rootCid.Type()
+	if rootCID, err := cid.Decode(rootID); err == nil {
+		multicodec := rootCID.Type()
+		var base mbase.Encoding = mbase.Base32
 
-		// PeerIDs represented as CIDv1 are expected to have libp2p-key
-		// multicodec (https://github.com/libp2p/specs/pull/209).
-		// We ease the transition by fixing multicodec on the fly:
-		// https://github.com/ipfs/go-ipfs/issues/5287#issuecomment-492163929
-		if isPeerIDNamespace(ns) && multicodec != cid.Libp2pKey {
-			multicodec = cid.Libp2pKey
+		// Normalizations specific to /ipns/{libp2p-key}
+		if isPeerIDNamespace(ns) {
+			// Using Base36 for /ipns/ for consistency
+			// Context: https://github.com/ipfs/go-ipfs/pull/7441#discussion_r452372828
+			base = mbase.Base36
+
+			// PeerIDs represented as CIDv1 are expected to have libp2p-key
+			// multicodec (https://github.com/libp2p/specs/pull/209).
+			// We ease the transition by fixing multicodec on the fly:
+			// https://github.com/ipfs/go-ipfs/issues/5287#issuecomment-492163929
+			if multicodec != cid.Libp2pKey {
+				multicodec = cid.Libp2pKey
+			}
 		}
 
-		// if object turns out to be a valid CID,
-		// ensure text representation used in subdomain is CIDv1 in Base32
-		// https://github.com/ipfs/in-web-browsers/issues/89
-		rootID, err = cid.NewCidV1(multicodec, rootCid.Hash()).StringOfBase(mbase.Base32)
+		// Ensure CID text representation used in subdomain is compatible
+		// with the way DNS and URIs are implemented in user agents.
+		//
+		// 1. Switch to CIDv1 and enable case-insensitive Base encoding
+		//    to avoid issues when user agent force-lowercases the hostname
+		//    before making the request
+		//    (https://github.com/ipfs/in-web-browsers/issues/89)
+		rootCID = cid.NewCidV1(multicodec, rootCID.Hash())
+		rootID, err = rootCID.StringOfBase(base)
 		if err != nil {
-			// should not error, but if it does, its clealy not possible to
-			// produce a subdomain URL
-			return "", false
+			return "", err
+		}
+		// 2. Make sure CID fits in a DNS label, adjust encoding if needed
+		//    (https://github.com/ipfs/go-ipfs/issues/7318)
+		rootID, err = toDNSPrefix(rootID, rootCID)
+		if err != nil {
+			return "", err
 		}
 	}
 

--- a/test/sharness/t0184-http-proxy-over-p2p.sh
+++ b/test/sharness/t0184-http-proxy-over-p2p.sh
@@ -216,7 +216,7 @@ test_expect_success 'handle multipart/form-data http request' '
 '
 
 # subdomain gateway at *.p2p.example.com requires PeerdID in base32
-RECEIVER_ID_CIDv1=$( ipfs cid format -v 1 -b b --codec libp2p-key -- $RECEIVER_ID)
+RECEIVER_ID_CIDv1=$( ipfs cid format -v 1 --codec libp2p-key -b base36 -- $RECEIVER_ID)
 
 # OK: $peerid.p2p.example.com/http/index.txt
 test_expect_success "handle http request to a subdomain gateway" '


### PR DESCRIPTION
> The goal of this PR is to be alternative to #7358 and solve #7318 in a way that makes it possible to have functional TLS for IPNS on public subdomain gateways.


### Rationale 

If we split original CID into multiple sub labels (#7358) DNS resolution will work, but **no public gateway will be able to get TLS certificate** that supports double wildcards like `*.*.ipfs.example.com`. 

When splitting is used, visitors using web browsers will see a [TLS Error page](https://user-images.githubusercontent.com/157609/86123445-cc829180-bad9-11ea-8471-83683ee48654.png), which effectively kills UX and defeats the purpose of subdomain gateway (one step forward  by increasing security by providing Origin isolation, two steps backward by removing ability to do TLS validation when loading website backed by a long CID).

Given this reality, I believe a better trade off could be to try shortening CID by converting it to Base36, and if that fails return an error before redirect to subdomain occurs.


### This PR

- adds subdomain gateway support for ED25519 CIDs in a way that fits in a single DNS label to enable TLS for every IPNS website.
- cleans up subdomain redirect logic and adds more explicit error handling so user gets human-readable error with proper IPFS context instead of generic DNS failure 

### TL;DR on router logic:

When CID is longer than 63 characters, router at /ipfs/* and /ipns/* converts to Base36, and if that does not help, returns a human readable 400 Bad Request error.


### Examples

Given a subdomain gateway at `example.com`:

ED25519 fits perfectly when converted to Base36, so it gets loaded just fine:
```
http://example.com/ipns/12D3KooWP3ggTJV8LGckDHc4bVyXGhEWuBskoFyE6Rn2BJBqJtpa 
  → HTTP301 – http://k51qzi5uqu5dl2yn0d6xu8q5aqa61jh8zeyixz9tsju80n15ssiyew48912c63.ipns.example.com
```

CID produced by `ipfs add --cid-version 1 --hash sha2-512` is too long, so an error is returned instead:

```
http://example.com/ipfs/bafkrgqhhyivzstcz3hhswshfjgy6ertgmnqeleynhwt4dlfsthi4hn7zgh4uvlsb5xncykzapi3ocd4lzogukir6ksdy6wzrnz6ohnv4aglcs 
  → HTTP 400 "CID incompatible with DNS label length limit of 63"
```

Note that returning this error overrides https://github.com/ipfs/go-ipfs/pull/6982 which means tools like `curl` won't be able to load content from long CIDs via the subdomain gateway. I don't think that is a bug, pretty sure it is how we want it, but mentioning here for completenes. 

### Why we dropped the previous iteration

We looked into automatically replacing root node which has shorter CID, but as noted in https://github.com/ipfs/go-ipfs/pull/7441#issuecomment-640686006 its not worth it.

<details>
  <summary>Click here to expand notes from that older version</summary>


> ## **Note:** This is WIP – don't look at the code yet, opening draft PR for early feedback on the idea

### TL;DR

The idea evaluated here is to redirect `example.com/ipfs/$CID` to `$dnsCID.ipfs.example.com` where `$dnsCID` is a new CID created with a hash function known to fit in a single DNS label (<=63chars).

This way public gateways can **enable HTTPS without TLS errors for content roots backed by longer hash functions**.

### Rationale 

If we split original CID into multiple sub labels (#7358) DNS resolution will work, but **no public gateway will be able to get TLS certificate** that supports double wildcards like `*.*.ipfs.example.com`. This means [errors like this](https://blog.almonit.eth.link#x-ipfs-companion-no-redirect).

This means when splitting is used, visitors using web browsers will see a TLS Error page, which effectively kills UX and defeats the purpose of subdomain gateway (one step forward  by increasing security by providing Origin isolation, two steps backward by removing ability to do TLS validation when loading website backed by a long CID).

Given this reality, I believe a better trade off could be to create a new root CID that is compatible with DNS and make websites work in existing user agents that way.

Thoughts?

### Open questions

- Is this worth it?
- **Should we redirect to a warning page, that explains original CID can't be loaded over DNS, and gives user a choce if they want to rehash and proceed to "new CID" (..or open it from a well-known non-subdomain gateway?)** 
- Which API to use? How to ensure newly minted CID is provided to the network?
- Should we do the same from IPNS? (un-inlining ed25519) or do we want to opportunistically use Base36 there instead?
- Should we keep support for split CIDs, and redirect them to a new CID that fits in a single label?

</details>
