### PR TITLE
fix(migration): correctly migrate quic addresses

### DIFF
--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var DistPath = "https://ipfs.io/ipfs/QmRnvRrRwto4QAMuwWeEU9GpNaHKqQPdvdrNeGaXg7yruC"
+var DistPath = "https://ipfs.io/ipfs/QmQWvUrSwGHWKaoJnUrLQoBy9ikfiiyRrXKBFSHUTcS6aM"
 
 func init() {
 	if dist := os.Getenv("IPFS_DIST_PATH"); dist != "" {


### PR DESCRIPTION
1. Don't add quic addresses when they're already present (correctly detect quic addresses).
2. Correctly distinguish between quic addresses and quic + relay addresses.
3. Only add quic addresses to mirror tcp addresses, not tcp/ws addresses.

fixes #7444