### PR TITLE
go: bump minimal dependency to 1.14.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.14.4
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -60,7 +60,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer: 
     docker: 
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.14.4
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.2-buster
+FROM golang:1.14.4-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.14.2
+GO_MIN_VERSION = 1.14.4
 export GO111MODULE=on
 
 


### PR DESCRIPTION
due to major bugfixes in the .4 release