### PR TITLE
fix(migration): migrate /ipfs/ bootstrappers to /p2p/

### DIFF
--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var DistPath = "https://ipfs.io/ipfs/QmQWvUrSwGHWKaoJnUrLQoBy9ikfiiyRrXKBFSHUTcS6aM"
+var DistPath = "https://ipfs.io/ipfs/Qmdo5m6bpQXCayzfGghyvgXJdVHSsXsCKDUo9vWktDKq3K"
 
 func init() {
 	if dist := os.Getenv("IPFS_DIST_PATH"); dist != "" {


### PR DESCRIPTION
1. We should have done this in 7-to-8 anyways, but didn't in some cases.
2. We assume these addresses use /p2p/ in the 9-to-10 migration.

This should be the final iteration of this migration...