### PR TITLE
feat: gateway redirect to another domain

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -92,9 +92,16 @@ func HostnameOption() ServeOption {
 
 					// Should this gateway use subdomains instead of paths?
 					if gw.UseSubdomains {
+						hostname := r.Host
+
+						// Redirect to another host if configured
+						if gw.RedirectHost != "" {
+							hostname = gw.RedirectHost
+						}
+
 						// Yes, redirect if applicable
 						// Example: dweb.link/ipfs/{cid} → {cid}.ipfs.dweb.link
-						if newURL, ok := toSubdomainURL(r.Host, r.URL.Path, r); ok {
+						if newURL, ok := toSubdomainURL(hostname, r.URL.Path, r); ok {
 							// Just to be sure single Origin can't be abused in
 							// web browsers that ignored the redirect for some
 							// reason, Clear-Site-Data header clears browsing


### PR DESCRIPTION
This PR add a way to configure the gateway redirection (path to CID style) to another domain.

Benefits include following the recommended practice of hosting the CID style gateway on another domain to get a strong Origin isolation. Additionally it allow us (Infura) to migrate our traffic out of infura.io in one painless step at the same time.

Although I tested it locally (including running on :80), some unit tests would be nice to have. It's tricky to do though with the current code structure as `HostnameOption()` require a full `IpfsNode` just to get the config.

cc @lidel

Note: require https://github.com/ipfs/go-ipfs-config/pull/101