### PR TITLE
fix: Use the -p option in Dockerfile to make parents as needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG IPFS_PLUGINS
 # Build the thing.
 # Also: fix getting HEAD commit hash via git rev-parse.
 RUN cd $SRC_DIR \
-  && mkdir .git/objects \
+  && mkdir -p .git/objects \
   && make build GOTAGS=openssl IPFS_PLUGINS=$IPFS_PLUGINS
 
 # Get su-exec, a very minimal tool for dropping privileges,


### PR DESCRIPTION
Building the go-ipfs docker image from the zip archive fails because it has no `.git` folder.
The `mkdir .git/objects` is at fault here. I fixed it by adding `-p` to it.

This fixes #7420