### PR TITLE
systemd: specify repo path, to avoid unnecessary subdirectory

### DIFF
--- a/misc/systemd/ipfs-hardened.service
+++ b/misc/systemd/ipfs-hardened.service
@@ -62,6 +62,7 @@ Type=notify
 User=ipfs
 Group=ipfs
 StateDirectory=ipfs
+Environment=IPFS_PATH="${HOME}"
 ExecStart=/usr/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT

--- a/misc/systemd/ipfs.service
+++ b/misc/systemd/ipfs.service
@@ -33,6 +33,7 @@ Type=notify
 User=ipfs
 Group=ipfs
 StateDirectory=ipfs
+Environment=IPFS_PATH="${HOME}"
 ExecStart=/usr/bin/ipfs daemon --init --migrate
 Restart=on-failure
 KillSignal=SIGINT


### PR DESCRIPTION
## Reational

Currently, the service files will create a hidden directory '/var/lib/ipfs/.ipfs/' which is not necessary for a system-user installation since it won't store any additional files - like in a regular user directory.

This change will set the directory to '/var/lib/ipfs/' to avoid this.