### PR TITLE
feat: transport config

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -174,7 +174,7 @@ Headers.
 		cmds.BoolOption(migrateKwd, "If true, assume yes at the migrate prompt. If false, assume no."),
 		cmds.BoolOption(enablePubSubKwd, "Instantiate the ipfs daemon with the experimental pubsub feature enabled."),
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable IPNS record distribution through pubsub; enables pubsub."),
-		cmds.BoolOption(enableMultiplexKwd, "Add the experimental 'go-multiplex' stream muxer to libp2p on construction.").WithDefault(true),
+		cmds.BoolOption(enableMultiplexKwd, "DEPRECATED"),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
@@ -296,7 +296,10 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	offline, _ := req.Options[offlineKwd].(bool)
 	ipnsps, _ := req.Options[enableIPNSPubSubKwd].(bool)
 	pubsub, _ := req.Options[enablePubSubKwd].(bool)
-	mplex, _ := req.Options[enableMultiplexKwd].(bool)
+	if _, hasMplex := req.Options[enableMultiplexKwd]; hasMplex {
+		log.Errorf("The mplex multiplexer has been enabled by default and the experimental %s flag has been removed.")
+		log.Errorf("To disable this multiplexer, please configure `Swarm.Transports.Multiplexers'.")
+	}
 
 	// Start assembling node config
 	ncfg := &core.BuildCfg{
@@ -307,7 +310,6 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		ExtraOpts: map[string]bool{
 			"pubsub": pubsub,
 			"ipnsps": ipnsps,
-			"mplex":  mplex,
 		},
 		//TODO(Kubuxu): refactor Online vs Offline by adding Permanent vs Ephemeral
 	}

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -9,6 +9,7 @@ import (
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	config "github.com/ipfs/go-ipfs-config"
 	util "github.com/ipfs/go-ipfs-util"
+	log "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 
@@ -22,12 +23,12 @@ import (
 	"go.uber.org/fx"
 )
 
+var logger = log.Logger("core:constructor")
+
 var BaseLibP2P = fx.Options(
 	fx.Provide(libp2p.UserAgent),
 	fx.Provide(libp2p.PNet),
 	fx.Provide(libp2p.ConnectionManager),
-	fx.Provide(libp2p.Transports),
-
 	fx.Provide(libp2p.Host),
 
 	fx.Provide(libp2p.DiscoveryHandler),
@@ -108,19 +109,33 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		autonat = fx.Provide(libp2p.AutoNATService(cfg.AutoNAT.Throttle))
 	}
 
-	// Gather all the options
+	// If `cfg.Swarm.DisableRelay` is set and `Network.Relay` isn't, use the former.
+	enableRelay := cfg.Swarm.Transports.Network.Relay.WithDefault(!cfg.Swarm.DisableRelay) //nolint
 
+	// Warn about a deprecated option.
+	//nolint
+	if cfg.Swarm.DisableRelay {
+		logger.Error("The `Swarm.DisableRelay' config field is deprecated.")
+		if enableRelay {
+			logger.Error("`Swarm.DisableRelay' has been overridden by `Swarm.Transports.Network.Relay'")
+		} else {
+			logger.Error("Use the `Swarm.Transports.Network.Relay' config field instead")
+		}
+	}
+
+	// Gather all the options
 	opts := fx.Options(
 		BaseLibP2P,
 
 		fx.Provide(libp2p.AddrFilters(cfg.Swarm.AddrFilters)),
 		fx.Provide(libp2p.AddrsFactory(cfg.Addresses.Announce, cfg.Addresses.NoAnnounce)),
-		fx.Provide(libp2p.SmuxTransport(bcfg.getOpt("mplex"))),
-		fx.Provide(libp2p.Relay(cfg.Swarm.DisableRelay, cfg.Swarm.EnableRelayHop)),
+		fx.Provide(libp2p.SmuxTransport(cfg.Swarm.Transports)),
+		fx.Provide(libp2p.Relay(enableRelay, cfg.Swarm.EnableRelayHop)),
+		fx.Provide(libp2p.Transports(cfg.Swarm.Transports)),
 		fx.Invoke(libp2p.StartListening(cfg.Addresses.Swarm)),
 		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled, cfg.Discovery.MDNS.Interval)),
 
-		fx.Provide(libp2p.Security(!bcfg.DisableEncryptedConnections, cfg.Experimental.OverrideSecurityTransports)),
+		fx.Provide(libp2p.Security(!bcfg.DisableEncryptedConnections, cfg.Swarm.Transports)),
 
 		fx.Provide(libp2p.Routing),
 		fx.Provide(libp2p.BaseRouting),

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -5,17 +5,16 @@ import (
 	relay "github.com/libp2p/go-libp2p-circuit"
 )
 
-func Relay(disable, enableHop bool) func() (opts Libp2pOpts, err error) {
+func Relay(enableRelay, enableHop bool) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		if disable {
-			// Enabled by default.
-			opts.Opts = append(opts.Opts, libp2p.DisableRelay())
-		} else {
+		if enableRelay {
 			relayOpts := []relay.RelayOpt{}
 			if enableHop {
 				relayOpts = append(relayOpts, relay.OptHop)
 			}
 			opts.Opts = append(opts.Opts, libp2p.EnableRelay(relayOpts...))
+		} else {
+			opts.Opts = append(opts.Opts, libp2p.DisableRelay())
 		}
 		return
 	}

--- a/core/node/libp2p/sec.go
+++ b/core/node/libp2p/sec.go
@@ -1,0 +1,39 @@
+package libp2p
+
+import (
+	config "github.com/ipfs/go-ipfs-config"
+	"github.com/libp2p/go-libp2p"
+	noise "github.com/libp2p/go-libp2p-noise"
+	secio "github.com/libp2p/go-libp2p-secio"
+	tls "github.com/libp2p/go-libp2p-tls"
+)
+
+func Security(enabled bool, tptConfig config.Transports) interface{} {
+	if !enabled {
+		return func() (opts Libp2pOpts) {
+			// TODO: shouldn't this be Errorf to guarantee visibility?
+			log.Warnf(`Your IPFS node has been configured to run WITHOUT ENCRYPTED CONNECTIONS.
+		You will not be able to connect to any nodes configured to use encrypted connections`)
+			opts.Opts = append(opts.Opts, libp2p.NoSecurity)
+			return opts
+		}
+	}
+
+	// Using the new config options.
+	return func() (opts Libp2pOpts) {
+		opts.Opts = append(opts.Opts, prioritizeOptions([]priorityOption{{
+			priority:        tptConfig.Security.TLS,
+			defaultPriority: 100,
+			opt:             libp2p.Security(tls.ID, tls.New),
+		}, {
+			priority:        tptConfig.Security.SECIO,
+			defaultPriority: 200,
+			opt:             libp2p.Security(secio.ID, secio.New),
+		}, {
+			priority:        tptConfig.Security.Noise,
+			defaultPriority: 300,
+			opt:             libp2p.Security(noise.ID, noise.New),
+		}}))
+		return opts
+	}
+}

--- a/core/node/libp2p/sec.go
+++ b/core/node/libp2p/sec.go
@@ -11,8 +11,7 @@ import (
 func Security(enabled bool, tptConfig config.Transports) interface{} {
 	if !enabled {
 		return func() (opts Libp2pOpts) {
-			// TODO: shouldn't this be Errorf to guarantee visibility?
-			log.Warnf(`Your IPFS node has been configured to run WITHOUT ENCRYPTED CONNECTIONS.
+			log.Errorf(`Your IPFS node has been configured to run WITHOUT ENCRYPTED CONNECTIONS.
 		You will not be able to connect to any nodes configured to use encrypted connections`)
 			opts.Opts = append(opts.Opts, libp2p.NoSecurity)
 			return opts

--- a/core/node/libp2p/smux.go
+++ b/core/node/libp2p/smux.go
@@ -1,54 +1,79 @@
 package libp2p
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
+	config "github.com/ipfs/go-ipfs-config"
 	"github.com/libp2p/go-libp2p"
 	smux "github.com/libp2p/go-libp2p-core/mux"
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	yamux "github.com/libp2p/go-libp2p-yamux"
 )
 
-func makeSmuxTransportOption(mplexExp bool) libp2p.Option {
+func yamuxTransport() smux.Multiplexer {
+	tpt := *yamux.DefaultTransport
+	tpt.AcceptBacklog = 512
+	if os.Getenv("YAMUX_DEBUG") != "" {
+		tpt.LogOutput = os.Stderr
+	}
+
+	return &tpt
+}
+
+func makeSmuxTransportOption(tptConfig config.Transports) (libp2p.Option, error) {
 	const yamuxID = "/yamux/1.0.0"
 	const mplexID = "/mplex/6.7.0"
 
 	ymxtpt := *yamux.DefaultTransport
 	ymxtpt.AcceptBacklog = 512
 
-	if os.Getenv("YAMUX_DEBUG") != "" {
-		ymxtpt.LogOutput = os.Stderr
-	}
-
-	muxers := map[string]smux.Multiplexer{yamuxID: &ymxtpt}
-	if mplexExp {
-		muxers[mplexID] = mplex.DefaultTransport
-	}
-
-	// Allow muxer preference order overriding
-	order := []string{yamuxID, mplexID}
 	if prefs := os.Getenv("LIBP2P_MUX_PREFS"); prefs != "" {
-		order = strings.Fields(prefs)
-	}
+		// Using legacy LIBP2P_MUX_PREFS variable.
+		log.Error("LIBP2P_MUX_PREFS is now deprecated.")
+		log.Error("Use the `Swarm.Transports.Multiplexers' config field.")
+		muxers := strings.Fields(prefs)
+		enabled := make(map[string]bool, len(muxers))
 
-	opts := make([]libp2p.Option, 0, len(order))
-	for _, id := range order {
-		tpt, ok := muxers[id]
-		if !ok {
-			log.Warn("unknown or duplicate muxer in LIBP2P_MUX_PREFS: %s", id)
-			continue
+		var opts []libp2p.Option
+		for _, tpt := range muxers {
+			if enabled[tpt] {
+				return nil, fmt.Errorf(
+					"duplicate muxer found in LIBP2P_MUX_PREFS: %s",
+					tpt,
+				)
+			}
+			switch tpt {
+			case yamuxID:
+				opts = append(opts, libp2p.Muxer(tpt, yamuxTransport))
+			case mplexID:
+				opts = append(opts, libp2p.Muxer(tpt, mplex.DefaultTransport))
+			default:
+				return nil, fmt.Errorf("unknown muxer: %s", tpt)
+			}
 		}
-		delete(muxers, id)
-		opts = append(opts, libp2p.Muxer(id, tpt))
+		return libp2p.ChainOptions(opts...), nil
+	} else {
+		return prioritizeOptions([]priorityOption{{
+			priority:        tptConfig.Multiplexers.Yamux,
+			defaultPriority: 100,
+			opt:             libp2p.Muxer(yamuxID, yamuxTransport),
+		}, {
+			priority:        tptConfig.Multiplexers.Mplex,
+			defaultPriority: 200,
+			opt:             libp2p.Muxer(mplexID, mplex.DefaultTransport),
+		}}), nil
 	}
-
-	return libp2p.ChainOptions(opts...)
 }
 
-func SmuxTransport(mplex bool) func() (opts Libp2pOpts, err error) {
+func SmuxTransport(tptConfig config.Transports) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		opts.Opts = append(opts.Opts, makeSmuxTransportOption(mplex))
-		return
+		res, err := makeSmuxTransportOption(tptConfig)
+		if err != nil {
+			return opts, err
+		}
+		opts.Opts = append(opts.Opts, res)
+		return opts, nil
 	}
 }

--- a/core/node/libp2p/transport.go
+++ b/core/node/libp2p/transport.go
@@ -3,63 +3,44 @@ package libp2p
 import (
 	"fmt"
 
-	"github.com/libp2p/go-libp2p"
+	config "github.com/ipfs/go-ipfs-config"
+	libp2p "github.com/libp2p/go-libp2p"
 	metrics "github.com/libp2p/go-libp2p-core/metrics"
-	noise "github.com/libp2p/go-libp2p-noise"
 	libp2pquic "github.com/libp2p/go-libp2p-quic-transport"
-	secio "github.com/libp2p/go-libp2p-secio"
-	tls "github.com/libp2p/go-libp2p-tls"
+	tcp "github.com/libp2p/go-tcp-transport"
+	websocket "github.com/libp2p/go-ws-transport"
 
 	"go.uber.org/fx"
 )
 
-// default security transports for libp2p
-var defaultSecurityTransports = []string{"tls", "secio", "noise"}
+func Transports(tptConfig config.Transports) interface{} {
+	return func(pnet struct {
+		fx.In
+		Fprint PNetFingerprint `optional:"true"`
+	}) (opts Libp2pOpts, err error) {
+		privateNetworkEnabled := pnet.Fprint != nil
 
-func Transports(pnet struct {
-	fx.In
-	Fprint PNetFingerprint `optional:"true"`
-}) (opts Libp2pOpts) {
-	opts.Opts = append(opts.Opts, libp2p.DefaultTransports)
-	if pnet.Fprint == nil {
-		opts.Opts = append(opts.Opts, libp2p.Transport(libp2pquic.NewTransport))
-	}
-	return opts
-}
-
-func Security(enabled bool, securityTransportOverride []string) interface{} {
-	if !enabled {
-		return func() (opts Libp2pOpts) {
-			// TODO: shouldn't this be Errorf to guarantee visibility?
-			log.Warnf(`Your IPFS node has been configured to run WITHOUT ENCRYPTED CONNECTIONS.
-		You will not be able to connect to any nodes configured to use encrypted connections`)
-			opts.Opts = append(opts.Opts, libp2p.NoSecurity)
-			return opts
+		if tptConfig.Network.TCP.WithDefault(true) {
+			opts.Opts = append(opts.Opts, libp2p.Transport(tcp.NewTCPTransport))
 		}
-	}
 
-	securityTransports := defaultSecurityTransports
-	if len(securityTransportOverride) > 0 {
-		securityTransports = securityTransportOverride
-	}
-
-	var libp2pOpts []libp2p.Option
-	for _, tpt := range securityTransports {
-		switch tpt {
-		case "tls":
-			libp2pOpts = append(libp2pOpts, libp2p.Security(tls.ID, tls.New))
-		case "secio":
-			libp2pOpts = append(libp2pOpts, libp2p.Security(secio.ID, secio.New))
-		case "noise":
-			libp2pOpts = append(libp2pOpts, libp2p.Security(noise.ID, noise.New))
-		default:
-			return fx.Error(fmt.Errorf("invalid security transport specified in config: %s", tpt))
+		if tptConfig.Network.Websocket.WithDefault(true) {
+			opts.Opts = append(opts.Opts, libp2p.Transport(websocket.New))
 		}
-	}
 
-	return func() (opts Libp2pOpts) {
-		opts.Opts = append(opts.Opts, libp2p.ChainOptions(libp2pOpts...))
-		return opts
+		if tptConfig.Network.QUIC.WithDefault(!privateNetworkEnabled) {
+			if privateNetworkEnabled {
+				// QUIC was force enabled while the private network was turned on.
+				// Fail and tell the user.
+				return opts, fmt.Errorf(
+					"The QUIC transport does not support private networks. " +
+						"Please disable Swarm.Transports.Network.QUIC.",
+				)
+			}
+			opts.Opts = append(opts.Opts, libp2p.Transport(libp2pquic.NewTransport))
+		}
+
+		return opts, nil
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@ is read once at node instantiation, either for an offline command, or when
 starting the daemon. Commands that execute on a running daemon do not read the
 config file at runtime.
 
-#### Profiles
+## Profiles
 
 Configuration profiles allow to tweak configuration quickly. Profiles can be
 applied with `--profile` flag to `ipfs init` or with the `ipfs config profile
@@ -88,6 +88,46 @@ documented in `ipfs config profile --help`.
   Reduces daemon overhead on the system. May affect node
   functionality - performance of content discovery and data
   fetching may be degraded.
+
+## Types
+
+This document refers to the standard JSON types (e.g., `null`, `string`,
+`number`, etc.), as well as a few custom types, described below.
+
+### `flag`
+
+Flags allow enabling and disabling features. However, unlike simple booleans,
+they can also be `null` (or omitted) to indicate that the default value should
+be chosen. This makes it easier for go-ipfs to change the defaults in the
+future unless the user _explicitly_ sets the flag to either `true` (enabled) or
+`false` (disabled). Flags have three possible states:
+
+- `null` or missing (apply the default value).
+- `true` (enabled)
+- `false` (disabled)
+
+### `priority`
+
+Priorities allow specifying the priority of a feature/protocol and disabling the
+feature/protocol. Priorities can take one of the following values:
+
+- `null`/missing (apply the default priority, same as with flags)
+- `false` (disabled)
+- `1 - 2^63` (priority, lower is preferred)
+
+### `strings`
+
+Strings is a special type for conveniently specifying a single string, an array
+of strings, or null:
+
+- `null`
+- `"a single string"`
+- `["an", "array", "of", "strings"]`
+
+### `duration`
+
+Duration is a type for describing lengths of time, using the same format go
+does (e.g, `"1d2h4m40.01s"`).
 
 ## Table of Contents
 
@@ -176,6 +216,8 @@ Supported Transports:
 
 Default: `/ip4/127.0.0.1/tcp/5001`
 
+Type: `strings`
+
 ### `Addresses.Gateway`
 
 Multiaddr or array of multiaddrs describing the address to serve the local
@@ -187,6 +229,8 @@ Supported Transports:
 * unix - `/unix/path/to/socket`
 
 Default: `/ip4/127.0.0.1/tcp/8080`
+
+Type: `strings`
 
 ### `Addresses.Swarm`
 
@@ -209,6 +253,8 @@ Default:
 ]
 ```
 
+Type: `array[string]`
+
 ### `Addresses.Announce`
 
 If non-empty, this array specifies the swarm addresses to announce to the
@@ -216,10 +262,14 @@ network. If empty, the daemon will announce inferred swarm addresses.
 
 Default: `[]`
 
+Type: `array[string]`
+
 ### `Addresses.NoAnnounce`
 Array of swarm addresses not to announce to the network.
 
 Default: `[]`
+
+Type: `array[string]`
 
 ## `API`
 Contains information used by the API gateway.
@@ -235,6 +285,8 @@ Example:
 ```
 
 Default: `null`
+
+Type: `object[string -> array[string]]`
 
 ## `AutoNAT`
 
@@ -253,6 +305,8 @@ field can take one of two values:
 
 Additional modes may be added in the future.
 
+Type: `string` (can only be "enabled" and "disabled")
+
 ### `AutoNAT.Throttle`
 
 When set, this option configure's the AutoNAT services throttling behavior. By
@@ -265,11 +319,15 @@ Configures how many AutoNAT requests to service per `AutoNAT.Throttle.Interval`.
 
 Default: 30
 
+Type: `integer`
+
 ### `AutoNAT.Throttle.PeerLimit`
 
 Configures how many AutoNAT requests per-peer to service per `AutoNAT.Throttle.Interval`.
 
 Default: 3
+
+Type: `integer`
 
 ### `AutoNAT.Throttle.Interval`
 
@@ -277,12 +335,16 @@ Configures the interval for the above limits.
 
 Default: 1 Minute
 
+Type: `duration`
+
 ## `Bootstrap`
 
 Bootstrap is an array of multiaddrs of trusted nodes to connect to in order to
 initiate a connection to the network.
 
 Default: The ipfs.io bootstrap nodes
+
+Type: `array[string]`
 
 ## `Datastore`
 
@@ -294,7 +356,9 @@ storage system.
 A soft upper limit for the size of the ipfs repository's datastore. With `StorageGCWatermark`,
 is used to calculate whether to trigger a gc run (only if `--enable-gc` flag is set).
 
-Default: `10GB`
+Default: `"10GB"`
+
+Type: `string` (size)
 
 ### `Datastore.StorageGCWatermark`
 
@@ -304,6 +368,8 @@ option defaults to false currently).
 
 Default: `90`
 
+Type: `integer`
+
 ### `Datastore.GCPeriod`
 
 A time duration specifying how frequently to run a garbage collection. Only used
@@ -311,12 +377,16 @@ if automatic gc is enabled.
 
 Default: `1h`
 
+Type: `duration` or an empty string for the default value.
+
 ### `Datastore.HashOnRead`
 
 A boolean value. If set to true, all block reads from disk will be hashed and
 verified. This will cause increased CPU utilization.
 
 Default: `false`
+
+Type: `bool`
 
 ### `Datastore.BloomFilterSize`
 
@@ -334,8 +404,9 @@ we'd want to use 1199120 bytes. As of writing, [7 hash
 functions](https://github.com/ipfs/go-ipfs-blockstore/blob/547442836ade055cc114b562a3cc193d4e57c884/caching.go#L22)
 are used, so the constant `k` is 7 in the formula.
 
+Default: `0` (disabled)
 
-Default: `0`
+Type: `integer`
 
 ### `Datastore.Spec`
 
@@ -381,6 +452,8 @@ Default:
 }
 ```
 
+Type: `object`
+
 ## `Discovery`
 
 Contains options for configuring ipfs node discovery mechanisms.
@@ -395,9 +468,13 @@ A boolean value for whether or not mdns should be active.
 
 Default: `true`
 
+Type: `bool`
+
 #### `Discovery.MDNS.Interval`
 
 A number of seconds to wait between discovery checks.
+
+Type: `integer` (_not_ a duration)
 
 ## `Gateway`
 
@@ -410,6 +487,8 @@ and will not fetch files from the network.
 
 Default: `false`
 
+Type: `bool`
+
 ### `Gateway.NoDNSLink`
 
 A boolean to configure whether DNSLink lookup for value in `Host` HTTP header
@@ -417,6 +496,8 @@ should be performed.  If DNSLink is present, content path stored in the DNS TXT
 record becomes the `/` and respective payload is returned to the client.
 
 Default: `false`
+
+Type: `bool`
 
 ### `Gateway.HTTPHeaders`
 
@@ -437,17 +518,23 @@ Default:
 }
 ```
 
+Type: `object[string -> array[string]]`
+
 ### `Gateway.RootRedirect`
 
 A url to redirect requests for `/` to.
 
 Default: `""`
 
+Type: `string`
+
 ### `Gateway.Writable`
 
 A boolean to configure whether the gateway is writeable or not.
 
 Default: `false`
+
+Type: `bool`
 
 ### `Gateway.PathPrefixes`
 
@@ -479,6 +566,7 @@ location /blog/ {
 
 Default: `[]`
 
+Type: `array[string]`
 
 ### `Gateway.PublicGateways`
 
@@ -504,6 +592,8 @@ Example:
 Above enables `http://example.com/ipfs/*` and `http://example.com/ipns/*` but not `http://example.com/api/*`
 
 Default: `[]`
+
+Type: `array[string]`
 
 #### `Gateway.PublicGateways: UseSubdomains`
 
@@ -542,6 +632,7 @@ between content roots.
 
 Default: `false`
 
+Type: `bool`
 
 #### `Gateway.PublicGateways: NoDNSLink`
 
@@ -550,6 +641,8 @@ HTTP header should be resolved. Overrides global setting.
 If `Paths` are defined, they take priority over DNSLink.
 
 Default: `false` (DNSLink lookup enabled by default for every defined hostname)
+
+Type: `bool`
 
 #### Implicit defaults of `Gateway.PublicGateways`
 
@@ -636,23 +729,33 @@ The unique PKI identity label for this configs peer. Set on init and never read,
 it's merely here for convenience. Ipfs will always generate the peerID from its
 keypair at runtime.
 
+Type: `string`
+
 ### `Identity.PrivKey`
 
 The base64 encoded protobuf describing (and containing) the nodes private key.
+
+Type: `string`
 
 ## `Ipns`
 
 ### `Ipns.RepublishPeriod`
 
 A time duration specifying how frequently to republish ipns records to ensure
-they stay fresh on the network. If unset, we default to 4 hours.
+they stay fresh on the network.
+
+Default: 4 hours.
+
+Type: `interval` or an empty string for the default.
 
 ### `Ipns.RecordLifetime`
 
 A time duration specifying the value to set on ipns records for their validity
 lifetime.
 
-If unset, we default to 24 hours.
+Default: 24 hours.
+
+Type: `interval` or an empty string for the default.
 
 ### `Ipns.ResolveCacheSize`
 
@@ -660,6 +763,8 @@ The number of entries to store in an LRU cache of resolved ipns entries. Entries
 will be kept cached until their lifetime is expired.
 
 Default: `128`
+
+Type: `integer`
 
 ## `Mounts`
 
@@ -669,9 +774,17 @@ FUSE mount point configuration options.
 
 Mountpoint for `/ipfs/`.
 
+Default: `/ipfs`
+
+Type: `string`
+
 ### `Mounts.IPNS`
 
 Mountpoint for `/ipns/`.
+
+Default: `/ipns`
+
+Type: `string`
 
 ### `Mounts.FuseAllowOther`
 
@@ -693,6 +806,8 @@ Sets the default router used by pubsub to route messages to peers. This can be o
   
 Default: `"gossipsub"`
 
+Type: `string`
+
 [gossipsub]: https://github.com/libp2p/specs/tree/master/pubsub/gossipsub
 
 ### `Pubsub.DisableSigning`
@@ -705,6 +820,8 @@ message because spoofed messages can be used to silence real messages by
 intentionally re-using the real message's message ID.
 
 Default: `false`
+
+Type: `bool`
 
 ### `Peering`
 
@@ -756,6 +873,10 @@ The set of peers with which to peer. Each entry is of the form:
 
 Additional fields may be added in the future.
 
+Default: empty.
+
+Type: `array[peering]`
+
 ## `Reprovider`
 
 ### `Reprovider.Interval`
@@ -769,12 +890,18 @@ not being able to discover that you have the objects that you have. If you want
 to have this disabled and keep the network aware of what you have, you must
 manually announce your content periodically.
 
+Type: `array[peering]`
+
 ### `Reprovider.Strategy`
 
 Tells reprovider what should be announced. Valid strategies are:
-  - "all" (default) - announce all stored data
+  - "all" - announce all stored data
   - "pinned" - only announce pinned data
   - "roots" - only announce directly pinned keys and root keys of recursive pins
+  
+Default: all
+
+Type: `string` (or unset for the default)
 
 ## `Routing`
 
@@ -817,6 +944,9 @@ unless you're sure your node is reachable from the public network.
 }
 ```  
   
+Default: dht
+
+Type: `string` (or unset for the default)
 
 ## `Swarm`
 
@@ -836,12 +966,19 @@ preventing dials to all non-routable IP addresses (e.g., `192.168.0.0/16`) but
 you should always check settings against your own network and/or hosting
 provider.
 
+Default: `[]`
+
+Type: `array[string]`
 
 ### `Swarm.DisableBandwidthMetrics`
 
 A boolean value that when set to true, will cause ipfs to not keep track of
 bandwidth metrics. Disabling bandwidth metrics can lead to a slight performance
 improvement, as well as a reduction in memory usage.
+
+Default: `false`
+
+Type: `bool`
 
 ### `Swarm.DisableNatPortMap`
 
@@ -852,11 +989,21 @@ up an external port and forward it to the port go-ipfs is running on. When this
 works (i.e., when your router supports NAT port forwarding), it makes the local
 go-ipfs node accessible from the public internet.
 
+Default: `false`
+
+Type: `bool`
+
 ### `Swarm.DisableRelay`
+
+Deprecated: Set `Swarm.Transports.Network.Relay` to `false`.
 
 Disables the p2p-circuit relay transport. This will prevent this node from
 connecting to nodes behind relays, or accepting connections from nodes behind
 relays.
+
+Default: `false`
+
+Type: `bool`
 
 ### `Swarm.EnableRelayHop`
 
@@ -866,11 +1013,19 @@ WARNING: Do not enable this option unless you know what you're doing. Other
 peers will randomly decide to use your node as a relay and consume _all_
 available bandwidth. There is _no_ rate-limiting.
 
+Default: `false`
+
+Type: `bool`
+
 ### `Swarm.EnableAutoRelay`
 
 Enables "automatic relay" mode for this node. This option does two _very_
 different things based on the `Swarm.EnableRelayHop`. See
 [#7228](https://github.com/ipfs/go-ipfs/issues/7228) for context.
+
+Default: `false`
+
+Type: `bool`
 
 #### Mode 1: `EnableRelayHop` is `false`
 
@@ -906,30 +1061,24 @@ be configured to keep.
 Sets the type of connection manager to use, options are: `"none"` (no connection
 management) and `"basic"`.
 
+Default: `"basic"`
+
+Type: `string` (one of `"basic"`, `"none"`, or `""` (default, i.e. `"basic"`).
+
 #### Basic Connection Manager
 
-##### `Swarm.ConnMgr.LowWater`
+The basic connection manager uses a "high water", a "low water", and internal
+scoring to periodically close connections to free up resources. When a node
+using the basic connection manager reaches `HighWater` idle connections, it will
+close the least useful ones until it reaches `LowWater` idle connections.
 
-LowWater is the minimum number of connections to maintain.
+The connection manager considers a connection idle if:
 
-##### `Swarm.ConnMgr.HighWater`
-
-HighWater is the number of connections that, when exceeded, will trigger a
-connection GC operation.
-
-##### `Swarm.ConnMgr.GracePeriod`
-
-GracePeriod is a time duration that new connections are immune from being closed
-by the connection manager.
-
-The "basic" connection manager tries to keep between `LowWater` and `HighWater`
-connections. It works by:
-
-1. Keeping all connections until `HighWater` connections is reached.
-2. Once `HighWater` is reached, it closes connections until `LowWater` is
-   reached.
-3. To prevent thrashing, it never closes connections established within the
-   `GracePeriod`.
+* It has not been explicitly _protected_ by some subsystem. For example, Bitswap
+  will protect connections to peers from which it is actively downloading data,
+  the DHT will protect some peers for routing, and the peering subsystem will
+  protect all "peered" nodes.
+* It has existed for longer than the `GracePeriod`.
 
 **Example:**
 
@@ -945,3 +1094,197 @@ connections. It works by:
   }
 }
 ```
+
+##### `Swarm.ConnMgr.LowWater`
+
+LowWater is the number of connections that the basic connection manager will
+trim down to.
+
+Default: `600`
+
+Type: `integer`
+
+##### `Swarm.ConnMgr.HighWater`
+
+HighWater is the number of connections that, when exceeded, will trigger a
+connection GC operation. Note: protected/recently formed connections don't count
+towards this limit.
+
+Default: `900`
+
+Type: `integer`
+
+##### `Swarm.ConnMgr.GracePeriod`
+
+GracePeriod is a time duration that new connections are immune from being closed
+by the connection manager.
+
+Default: `"20s"`
+
+Type: `duration`
+
+### `Swarm.Transports`
+
+Configuration section for libp2p transports. An empty configuration will apply
+the defaults.
+
+### `Swarm.Transports.Network`
+
+Configuration section for libp2p _network_ transports. Transports enabled in
+this section will be used for dialing. However, to receive connections on these
+transports, multiaddrs for these transports must be added to `Addresses.Swarm`.
+
+Supported transports are: QUIC, TCP, WS, and Relay.
+
+Each field in this section is a `flag`.
+
+#### `Swarm.Transports.Network.TCP`
+
+[TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) is the most
+widely used transport by go-ipfs nodes. It doesn't directly support encryption
+and/or multiplexing, so libp2p will layer a security & multiplexing transport
+over it.
+
+Default: Enabled
+
+Type: `flag`
+
+Listen Addresses:
+* /ip4/0.0.0.0/tcp/4001 (default)
+* /ip6/::/tcp/4001 (default) 
+
+#### `Swarm.Transports.Network.Websocket`
+
+[Websocket](https://en.wikipedia.org/wiki/WebSocket) is a transport usually used
+to connect to non-browser-based IPFS nodes from browser-based js-ipfs nodes.
+
+While it's enabled by default for dialing, go-ipfs doesn't listen on this
+transport by default.
+
+Default: Enabled
+
+Type: `flag`
+
+Listen Addresses:
+* /ip4/0.0.0.0/tcp/4002/ws
+* /ip6/::/tcp/4002/ws
+
+#### `Swarm.Transports.Network.QUIC`
+
+[QUIC](https://en.wikipedia.org/wiki/QUIC) is a UDP-based transport with
+built-in encryption and multiplexing. The primary benefits over TCP are:
+
+1. It doesn't require a file descriptor per connection, easing the load on the OS.
+2. It currently takes 2 round trips to establish a connection (our TCP transport
+   currently takes 6).
+
+Default: Enabled
+
+Type: `flag`
+
+Listen Addresses:
+* /ip4/0.0.0.0/udp/4001/quic (default)
+* /ip6/::/udp/4001/quic (default)
+
+#### `Swarm.Transports.Network.Relay`
+
+[Libp2p Relay](https://github.com/libp2p/specs/tree/master/relay) proxy
+transport that forms connections by hopping between multiple libp2p nodes. This
+transport is primarily useful for bypassing firewalls and NATs.
+
+Default: Enabled
+
+Type: `flag`
+
+Listen Addresses: This transport is special. Any node that enables this
+transport can receive inbound connections on this transport, without specifying
+a listen address.
+
+### `Swarm.Transports.Security`
+
+Configuration section for libp2p _security_ transports. Transports enabled in
+this section will be used to secure unencrypted connections.
+
+Security transports are configured with the `priority` type.
+
+When establishing an _outbound_ connection, go-ipfs will try each security
+transport in priority order (lower first), until it finds a protocol that the
+receiver supports. When establishing an _inbound_ connection, go-ipfs will let
+the initiator choose the protocol, but will refuse to use any of the disabled
+transports.
+
+Supported transports are: TLS (priority 100), SECIO (priority 200), Noise
+(priority 300).
+
+No default priority will ever be less than 100.
+
+#### `Swarm.Transports.Security.TLS`
+
+[TLS](https://github.com/libp2p/specs/tree/master/tls) (1.3) is the default
+security transport as of go-ipfs 0.5.0. It's also the most scrutinized and
+trusted security transport.
+
+Default: `100`
+
+Type: `priority`
+
+#### `Swarm.Transports.Security.SECIO`
+
+[SECIO](https://github.com/libp2p/specs/tree/master/secio) is the most widely
+supported IPFS & libp2p security transport. However, it is currently being
+phased out in favor of more popular and better vetted protocols like TLS and
+Noise.
+
+Default: `200`
+
+Type: `priority`
+
+#### `Swarm.Transports.Security.Noise`
+
+[Noise](https://github.com/libp2p/specs/tree/master/noise) is slated to replace
+TLS as the cross-platform, default libp2p protocol due to ease of
+implementation. It is currently enabled by default but with low priority as it's
+not yet widely supported.
+
+Default: `300`
+
+Type: `priority`
+
+### `Swarm.Transports.Multiplexers`
+
+Configuration section for libp2p _multiplexer_ transports. Transports enabled in
+this section will be used to multiplex duplex connections.
+
+Multiplexer transports are secured the same way security transports are, with
+the `priority` type. Like with security transports, the initiator gets their
+first choice.
+
+Supported transports are: Yamux (priority 100) and Mplex (priority 200)
+
+No default priority will ever be less than 100.
+
+### `Swarm.Transports.Multiplexers.Yamux`
+
+Yamux is the default multiplexer used when communicating between go-ipfs nodes.
+
+Default: `100`
+
+Type: `priority`
+
+### `Swarm.Transports.Multiplexers.Mplex`
+
+Mplex is the default multiplexer used when communicating between go-ipfs and all
+other IPFS and libp2p implementations. Unlike Yamux:
+
+* Mplex is a simpler protocol.
+* Mplex is more efficient.
+* Mplex does not have built-in keepalives.
+* Mplex does not support backpressure. Unfortunately, this means that, if a
+  single stream to a peer gets backed up for a period of time, the mplex
+  transport will kill the stream to allow the others to proceed. On the other
+  hand, the lack of backpressure means mplex can be significantly faster on some
+  high-latency connections.
+
+Default: `200`
+
+Type: `priority`

--- a/docs/config.md
+++ b/docs/config.md
@@ -216,7 +216,7 @@ Supported Transports:
 
 Default: `/ip4/127.0.0.1/tcp/5001`
 
-Type: `strings`
+Type: `strings` (multiaddrs)
 
 ### `Addresses.Gateway`
 
@@ -230,7 +230,7 @@ Supported Transports:
 
 Default: `/ip4/127.0.0.1/tcp/8080`
 
-Type: `strings`
+Type: `strings` (multiaddrs)
 
 ### `Addresses.Swarm`
 
@@ -253,7 +253,7 @@ Default:
 ]
 ```
 
-Type: `array[string]`
+Type: `array[string]` (multiaddrs)
 
 ### `Addresses.Announce`
 
@@ -262,14 +262,14 @@ network. If empty, the daemon will announce inferred swarm addresses.
 
 Default: `[]`
 
-Type: `array[string]`
+Type: `array[string]` (multiaddrs)
 
 ### `Addresses.NoAnnounce`
 Array of swarm addresses not to announce to the network.
 
 Default: `[]`
 
-Type: `array[string]`
+Type: `array[string]` (multiaddrs)
 
 ## `API`
 Contains information used by the API gateway.
@@ -286,7 +286,7 @@ Example:
 
 Default: `null`
 
-Type: `object[string -> array[string]]`
+Type: `object[string -> array[string]]` (header names -> array of header values)
 
 ## `AutoNAT`
 
@@ -305,7 +305,7 @@ field can take one of two values:
 
 Additional modes may be added in the future.
 
-Type: `string` (can only be "enabled" and "disabled")
+Type: `string` (one of `"enabled"` or `"disabled"`)
 
 ### `AutoNAT.Throttle`
 
@@ -319,7 +319,7 @@ Configures how many AutoNAT requests to service per `AutoNAT.Throttle.Interval`.
 
 Default: 30
 
-Type: `integer`
+Type: `integer` (non-negative, `0` means unlimited)
 
 ### `AutoNAT.Throttle.PeerLimit`
 
@@ -327,7 +327,7 @@ Configures how many AutoNAT requests per-peer to service per `AutoNAT.Throttle.I
 
 Default: 3
 
-Type: `integer`
+Type: `integer` (non-negative, `0` means unlimited)
 
 ### `AutoNAT.Throttle.Interval`
 
@@ -335,7 +335,7 @@ Configures the interval for the above limits.
 
 Default: 1 Minute
 
-Type: `duration`
+Type: `duration` (when `0`/unset, the default value is used)
 
 ## `Bootstrap`
 
@@ -344,7 +344,7 @@ initiate a connection to the network.
 
 Default: The ipfs.io bootstrap nodes
 
-Type: `array[string]`
+Type: `array[string]` (multiaddrs)
 
 ## `Datastore`
 
@@ -368,7 +368,7 @@ option defaults to false currently).
 
 Default: `90`
 
-Type: `integer`
+Type: `integer` (0-100%)
 
 ### `Datastore.GCPeriod`
 
@@ -377,7 +377,7 @@ if automatic gc is enabled.
 
 Default: `1h`
 
-Type: `duration` or an empty string for the default value.
+Type: `duration` (an empty string means the default value)
 
 ### `Datastore.HashOnRead`
 
@@ -406,7 +406,7 @@ are used, so the constant `k` is 7 in the formula.
 
 Default: `0` (disabled)
 
-Type: `integer`
+Type: `integer` (non-negative, bytes)
 
 ### `Datastore.Spec`
 
@@ -474,7 +474,9 @@ Type: `bool`
 
 A number of seconds to wait between discovery checks.
 
-Type: `integer` (_not_ a duration)
+Default: `5`
+
+Type: `integer` (integer seconds, 0 means the default)
 
 ## `Gateway`
 
@@ -526,7 +528,7 @@ A url to redirect requests for `/` to.
 
 Default: `""`
 
-Type: `string`
+Type: `string` (url)
 
 ### `Gateway.Writable`
 
@@ -729,13 +731,13 @@ The unique PKI identity label for this configs peer. Set on init and never read,
 it's merely here for convenience. Ipfs will always generate the peerID from its
 keypair at runtime.
 
-Type: `string`
+Type: `string` (peer ID)
 
 ### `Identity.PrivKey`
 
 The base64 encoded protobuf describing (and containing) the nodes private key.
 
-Type: `string`
+Type: `string` (base64 encoded)
 
 ## `Ipns`
 
@@ -764,7 +766,7 @@ will be kept cached until their lifetime is expired.
 
 Default: `128`
 
-Type: `integer`
+Type: `integer` (non-negative, 0 means the default)
 
 ## `Mounts`
 
@@ -776,7 +778,7 @@ Mountpoint for `/ipfs/`.
 
 Default: `/ipfs`
 
-Type: `string`
+Type: `string` (filesystem path)
 
 ### `Mounts.IPNS`
 
@@ -784,7 +786,7 @@ Mountpoint for `/ipns/`.
 
 Default: `/ipns`
 
-Type: `string`
+Type: `string` (filesystem path)
 
 ### `Mounts.FuseAllowOther`
 
@@ -806,7 +808,7 @@ Sets the default router used by pubsub to route messages to peers. This can be o
   
 Default: `"gossipsub"`
 
-Type: `string`
+Type: `string` (one of `"floodsub"`, `"gossipsub"`, or `""` (apply default))
 
 [gossipsub]: https://github.com/libp2p/specs/tree/master/pubsub/gossipsub
 
@@ -1054,16 +1056,22 @@ Please use [`AutoNAT.ServiceMode`][].
 ### `Swarm.ConnMgr`
 
 The connection manager determines which and how many connections to keep and can
-be configured to keep.
+be configured to keep. Go-ipfs currently supports two connection managers:
+
+* none: never close idle connections.
+* basic: the default connection manager.
+
+Default: basic
 
 #### `Swarm.ConnMgr.Type`
 
 Sets the type of connection manager to use, options are: `"none"` (no connection
 management) and `"basic"`.
 
-Default: `"basic"`
+Default: "basic".
 
-Type: `string` (one of `"basic"`, `"none"`, or `""` (default, i.e. `"basic"`).
+Type: `string` (when unset or `""`, the default connection manager is applied
+and all `ConnMgr` fields are ignored).
 
 #### Basic Connection Manager
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -98,6 +98,8 @@ $ ipfs resolve -r /ipns/dnslink-test2.example.com
 
 ## `LIBP2P_MUX_PREFS`
 
+Deprecated: Use the `Swarm.Transports.Multiplexers` config field.
+
 Tells go-ipfs which multiplexers to use in which order.
 
 Default: "/yamux/1.0.0 /mplex/6.7.0"

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -550,12 +550,17 @@ Experimental, enabled by default
 
 ### How to enable
 
-While the Noise transport is now shipped and enabled by default in go-ipfs, it won't be used by default for most connections because TLS and SECIO are currently preferred. If you'd like to test out the Noise transport, you can use the `Experimental.OverrideSecurityTransports` option to enable, disable, and reorder security transports.
-
-For example, to prefer noise over TLS and disable SECIO, run:
+While the Noise transport is now shipped and enabled by default in go-ipfs, it won't be used by default for most connections because TLS and SECIO are currently preferred. If you'd like to test out the Noise transport, you can increase the priority of the noise transport:
 
 ```
-ipfs config --json Experimental.OverrideSecurityTransports '["noise", "tls"]'
+ipfs config --json Swarm.Transports.Security.Noise 1
+```
+
+Or even disable TLS and/or SECIO (not recommended for the moment):
+
+```
+ipfs config --json Swarm.Transports.Security.TLS false
+ipfs config --json Swarm.Transports.Security.SECIO false
 ```
 
 ### Road to being a real feature

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-cmds v0.2.9
-	github.com/ipfs/go-ipfs-config v0.7.1
+	github.com/ipfs/go-ipfs-config v0.8.0
 	github.com/ipfs/go-ipfs-ds-help v0.1.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
@@ -83,6 +83,8 @@ require (
 	github.com/libp2p/go-libp2p-tls v0.1.3
 	github.com/libp2p/go-libp2p-yamux v0.2.8
 	github.com/libp2p/go-socket-activation v0.0.2
+	github.com/libp2p/go-tcp-transport v0.2.0
+	github.com/libp2p/go-ws-transport v0.3.1
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/miekg/dns v1.1.29 // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.2.9 h1:zQTENe9UJrtCb2bOtRoDGjtuo3rQjmuPdPnVlqoBV/M=
 github.com/ipfs/go-ipfs-cmds v0.2.9/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
-github.com/ipfs/go-ipfs-config v0.7.1 h1:57ZzoiUIbOIT01x1RconKtCv1MElV/6+kqW8hZY9NJ4=
-github.com/ipfs/go-ipfs-config v0.7.1/go.mod h1:GQUxqb0NfkZmEU92PxqqqLVVFTLpoGGUlBaTyDaAqrE=
+github.com/ipfs/go-ipfs-config v0.8.0 h1:4Tc7DC3dz4e7VadOjxXxFQGTQ1g7EYZClJ/ih8qOrxE=
+github.com/ipfs/go-ipfs-config v0.8.0/go.mod h1:GQUxqb0NfkZmEU92PxqqqLVVFTLpoGGUlBaTyDaAqrE=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/test/sharness/t0130-multinode.sh
+++ b/test/sharness/t0130-multinode.sh
@@ -88,24 +88,27 @@ test_expect_success "set up /tcp testbed" '
   iptb testbed create -type localipfs -count 5 -force -init
 '
 
-# test multiplex muxer
-export LIBP2P_MUX_PREFS="/mplex/6.7.0"
-run_advanced_test
-unset LIBP2P_MUX_PREFS
-
 # test default configuration
+run_advanced_test
+
+# test multiplex muxer
+test_expect_success "disable yamux" '
+  iptb run -- ipfs config --json Swarm.Transports.Multiplexers.Yamux false
+'
 run_advanced_test
 
 test_expect_success "set up /ws testbed" '
   iptb testbed create -type localipfs -count 5 -attr listentype,ws -force -init
 '
 
-# test multiplex muxer
-export LIBP2P_MUX_PREFS="/mplex/6.7.0"
-run_advanced_test "--enable-mplex-experiment"
-unset LIBP2P_MUX_PREFS
-
 # test default configuration
+run_advanced_test
+
+# test multiplex muxer
+test_expect_success "disable yamux" '
+  iptb run -- ipfs config --json Swarm.Transports.Multiplexers.Yamux false
+'
+
 run_advanced_test
 
 

--- a/test/sharness/t0190-quic-ping.sh
+++ b/test/sharness/t0190-quic-ping.sh
@@ -11,8 +11,8 @@ test_expect_success 'init iptb' '
   iptb testbed create -type localipfs -count 2 -init
 '
 
-addr1='"[\"/ip4/127.0.0.1/udp/0/quic/\"]"'
-addr2='"[\"/ip4/127.0.0.1/udp/0/quic/\"]"'
+addr1='"[\"/ip4/127.0.0.1/udp/0/quic\"]"'
+addr2='"[\"/ip4/127.0.0.1/udp/0/quic\"]"'
 test_expect_success "add QUIC swarm addresses" '
   ipfsi 0 config --json Addresses.Swarm '$addr1' &&
   ipfsi 1 config --json Addresses.Swarm '$addr2'

--- a/test/sharness/t0191-noise.sh
+++ b/test/sharness/t0191-noise.sh
@@ -11,14 +11,14 @@ test_expect_success 'init iptb' '
   iptb testbed create -type localipfs -count 3 -init
 '
 
-noise_transports='"[\"noise\"]"'
-other_transports='"[\"tls\",\"secio\"]"'
 tcp_addr='"[\"/ip4/127.0.0.1/tcp/0\"]"'
 test_expect_success "configure security transports" '
-  ipfsi 0 config --json Experimental.OverrideSecurityTransports '${noise_transports}' &&
-  ipfsi 1 config --json Experimental.OverrideSecurityTransports '${noise_transports}' &&
-  ipfsi 2 config --json Experimental.OverrideSecurityTransports '${other_transports}' &&
-  iptb run -- ipfs config --json Addresses.Swarm '${tcp_addr}'
+iptb run <<CMDS
+  [0,1] -- ipfs config --json Swarm.Transports.Security.TLS false &&
+  [0,1] -- ipfs config --json Swarm.Transports.Security.SECIO false &&
+  2     -- ipfs config --json Swarm.Transports.Security.Noise false &&
+        -- ipfs config --json Addresses.Swarm '${tcp_addr}'
+CMDS
 '
 
 startup_cluster 2


### PR DESCRIPTION
Add a config section for configuring transports. This way, users can disable transports (especially QUIC), and set muxer/security transport priorities.