### PR TITLE
fix 3 bugs responsible for a goroutine leak (plus one other bug)

### DIFF
--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -120,6 +120,9 @@ func (api *NameAPI) Search(ctx context.Context, name string, opts ...caopts.Name
 // Resolve attempts to resolve the newest version of the specified name and
 // returns its path.
 func (api *NameAPI) Resolve(ctx context.Context, name string, opts ...caopts.NameResolveOption) (path.Path, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	results, err := api.Search(ctx, name, opts...)
 	if err != nil {
 		return nil, err

--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -124,7 +124,7 @@ func HostnameOption() ServeOption {
 				// Not a whitelisted path
 
 				// Try DNSLink, if it was not explicitly disabled for the hostname
-				if !gw.NoDNSLink && isDNSLinkRequest(n.Context(), coreApi, r) {
+				if !gw.NoDNSLink && isDNSLinkRequest(r.Context(), coreApi, r) {
 					// rewrite path and handle as DNSLink
 					r.URL.Path = "/ipns/" + stripPort(r.Host) + r.URL.Path
 					childMux.ServeHTTP(w, r)
@@ -176,7 +176,7 @@ func HostnameOption() ServeOption {
 			// 1. is wildcard DNSLink enabled (Gateway.NoDNSLink=false)?
 			// 2. does Host header include a fully qualified domain name (FQDN)?
 			// 3. does DNSLink record exist in DNS?
-			if !cfg.Gateway.NoDNSLink && isDNSLinkRequest(n.Context(), coreApi, r) {
+			if !cfg.Gateway.NoDNSLink && isDNSLinkRequest(r.Context(), coreApi, r) {
 				// rewrite path and handle as DNSLink
 				r.URL.Path = "/ipns/" + stripPort(r.Host) + r.URL.Path
 				childMux.ServeHTTP(w, r)

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -86,16 +86,19 @@ func (ns *mpns) Resolve(ctx context.Context, name string, options ...opts.Resolv
 }
 
 func (ns *mpns) ResolveAsync(ctx context.Context, name string, options ...opts.ResolveOpt) <-chan Result {
-	res := make(chan Result, 1)
 	if strings.HasPrefix(name, "/ipfs/") {
 		p, err := path.ParsePath(name)
+		res := make(chan Result, 1)
 		res <- Result{p, err}
+		close(res)
 		return res
 	}
 
 	if !strings.HasPrefix(name, "/") {
 		p, err := path.ParsePath("/ipfs/" + name)
+		res := make(chan Result, 1)
 		res <- Result{p, err}
+		close(res)
 		return res
 	}
 


### PR DESCRIPTION
Alone, these three bugs were benign. But all together, they'd cause us to slowly leak `name.Search()` goroutines when resolving a name failed in some cases.

* We were using the wrong context to resolve dnslink records.
* We weren't reading the entire channel returned by `api.Name().Search()` but _also_ weren't canceling the context.
* We were returning results after returning errors. If we were canceling the context, or reading the entire channel, this would have been fine. But we shouldn't be doing this anyways.

The last bug fix (closing the response channel) was actually my first attempt to fix the bug, but it's related to this issue.