### PR TITLE
feat: add snap package configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ vendor
 go-ipfs-source.tar.gz
 docs/examples/go-ipfs-as-a-library/example-folder/Qm*
 /test/sharness/t0054-dag-car-import-export-data/*.car
+
+# ignore build output from snapcraft
+/ipfs_*.snap
+/parts
+/stage
+/prime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.14.4-buster
+# Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
+FROM golang:1.14.4-buster 
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,4 @@
 # This snap will build go-ipfs from source.
-# See: https://github.com/ipfs-shipyard/ipfs-snap for more details
 name: ipfs
 summary: global, versioned, peer-to-peer filesystem # 79 char long summary
 description: |
@@ -15,10 +14,15 @@ base: core18
 grade: stable
 confinement: strict
 
+# skip building on `ppc64el` and `s390x` to save some cpu cycles.
+architectures:
+  - build-on: [amd64, arm64, armhf, i386]
+
 apps:
   ipfs:
     command: ipfs
-    plugs: [network, network-bind, removable-media]
+    # the home plug is included so the user can `ipfs add` files from their home dir without a permission error.
+    plugs: [home, network, network-bind, removable-media]
     environment:
       # Snaps versions are isolated by default. This keeps the same ipfs repo across upgrades.
       IPFS_PATH: "$SNAP_USER_COMMON"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,8 +26,6 @@ apps:
 parts:
   ipfs:
     source: '.'
-    # TODO: set this to master when porting this file to ipfs/go-ipfs.
-    # Setting it explicitly lets us build the missing versions 0.5 and 0.6
     source-tag: master
     plugin: go
     # keep me up to date with the go version that go-ipfs expects to be built with.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,46 @@
+# This snap will build go-ipfs from source.
+# See: https://github.com/ipfs-shipyard/ipfs-snap for more details
+name: ipfs
+summary: global, versioned, peer-to-peer filesystem # 79 char long summary
+description: |
+  IPFS combines good ideas from Git, BitTorrent, Kademlia, SFS, and the Web.
+  It is like a single bittorrent swarm, exchanging git objects. IPFS provides
+  an interface as simple as the HTTP web, but with permanence built in. You
+  can also mount the world at /ipfs.
+
+# fetch the version number in the `ipfs` part rather than hardcode it here
+# see: https://snapcraft.io/docs/using-external-metadata#heading--scriptlet
+adopt-info: ipfs
+base: core18
+grade: stable
+confinement: strict
+
+apps:
+  ipfs:
+    command: ipfs
+    plugs: [network, network-bind, removable-media]
+    environment:
+      # Snaps versions are isolated by default. This keeps the same ipfs repo across upgrades.
+      IPFS_PATH: "$SNAP_USER_COMMON"
+
+parts:
+  ipfs:
+    source: '.'
+    # TODO: set this to master when porting this file to ipfs/go-ipfs.
+    # Setting it explicitly lets us build the missing versions 0.5 and 0.6
+    source-tag: master
+    plugin: go
+    # keep me up to date with the go version that go-ipfs expects to be built with.
+    go-channel: 1.14/stable
+    go-importpath: github.com/ipfs/go-ipfs
+    build-packages:
+        - build-essential
+
+    # use `make` to build and set the snap version from `ipfs version` output
+    override-build: |
+      export GOPATH=$SNAPCRAFT_PART_BUILD/go
+      make install
+      cp $SNAPCRAFT_PART_BUILD/go/bin/ipfs $SNAPCRAFT_PART_INSTALL
+      export IPFS_VERSION=$($SNAPCRAFT_PART_BUILD/go/bin/ipfs version --commit | cut -c 14-)
+      echo "found version $IPFS_VERSION"
+      snapcraftctl set-version $IPFS_VERSION

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,10 +14,6 @@ base: core18
 grade: stable
 confinement: strict
 
-# skip building on `ppc64el` and `s390x` to save some cpu cycles.
-architectures:
-  - build-on: [amd64, arm64, armhf, i386]
-
 apps:
   ipfs:
     command: ipfs


### PR DESCRIPTION
Simplify keeping the snap package up to date by including the snapcraft.yaml in the repo.

We can then wire up the snapstore to autobuild the package for amd64, i386, arm* etc.

Many thanks to @elopio for the work of getting ipfs into the snap store in the first place, and to @bertrandfalguiere and @mkg20001 for pushing it forwards.

To try it out, install `snapcraft` and run it from the root of the project folder. That will build go-ipfs and create a .snap file for your current system architecuture. See: https://github.com/ipfs-shipyard/ipfs-snap for more information.

Fixes #7250
WIP #3595

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>