### PR TITLE
chore: use published ipfs-interop module instead of master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
           name: Installing dependencies
           command: |
             npm init -y
-            npm install ipfs@^0.47.0
-            npm install ipfs-interop@^1.0.0
+            npm install ipfs@^0.48.1
+            npm install ipfs-interop@^2.0.0
             npm install mocha-circleci-reporter@0.0.3
           working_directory: ~/ipfs/go-ipfs/interop
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           command: |
             mkdir -p /tmp/test-results/interop/
             export MOCHA_FILE="$(mktemp /tmp/test-results/interop/unit.XXXXXX.xml)"
-            node_modules/.bin/ipfs-interop -- -t node -f $(sed -n -e "s|^require('\(.*\)')$|test/\1|p" node_modules/ipfs-interop/test/node.js | circleci tests split) -- --reporter mocha-circleci-reporter
+            npx ipfs-interop -- -t node -f $(sed -n -e "s|^require('\(.*\)')$|test/\1|p" node_modules/ipfs-interop/test/node.js | circleci tests split) -- --reporter mocha-circleci-reporter
           working_directory: ~/ipfs/go-ipfs/interop
           environment:
             IPFS_REUSEPORT: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,8 @@ executors:
       IPFS_REUSEPORT: false
       LIBP2P_ALLOW_WEAK_RSA_KEYS: 1
       E2E_IPFSD_TYPE: go
-  dockerizer: 
-    docker: 
+  dockerizer:
+    docker:
       - image: circleci/golang:1.14.4
     environment:
       IMAGE_NAME: ipfs/go-ipfs
@@ -100,7 +100,7 @@ jobs:
     - run: |
         make -j 1 test/unit/gotest.junit.xml \
         && [[ ! $(jq -s -c 'map(select(.Action == "fail")) | .[]' test/unit/gotest.json) ]]
-    - run: 
+    - run:
         when: always
         command: bash <(curl -s https://codecov.io/bash) -cF unittests -X search -f coverage/unit_tests.coverprofile
 
@@ -171,35 +171,19 @@ jobs:
       - attach_workspace:
           at: /tmp/circleci-workspace
       - run:
-          name: Cloning
-          command: |
-            git clone https://github.com/ipfs/interop.git
-            git -C interop log -1
-      - restore_cache:
-          keys:
-            - v2-interop-{{ checksum "~/ipfs/go-ipfs/interop/package-lock.json" }}
-            - v2-interop-
-      - run:
           name: Installing dependencies
           command: |
-            npm install
-          working_directory: ~/ipfs/go-ipfs/interop
-      - save_cache:
-          key: v2-interop-{{ checksum "~/ipfs/go-ipfs/interop/package-lock.json" }}
-          paths:
-            - ~/ipfs/go-ipfs/interop/node_modules
-      - run:
-          name: Installing reporting tools
-          command: |
-            npm install --save-dev mocha-circleci-reporter@0.0.3
+            npm init -y
+            npm install ipfs@^0.47.0
+            npm install ipfs-interop@^1.0.0
+            npm install mocha-circleci-reporter@0.0.3
           working_directory: ~/ipfs/go-ipfs/interop
       - run:
           name: Running tests
           command: |
             mkdir -p /tmp/test-results/interop/
             export MOCHA_FILE="$(mktemp /tmp/test-results/interop/unit.XXXXXX.xml)"
-            node_modules/.bin/mocha --reporter mocha-circleci-reporter \
-              $(sed -n -e "s|^require('\(.*\)')$|test/\1|p" test/node.js | circleci tests split)
+            node_modules/.bin/ipfs-interop -- -t node -f $(sed -n -e "s|^require('\(.*\)')$|test/\1|p" node_modules/ipfs-interop/test/node.js | circleci tests split) -- --reporter mocha-circleci-reporter
           working_directory: ~/ipfs/go-ipfs/interop
           environment:
             IPFS_REUSEPORT: false
@@ -386,12 +370,12 @@ workflows:
   # also means tag-based jobs can only depend on other tag-based jobs, so we
   # use a separate workflow because every job needs to be tagged together.
   # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
-  docker-on-tag: 
+  docker-on-tag:
     jobs:
       - docker-build:
-          filters: *only-version-tags 
+          filters: *only-version-tags
       - docker-push:
           context: dockerhub
-          filters: *only-version-tags 
+          filters: *only-version-tags
           requires:
             - docker-build


### PR DESCRIPTION
Changes the CI pipeline to use a published version of the `ipfs-interop` module instead of whatever's the HEAD of master in order to control the versions of what's being tested.

Otherwise it becomes hard to release breaking changes in an ordered fashion.