### PR TITLE
use t.Cleanup() to reduce the need to clean up servers in tests

### DIFF
--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -135,6 +135,7 @@ func newTestServerAndNode(t *testing.T, ns mockNamesys) (*httptest.Server, iface
 	// listener, and server with handler. yay cycles.
 	dh := &delegatedHandler{}
 	ts := httptest.NewServer(dh)
+	t.Cleanup(func() { ts.Close() })
 
 	dh.Handler, err = makeHandler(n,
 		ts.Listener,
@@ -157,7 +158,6 @@ func newTestServerAndNode(t *testing.T, ns mockNamesys) (*httptest.Server, iface
 func TestGatewayGet(t *testing.T) {
 	ns := mockNamesys{}
 	ts, api, ctx := newTestServerAndNode(t, ns)
-	defer ts.Close()
 
 	k, err := api.Unixfs().Add(ctx, files.NewBytesFile([]byte("fnord")))
 	if err != nil {
@@ -238,7 +238,6 @@ func TestGatewayGet(t *testing.T) {
 func TestPretty404(t *testing.T) {
 	ns := mockNamesys{}
 	ts, api, ctx := newTestServerAndNode(t, ns)
-	defer ts.Close()
 
 	f1 := files.NewMapDirectory(map[string]files.Node{
 		"ipfs-404.html": files.NewBytesFile([]byte("Custom 404")),
@@ -303,7 +302,6 @@ func TestIPNSHostnameRedirect(t *testing.T) {
 	ns := mockNamesys{}
 	ts, api, ctx := newTestServerAndNode(t, ns)
 	t.Logf("test server url: %s", ts.URL)
-	defer ts.Close()
 
 	// create /ipns/example.net/foo/index.html
 
@@ -391,7 +389,6 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	ns := mockNamesys{}
 	ts, api, ctx := newTestServerAndNode(t, ns)
 	t.Logf("test server url: %s", ts.URL)
-	defer ts.Close()
 
 	f1 := files.NewMapDirectory(map[string]files.Node{
 		"file.txt": files.NewBytesFile([]byte("1")),
@@ -601,7 +598,6 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 func TestCacheControlImmutable(t *testing.T) {
 	ts, _, _ := newTestServerAndNode(t, nil)
 	t.Logf("test server url: %s", ts.URL)
-	defer ts.Close()
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+emptyDir+"/", nil)
 	if err != nil {
@@ -627,7 +623,6 @@ func TestCacheControlImmutable(t *testing.T) {
 func TestGoGetSupport(t *testing.T) {
 	ts, _, _ := newTestServerAndNode(t, nil)
 	t.Logf("test server url: %s", ts.URL)
-	defer ts.Close()
 
 	// mimic go-get
 	req, err := http.NewRequest(http.MethodGet, ts.URL+emptyDir+"?go-get=1", nil)
@@ -651,7 +646,6 @@ func TestVersion(t *testing.T) {
 	ns := mockNamesys{}
 	ts, _, _ := newTestServerAndNode(t, ns)
 	t.Logf("test server url: %s", ts.URL)
-	defer ts.Close()
 
 	req, err := http.NewRequest(http.MethodGet, ts.URL+"/version", nil)
 	if err != nil {


### PR DESCRIPTION
https://golang.org/pkg/testing/#B.Cleanup