### PR TITLE
ipfs name resolve --dht-record-count flag fix

### DIFF
--- a/core/commands/name/ipns.go
+++ b/core/commands/name/ipns.go
@@ -99,7 +99,7 @@ Resolve the value of a dnslink:
 		}
 
 		recursive, _ := req.Options[recursiveOptionName].(bool)
-		rc, rcok := req.Options[dhtRecordCountOptionName].(int)
+		rc, rcok := req.Options[dhtRecordCountOptionName].(uint)
 		dhtt, dhttok := req.Options[dhtTimeoutOptionName].(string)
 		stream, _ := req.Options[streamOptionName].(bool)
 
@@ -111,7 +111,7 @@ Resolve the value of a dnslink:
 			opts = append(opts, options.Name.ResolveOption(nsopts.Depth(1)))
 		}
 		if rcok {
-			opts = append(opts, options.Name.ResolveOption(nsopts.DhtRecordCount(uint(rc))))
+			opts = append(opts, options.Name.ResolveOption(nsopts.DhtRecordCount(rc)))
 		}
 		if dhttok {
 			d, err := time.ParseDuration(dhtt)


### PR DESCRIPTION
We were previously using `int` instead of `uint` which caused the `rcok` to always be false.

We should probably have a test that makes sure the various flags work, but in the sake of expediency with the upcoming release and the fact that this small fix looks right I didn't bother.

Would welcome a test here.