### PR TITLE
Added new plugin type: PluginScoreLedger

### DIFF
--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -26,13 +26,26 @@ import (
 
 // NewMockNode constructs an IpfsNode for use in tests.
 func NewMockNode() (*core.IpfsNode, error) {
+	return NewMockNodeWithConfig(nil)
+}
+
+// Constructs an IpfsNode with the specified configuration for use in
+// tests.
+func NewMockNodeWithConfig(conf *config.Config) (*core.IpfsNode, error) {
 	ctx := context.Background()
 
-	// effectively offline, only peer in its network
-	return core.NewNode(ctx, &core.BuildCfg{
+	bcfg := &core.BuildCfg{
 		Online: true,
 		Host:   MockHostOption(mocknet.New(ctx)),
-	})
+	}
+	if conf != nil {
+		bcfg.Repo = &repo.Mock{
+			D: syncds.MutexWrap(datastore.NewMapDatastore()),
+			C: *conf,
+		}
+	}
+	// effectively offline, only peer in its network
+	return core.NewNode(ctx, bcfg)
 }
 
 func MockHostOption(mn mocknet.Mocknet) libp2p2.HostOption {

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -259,10 +259,13 @@ func Online(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	}
 
 	/* don't provide from bitswap when the strategic provider service is active */
-	shouldBitswapProvide := !cfg.Experimental.StrategicProviding
+	onlinex, err := OnlineExchange(!cfg.Experimental.StrategicProviding, cfg.Experimental.WithScoreLedger)
+	if err != nil {
+		return fx.Error(err)
+	}
 
 	return fx.Options(
-		fx.Provide(OnlineExchange(shouldBitswapProvide)),
+		fx.Provide(onlinex),
 		maybeProvide(Graphsync, cfg.Experimental.GraphsyncEnabled),
 		fx.Provide(Namesys(ipnsCacheSize)),
 		fx.Provide(Peering),

--- a/go.mod
+++ b/go.mod
@@ -111,3 +111,7 @@ require (
 )
 
 go 1.13
+
+replace github.com/ipfs/go-ipfs-config v0.9.0 => github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc
+
+replace github.com/ipfs/go-bitswap v0.2.20 => github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5

--- a/go.mod
+++ b/go.mod
@@ -114,4 +114,4 @@ go 1.13
 
 replace github.com/ipfs/go-ipfs-config v0.9.0 => github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc
 
-replace github.com/ipfs/go-bitswap v0.2.20 => github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5
+replace github.com/ipfs/go-bitswap v0.2.20 => github.com/ipfs/go-bitswap v0.2.21-0.20200903122846-00f4df8d04e2

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/ipfs/go-bitswap v0.1.3/go.mod h1:YEQlFy0kkxops5Vy+OxWdRSEZIoS7I7KDIwo
 github.com/ipfs/go-bitswap v0.1.8/go.mod h1:TOWoxllhccevbWFUR2N7B1MTSVVge1s6XSMiCSA4MzM=
 github.com/ipfs/go-bitswap v0.2.20 h1:Zfi5jDUoqxDThORUznqdeL77DdGniAzlccNJ4vr+Itc=
 github.com/ipfs/go-bitswap v0.2.20/go.mod h1:C7TwBgHnu89Q8sHsTJP7IhUqF9XYLe71P4tT5adgmYo=
+github.com/ipfs/go-bitswap v0.2.21-0.20200903122846-00f4df8d04e2 h1:t0qkfTluTgPCVew75dPzsgUgUNTeBo+VsAw1VsHpdrw=
+github.com/ipfs/go-bitswap v0.2.21-0.20200903122846-00f4df8d04e2/go.mod h1:C7TwBgHnu89Q8sHsTJP7IhUqF9XYLe71P4tT5adgmYo=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
@@ -1206,8 +1208,6 @@ github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c/go.mod h1:
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
 github.com/whyrusleeping/yamux v1.1.5/go.mod h1:E8LnQQ8HKx5KD29HZFUwM1PxCOdPRzGwur1mcYhXcD8=
-github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5 h1:QGeq6h0+aajUikwDovvuPzLdqvENj8Ik92KOvRFBjw8=
-github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5/go.mod h1:C7TwBgHnu89Q8sHsTJP7IhUqF9XYLe71P4tT5adgmYo=
 github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc h1:aw5s9cBJKb8S/E/Vv+sUVaEFX8eElD5SX6aI1OsuQcc=
 github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc/go.mod h1:GQUxqb0NfkZmEU92PxqqqLVVFTLpoGGUlBaTyDaAqrE=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=

--- a/go.sum
+++ b/go.sum
@@ -1206,6 +1206,10 @@ github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c/go.mod h1:
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
 github.com/whyrusleeping/yamux v1.1.5/go.mod h1:E8LnQQ8HKx5KD29HZFUwM1PxCOdPRzGwur1mcYhXcD8=
+github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5 h1:QGeq6h0+aajUikwDovvuPzLdqvENj8Ik92KOvRFBjw8=
+github.com/wolneykien/go-bitswap v0.2.21-0.20200822132638-80c1a81b63e5/go.mod h1:C7TwBgHnu89Q8sHsTJP7IhUqF9XYLe71P4tT5adgmYo=
+github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc h1:aw5s9cBJKb8S/E/Vv+sUVaEFX8eElD5SX6aI1OsuQcc=
+github.com/wolneykien/go-ipfs-config v0.9.1-0.20200822153552-ebf11a6556cc/go.mod h1:GQUxqb0NfkZmEU92PxqqqLVVFTLpoGGUlBaTyDaAqrE=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/plugin/scoreledger.go
+++ b/plugin/scoreledger.go
@@ -1,0 +1,12 @@
+package plugin
+
+import (
+	"github.com/ipfs/go-bitswap/decision"
+)
+
+// With a PluginScoreLedger plugin it is possible to replace the default
+// BitSwap decision logic with a different one.
+type PluginScoreLedger interface {
+	Plugin
+	Ledger() (decision.ScoreLedger, error)
+}

--- a/test/integration/plugins_common_test.go
+++ b/test/integration/plugins_common_test.go
@@ -1,0 +1,27 @@
+package integrationtest
+
+import (
+	"github.com/ipfs/go-ipfs/plugin"
+	"github.com/ipfs/go-ipfs/plugin/loader"
+)
+
+// Initializes a newly created loader with the given plugin objects
+// (not plugin names or files).
+func loadPlugins(pls ...plugin.Plugin) (*loader.PluginLoader, error) {
+	plugins, err := loader.NewPluginLoader("")
+	if err != nil {
+		return nil, err
+	}
+	for _, pl := range pls {
+		if err := plugins.Load(pl); err != nil {
+			return nil, err
+		}
+	}
+	if err := plugins.Initialize(); err != nil {
+		return nil, err
+	}
+	if err := plugins.Inject(); err != nil {
+		return nil, err
+	}
+	return plugins, nil
+}

--- a/test/integration/scoreledger_test.go
+++ b/test/integration/scoreledger_test.go
@@ -1,0 +1,113 @@
+package integrationtest
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap/decision"
+	config "github.com/ipfs/go-ipfs-config"
+	"github.com/ipfs/go-ipfs/core"
+	mock "github.com/ipfs/go-ipfs/core/mock"
+	"github.com/ipfs/go-ipfs/plugin"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+func TestScoreLedgerNotLoaded(t *testing.T) {
+	n, err := nodeWithNamedScoreLedger("testledger")
+	if err == nil {
+		n.Close()
+		t.Fatal("Expected to fail")
+	}
+	if err != nil {
+		if err.Error() != "score ledger 'testledger' not found, check if plugin is loaded" {
+			t.Fatal("Unexpected error message")
+		}
+	}
+}
+
+func TestScoreLedgerLoadStartStop(t *testing.T) {
+	tp := &testingScoreLedgerPlugin{
+		ledger: newTestingScoreLedger(),
+	}
+	plugins, err := loadPlugins(tp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plugins.Close()
+
+	n, err := nodeWithNamedScoreLedger("testledger")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Close()
+
+	select {
+	case <-tp.ledger.started:
+		if !tp.ledger.initialized {
+			t.Fatal("Expected the score ledger to be initialized")
+		}
+	case <-time.After(time.Second * 5):
+		t.Fatal("Expected the score ledger to be started within 5s")
+	}
+
+	n.Close()
+	select {
+	case <-tp.ledger.closed:
+	case <-time.After(time.Second * 5):
+		t.Fatal("Expected the score ledger to be closed within 5s")
+	}
+}
+
+func nodeWithNamedScoreLedger(name string) (*core.IpfsNode, error) {
+	cfg, err := config.Init(ioutil.Discard, 2048)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Experimental.WithScoreLedger = name
+	return mock.NewMockNodeWithConfig(cfg)
+}
+
+type testingScoreLedger struct {
+	initialized bool
+	started     chan struct{}
+	closed      chan struct{}
+}
+
+func newTestingScoreLedger() *testingScoreLedger {
+	return &testingScoreLedger{
+		false,
+		make(chan struct{}),
+		make(chan struct{}),
+	}
+}
+
+func (tsl *testingScoreLedger) Init(scorePeer decision.ScorePeerFunc) {
+	tsl.initialized = true
+}
+func (tsl *testingScoreLedger) GetReceipt(p peer.ID) *decision.Receipt {
+	return nil
+}
+func (tsl *testingScoreLedger) AddToSentBytes(p peer.ID, n int)     {}
+func (tsl *testingScoreLedger) AddToReceivedBytes(p peer.ID, n int) {}
+func (tsl *testingScoreLedger) PeerConnected(p peer.ID)             {}
+func (tsl *testingScoreLedger) PeerDisconnected(p peer.ID)          {}
+func (tsl *testingScoreLedger) Start() {
+	close(tsl.started)
+}
+func (tsl *testingScoreLedger) Close() {
+	close(tsl.closed)
+}
+
+type testingScoreLedgerPlugin struct {
+	ledger *testingScoreLedger
+}
+
+func (tp *testingScoreLedgerPlugin) Name() string    { return "testledger" }
+func (tp *testingScoreLedgerPlugin) Version() string { return "0.0.0" }
+func (tp *testingScoreLedgerPlugin) Init(env *plugin.Environment) error {
+	return nil
+}
+func (tp *testingScoreLedgerPlugin) Ledger() (decision.ScoreLedger, error) {
+	return tp.ledger, nil
+}


### PR DESCRIPTION
With a PluginScoreLedger plugin it is now possible to replace the
default BitSwap decision logic with a different one. The plugin
support depends on the experimental BitSwap option `WithScoreLedger`
— see `80c1a81b63e5` and related commits in the `go-bitswap` project
and also `ebf11a6556cc` commit in the `go-ipfs-config` project.

A map of score ledgers and new `RegisterScoreLedger` function were
added to `core/node/core.go` in order to support score ledger
injection. The selection of the particular ledger is now possible with
enchanced `OnlineExchange()` function accepting the name of the
ledger (`""` is used for the default behavior). It is configured with
`Experimental.WithScoreLedger` configuration option.

In order to check this modifications and plugin loading two new tests
were added to `test/integration` package: `TestScoreLedgerNotLoaded`
and `TestScoreLedgerLoadStartStop`. To minimize code duplication I've
decided to slightly modify the `core/mock/mock.go` adding new
`NewMockNodeWithConfig()` function there. The code that loads and
injects plugin objects is placed in the `plugins_common_test.go` to
help implementing other plugin tests.