### PR TITLE
Adding `ipfs swarm stat` command.

### DIFF
--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -212,6 +212,7 @@ func TestCommands(t *testing.T) {
 		"/swarm/filters/add",
 		"/swarm/filters/rm",
 		"/swarm/peers",
+		"/swarm/stat",
 		"/tar",
 		"/tar/add",
 		"/tar/cat",


### PR DESCRIPTION
This is similar to `ipfs repo stat`.
Support Text and Json encoding.
Output:
```
ListenAddr: 10
ConnectedPeers: 15
KnownPeers: 136
```