### PR TITLE
docs(config): X-Forwarded-Host

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -702,11 +702,11 @@ Below is a list of the most common public gateway setups.
        }
      }'
    ```
-   **Note I:** this enables automatic redirects from content paths to subdomains:  
+   **Backward-compatible:** this feature enables automatic redirects from content paths to subdomains:  
    `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.dweb.link`  
-   **Note II:** if you run go-ipfs behind a reverse proxy that provides TLS, make it add a `X-Forwarded-Proto: https` HTTP header to ensure users are redirected to `https://`, not `http://`. The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`.:    
+   **X-Forwarded-Proto:** if you run go-ipfs behind a reverse proxy that provides TLS, make it add a `X-Forwarded-Proto: https` HTTP header to ensure users are redirected to `https://`, not `http://`. The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`.:    
    `http://dweb.link/ipfs/{cid}` → `https://{cid}.ipfs.dweb.link`  
-   **Note III:** we also support `X-Forwarded-Proto: example.com` if you want to override subdomain gateway host from the original request:
+   **X-Forwarded-Host:** we also support `X-Forwarded-Host: example.com` if you want to override subdomain gateway host from the original request:
    `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.example.com`
    
 


### PR DESCRIPTION
This fixes the mistake where `X-Forwarded-Host` was named `X-Forwarded-Proto` and makes it easier to discover both options.