### PR TITLE
Gateway proxying for {cid}.ipfs and {cid}.ipns hostnames

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -78,6 +78,21 @@ func HostnameOption() ServeOption {
 				host = xHost
 			}
 
+			// Are we being asked to proxy a {cid}.ipfs or {cid}.ipns host?
+			if strings.HasSuffix(host, ".ipfs") || strings.HasSuffix(host, ".ipns") {
+				labels := strings.Split(host, ".")
+				if len(labels) == 2 {
+					rootID := labels[0]
+					ns := labels[1]
+					if _, err := cid.Decode(rootID); err == nil {
+						r.URL.Path = "/" + ns + "/" + rootID + r.URL.Path
+						// Serve path request
+						childMux.ServeHTTP(w, r)
+						return
+					}
+				}
+			}
+
 			// HTTP Host & Path check: is this one of our  "known gateways"?
 			if gw, ok := isKnownHostname(host, knownGateways); ok {
 				// This is a known gateway but request is not using


### PR DESCRIPTION
Hi! I have been looking for a way to reduce the friction for users to get started browsing IPFS websites, in order to encourage more widespread adoption. I was wondering if there is an URI format for IPFS where:

* URIs for IPFS websites are relatively simple, don't include a gateway address or require redirecting to localhost
* URIs are compatible with existing browsers
* Users' privacy is protected when they browse across different IPFS sites
* Users aren't required to install a native "helper app" to browse IPFS sites "natively"

An approach that seems to address these issues is to use a URI format whereby:
* ipfs hashes are written as http://{CIDv1}.ipfs/...
* ipns hashes are written as http://{CIDv1}.ipns/...

For example, the Wikipedia mirror URI is written as http://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs/wiki/

I believe this new address format has a few advantages:

* There's no gateway domain, so users can immediately see that an IPFS site does not belong to a particular gateway, but rather stands on its own. The URI format already looks mostly familiar to new users because it begins with http://, and suggests it might be a website in the "ipfs" category.

* The address format is already compatible with browsers, and http:// URIs are automatically turned into clickable links by, Google Docs, Github, etc.

* Web browsers are moving toward isolating state (including cookies and supercookies) by eTLD+1. Once that is implemented, each {CIDv1}.ipfs domain will automatically gets its own cookie jar.

* Because we are using the proxy mechanism, a WebExtensions add-on is enough to get these URIs to connect: no native helper app is needed to make this address format work in browsers that support WebExtensions.

It turns out that, to get this URI format to work in most browsers, we can use common browser functionality. A small patch (this pull request) enhances the gateway so that it acts as an HTTP(S) proxy for such URIs. (The patch doesn't interfere with any of the existing functionality of go-ipfs.) To start browsing, the user needs only to install an add-on that makes a proxy connection to a go-ipfs gateway (remote or local) specifically for requests to IPFS in the proposed URI format. As a proof of principle, I wrote a simple add-on for Firefox, Chrome, and Edge that makes use of this proxy functionality:

https://github.com/arthuredelstein/dweb-proxy/

If you want to try it yourself, here's the installable add-on for Firefox: https://arthuredelstein.net/dweb/. It takes 60 seconds to try, and on installation provides some helpful example URIs for testing. And if you run ./ipfs daemon locally, you can direct the add-on to proxy its connections through http://localhost:8080, to support the same URI format.

Here's a screenshot of the add-on in use: 
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/355566/93151727-8b9a2200-f6b1-11ea-9d05-034c5bf05a2e.png">

Helpfully, the gateway already works as a proxy for .eth domains. So you can also enter http://ethereum.eth in the browser's address bar and it just works.

My goal is to make this patch suitable for existing public gateways (such as cloudflare-ipfs.com) that can handle larger numbers of users. Then any add-on supporting this URI format will be able to offer performant support at scale.

I also think this approach helps to demonstrate that native IPFS support in browsers won't need to be a major lift. That is: no significant modifications to browser internals, apart from a p2p networking component, will be required to support this URI format.

I hope this pull request is of interest! I'd be glad to discuss this patch further and make any revisions as needed.