### PR TITLE
feat(gateway): Content-Disposition improvements

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -34,6 +34,8 @@ const (
 	ipnsPathPrefix = "/ipns/"
 )
 
+var onlyAscii = regexp.MustCompile("[[:^ascii:]]")
+
 // gatewayHandler is a HTTP handler that serves IPFS objects (accessible by default at /ipfs/<path>)
 // (it serves requests like GET /ipfs/QmVRzPKPzNtSrEzBFm2UZfxmPAgnaLke4DMcerbsGGSaFe/link)
 type gatewayHandler struct {
@@ -265,7 +267,9 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			if r.URL.Query().Get("download") == "true" {
 				disposition = "attachment"
 			}
-			w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename*=UTF-8''%s", disposition, url.PathEscape(urlFilename)))
+			utf8Name := url.PathEscape(urlFilename)
+			asciiName := url.PathEscape(onlyAscii.ReplaceAllLiteralString(urlFilename, "_"))
+			w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename=\"%s\"; filename*=UTF-8''%s", disposition, asciiName, utf8Name))
 			name = urlFilename
 		} else {
 			name = getFilename(urlPath)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -261,7 +261,11 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		urlFilename := r.URL.Query().Get("filename")
 		var name string
 		if urlFilename != "" {
-			w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename*=UTF-8''%s", url.PathEscape(urlFilename)))
+			disposition := "inline"
+			if r.URL.Query().Get("download") == "true" {
+				disposition = "attachment"
+			}
+			w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename*=UTF-8''%s", disposition, url.PathEscape(urlFilename)))
 			name = urlFilename
 		} else {
 			name = getFilename(urlPath)

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -49,6 +49,16 @@ your query string to explicitly specify the filename. For example:
 
 > https://ipfs.io/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt
 
+When you try to save above page, you browser will use passed `filename` instead of a CID.
+
+## Downloads
+
+It is possible to skip browser rendering of supported filetypes (plain text,
+images, audio, video, PDF) and trigger immediate "save as" dialog by appending
+`&download=true`:
+
+> https://ipfs.io/ipfs/QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG?filename=hello_world.txt&download=true
+
 ## MIME-Types
 
 TODO

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -32,13 +32,13 @@ test_expect_success "GET IPFS path succeeds" '
 '
 
 test_expect_success "GET IPFS path with explicit ?filename succeeds with proper header" "
-  curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест' &&
-  grep -F \"Content-Disposition: inline; filename*=UTF-8''test%D1%82%D0%B5%D1%81%D1%82\" actual_headers
+  curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест.pdf' &&
+  grep -F 'Content-Disposition: inline; filename=\"test____.pdf\"; filename*=UTF-8'\'\''test%D1%82%D0%B5%D1%81%D1%82.pdf' actual_headers
 "
 
-test_expect_success "GET IPFS path with explicit ?filename and download=true succeeds with proper header" "
-  curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест&download=true' &&
-  grep -F \"Content-Disposition: attachment; filename*=UTF-8''test%D1%82%D0%B5%D1%81%D1%82\" actual_headers
+test_expect_success "GET IPFS path with explicit ?filename and &download=true succeeds with proper header" "
+  curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест.mp4&download=true' &&
+  grep -F 'Content-Disposition: attachment; filename=\"test____.mp4\"; filename*=UTF-8'\'\''test%D1%82%D0%B5%D1%81%D1%82.mp4' actual_headers
 "
 
 # https://github.com/ipfs/go-ipfs/issues/4025#issuecomment-342250616

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -31,9 +31,14 @@ test_expect_success "GET IPFS path succeeds" '
   curl -sfo actual "http://127.0.0.1:$port/ipfs/$HASH"
 '
 
-test_expect_success "GET IPFS path with explicit filename succeeds with proper header" "
+test_expect_success "GET IPFS path with explicit ?filename succeeds with proper header" "
   curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест' &&
   grep -F \"Content-Disposition: inline; filename*=UTF-8''test%D1%82%D0%B5%D1%81%D1%82\" actual_headers
+"
+
+test_expect_success "GET IPFS path with explicit ?filename and download=true succeeds with proper header" "
+  curl -fo actual -D actual_headers 'http://127.0.0.1:$port/ipfs/$HASH?filename=testтест&download=true' &&
+  grep -F \"Content-Disposition: attachment; filename*=UTF-8''test%D1%82%D0%B5%D1%81%D1%82\" actual_headers
 "
 
 # https://github.com/ipfs/go-ipfs/issues/4025#issuecomment-342250616


### PR DESCRIPTION
This PR improves the way gateway supports `Content-Disposition`, an HTTP header used by browsers as a name hint when saving a file:

- ASCII-only fallback for old browsers that do not implement RFC 5987 (Closes #7648)
- Support for direct download mode with `Content-Disposition: attachment` when `?filename` is accompanied by `&download=true` 

This is a fully backward-compatible change, sharness tests included.

cc (https://github.com/ipfs/go-ipfs/pull/4177  – @voker57 @crackcomm @radfish) https://github.com/ipfs/in-web-browsers/issues/132 @andrew @gozala @autonome 