### PR TITLE
Add missing plugin support on FreeBSD

### DIFF
--- a/plugin/loader/load_nocgo.go
+++ b/plugin/loader/load_nocgo.go
@@ -1,5 +1,5 @@
 // +build !cgo,!noplugin
-// +build linux darwin
+// +build linux darwin freebsd
 
 package loader
 

--- a/plugin/loader/load_unix.go
+++ b/plugin/loader/load_unix.go
@@ -1,5 +1,5 @@
 // +build cgo,!noplugin
-// +build linux darwin
+// +build linux darwin freebsd
 
 package loader
 


### PR DESCRIPTION
Go plugins are supported on FreeBSD, but build tags in `plugin/loader/load_unix.go` enable IPFS plugins only on Linux and Darwin.