### PR TITLE
fix(gw): preserve query on website redirect

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -290,7 +290,12 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		goget := r.URL.Query().Get("go-get") == "1"
 		if dirwithoutslash && !goget {
 			// See comment above where originalUrlPath is declared.
-			http.Redirect(w, r, originalUrlPath+"/", 302)
+			suffix := "/"
+			if r.URL.RawQuery != "" {
+				// preserve query parameters
+				suffix = suffix + "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, originalUrlPath+suffix, 302)
 			return
 		}
 


### PR DESCRIPTION
> **TLDR** We were losing query params on redirect, this PR fixes that.

This PR preserves query parameters during internal redirect of http gateway and adds sharness test to guard against regression in the way `index.html` detection works.

## Description of fixed problem

When  `/foo?bar=buz` was requested and `/foo/index.html` existed, 
gateway redirected to `/foo/` and that redirect did not preserve query params.

Problematic code was:
1. https://github.com/ipfs/go-ipfs/blob/v0.7.0/core/corehttp/gateway_handler.go#L180
2. https://github.com/ipfs/go-ipfs/blob/v0.7.0/core/corehttp/gateway_handler.go#L283-L285


cc @mburns  @hsanjuan