### PR TITLE
preliminary support for unixfs Mode and ModTime

### DIFF
--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -262,7 +262,22 @@ func (i *identityWriteCloser) Close() error {
 	return nil
 }
 
+func updateFileMeta(fn files.Node, filename string) error {
+	if t := fn.ModTime(); !t.IsZero() {
+		if err := os.Chtimes(filename, t, t); err != nil {
+			return err
+		}
+	}
+	if mode := fn.Mode(); mode != 0 {
+		if err := os.Chmod(filename, mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func fileArchive(f files.Node, name string, archive bool, compression int) (io.Reader, error) {
+	var err error = nil
 	cleaned := gopath.Clean(name)
 	_, filename := gopath.Split(cleaned)
 
@@ -285,14 +300,20 @@ func fileArchive(f files.Node, name string, archive bool, compression int) (io.R
 		return nil, err
 	}
 
-	closeGzwAndPipe := func() {
+	closeGzwAndPipe := func() error {
 		if err := maybeGzw.Close(); checkErrAndClosePipe(err) {
-			return
+			return nil
 		}
 		if err := bufw.Flush(); checkErrAndClosePipe(err) {
-			return
+			return nil
 		}
 		pipew.Close() // everything seems to be ok.
+		if !archive {
+			if err := updateFileMeta(f, filename); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if !archive && compression != gzip.NoCompression {
@@ -306,7 +327,7 @@ func fileArchive(f files.Node, name string, archive bool, compression int) (io.R
 			if _, err := io.Copy(maybeGzw, r); checkErrAndClosePipe(err) {
 				return
 			}
-			closeGzwAndPipe() // everything seems to be ok
+			err = closeGzwAndPipe() // everything seems to be ok
 		}()
 	} else {
 		// the case for 1. archive, and 2. not archived and not compressed, in which tar is used anyway as a transport format
@@ -323,11 +344,11 @@ func fileArchive(f files.Node, name string, archive bool, compression int) (io.R
 				return
 			}
 			w.Close()         // close tar writer
-			closeGzwAndPipe() // everything seems to be ok
+			err = closeGzwAndPipe() // everything seems to be ok
 		}()
 	}
 
-	return piper, nil
+	return piper, err
 }
 
 func newMaybeGzWriter(w io.Writer, compression int) (io.WriteCloser, error) {

--- a/core/coreapi/unixfs.go
+++ b/core/coreapi/unixfs.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/ipfs/go-ipfs/core"
-
 	"github.com/ipfs/go-ipfs/core/coreunix"
 
 	blockservice "github.com/ipfs/go-blockservice"
@@ -134,6 +133,10 @@ func (api *UnixfsAPI) Add(ctx context.Context, files files.Node, opts ...options
 	fileAdder.RawLeaves = settings.RawLeaves
 	fileAdder.NoCopy = settings.NoCopy
 	fileAdder.CidBuilder = prefix
+	fileAdder.PreserveMode = settings.PreserveMode
+	fileAdder.PreserveMtime = settings.PreserveMtime
+	fileAdder.FileMode = settings.Mode
+	fileAdder.FileMtime = settings.Mtime
 
 	switch settings.Layout {
 	case options.BalancedLayout:


### PR DESCRIPTION
This commit introduces initial Mode and ModTime support
for single filesystem files and webfiles.

The ipfs add options --preserve-mode and --preserve-mtime are
used to store the original mode and last modified time of the
file being added, the options --mode, --mtime and --mtime-nsecs
are used to store custom values.

A custom value of 0 is a no-op.

The preserve flags and custom options are mutually exclusive,
if both are provided the custom options take precedence.

Closes #6920