### PR TITLE
Clarify the differences between all the file APIs.

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -417,9 +417,9 @@ const (
 
 var filesLsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directories in the local mutable namespace.",
+		Tagline: "List directories in the local mutable namespace. (Both IPFS and MFS paths)",
 		ShortDescription: `
-List directories in the local mutable namespace.
+List directories in the local mutable namespace (Both IPFS and MFS paths).
 
 Examples:
 

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -419,7 +419,7 @@ var filesLsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List directories in the local mutable namespace.",
 		ShortDescription: `
-List directories in the local mutable namespace (Works on both IPFS and MFS paths).
+List directories in the local mutable namespace (works on both IPFS and MFS paths).
 
 Examples:
 

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -417,9 +417,9 @@ const (
 
 var filesLsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directories in the local mutable namespace. (Both IPFS and MFS paths)",
+		Tagline: "List directories in the local mutable namespace.",
 		ShortDescription: `
-List directories in the local mutable namespace (Both IPFS and MFS paths).
+List directories in the local mutable namespace (Works on both IPFS and MFS paths).
 
 Examples:
 

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -47,9 +47,9 @@ const (
 
 var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directory contents for Unix filesystem objects. (Only IPFS paths)",
+		Tagline: "List directory contents for Unix filesystem objects.",
 		ShortDescription: `
-Displays the contents of an IPFS or IPNS object(s) at the given path, with
+Displays the contents of an IPFS or IPNS object(s) at the given path, (Won't work with MFS paths - Use 'ipfs files ls' instead) with
 the following format:
 
   <link base58 hash> <link size in bytes> <link name>

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -47,7 +47,7 @@ const (
 
 var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directory contents for Unix filesystem objects.",
+		Tagline: "List directory contents for Unix filesystem objects. (Only IPFS paths)",
 		ShortDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path, with
 the following format:

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -49,7 +49,7 @@ var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List directory contents for Unix filesystem objects.",
 		ShortDescription: `
-Displays the contents of an IPFS or IPNS object(s) at the given path, (Won't work with MFS paths - Use 'ipfs files ls' instead) with
+Displays the contents of an IPFS or IPNS object(s) at the given path, with
 the following format:
 
   <link base58 hash> <link size in bytes> <link name>

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -42,10 +42,7 @@ The JSON output contains size information. For files, the child size
 is the total size of the file contents. For directories, the child
 size is the IPFS link size.
 
-This functionality is deprecated, and will be removed in future versions. If
-possible, please use 'ipfs ls' instead.
-
-It is deprecated because 'ipfs file ls' drop some of the ipfs specific info and almost same as 'ipfs ls'
+This functionality is deprecated, and will be removed in future versions as it duplicates the functionality of 'ipfs ls'.
 `,
 		LongDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path.
@@ -64,10 +61,7 @@ Example:
     > ipfs file ls /ipfs/QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ
     cat.jpg
 
-This functionality is deprecated, and will be removed in future versions. If
-possible, please use 'ipfs ls' instead.
-
-It is deprecated because 'ipfs file ls' drop some of the ipfs specific info and almost same as 'ipfs ls'
+This functionality is deprecated, and will be removed in future versions as it duplicates the functionality of 'ipfs ls'.
 `,
 	},
 

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -34,7 +34,7 @@ type LsOutput struct {
 
 var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directory contents for Unix filesystem objects. Deprecated: Use 'ipfs ls' instead",
+		Tagline: "List directory contents for Unix filesystem objects. Deprecated: Use 'ipfs ls' instead.",
 		ShortDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path.
 

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -34,7 +34,7 @@ type LsOutput struct {
 
 var LsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List directory contents for Unix filesystem objects.",
+		Tagline: "List directory contents for Unix filesystem objects. Deprecated: Use 'ipfs ls' instead",
 		ShortDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path.
 
@@ -44,6 +44,8 @@ size is the IPFS link size.
 
 This functionality is deprecated, and will be removed in future versions. If
 possible, please use 'ipfs ls' instead.
+
+It is deprecated because 'ipfs file ls' drop some of the ipfs specific info and almost same as 'ipfs ls'
 `,
 		LongDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path.
@@ -64,6 +66,8 @@ Example:
 
 This functionality is deprecated, and will be removed in future versions. If
 possible, please use 'ipfs ls' instead.
+
+It is deprecated because 'ipfs file ls' drop some of the ipfs specific info and almost same as 'ipfs ls'
 `,
 	},
 

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -43,6 +43,7 @@ is the total size of the file contents. For directories, the child
 size is the IPFS link size.
 
 This functionality is deprecated, and will be removed in future versions as it duplicates the functionality of 'ipfs ls'.
+If possible, please use 'ipfs ls' instead.
 `,
 		LongDescription: `
 Displays the contents of an IPFS or IPNS object(s) at the given path.
@@ -62,6 +63,7 @@ Example:
     cat.jpg
 
 This functionality is deprecated, and will be removed in future versions as it duplicates the functionality of 'ipfs ls'.
+If possible, please use 'ipfs ls' instead.
 `,
 	},
 


### PR DESCRIPTION
Closes https://github.com/ipfs/ipfs-docs/issues/301

As mentioned in https://discuss.ipfs.io/t/why-is-ipfs-files-ls-being-deprecated/7881/9

- [x] Clarify that ipfs file ls is being
    - [x] Why it's being deprecated.
    - [x] Users should use ipfs ls instead.
- [x] Explain that ipfs ls works on IPFS paths, and ipfs files ls works on both IPFS paths and MFS paths.