### PR TITLE
chore: update interop tests and js-ipfs version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,8 @@ jobs:
           name: Installing dependencies
           command: |
             npm init -y
-            npm install ipfs@^0.50.1
-            npm install ipfs-interop@^3.0.0
+            npm install ipfs@^0.52.2
+            npm install ipfs-interop@^4.0.0
             npm install mocha-circleci-reporter@0.0.3
           working_directory: ~/ipfs/go-ipfs/interop
       - run:


### PR DESCRIPTION
The internal bin path for js-ipfs changed recently so a major bump to the interop tests was required, this PR updates to the new version.