### PR TITLE
[WIP] Emit DHT LookupEvents from DHT commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,7 @@ require (
 )
 
 go 1.14
+
+replace (
+	github.com/libp2p/go-libp2p-kad-dht => ../../libp2p/go-libp2p-kad-dht
+)


### PR DESCRIPTION
This gives us access to the DHT's LookupEvents that can be processed by github.com/libp2p/py-libp2p-xor when using `--enc=json`.

The go.mod here has been updated to make LookupEvents more JSON compatible and will get referenced here soon.