### PR TITLE
Update GitHub documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -3,7 +3,7 @@ name: 'Documentation Issue'
 about: 'Report missing, erroneous docs, broken links or propose new go-ipfs docs'
 labels: topic/docs-ipfs, need/triage
 ---
-<!-- Problems with documentation on https://docs.ipfs.io should be reported to https://github.com/ipfs/docs -->
+<!-- Problems with documentation on https://docs.ipfs.io should be reported to https://github.com/ipfs/ipfs-docs -->
 
 #### Location
 


### PR DESCRIPTION
Uses the correct URL for the documentation repo