### PR TITLE
Improve error message when running key command that locks repo

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -69,22 +69,7 @@ environment variable:
 	},
 	NoRemote: true,
 	Extra:    commands.CreateCmdExtras(commands.SetDoesNotUseRepo(true), commands.SetDoesNotUseConfigAsInput(true)),
-	PreRun: func(req *cmds.Request, env cmds.Environment) error {
-		cctx := env.(*oldcmds.Context)
-		daemonLocked, err := fsrepo.LockedByOtherProcess(cctx.ConfigRoot)
-		if err != nil {
-			return err
-		}
-
-		log.Info("checking if daemon is running...")
-		if daemonLocked {
-			log.Debug("ipfs daemon is running")
-			e := "ipfs daemon is running. please stop it to run this command"
-			return cmds.ClientError(e)
-		}
-
-		return nil
-	},
+	PreRun:   commands.DaemonNotRunning,
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		cctx := env.(*oldcmds.Context)
 		empty, _ := req.Options[emptyRepoOptionName].(bool)

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -150,7 +150,7 @@ path can be specified with '--output=<path>' or '-o=<path>'.
 		cmds.StringOption(outputOptionName, "o", "The path where the output should be stored."),
 	},
 	NoRemote: true,
-	PreRun:   daemonNotRunning,
+	PreRun:   DaemonNotRunning,
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		name := req.Arguments[0]
 
@@ -230,7 +230,6 @@ var keyImportCmd = &cmds.Command{
 		cmds.StringArg("name", true, false, "name to associate with key in keychain"),
 		cmds.FileArg("key", true, false, "key provided by generate or export"),
 	},
-	PreRun: daemonNotRunning,
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		name := req.Arguments[0]
 
@@ -461,7 +460,7 @@ environment variable:
 		cmds.IntOption(keyStoreSizeOptionName, "s", "size of the key to generate"),
 	},
 	NoRemote: true,
-	PreRun:   daemonNotRunning,
+	PreRun:   DaemonNotRunning,
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		cctx := env.(*oldcmds.Context)
 		nBitsForKeypair, nBitsGiven := req.Options[keyStoreSizeOptionName].(int)
@@ -544,7 +543,9 @@ func keyOutputListEncoders() cmds.EncoderFunc {
 	})
 }
 
-func daemonNotRunning(req *cmds.Request, env cmds.Environment) error {
+// DaemonNotRunning checks to see if the ipfs repo is locked, indicating that
+// the daemon is running, and returns and error if the daemon is running.
+func DaemonNotRunning(req *cmds.Request, env cmds.Environment) error {
 	cctx := env.(*oldcmds.Context)
 	daemonLocked, err := fsrepo.LockedByOtherProcess(cctx.ConfigRoot)
 	if err != nil {

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -167,6 +167,24 @@ ipfs key rm key_ed25519
     test_must_fail ipfs key rename -f fooed self 2>&1 | tee key_rename_out &&
     grep -q "Error: cannot overwrite key with name" key_rename_out
   '
+
+  test_launch_ipfs_daemon
+
+  test_expect_success "online import rsa key" '
+    ipfs key import generated_rsa_key generated_rsa_key.key > roundtrip_rsa_key_id &&
+    test_cmp rsa_key_id roundtrip_rsa_key_id
+  '
+
+  test_must_fail "online export rsa key" '
+    ipfs key export generated_rsa_key
+  '
+
+  test_must_fail "online rotate rsa key" '
+    ipfs key rotate
+  '
+  
+  test_kill_ipfs_daemon
+
 }
 
 test_check_rsa2048_sk() {


### PR DESCRIPTION
Fixes Issue #7814

ipfs key commands that open the repo directly will not work when another process has the repo open and locked.  For this reason these commands cannot run when the ipfs daemon is running, and an informative error message should be given to the user.

This is already done for the `ipfs key rotate` command, and should be done for other commands that directly open and lock the repo.  This PR applies the same PreRun check to these commands as is used for `ipfs key rotate`.

While unlikely, it is possible to see the error reported if another process opens the repo at the same moment.  In that case the "someone else has the lock" error is shown.