### PR TITLE
docs: improved --help for pin remote commands

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -106,7 +106,7 @@ The above command will block until remote service returns 'pinned' status,
 which may take time depending on the size and available providers of the pinned
 data.
 
-If you prefer to not wait for pinning confirmation and return immediatelly
+If you prefer to not wait for pinning confirmation and return immediately
 after remote service confirms 'queued' status, add the '--background' flag:
 
   $ ipfs pin remote add --service=mysrv --name=mypin --background bafkqaaa
@@ -240,7 +240,7 @@ Returns a list of objects that are pinned to a remote pinning service.
 		LongDescription: `
 Returns a list of objects that are pinned to a remote pinning service.
 
-NOTE: by default it will only show matching objects in 'pinned' state.
+NOTE: By default, it will only show matching objects in 'pinned' state.
 Pass '--status=queued,pinning,pinned,failed' to list pins in all states.
 `,
 	},
@@ -248,8 +248,8 @@ Pass '--status=queued,pinning,pinned,failed' to list pins in all states.
 	Arguments: []cmds.Argument{},
 	Options: []cmds.Option{
 		pinServiceNameOption,
-		cmds.StringOption(pinNameOptionName, "Return pins with names that contain provided value (case-sensitive, exact match)."),
-		cmds.DelimitedStringsOption(",", pinCIDsOptionName, "Return pins for the specified CIDs (comma separated)."),
+		cmds.StringOption(pinNameOptionName, "Return pins with names that contain the value provided (case-sensitive, exact match)."),
+		cmds.DelimitedStringsOption(",", pinCIDsOptionName, "Return pins for the specified CIDs (comma-separated)."),
 		cmds.DelimitedStringsOption(",", pinStatusOptionName, "Return pins with the specified statuses (queued,pinning,pinned,failed).").WithDefault([]string{"pinned"}),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
@@ -325,11 +325,11 @@ func lsRemote(ctx context.Context, req *cmds.Request, c *pinclient.Client) (chan
 var rmRemotePinCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:          "Remove pins from remote pinning service.",
-		ShortDescription: "Removes the remote pin allowing it to be garbage collected if needed.",
+		ShortDescription: "Removes the remote pin, allowing it to be garbage-collected if needed.",
 		LongDescription: `
-Removes remote pins allowing them to be garbage collected if needed.
+Removes remote pins, allowing them to be garbage-collected if needed.
 
-This command accepts the same search query parameters as 'ls' and it is a good
+This command accepts the same search query parameters as 'ls', and it is good
 practice to execute 'ls' before 'rm' to confirm the list of pins to be removed.
 
 To remove a single pin for a specific CID:
@@ -337,14 +337,14 @@ To remove a single pin for a specific CID:
   $ ipfs pin remote ls --service=mysrv --cid=bafkqaaa
   $ ipfs pin remote rm --service=mysrv --cid=bafkqaaa
 
-When more than one pin is matching the query on the remote service an error is
-returned.  To confirm removal of multiple pins pass '--force':
+When more than one pin matches the query on the remote service, an error is
+returned.  To confirm the removal of multiple pins, pass '--force':
 
   $ ipfs pin remote ls --service=mysrv --name=popular-name
   $ ipfs pin remote rm --service=mysrv --name=popular-name --force
 
 NOTE: When no '--status' is passed, implicit '--status=pinned' is used.
-To list and then remove all pending pin requests pass an explicit status list:
+To list and then remove all pending pin requests, pass an explicit status list:
 
   $ ipfs pin remote ls --service=mysrv --status=queued,pinning,failed
   $ ipfs pin remote rm --service=mysrv --status=queued,pinning,failed --force
@@ -403,9 +403,9 @@ To list and then remove all pending pin requests pass an explicit status list:
 var addRemotePinServiceCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline:          "Add remote pinning service.",
-		ShortDescription: "Add a credentials for access to a remote pinning service.",
+		ShortDescription: "Add credentials for access to a remote pinning service.",
 		LongDescription: `
-Add a credentials for access to a remote pinning service and store them in the
+Add credentials for access to a remote pinning service and store them in the
 config under Pinning.RemoteServices map.
 
 TIP:
@@ -517,8 +517,8 @@ var lsRemotePinServiceCmd = &cmds.Command{
 		LongDescription: `
 List remote pinning services.
 
-By default only a name and an endpoint are listed, however one can pass '--stat'
-to test each endpoint by fetching pin counts for each state:
+By default, only a name and an endpoint are listed; however, one can pass
+'--stat' to test each endpoint by fetching pin counts for each state:
 
   $ ipfs pin remote service ls --stat
   goodsrv   https://pin-api.example.com 0/0/0/0

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -56,8 +56,9 @@ const pinNameOptionName = "name"
 const pinCIDsOptionName = "cid"
 const pinStatusOptionName = "status"
 const pinServiceNameOptionName = "service"
-const pinServiceEndpointOptionName = "endpoint"
-const pinServiceKeyOptionName = "key"
+const pinServiceNameArgName = pinServiceNameOptionName
+const pinServiceEndpointArgName = "endpoint"
+const pinServiceKeyArgName = "key"
 const pinServiceStatOptionName = "stat"
 const pinBackgroundOptionName = "background"
 const pinForceOptionName = "force"
@@ -119,7 +120,7 @@ Status of background pin requests can be inspected with the 'ls' command:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path-or-cid", true, false, "Path to object(s) to be pinned."),
+		cmds.StringArg("ipfs-path", true, false, "Path to object(s) to be pinned."),
 	},
 	Options: []cmds.Option{
 		pinServiceNameOption,
@@ -421,9 +422,9 @@ TIP:
 `,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg(pinServiceNameOptionName, true, false, "Service name."),
-		cmds.StringArg(pinServiceEndpointOptionName, true, false, "Service endpoint."),
-		cmds.StringArg(pinServiceKeyOptionName, true, false, "Service key."),
+		cmds.StringArg(pinServiceNameArgName, true, false, "Service name."),
+		cmds.StringArg(pinServiceEndpointArgName, true, false, "Service endpoint."),
+		cmds.StringArg(pinServiceKeyArgName, true, false, "Service key."),
 	},
 	Type: nil,
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {


### PR DESCRIPTION
> Part of https://github.com/ipfs/go-ipfs/issues/7559 and https://github.com/ipfs/go-ipfs/issues/7707 closes #7825

This PR adds docs in form of a longer description that is displayed when `--help` is passed on the CLI.
Those are pretty important, as CLI crowd often does not read docs online, and prefer to explore features this way. 

While at it, unified some language to match fields in the config file and other places (thx @Gozala!) + included some tips and best practices which should improve onboarding experience.

@jessicaschilling this falls under our effort to improve onboarding: lmk if anything sounds awkward, or we could rephrase to make it even more intuitive.

cc @ipfs/wg-pinning-services 



# `--help` previews

Below are previews of the initial version of this PR:

<details>
  <summary>Click to expand: ipfs pin remote service add --help</summary>

```
USAGE
  ipfs pin remote service add <service> <endpoint> <key> - Add remote pinning service.

SYNOPSIS
  ipfs pin remote service add [--] <service> <endpoint> <key>

ARGUMENTS

  <service>  - Service name.
  <endpoint> - Service endpoint.
  <key>      - Service key.

DESCRIPTION

  Add a credentials for access to a remote pinning service and store them in the
  config under Pinning.RemoteServices map.
  
  TIP:
  
    To add services and test them by fetching pin count stats:
  
    $ ipfs pin remote service add goodsrv https://pin-api.example.com secret-key
    $ ipfs pin remote service add badsrv  https://bad-api.example.com invalid-key
    $ ipfs pin remote service ls --stat
    goodsrv   https://pin-api.example.com 0/0/0/0
    badsrv    https://bad-api.example.com invalid
```
</details>

<details>
  <summary>Click to expand: ipfs pin remote service ls --help</summary>

```
USAGE
  ipfs pin remote service ls - List remote pinning services.

SYNOPSIS
  ipfs pin remote service ls [--stat]

OPTIONS

  --stat  bool - Try to fetch and display current pin count on remote service (queued/pinning/pinned/failed). Default: false.

DESCRIPTION

  List remote pinning services.
  
  By default only a name and an endpoint are listed, however one can pass '--stat'
  to test each endpoint by fetching pin counts for each state:
  
    $ ipfs pin remote service ls --stat
    goodsrv   https://pin-api.example.com 0/0/0/0
    badsrv    https://bad-api.example.com invalid
  
  TIP: pass '--enc=json' for more useful JSON output.
```
</details>

<details>
  <summary>Click to expand: ipfs pin remote add --help</summary>

```
USAGE
  ipfs pin remote add <ipfs-path-or-cid> - Pin object to remote pinning service.

SYNOPSIS
  ipfs pin remote add [--service=<service>] [--name=<name>] [--background] [--] <ipfs-path-or-cid>

ARGUMENTS

  <ipfs-path-or-cid> - Path to object(s) to be pinned.

OPTIONS

  --service     string - Name of the remote pinning service to use (mandatory).
  --name        string - An optional name for the pin.
  --background  bool   - Add to the queue on the remote service and return immediately (does not wait for pinned status). Default: false.

DESCRIPTION

  Asks remote pinning service to pin an IPFS object from a given path or a CID.
  
  To pin CID 'bafkqaaa' to service named 'mysrv' under a pin named 'mypin':
  
    $ ipfs pin remote add --service=mysrv --name=mypin bafkqaaa
  
  The above command will block until remote service returns 'pinned' status,
  which may take time depending on the size and available providers of the pinned
  data.
  
  If you prefer to not wait for pinning confirmation and return immediatelly
  after remote service confirms 'queued' status, add the '--background' flag:
  
    $ ipfs pin remote add --service=mysrv --name=mypin --background bafkqaaa
  
  Status of background pin requests can be inspected with the 'ls' command:
  
    $ ipfs pin remote ls --service=mysrv --cid=bafkqaaa --status=queued,pinning,pinned,failed

```
</details>


<details>
  <summary>Click to expand: ipfs pin remote ls --help</summary>

```
USAGE
  ipfs pin remote ls - List objects pinned to remote pinning service.

SYNOPSIS
  ipfs pin remote ls [--service=<service>] [--name=<name>] [--cid=<cid>]... [--status=<status>]...

OPTIONS

  --service  string - Name of the remote pinning service to use (mandatory).
  --name     string - Return pins with names that contain provided value (case-sensitive, exact match).
  --cid      array  - Return pins for the specified CIDs (comma separated).
  --status   array  - Return pins with the specified statuses (queued,pinning,pinned,failed). Default: [pinned].

DESCRIPTION

  Returns a list of objects that are pinned to a remote pinning service.
  
  NOTE: by default it will only show matching objects in 'pinned' state.
  Pass '--status=queued,pinning,pinned,failed' to list pins in all states
```
</details>



<details>
  <summary>Click to expand: ipfs pin remote rm --help</summary>

```
USAGE
  ipfs pin remote rm - Remove pins from remote pinning service.

SYNOPSIS
  ipfs pin remote rm [--service=<service>] [--name=<name>] [--cid=<cid>]... [--status=<status>]... [--force]

OPTIONS

  --service  string - Name of the remote pinning service to use (mandatory).
  --name     string - Remove pins with names that contain provided value (case-sensitive, exact match).
  --cid      array  - Remove pins for the specified CIDs.
  --status   array  - Remove pins with the specified statuses (queued,pinning,pinned,failed). Default: [pinned].
  --force    bool   - Allow removal of multiple pins matching the query without additional confirmation. Default: false.

DESCRIPTION

  Removes remote pins allowing them to be garbage collected if needed.
  
  This command accepts the same search query parameters as 'ls' and it is a good
  practice to execute 'ls' before 'rm' to confirm the list of pins to be removed.
  
  To remove a single pin for a specific CID:
  
    $ ipfs pin remote ls --service=mysrv --cid=bafkqaaa
    $ ipfs pin remote rm --service=mysrv --cid=bafkqaaa
  
  When more than one pin is matching the query on the remote service an error is
  returned.  To confirm removal of multiple pins pass '--force':
  
    $ ipfs pin remote ls --service=mysrv --name=popular-name
    $ ipfs pin remote rm --service=mysrv --name=popular-name --force
  
  NOTE: When no '--status' is passed, implicit '--status=pinned' is used.
  To list and then remove all pending pin requests pass an explicit status list:
  
    $ ipfs pin remote ls --service=mysrv --status=queued,pinning,failed
    $ ipfs pin remote rm --service=mysrv --status=queued,pinning,failed --force

```
</details>