### PR TITLE
fix: normalize remote service endpoint

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -740,7 +740,7 @@ func getRemotePinServiceInfo(env cmds.Environment, name string) (endpoint, key s
 
 func normalizeEndpoint(endpoint string) (string, error) {
 	uri, err := neturl.ParseRequestURI(endpoint)
-	if err != nil || !strings.HasPrefix(uri.Scheme, "http") {
+	if err != nil || !(uri.Scheme == "http" || uri.Scheme == "https") {
 		return "", fmt.Errorf("service endpoint must be a valid HTTP URL")
 	}
 

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -752,7 +752,7 @@ func normalizeEndpoint(endpoint string) (string, error) {
 	uri.Path = strings.TrimSuffix(uri.Path, "/")
 
 	// remove any query params
-	if uri.RawQuery != "" || uri.RawFragment != "" {
+	if uri.RawQuery != "" {
 		return "", fmt.Errorf("service endpoint should be provided without any query parameters")
 	}
 

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -444,13 +444,11 @@ TIP:
 		}
 
 		name := req.Arguments[0]
-		url := req.Arguments[1]
-		key := req.Arguments[2]
-
-		endpoint, err := normalizeEndpoint(url)
+		endpoint, err := normalizeEndpoint(req.Arguments[1])
 		if err != nil {
 			return err
 		}
+		key := req.Arguments[2]
 
 		cfg, err := repo.Config()
 		if err != nil {
@@ -705,18 +703,14 @@ func getRemotePinService(env cmds.Environment, name string) (*pinclient.Client, 
 	if name == "" {
 		return nil, fmt.Errorf("remote pinning service name not specified")
 	}
-	url, key, err := getRemotePinServiceInfo(env, name)
-	if err != nil {
-		return nil, err
-	}
-	endpoint, err := normalizeEndpoint(url)
+	endpoint, key, err := getRemotePinServiceInfo(env, name)
 	if err != nil {
 		return nil, err
 	}
 	return pinclient.NewClient(endpoint, key), nil
 }
 
-func getRemotePinServiceInfo(env cmds.Environment, name string) (url, key string, err error) {
+func getRemotePinServiceInfo(env cmds.Environment, name string) (endpoint, key string, err error) {
 	cfgRoot, err := cmdenv.GetConfigRoot(env)
 	if err != nil {
 		return "", "", err
@@ -737,7 +731,11 @@ func getRemotePinServiceInfo(env cmds.Environment, name string) (url, key string
 	if !present {
 		return "", "", fmt.Errorf("service not known")
 	}
-	return service.Api.Endpoint, service.Api.Key, nil
+	endpoint, err = normalizeEndpoint(service.Api.Endpoint)
+	if err != nil {
+		return "", "", err
+	}
+	return endpoint, service.Api.Key, nil
 }
 
 func normalizeEndpoint(endpoint string) (string, error) {

--- a/core/commands/pin/remotepin_test.go
+++ b/core/commands/pin/remotepin_test.go
@@ -22,16 +22,26 @@ func TestNormalizeEndpoint(t *testing.T) {
 		},
 		{
 			in:  "https://3.example.com/pins/",
-			err: "",
-			out: "https://3.example.com",
+			err: "service endpoint should be provided without the /pins suffix",
+			out: "",
 		},
 		{
 			in:  "https://4.example.com/pins",
-			err: "",
-			out: "https://4.example.com",
+			err: "service endpoint should be provided without the /pins suffix",
+			out: "",
 		},
 		{
-			in:  "http://192.168.0.5:45000/pins",
+			in:  "https://5.example.com/./some//nonsense/../path/../path/",
+			err: "",
+			out: "https://5.example.com/some/path",
+		},
+		{
+			in:  "https://6.example.com/endpoint/?query=val",
+			err: "service endpoint should be provided without any query parameters",
+			out: "",
+		},
+		{
+			in:  "http://192.168.0.5:45000/",
 			err: "",
 			out: "http://192.168.0.5:45000",
 		},
@@ -44,12 +54,12 @@ func TestNormalizeEndpoint(t *testing.T) {
 
 	for _, tc := range cases {
 		out, err := normalizeEndpoint(tc.in)
-		if out != tc.out {
-			t.Errorf("unexpected endpoint for %q: expected %q; got %q", tc.in, tc.out, out)
-			continue
-		}
 		if err != nil && tc.err != err.Error() {
 			t.Errorf("unexpected error for %q: expected %q; got %q", tc.in, tc.err, err)
+			continue
+		}
+		if out != tc.out {
+			t.Errorf("unexpected endpoint for %q: expected %q; got %q", tc.in, tc.out, out)
 			continue
 		}
 	}

--- a/core/commands/pin/remotepin_test.go
+++ b/core/commands/pin/remotepin_test.go
@@ -1,0 +1,57 @@
+package pin
+
+import (
+	"testing"
+)
+
+func TestNormalizeEndpoint(t *testing.T) {
+	cases := []struct {
+		in  string
+		err string
+		out string
+	}{
+		{
+			in:  "https://1.example.com",
+			err: "",
+			out: "https://1.example.com",
+		},
+		{
+			in:  "https://2.example.com/",
+			err: "",
+			out: "https://2.example.com",
+		},
+		{
+			in:  "https://3.example.com/pins/",
+			err: "",
+			out: "https://3.example.com",
+		},
+		{
+			in:  "https://4.example.com/pins",
+			err: "",
+			out: "https://4.example.com",
+		},
+		{
+			in:  "http://192.168.0.5:45000/pins",
+			err: "",
+			out: "http://192.168.0.5:45000",
+		},
+		{
+			in:  "foo://4.example.com/pins",
+			err: "service endpoint must be a valid HTTP URL",
+			out: "",
+		},
+	}
+
+	for _, tc := range cases {
+		out, err := normalizeEndpoint(tc.in)
+		if out != tc.out {
+			t.Errorf("unexpected endpoint for %q: expected %q; got %q", tc.in, tc.out, out)
+			continue
+		}
+		if err != nil && tc.err != err.Error() {
+			t.Errorf("unexpected error for %q: expected %q; got %q", tc.in, tc.err, err)
+			continue
+		}
+	}
+
+}

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -37,6 +37,12 @@ test_expect_success "creating test user on remote pinning service" '
   ipfs pin remote service add test_invalid_url_dns_svc https://invalid-service.example.com fake_api_key
 '
 
+# add a service with a invalid endpoint
+test_expect_success "adding remote service with invalid endpoint" '
+  test_expect_code 1 ipfs pin remote service add test_endpoint_no_protocol invalid-service.example.com fake_api_key &&
+  test_expect_code 1 ipfs pin remote service add test_endpoint_bad_protocol xyz://invalid-service.example.com fake_api_key
+'
+
 test_expect_success "test 'ipfs pin remote service ls'" '
   ipfs pin remote service ls | tee ls_out &&
   grep -q test_pin_svc ls_out &&


### PR DESCRIPTION
> Closes #7826 reported by @gozala, needed for 0.8.0 (#7707)

This PR adds URI normalization for HTTP-based remote pinning service endpoint and applies it:
1. before endpoint is stored in  `$IPFS_PATH/config` (when user adds via `pin remote service add`)
2. after endpoint is read from config (in case someone entered it up manually)

ps. alternative approach is to address this upstream in [go-pinning-service-http-client](https://github.com/ipfs/go-pinning-service-http-client), but by doing it in `pin remote` command code we ensure invalid/malformed URIs are not saved to the config file, which is a better UX.