### PR TITLE
fix: remote services ls always return a list

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -486,7 +486,7 @@ var lsRemotePinServiceCmd = &cmds.Command{
 			return err
 		}
 		if cfg.Pinning.RemoteServices == nil {
-			return nil // no pinning services added yet
+			return cmds.EmitOnce(res, &PinServicesList{make([]ServiceDetails, 0)})
 		}
 		services := cfg.Pinning.RemoteServices
 		result := PinServicesList{make([]ServiceDetails, 0, len(services))}

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -20,6 +20,14 @@ TEST_PIN_SVC_KEY=$(curl -s -X POST "$TEST_PIN_SVC/users" -d email="go-ipfs-sharn
 
 # pin remote service  add|ls|rm
 
+# confirm empty service list response has proper json struct
+# https://github.com/ipfs/go-ipfs/pull/7829
+test_expect_success "test 'ipfs pin remote service ls' JSON on empty list" '
+  ipfs pin remote service ls --stat --enc=json | tee empty_ls_out &&
+  echo "{\"RemoteServices\":[]}" > exp_ls_out &&
+  test_cmp exp_ls_out empty_ls_out
+'
+
 # add valid and invalid services
 test_expect_success "creating test user on remote pinning service" '
   echo CI host IP address ${TEST_PIN_SVC} &&


### PR DESCRIPTION
> Closes #7824 cc @Gozala needed for 0.8.0 (#7707)


This PR ensures `ipfs pin remote service ls --enc=json`returns a valid JSON with an empty list, even when `Pinning.RemoteServices` is missing from the config (eg. right after `ipfs init`, before any services are added/removed)

```console
$ ipfs pin remote service ls --stat --enc=json
{"RemoteServices":[]}
```