### PR TITLE
Escape non-printable characters in user output

### DIFF
--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -353,7 +353,7 @@ only-hash, and progress/status related flags) will change the final hash.
 							if quiet {
 								fmt.Fprintf(os.Stdout, "%s\n", output.Hash)
 							} else {
-								fmt.Fprintf(os.Stdout, "added %s %s\n", output.Hash, output.Name)
+								fmt.Fprintf(os.Stdout, "added %s %s\n", output.Hash, cmdenv.EscNonPrint(output.Name))
 							}
 
 						} else {

--- a/core/commands/cmdenv/env.go
+++ b/core/commands/cmdenv/env.go
@@ -72,10 +72,11 @@ func GetConfigRoot(env cmds.Environment) (string, error) {
 	return ctx.ConfigRoot, nil
 }
 
-// EscNonPrint converts non-printable characters and backslash into Go
-// escape sequences, if the given string contains any.
+// EscNonPrint converts non-printable characters and backslash into Go escape
+// sequences.  This is done to display all characters in a string, including
+// those that would otherwise not be displayed or have an undesirable effect on
+// the display.
 func EscNonPrint(s string) string {
-	// First see if escaping is needed, to avoid creating garbage.
 	if !needEscape(s) {
 		return s
 	}

--- a/core/commands/cmdenv/env.go
+++ b/core/commands/cmdenv/env.go
@@ -72,13 +72,27 @@ func GetConfigRoot(env cmds.Environment) (string, error) {
 	return ctx.ConfigRoot, nil
 }
 
-// EscNonPrint converts control characters and non-printable characters into Go
+// EscNonPrint converts non-printable characters and backslash into Go
 // escape sequences, if the given string contains any.
 func EscNonPrint(s string) string {
+	// First see if escaping is needed, to avoid creating garbage.
+	if !needEscape(s) {
+		return s
+	}
+
+	esc := strconv.Quote(s)
+	// Remove first and last quote, and unescape quotes.
+	return strings.ReplaceAll(esc[1:len(esc)-1], `\"`, `"`)
+}
+
+func needEscape(s string) bool {
+	if strings.ContainsRune(s, '\\') {
+		return true
+	}
 	for _, r := range s {
 		if !strconv.IsPrint(r) {
-			return strings.Trim(strconv.Quote(s), "\"")
+			return true
 		}
 	}
-	return s
+	return false
 }

--- a/core/commands/cmdenv/env.go
+++ b/core/commands/cmdenv/env.go
@@ -2,6 +2,7 @@ package cmdenv
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ipfs/go-ipfs/commands"
@@ -69,4 +70,15 @@ func GetConfigRoot(env cmds.Environment) (string, error) {
 	}
 
 	return ctx.ConfigRoot, nil
+}
+
+// EscNonPrint converts control characters and non-printable characters into Go
+// escape sequences, if the given string contains any.
+func EscNonPrint(s string) string {
+	for _, r := range s {
+		if !strconv.IsPrint(r) {
+			return strings.Trim(strconv.Quote(s), "\"")
+		}
+	}
+	return s
 }

--- a/core/commands/cmdenv/env_test.go
+++ b/core/commands/cmdenv/env_test.go
@@ -1,0 +1,48 @@
+package cmdenv
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestEscNonPrint(t *testing.T) {
+	b := []byte("hello")
+	b[2] = 0x7f
+	s := string(b)
+	if !needEscape(s) {
+		t.Fatal("string needs escaping")
+	}
+	if !hasNonPrintable(s) {
+		t.Fatal("expected non-printable")
+	}
+	if hasNonPrintable(EscNonPrint(s)) {
+		t.Fatal("escaped string has non-printable")
+	}
+	if EscNonPrint(`hel\lo`) != `hel\\lo` {
+		t.Fatal("backslash not escaped")
+	}
+
+	s = `hello`
+	if needEscape(s) {
+		t.Fatal("string does not need escaping")
+	}
+	if EscNonPrint(s) != s {
+		t.Fatal("string should not have changed")
+	}
+	s = `"hello"`
+	if EscNonPrint(s) != s {
+		t.Fatal("string should not have changed")
+	}
+	if EscNonPrint(`"hel\"lo"`) != `"hel\\"lo"` {
+		t.Fatal("did not get expected escaped string")
+	}
+}
+
+func hasNonPrintable(s string) bool {
+	for _, r := range s {
+		if !strconv.IsPrint(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	ncmd "github.com/ipfs/go-ipfs/core/commands/name"
 	namesys "github.com/ipfs/go-ipfs/namesys"
 	nsopts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
@@ -77,7 +78,7 @@ The resolver can recursively resolve:
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *ncmd.ResolvedPath) error {
-			fmt.Fprintln(w, out.Path.String())
+			fmt.Fprintln(w, cmdenv.EscNonPrint(out.Path.String()))
 			return nil
 		}),
 	},

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -383,9 +383,9 @@ var keyRenameCmd = &cmds.Command{
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, kro *KeyRenameOutput) error {
 			if kro.Overwrite {
-				fmt.Fprintf(w, "Key %s renamed to %s with overwriting\n", kro.Id, kro.Now)
+				fmt.Fprintf(w, "Key %s renamed to %s with overwriting\n", kro.Id, cmdenv.EscNonPrint(kro.Now))
 			} else {
-				fmt.Fprintf(w, "Key %s renamed to %s\n", kro.Id, kro.Now)
+				fmt.Fprintf(w, "Key %s renamed to %s\n", kro.Id, cmdenv.EscNonPrint(kro.Now))
 			}
 			return nil
 		}),
@@ -547,9 +547,9 @@ func keyOutputListEncoders() cmds.EncoderFunc {
 		tw := tabwriter.NewWriter(w, 1, 2, 1, ' ', 0)
 		for _, s := range list.Keys {
 			if withID {
-				fmt.Fprintf(tw, "%s\t%s\t\n", s.Id, s.Name)
+				fmt.Fprintf(tw, "%s\t%s\t\n", s.Id, cmdenv.EscNonPrint(s.Name))
 			} else {
-				fmt.Fprintf(tw, "%s\n", s.Name)
+				fmt.Fprintf(tw, "%s\n", cmdenv.EscNonPrint(s.Name))
 			}
 		}
 		tw.Flush()

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -251,7 +251,7 @@ func tabularOutput(req *cmds.Request, w io.Writer, out *LsOutput, lastObjectHash
 				}
 			}
 
-			fmt.Fprintf(tw, s, link.Hash, link.Size, link.Name)
+			fmt.Fprintf(tw, s, link.Hash, link.Size, cmdenv.EscNonPrint(link.Name))
 		}
 	}
 	tw.Flush()

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -119,8 +119,8 @@ baz
 	Type: config.Mounts{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, mounts *config.Mounts) error {
-			fmt.Fprintf(w, "IPFS mounted at: %s\n", mounts.IPFS)
-			fmt.Fprintf(w, "IPNS mounted at: %s\n", mounts.IPNS)
+			fmt.Fprintf(w, "IPFS mounted at: %s\n", cmdenv.EscNonPrint(mounts.IPFS))
+			fmt.Fprintf(w, "IPNS mounted at: %s\n", cmdenv.EscNonPrint(mounts.IPNS))
 
 			return nil
 		}),

--- a/core/commands/name/publish.go
+++ b/core/commands/name/publish.go
@@ -154,7 +154,7 @@ Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by
 			if quieter {
 				_, err = fmt.Fprintln(w, cmdenv.EscNonPrint(ie.Name))
 			} else {
-				_, err = fmt.Fprintf(w, "Published to %s: %s\n", cmdenv.EscNonPrint(ie.Name), ie.Value)
+				_, err = fmt.Fprintf(w, "Published to %s: %s\n", cmdenv.EscNonPrint(ie.Name), cmdenv.EscNonPrint(ie.Value))
 			}
 			return err
 		}),

--- a/core/commands/name/publish.go
+++ b/core/commands/name/publish.go
@@ -152,9 +152,9 @@ Alternatively, publish an <ipfs-path> using a valid PeerID (as listed by
 			var err error
 			quieter, _ := req.Options[quieterOptionName].(bool)
 			if quieter {
-				_, err = fmt.Fprintln(w, ie.Name)
+				_, err = fmt.Fprintln(w, cmdenv.EscNonPrint(ie.Name))
 			} else {
-				_, err = fmt.Fprintf(w, "Published to %s: %s\n", ie.Name, ie.Value)
+				_, err = fmt.Fprintf(w, "Published to %s: %s\n", cmdenv.EscNonPrint(ie.Name), ie.Value)
 			}
 			return err
 		}),

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -167,7 +167,7 @@ multihash.
 				fmt.Fprintln(tw, "Hash\tSize\tName")
 			}
 			for _, link := range out.Links {
-				fmt.Fprintf(tw, "%s\t%v\t%s\n", link.Hash, link.Size, link.Name)
+				fmt.Fprintf(tw, "%s\t%v\t%s\n", link.Hash, link.Size, cmdenv.EscNonPrint(link.Name))
 			}
 			tw.Flush()
 

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -254,7 +254,7 @@ Returns a list of objects that are pinned to a remote pinning service.
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *RemotePinOutput) error {
 			// pin remote ls produces a flat output similar to legacy pin ls
-			fmt.Fprintf(w, "%s\t%s\t%s\n", out.Cid, out.Status, out.Name)
+			fmt.Fprintf(w, "%s\t%s\t%s\n", out.Cid, out.Status, cmdenv.EscNonPrint(out.Name))
 			return nil
 		}),
 	},

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -205,7 +205,7 @@ To use, the daemon must be run with '--enable-pubsub-experiment'.
 
 func stringListEncoder(req *cmds.Request, w io.Writer, list *stringList) error {
 	for _, str := range list.Strings {
-		_, err := fmt.Fprintf(w, "%s\n", str)
+		_, err := fmt.Fprintf(w, "%s\n", cmdenv.EscNonPrint(str))
 		if err != nil {
 			return err
 		}

--- a/core/commands/unixfs/ls.go
+++ b/core/commands/unixfs/ls.go
@@ -213,12 +213,12 @@ If possible, please use 'ipfs ls' instead.
 				if len(out.Arguments) > 1 {
 					for _, arg := range directories[i:] {
 						if out.Arguments[arg] == hash {
-							fmt.Fprintf(tw, "%s:\n", arg)
+							fmt.Fprintf(tw, "%s:\n", cmdenv.EscNonPrint(arg))
 						}
 					}
 				}
 				for _, link := range object.Links {
-					fmt.Fprintf(tw, "%s\n", link.Name)
+					fmt.Fprintf(tw, "%s\n", cmdenv.EscNonPrint(link.Name))
 				}
 			}
 			tw.Flush()

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -19,6 +19,7 @@ test_ls_cmd() {
     random 128 42 >testData/d1/128 &&
     echo "world" >testData/d2/a &&
     random 1024 42 >testData/d2/1024 &&
+    echo "badname" >testData/d2/`echo -e "bad\x7fname.txt"` &&
     ipfs add -r testData >actual_add
   '
 
@@ -28,30 +29,32 @@ added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
 added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
 added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
 added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
+added QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn testData/d2/bad\u007fname.txt
 added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
 added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
 added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
-added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
-added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
+added Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy testData/d2
+added QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 testData
 EOF
     test_cmp expected_add actual_add
   '
 
   test_expect_success "'ipfs ls <three dir hashes>' succeeds" '
-    ipfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+    ipfs ls QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
   '
 
   test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss - d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy - d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy - d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5 f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5 f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6    a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8    bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128 128
@@ -61,20 +64,21 @@ EOF
   '
 
   test_expect_success "'ipfs ls --size=false <three dir hashes>' succeeds" '
-    ipfs ls --size=false QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
+    ipfs ls --size=false QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
   '
 
   test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128
@@ -84,22 +88,23 @@ EOF
   '
 
   test_expect_success "'ipfs ls --headers <three dir hashes>' succeeds" '
-    ipfs ls --headers QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_headers
+    ipfs ls --headers QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_headers
   '
 
   test_expect_success "'ipfs ls --headers  <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_headers &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 Hash                                           Size Name
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -    d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy -    d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -    d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5    f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5    f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 Hash                                           Size Name
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6    a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8    bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 Hash                                           Size Name
@@ -110,7 +115,7 @@ EOF
   '
 
   test_expect_success "'ipfs ls --size=false --cid-base=base32 <three dir hashes>' succeeds" '
-    ipfs ls --size=false --cid-base=base32 $(cid-fmt -v 1 -b base32 %s QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss) >actual_ls_base32
+    ipfs ls --size=false --cid-base=base32 $(cid-fmt -v 1 -b base32 %s QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss) >actual_ls_base32
   '
 
   test_expect_success "'ipfs ls --size=false --cid-base=base32 <three dir hashes>' output looks good" '
@@ -130,6 +135,7 @@ test_ls_cmd_streaming() {
     random 128 42 >testData/d1/128 &&
     echo "world" >testData/d2/a &&
     random 1024 42 >testData/d2/1024 &&
+    echo "badname" >testData/d2/`echo -e "bad\x7fname.txt"` &&
     ipfs add -r testData >actual_add
   '
 
@@ -139,30 +145,32 @@ added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
 added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
 added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
 added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
+added QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn testData/d2/bad\u007fname.txt
 added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
 added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
 added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
-added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
-added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
+added Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy testData/d2
+added QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 testData
 EOF
     test_cmp expected_add actual_add
   '
 
   test_expect_success "'ipfs ls --stream <three dir hashes>' succeeds" '
-    ipfs ls --stream QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
+    ipfs ls --stream QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --stream <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -         d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy -         d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -         d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5         f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5         f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024      1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6         a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8         bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128       128
@@ -172,20 +180,21 @@ EOF
   '
 
   test_expect_success "'ipfs ls --size=false --stream <three dir hashes>' succeeds" '
-    ipfs ls --size=false --stream QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
+    ipfs ls --size=false --stream QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream
   '
 
   test_expect_success "'ipfs ls --size=false --stream <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 128
@@ -195,22 +204,23 @@ EOF
   '
 
   test_expect_success "'ipfs ls --stream --headers <three dir hashes>' succeeds" '
-    ipfs ls --stream --headers QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream_headers
+    ipfs ls --stream --headers QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21 Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls_stream_headers
   '
 
   test_expect_success "'ipfs ls --stream --headers  <three dir hashes>' output looks good" '
     cat <<-\EOF >expected_ls_stream_headers &&
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+QmRPX2PWaPGqzoVzqNcQkueijHVzPicjupnD7eLck6Rs21:
 Hash                                           Size      Name
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss -         d1/
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy -         d2/
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy -         d2/
 QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 5         f1
 QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 5         f2
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Qmf9nCpkCfa8Gtz5m1NJMeHBWcBozKRcbdom338LukPAjy:
 Hash                                           Size      Name
 QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1024      1024
 QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 6         a
+QmQSLRRd1Lxn6NMsWmmj2g9W3LtSRfmVAVqU3ShneLUrbn 8         bad\u007fname.txt
 
 QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
 Hash                                           Size      Name


### PR DESCRIPTION
Replaces control characters and non-printable characters with escape sequences, in any fields that are printed by the CLI, which could have been user input.

Output from `ipfs cat` is unchanged.