### PR TITLE
feat(gw): DNSLink names on https:// subdomains

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -414,7 +414,7 @@ func toDNSLabel(rootID string, rootCID cid.Cid) (dnsCID string, err error) {
 }
 
 // Returns true if HTTP request involves TLS certificate.
-// See https://github.com/ipfs/in-web-browsers/issues/169 to uderstand how it
+// See https://github.com/ipfs/in-web-browsers/issues/169 to understand how it
 // impacts DNSLink websites on public gateways.
 func isHTTPSRequest(r *http.Request) bool {
 	// X-Forwarded-Proto if added by a reverse proxy

--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -209,11 +209,14 @@ func HostnameOption() ServeOption {
 					// TLS cert if represented as a single DNS label:
 					// https://my-v--long-example-com.ipns.dweb.link
 					if ns == "ipns" && !strings.Contains(rootID, ".") {
-						// my-v--long-example-com → my.v-long.example.com
-						dnslinkFQDN := toDNSLinkFQDN(rootID)
-						if isDNSLinkName(r.Context(), coreAPI, dnslinkFQDN) {
-							// update path prefix to use real FQDN with DNSLink
-							pathPrefix = "/ipns/" + dnslinkFQDN
+						// if there is no TXT recordfor rootID
+						if !isDNSLinkName(r.Context(), coreAPI, rootID) {
+							// my-v--long-example-com → my.v-long.example.com
+							dnslinkFQDN := toDNSLinkFQDN(rootID)
+							if isDNSLinkName(r.Context(), coreAPI, dnslinkFQDN) {
+								// update path prefix to use real FQDN with DNSLink
+								pathPrefix = "/ipns/" + dnslinkFQDN
+							}
 						}
 					}
 				}

--- a/core/corehttp/hostname_test.go
+++ b/core/corehttp/hostname_test.go
@@ -106,6 +106,9 @@ func TestIsHTTPSRequest(t *testing.T) {
 	httpsRequest := httptest.NewRequest("GET", "https://https-request-stub.example.com", nil)
 	httpsProxiedRequest := httptest.NewRequest("GET", "http://proxied-https-request-stub.example.com", nil)
 	httpsProxiedRequest.Header.Set("X-Forwarded-Proto", "https")
+	httpProxiedRequest := httptest.NewRequest("GET", "http://proxied-http-request-stub.example.com", nil)
+	httpProxiedRequest.Header.Set("X-Forwarded-Proto", "http")
+	oddballRequest := httptest.NewRequest("GET", "foo://127.0.0.1:8080", nil)
 	for _, test := range []struct {
 		in  *http.Request
 		out bool
@@ -113,6 +116,8 @@ func TestIsHTTPSRequest(t *testing.T) {
 		{httpRequest, false},
 		{httpsRequest, true},
 		{httpsProxiedRequest, true},
+		{httpProxiedRequest, false},
+		{oddballRequest, false},
 	} {
 		out := isHTTPSRequest(test.in)
 		if out != test.out {

--- a/docs/config.md
+++ b/docs/config.md
@@ -709,8 +709,9 @@ Below is a list of the most common public gateway setups.
    ```
    **Backward-compatible:** this feature enables automatic redirects from content paths to subdomains:  
    `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.dweb.link`  
-   **X-Forwarded-Proto:** if you run go-ipfs behind a reverse proxy that provides TLS, make it add a `X-Forwarded-Proto: https` HTTP header to ensure users are redirected to `https://`, not `http://`. The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`.:    
+   **X-Forwarded-Proto:** if you run go-ipfs behind a reverse proxy that provides TLS, make it add a `X-Forwarded-Proto: https` HTTP header to ensure users are redirected to `https://`, not `http://`. It will also ensure DNSLink names are inlined to fit in a single DNS label, so they work fine with a wildcart TLS cert ([details](https://github.com/ipfs/in-web-browsers/issues/169)). The NGINX directive is `proxy_set_header X-Forwarded-Proto "https";`.:    
    `http://dweb.link/ipfs/{cid}` → `https://{cid}.ipfs.dweb.link`  
+   `http://dweb.link/ipns/your-dnslink.site.example.com` → `https://your--dnslink-site-example-com.ipfs.dweb.link`  
    **X-Forwarded-Host:** we also support `X-Forwarded-Host: example.com` if you want to override subdomain gateway host from the original request:
    `http://dweb.link/ipfs/{cid}` → `http://{cid}.ipfs.example.com`
    


### PR DESCRIPTION
>  Closes https://github.com/ipfs/in-web-browsers/issues/169, Closes https://github.com/ipfs/in-web-browsers/issues/174
>  cc @aschmahmann  @autonome @gozala @gmasgras @mburns 

>  :point_right:  I marked this as P0 because we want `dweb.link` to run this patch  when support for `ipns://{dnslink-name}` resolution lands in Brave stable  (https://github.com/brave/brave-browser/issues/10220). Without it, onboarding will include the TLS error, which is really bad UX. Ideally, we would include this  in 0.8 (https://github.com/ipfs/go-ipfs/issues/7707).

# TLDR

This PR enables users of public gateways to load DNSlink websites without TLS error described in https://github.com/ipfs/in-web-browsers/issues/169.

It not only makes DNSLink websites more resilient, but makes it easier to resolve `ipns://` URIs in Opera Mobile and Brave (when a public gateway is selected as a resolution method).

# Details


* This PR enables public subdomain gateways such as `dweb.link` to provide DNSLink hosting service over HTTPS with a 
standard single-level-wildcard TLS certificate.
  * Detailed problem statement and rationale for doing this can be found in https://github.com/ipfs/in-web-browsers/issues/169 
    * This PR implements "Option C" in a way that works with existing single-level-wildcard TLS certs present on the web 
    * Subdomain gateway will redirect to inlined DNSlink name only when `X-Forwarded-Proto: https`  is present (opt-in made by gateway operator), no additional configuration is needed.


## How DNSlink name inlining works

Below is a real life example of a DNSlink name inlined into a single DNS label that works with a wildcard TLS cert for `*.ipns.dweb.link`:

`/ipns/en.wikipedia-on-ipfs.org` →
`ipns://en.wikipedia-on-ipfs.org`  →
`https://dweb.link/ipns/en.wikipedia-on-ipfs.org` 
`https://en-wikipedia--on--ipfs-org.ipns.dweb.link` :point_left: _a single DNS label, no TLS error_

## Use cases fixed by this PR

* User wants to load `my.v-long.example.com` but the original HTTP server is down. The hostname has DNSLink set up.
User should be able to load website not only from a local gateway, but any public one.
* User of **Brave** [who does not run local node] or user of  **Opera Mobile** tries resolve `ipns://` URIs using public gateway (eg. `dweb.link`). 
  * This PR enables page load via a public gateways: `ipns://my.v-long.example.com`  → `https://dweb.link/ipns/my.v-long.example.com` → (HTTP 301) → `https://my-v--long-example-com.ipns.dweb.link`


