### PR TITLE
fix: replace pre-existing pins for MFS root

### DIFF
--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -93,7 +93,7 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 			// get the most recent MFS root cid
 			rootNode, err := node.RootNode()
 			if err != nil {
-				log.Errorf("pinning reading mfs root (%v)", err)
+				log.Errorf("pinning reading MFS root (%v)", err)
 				select {
 				case errCh <- err:
 				case <-cctx.Context().Done():
@@ -123,7 +123,7 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 					if err != nil {
 						log.Errorf("pinning parsing service %s repin interval %q", svcName, svcConfig.Policies.MFS.RepinInterval)
 						select {
-						case errCh <- fmt.Errorf("remote pinning service %s has invalid mfs pin interval (%v)", svcName, err):
+						case errCh <- fmt.Errorf("remote pinning service %s has invalid MFS.RepinInterval (%v)", svcName, err):
 						case <-cctx.Context().Done():
 							return
 						}
@@ -135,13 +135,13 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 				// do nothing, if MFS has not changed since last pin on the exact same service
 				if last, ok := lastPins[svcName]; ok {
 					if last.ServiceConfig == svcConfig && last.CID == rootCid && time.Since(last.Time) < repinInterval {
-						log.Infof("pinning mfs was pinned to %s recently, skipping", svcName)
+						log.Infof("pinning MFS was pinned to %s recently, skipping", svcName)
 						ch <- lastPin{}
 						continue
 					}
 				}
 
-				log.Infof("pinning mfs root %s to %s", rootCid, svcName)
+				log.Infof("pinning MFS root %s to %s", rootCid, svcName)
 				go func() {
 					if r, err := pinMFS(cctx.Context(), node, rootCid, svcName, svcConfig, errCh); err != nil {
 						ch <- lastPin{}
@@ -180,6 +180,7 @@ func pinMFS(
 	for ps := range lsPinCh {
 		if ps.GetPin().GetCid() == cid {
 			pinFound = true
+			break
 		}
 	}
 	if err := <-lsErrCh; err != nil {

--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -198,7 +198,7 @@ func pinMFS(
 	// CID of the current MFS root is already pinned, nothing to do
 	if alreadyPinned {
 		log.Infof("pinning MFS to %s: pin for %s already exists, skipping", svcName, cid)
-		return lastPin{}, nil
+		return lastPin{Time: time.Now(), ServiceName: svcName, ServiceConfig: svcConfig, CID: cid}, nil
 	}
 
 	// Prepare Pin.name

--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -134,7 +134,7 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 
 				// do nothing, if MFS has not changed since last pin on the exact same service
 				if last, ok := lastPins[svcName]; ok {
-					if last.ServiceConfig == svcConfig && last.CID == rootCid && time.Since(last.Time) < repinInterval {
+					if last.ServiceConfig == svcConfig && (last.CID == rootCid || time.Since(last.Time) < repinInterval) {
 						log.Infof("pinning MFS root to %s: %s was pinned recently, skipping", svcName, rootCid)
 						ch <- lastPin{}
 						continue

--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -182,7 +182,7 @@ func pinMFS(
 	for ps := range lsPinCh {
 		existingRequestID = ps.GetRequestId()
 		if ps.GetPin().GetCid() == cid {
-			alreadyPinned = true
+			alreadyPinned = ps.GetStatus() != pinclient.StatusFailed
 			break
 		}
 	}

--- a/cmd/ipfs/pinmfs_test.go
+++ b/cmd/ipfs/pinmfs_test.go
@@ -144,7 +144,7 @@ func TestPinMFSService(t *testing.T) {
 			},
 		},
 	}
-	testPinMFSServiceWithError(t, cfg_invalid_interval, "remote pinning service invalid_interval has invalid mfs pin interval")
+	testPinMFSServiceWithError(t, cfg_invalid_interval, "remote pinning service invalid_interval has invalid MFS.RepinInterval")
 	testPinMFSServiceWithError(t, cfg_valid_unnamed, "error while listing remote pins: empty response from remote pinning service")
 	testPinMFSServiceWithError(t, cfg_valid_named, "error while listing remote pins: empty response from remote pinning service")
 }

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -39,13 +39,13 @@ test_expect_success "test 'ipfs pin remote service ls'" '
 '
 
 test_expect_success "test enabling mfs pinning" '
-  ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval \"30s\" &&
+  ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval \"15s\" &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.PinName \"mfs_test_pin\" &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.Enable true &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval > repin_interval &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.PinName > pin_name &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.Enable > enable &&
-  echo 30s > expected_repin_interval &&
+  echo 15s > expected_repin_interval &&
   echo mfs_test_pin > expected_pin_name &&
   echo true > expected_enable &&
   test_cmp repin_interval expected_repin_interval &&
@@ -53,11 +53,12 @@ test_expect_success "test enabling mfs pinning" '
   test_cmp enable expected_enable
 '
 
-test_expect_success "verify mfs is being pinned" '
+test_expect_success "verify MFS root is being pinned" '
+  ipfs files cp /ipfs/bafkqaaa /mfs-pinning-test-$(date +%s.%N) &&
   sleep 60 &&
   ipfs files stat / --enc=json | jq -r .Hash > mfs_cid &&
-  ipfs pin remote ls --service=test_pin_mfs_svc --name=mfs_test_pin --enc=json | jq -r .Cid > pin_cid &&
-  cat mfs_cid pin_cid &&
+  ipfs pin remote ls --service=test_pin_mfs_svc --name=mfs_test_pin --status=queued,pinning,pinned,failed --enc=json | tee ls_out | jq -r .Cid > pin_cid &&
+  cat mfs_cid ls_out &&
   test_cmp mfs_cid pin_cid
 '
 

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -39,13 +39,13 @@ test_expect_success "test 'ipfs pin remote service ls'" '
 '
 
 test_expect_success "test enabling mfs pinning" '
-  ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval \"15s\" &&
+  ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval \"10s\" &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.PinName \"mfs_test_pin\" &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.Enable true &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.RepinInterval > repin_interval &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.PinName > pin_name &&
   ipfs config --json Pinning.RemoteServices.test_pin_mfs_svc.Policies.MFS.Enable > enable &&
-  echo 15s > expected_repin_interval &&
+  echo 10s > expected_repin_interval &&
   echo mfs_test_pin > expected_pin_name &&
   echo true > expected_enable &&
   test_cmp repin_interval expected_repin_interval &&
@@ -53,9 +53,22 @@ test_expect_success "test enabling mfs pinning" '
   test_cmp enable expected_enable
 '
 
+# expect PIN to be created
 test_expect_success "verify MFS root is being pinned" '
   ipfs files cp /ipfs/bafkqaaa /mfs-pinning-test-$(date +%s.%N) &&
-  sleep 60 &&
+  ipfs files flush &&
+  sleep 31 &&
+  ipfs files stat / --enc=json | jq -r .Hash > mfs_cid &&
+  ipfs pin remote ls --service=test_pin_mfs_svc --name=mfs_test_pin --status=queued,pinning,pinned,failed --enc=json | tee ls_out | jq -r .Cid > pin_cid &&
+  cat mfs_cid ls_out &&
+  test_cmp mfs_cid pin_cid
+'
+
+# expect existing PIN to be replaced
+test_expect_success "verify MFS root is being repinned on CID change" '
+  ipfs files cp /ipfs/bafkqaaa /mfs-pinning-repin-test-$(date +%s.%N) &&
+  ipfs files flush &&
+  sleep 31 &&
   ipfs files stat / --enc=json | jq -r .Hash > mfs_cid &&
   ipfs pin remote ls --service=test_pin_mfs_svc --name=mfs_test_pin --status=queued,pinning,pinned,failed --enc=json | tee ls_out | jq -r .Cid > pin_cid &&
   cat mfs_cid ls_out &&


### PR DESCRIPTION
This is a refactor of #7798 that replaces the existing MFS root pin (if present) instead of creating a new pin.

- find by name all pre-existing pins across all Statuses (not just 'pinned')
- replace pre-existing pin (or create a new one if none found)

Without this we would be adding duplicate pins when pinning service
is still processing previous pin request (queued, pinning):

```
QmV6QnQNuyJFq88fSVVY9u5fxftQEKu6unsD62QpLQSefP  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmbnBveHJSqcqmVK8UE64riotVzMGirCKYE1SQLXcG25dT  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
Qmf1FHNVp74F4TGtNg1myXZgaV4ApwmYgC8iXcUX8cidDy  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmXnVAeJ9braE7ho7hdPqkmd9cB2ewKtzXNcFFFm3W32EA  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmeSUtG78SnqoCLDnZw5kYx2w9QnCp8JhkKHxK537y2JET  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
Qmacb2NPrz1tzpB3GarzqaYuLb54o71iJAAL61jGbmJEmu  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmRk9WAfArEpEPw6xc5hTUmKPeRM85fUCJoSqGPWYfMCB4  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmVYD7stnRgG4HHgrnkpbCUvLTvjLmZbhTJNe5ZNx7bDmh  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs
QmTiCXsj9nwFCDpUxq3fAUvZW49s3FCHPtxb8KeYoGfmri  queued  policy/12D3KooWEcsoib3zFds4USH9bASPWBvJHRvfHYbxjR8QCHQ7y1vj/mfs

```

## Notes

-  `Replace`  at  Pinata will still produce duplicate pins, but for a different reason:
   -  This is temporary bug on their end and should not block us from switching to `Replace` method. 
    - Our CI should be green, because we don't use Pinata for tests there, and `Replace` from [rb-pinning-service-api](https://github.com/ipfs-shipyard/rb-pinning-service-api) works as expected.
