### PR TITLE
Make ipns publish related code more generic

### DIFF
--- a/core/coreapi/name.go
+++ b/core/coreapi/name.go
@@ -65,12 +65,13 @@ func (api *NameAPI) Publish(ctx context.Context, p path.Path, opts ...caopts.Nam
 	}
 
 	eol := time.Now().Add(options.ValidTime)
-	err = api.namesys.PublishWithEOL(ctx, k, pth, eol)
+
+	pid, err := peer.IDFromPrivateKey(k)
 	if err != nil {
 		return nil, err
 	}
 
-	pid, err := peer.IDFromPrivateKey(k)
+	err = api.namesys.PublishWithEOL(ctx, k, pth, eol, pid)
 	if err != nil {
 		return nil, err
 	}

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -26,6 +26,7 @@ import (
 	nsopts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
+	peer "github.com/libp2p/go-libp2p-peer"
 	id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 
@@ -68,11 +69,11 @@ func (m mockNamesys) ResolveAsync(ctx context.Context, name string, opts ...nsop
 	return out
 }
 
-func (m mockNamesys) Publish(ctx context.Context, name ci.PrivKey, value path.Path) error {
+func (m mockNamesys) Publish(ctx context.Context, name ci.PrivKey, value path.Path, pid peer.ID) error {
 	return errors.New("not implemented for mockNamesys")
 }
 
-func (m mockNamesys) PublishWithEOL(ctx context.Context, name ci.PrivKey, value path.Path, _ time.Time) error {
+func (m mockNamesys) PublishWithEOL(ctx context.Context, name ci.PrivKey, value path.Path, _ time.Time, pid peer.ID) error {
 	return errors.New("not implemented for mockNamesys")
 }
 

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -26,7 +26,7 @@ import (
 	nsopts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 	id "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 )
 

--- a/fuse/ipns/common.go
+++ b/fuse/ipns/common.go
@@ -8,6 +8,7 @@ import (
 	path "github.com/ipfs/go-path"
 	ft "github.com/ipfs/go-unixfs"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 // InitializeKeyspace sets the ipns record for the given key to
@@ -30,5 +31,10 @@ func InitializeKeyspace(n *core.IpfsNode, key ci.PrivKey) error {
 
 	pub := nsys.NewIpnsPublisher(n.Routing, n.Repo.Datastore())
 
-	return pub.Publish(ctx, key, path.FromCid(emptyDir.Cid()))
+	id, err := peer.IDFromPrivateKey(key)
+	if err != nil {
+		return err
+	}
+
+	return pub.Publish(ctx, key, path.FromCid(emptyDir.Cid()), id)
 }

--- a/fuse/ipns/common.go
+++ b/fuse/ipns/common.go
@@ -8,7 +8,7 @@ import (
 	path "github.com/ipfs/go-path"
 	ft "github.com/ipfs/go-unixfs"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 // InitializeKeyspace sets the ipns record for the given key to

--- a/namesys/interface.go
+++ b/namesys/interface.go
@@ -38,6 +38,7 @@ import (
 	path "github.com/ipfs/go-path"
 	opts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 // ErrResolveFailed signals an error when attempting to resolve.
@@ -98,9 +99,9 @@ type Publisher interface {
 
 	// Publish establishes a name-value mapping.
 	// TODO make this not PrivKey specific.
-	Publish(ctx context.Context, name ci.PrivKey, value path.Path) error
+	Publish(ctx context.Context, name ci.PrivKey, value path.Path, pid peer.ID) error
 
 	// TODO: to be replaced by a more generic 'PublishWithValidity' type
 	// call once the records spec is implemented
-	PublishWithEOL(ctx context.Context, name ci.PrivKey, value path.Path, eol time.Time) error
+	PublishWithEOL(ctx context.Context, name ci.PrivKey, value path.Path, eol time.Time, pid peer.ID) error
 }

--- a/namesys/namesys_test.go
+++ b/namesys/namesys_test.go
@@ -114,7 +114,13 @@ func TestPublishWithCache0(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = nsys.Publish(context.Background(), priv, p)
+
+	pid, err = peer.IDFromPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = nsys.Publish(context.Background(), priv, p, pid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +157,13 @@ func TestPublishWithTTL(t *testing.T) {
 	eol := time.Now().Add(2 * time.Second)
 
 	ctx := context.WithValue(context.Background(), "ipns-publish-ttl", ttl)
-	err = nsys.Publish(ctx, priv, p)
+
+	pid, err = peer.IDFromPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = nsys.Publish(ctx, priv, p, pid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/namesys/publisher_test.go
+++ b/namesys/publisher_test.go
@@ -3,9 +3,10 @@ package namesys
 import (
 	"context"
 	"crypto/rand"
-	"github.com/ipfs/go-path"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-path"
 
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -129,7 +130,12 @@ func TestAsyncDS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := publisher.Publish(ctx, ipnsFakeID.PrivateKey(), ipnsVal); err != nil {
+	pid, err := peer.IDFromPrivateKey(ipnsFakeID.PrivateKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publisher.Publish(ctx, ipnsFakeID.PrivateKey(), ipnsVal, pid); err != nil {
 		t.Fatal(err)
 	}
 

--- a/namesys/republisher/repub_test.go
+++ b/namesys/republisher/repub_test.go
@@ -14,7 +14,7 @@ import (
 
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-ipns"
-	"github.com/ipfs/go-ipns/pb"
+	ipns_pb "github.com/ipfs/go-ipns/pb"
 	path "github.com/ipfs/go-path"
 
 	"github.com/ipfs/go-ipfs/core"
@@ -73,7 +73,13 @@ func TestRepublish(t *testing.T) {
 	timeout := time.Second
 	for {
 		expiration = time.Now().Add(time.Second)
-		err := rp.PublishWithEOL(ctx, publisher.PrivateKey, p, expiration)
+
+		pid, err := peer.IDFromPrivateKey(publisher.PrivateKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = rp.PublishWithEOL(ctx, publisher.PrivateKey, p, expiration, pid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,7 +165,13 @@ func TestLongEOLRepublish(t *testing.T) {
 	name := "/ipns/" + publisher.Identity.Pretty()
 
 	expiration := time.Now().Add(time.Hour)
-	err := rp.PublishWithEOL(ctx, publisher.PrivateKey, p, expiration)
+
+	pid, err := peer.IDFromPrivateKey(publisher.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rp.PublishWithEOL(ctx, publisher.PrivateKey, p, expiration, pid)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/namesys/resolve_test.go
+++ b/namesys/resolve_test.go
@@ -11,6 +11,7 @@ import (
 	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
 	ipns "github.com/ipfs/go-ipns"
 	path "github.com/ipfs/go-path"
+	"github.com/libp2p/go-libp2p-core/peer"
 	testutil "github.com/libp2p/go-libp2p-testing/net"
 	tnet "github.com/libp2p/go-libp2p-testing/net"
 )
@@ -27,7 +28,13 @@ func TestRoutingResolve(t *testing.T) {
 	identity := tnet.RandIdentityOrFatal(t)
 
 	h := path.FromString("/ipfs/QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN")
-	err := publisher.Publish(context.Background(), identity.PrivateKey(), h)
+
+	pid, err := peer.IDFromPrivateKey(identity.PrivateKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = publisher.Publish(context.Background(), identity.PrivateKey(), h, pid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,8 +71,13 @@ func TestPrexistingExpiredRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pid, err := peer.IDFromPrivateKey(identity.PrivateKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Now, with an old record in the system already, try and publish a new one
-	err = publisher.Publish(context.Background(), identity.PrivateKey(), h)
+	err = publisher.Publish(context.Background(), identity.PrivateKey(), h, pid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,8 +109,13 @@ func TestPrexistingRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pid, err := peer.IDFromPrivateKey(identity.PrivateKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Now, with an old record in the system already, try and publish a new one
-	err = publisher.Publish(context.Background(), identity.PrivateKey(), h)
+	err = publisher.Publish(context.Background(), identity.PrivateKey(), h, pid)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This pull request will make IPNS publishing code more generic by adding peer.ID parameter and removing many redundant peer.IDFromPrivateKey(key) calls.