### PR TITLE
fix(gw): remove use of Clear-Site-Data in subdomain router

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -97,15 +97,6 @@ func HostnameOption() ServeOption {
 							return
 						}
 						if newURL != "" {
-							// Just to be sure single Origin can't be abused in
-							// web browsers that ignored the redirect for some
-							// reason, Clear-Site-Data header clears browsing
-							// data (cookies, storage etc) associated with
-							// hostname's root Origin
-							// Note: we can't use "*" due to bug in Chromium:
-							// https://bugs.chromium.org/p/chromium/issues/detail?id=898503
-							w.Header().Set("Clear-Site-Data", "\"cookies\", \"storage\"")
-
 							// Set "Location" header with redirect destination.
 							// It is ignored by curl in default mode, but will
 							// be respected by user agents that follow

--- a/docs/config.md
+++ b/docs/config.md
@@ -653,7 +653,6 @@ between content roots.
         }
     }
     ```
-<!-- **(not implemented yet)** due to the lack of Origin isolation, cookies and storage on `Paths` will be disabled by [Clear-Site-Data](https://github.com/ipfs/in-web-browsers/issues/157) header -->
 
 Default: `false`
 

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -181,13 +181,6 @@ test_localhost_gateway_response_should_contain \
   "http://localhost:$GWAY_PORT/ipfs/$DIR_CID/" \
   "Location: http://$DIR_CID.ipfs.localhost:$GWAY_PORT/"
 
-# Responses to the root domain of subdomain gateway hostname should Clear-Site-Data
-# https://github.com/ipfs/go-ipfs/issues/6975#issuecomment-597472477
-test_localhost_gateway_response_should_contain \
-  "request for localhost/ipfs/{CIDv1} returns Clear-Site-Data header to purge Origin cookies and storage" \
-  "http://localhost:$GWAY_PORT/ipfs/$CIDv1" \
-  'Clear-Site-Data: \"cookies\", \"storage\"'
-
 # We return body with HTTP 301 so existing cli scripts that use path-based
 # gateway do not break (curl doesn't auto-redirect without passing -L; wget
 # does not span across hostnames by default)


### PR DESCRIPTION
This PR removes use of buggy  `Clear-Site-Data` header and solves issue with Firefox: https://github.com/ipfs-shipyard/ipfs-companion/issues/977 
(Chromium browsers are not impacted, but they also barely support this header)

### TLDR 

-  Opening https://dweb.link/ipns/en.wikipedia-on-ipfs.org returns  `Clear-Site-Data` header and in Firefox it clears cookies before redirecting to  https://en-wikipedia--on--ipfs-org.ipns.dweb.link (afaik it should ignore the header on redirects, but that is not the case in Firefox 84)
- `Clear-Site-Data` support across vendors  is buggy in general, and  that is not just Firefox
- This PR removes `Clear-Site-Data` from the path-based router, fixing Firefox issue described in https://github.com/ipfs-shipyard/ipfs-companion/issues/977  

### Context

We used `Clear-Site-Data` as a failsafe/cushion during the transition period for local gateway exposed at http://localhost while we were still figuring out  security-related details.

In the final implementation subdomain gateways are now tied to a hostname explicitly, which removes the risk of cookies leaking,  removing the need for the header.

Turns out the [header support is still not implemented correctly in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=898503) and causes issues for Firefox users (https://github.com/ipfs-shipyard/ipfs-companion/issues/977), so let's just remove it.

cc @hsanjuan @gozala @autonome  for  :eyes: 
@aschmahmann should be small and clean enough to squeeze into 0.8.0 (https://github.com/ipfs/go-ipfs/issues/7707), but lmk if you prefer to push it to later one 