### PR TITLE
feat: support non-ICANN DNSLink names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/ipfs/go-verifcid v0.0.1
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/ipld/go-car v0.1.1-0.20201015032735-ff6ccdc46acc
-	github.com/jbenet/go-is-domain v1.0.5
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,6 @@ github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+
 github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec/go.mod h1:rGaEvXB4uRSZMmzKNLoXvTu1sfx+1kv/DojUlPrSZGs=
 github.com/jbenet/go-cienv v0.1.0 h1:Vc/s0QbQtoxX8MwwSLWWh+xNNZvM3Lw7NsTcHrvvhMc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
-github.com/jbenet/go-is-domain v1.0.5 h1:r92uiHbMEJo9Fkey5pMBtZAzjPQWic0ieo7Jw1jEuQQ=
-github.com/jbenet/go-is-domain v1.0.5/go.mod h1:xbRLRb0S7FgzDBTJlguhDVwLYM/5yNtvktxj2Ttfy7Q=
 github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c h1:uUx61FiAa1GI6ZmVd2wf2vULeQZIKG66eybjNXKYCz4=
 github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c/go.mod h1:sdx1xVM9UuLw1tXnhJWN3piypTUO3vCIHYmG15KE/dU=
 github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2/go.mod h1:8GXXJV31xl8whumTzdZsTt3RnUIiPqzkyf7mxToRCMs=

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -3,13 +3,12 @@ package namesys
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
-	"fmt"
 
 	path "github.com/ipfs/go-path"
 	opts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
-	isd "github.com/jbenet/go-is-domain"
 )
 
 const ethTLD = "eth"
@@ -53,7 +52,7 @@ func (r *DNSResolver) resolveOnceAsync(ctx context.Context, name string, options
 	segments := strings.SplitN(name, "/", 2)
 	domain := segments[0]
 
-	if !isd.IsDomain(domain) {
+	if !net.isDomainName(domain) {
 		out <- onceResult{err: fmt.Errorf("not a valid domain name: %s", domain)}
 		close(out)
 		return out

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -3,6 +3,7 @@ package namesys
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -12,7 +13,6 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	path "github.com/ipfs/go-path"
 	opts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
-	isd "github.com/jbenet/go-is-domain"
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	routing "github.com/libp2p/go-libp2p-core/routing"
@@ -162,7 +162,7 @@ func (ns *mpns) resolveOnceAsync(ctx context.Context, name string, options opts.
 
 	if err == nil {
 		res = ns.ipnsResolver
-	} else if isd.IsDomain(key) {
+	} else if net.isDomainName(key) {
 		res = ns.dnsResolver
 	} else {
 		res = ns.proquintResolver


### PR DESCRIPTION
This PR aims to decouple DNSLink resolution from the TLD safelist, enabling users to experiment with new TLDs with regular go-ipfs binary. 

Future work will include configurable DNS resolver per TLD, but this PR is scoped to simply make go-ipfs use DNS protocol, and don't care about TLDs specific to some explicitly blessed DNS network (ICANN, ENS, OpenNIC, etc).

- removes reliance on TLD safelist from `jbenet/go-is-domain`  as suggested in  https://github.com/jbenet/go-is-domain/issues/16#issuecomment-740967950 and  https://github.com/jbenet/go-is-domain/pull/19#pullrequestreview-584687951

- switch DNSLink checks to `net.isDomainName` which only cares about    name being compliant with RFC 1035, RFC 3696, and is not concerned   if TLD was blessed by ICANN or some other authority 

cc @autonome 



# TODO

- [ ]  find exported alternative to `net.isDomainName` or simply vendor snippet from https://golang.org/src/net/dnsclient.go?s=1626:1658#L53
