### PR TITLE
fix(build): preserve the GOFLAGS environment variable

### DIFF
--- a/cmd/ipfs/Rules.mk
+++ b/cmd/ipfs/Rules.mk
@@ -13,7 +13,7 @@ PATH := $(realpath $(d)):$(PATH)
 # DEPS_OO_$(d) += merkledag/pb/merkledag.pb.go namesys/pb/namesys.pb.go
 # DEPS_OO_$(d) += pin/internal/pb/header.pb.go unixfs/pb/unixfs.pb.go
 
-$(d)_flags =-ldflags="-X "github.com/ipfs/go-ipfs".CurrentCommit=$(git-hash)"
+$(d)_flags =-ldflags=-X="github.com/ipfs/go-ipfs.CurrentCommit=$(git-hash)"
 
 $(d)-try-build $(IPFS_BIN_$(d)): GOFLAGS += $(cmd/ipfs_flags)
 

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -22,16 +22,16 @@ TEST_GO :=
 TEST_GO_BUILD :=
 CHECK_GO :=
 
-go-pkg-name=$(shell $(GOCC) list $(go-tags) github.com/ipfs/go-ipfs/$(1))
-go-main-name=$(notdir $(call go-pkg-name,$(1)))$(?exe)
-go-curr-pkg-tgt=$(d)/$(call go-main-name,$(d))
-go-pkgs=$(shell $(GOCC) list github.com/ipfs/go-ipfs/...)
-
 # Go tags cannot be set in GOFLAGS.
 go-tags=$(if $(GOTAGS), -tags="$(call join-with,$(space),$(GOTAGS))")
 # These flags _may_ contain spaces so we can't use GOFLAGS either.
 go-flags="-asmflags=all='-trimpath=$(GOPATH)'" "-gcflags=all='-trimpath=$(GOPATH)'"
 go-flags-with-tags=$(go-flags)$(go-tags)
+
+# ignores GOFLAGS...
+go-pkg-name=$(shell $(GOCC) list $(GOFLAGS) $(go-flags-with-tags) github.com/ipfs/go-ipfs/$(1))
+go-main-name=$(notdir $(call go-pkg-name,$(1)))$(?exe)
+go-curr-pkg-tgt=$(d)/$(call go-main-name,$(d))
 
 define go-build-relative
 $(GOCC) build $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$<)"

--- a/plugin/loader/Rules.mk
+++ b/plugin/loader/Rules.mk
@@ -6,7 +6,7 @@ export IPFS_PLUGINS
 $(d)/preload.go: d:=$(d)
 $(d)/preload.go: $(d)/preload_list $(d)/preload.sh ALWAYS
 	$(d)/preload.sh > $@
-	go fmt $@ >/dev/null
+	$(GOCC) fmt $(go-global-flags) $@ >/dev/null
 
 DEPS_GO += $(d)/preload.go
 

--- a/plugin/plugins/Rules.mk
+++ b/plugin/plugins/Rules.mk
@@ -8,7 +8,7 @@ $(d)_plugins_main:=$(addsuffix /main/main.go,$($(d)_plugins))
 $($(d)_plugins_main): d:=$(d)
 $($(d)_plugins_main):
 	$(d)/gen_main.sh "$(dir $@).." "$(call go-pkg-name,$(dir $@)/..)"
-	$(GOCC) fmt $@ >/dev/null
+	$(GOCC) fmt $(go-global-flags) $@ >/dev/null
 
 $($(d)_plugins_so): %.so : %/main/main.go
 $($(d)_plugins_so): $$(DEPS_GO) ALWAYS


### PR DESCRIPTION
Previously, we avoided this variable because we were storing some flags with spaces (potentially). Unfortunately, that means these flags are not set for some commands (e.g., `go fmt`) leading to issues when building from vendored sources.

Now we:

1. Use GOFLAGS where possible.
2. Pass tags and special flags on the commandline where necessary.

This should fix #7881.