### PR TITLE
Set supported platforms by go-version

### DIFF
--- a/bin/check_version
+++ b/bin/check_version
@@ -34,27 +34,27 @@ check_at_least_version() {
     # We expect a version to be of form X.X.X
     # if the second dot doesn't match, we consider it a prerelease
 
-    if MIN_MIN=$(expr "$MIN_VERS" : "[^.]*\.\([0-9]\+\)"); then
+    if MIN_MIN=$(expr "$MIN_VERS" : "[^.]*\.\([0-9][0-9]*\)"); then
         # this captured digit is necessary, since expr returns code 1 if the output is empty
         if expr "$MIN_VERS" : "[^.]*\.[0-9]*\([0-9]\.\|[0-9]\$\)" >/dev/null; then
             MIN_PRERELEASE="0"
         else
             MIN_PRERELEASE="1"
         fi
-        MIN_FIX=$(expr "$MIN_VERS" : "[^.]*\.[0-9]\+[^0-9]\+\([0-9]\+\)") || MIN_FIX="0"
+        MIN_FIX=$(expr "$MIN_VERS" : "[^.]*\.[0-9][0-9]*[^0-9][^0-9]*\([0-9][0-9]*\)") || MIN_FIX="0"
     else
         MIN_MIN="0"
         MIN_PRERELEASE="0"
         MIN_FIX="0"
     fi
-    if CUR_MIN=$(expr "$CUR_VERS" : "[^.]*\.\([0-9]\+\)"); then
+    if CUR_MIN=$(expr "$CUR_VERS" : "[^.]*\.\([0-9][0-9]*\)"); then
         # this captured digit is necessary, since expr returns code 1 if the output is empty
         if expr "$CUR_VERS" : "[^.]*\.[0-9]*\([0-9]\.\|[0-9]\$\)" >/dev/null; then
             CUR_PRERELEASE="0"
         else
             CUR_PRERELEASE="1"
         fi
-        CUR_FIX=$(expr "$CUR_VERS" : "[^.]*\.[0-9]\+[^0-9]\+\([0-9]\+\)") || CUR_FIX="0"
+        CUR_FIX=$(expr "$CUR_VERS" :  "[^.]*\.[0-9][0-9]*[^0-9][^0-9]*\([0-9][0-9]*\)") || CUR_FIX="0"
     else
         CUR_MIN="0"
         CUR_PRERELEASE="0"

--- a/mk/util.mk
+++ b/mk/util.mk
@@ -17,9 +17,13 @@ SUPPORTED_PLATFORMS += linux-arm64
 SUPPORTED_PLATFORMS += linux-386
 SUPPORTED_PLATFORMS += linux-amd64
 
-SUPPORTED_PLATFORMS += darwin-386
 SUPPORTED_PLATFORMS += darwin-amd64
-
+ifeq ($(shell bin/check_go_version "1.15.0" 2>/dev/null; echo $$?),1)
+SUPPORTED_PLATFORMS += darwin-386
+endif
+ifeq ($(shell bin/check_go_version "1.16.0" 2>/dev/null; echo $$?),0)
+SUPPORTED_PLATFORMS += darwin-arm64
+endif
 SUPPORTED_PLATFORMS += freebsd-386
 SUPPORTED_PLATFORMS += freebsd-amd64
 


### PR DESCRIPTION
Looks like darwin-386 is in the list of supported platforms still as of 0.8.0, which won't compile on go-1.15 and up. And now there's darwin-arm64 (native Apple M1) starting on Go 1.16

This PR set supported platforms correctly by go version (no darwin-386 for >=1.15, no darwin-arm64 unless >=1.16)

It also makes a change to check-version as \+ is interpreted literally for `expr` on several POSIX systems including Mac.
License: MIT
Signed-off-by: hannahhoward <hannah@hannahhoward.net>