### PR TITLE
feat(gw): /ipfs/ipfs/{cid} → /ipfs/{cid}

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -238,7 +238,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 
 	parsedPath := ipath.New(urlPath)
 	if pathErr := parsedPath.IsValid(); pathErr != nil {
-		if fixupSuperfluousNamespace(w, urlPath, r.URL.RawQuery) {
+		if prefix == "" && fixupSuperfluousNamespace(w, urlPath, r.URL.RawQuery) {
 			// the error was due to redundant namespace, which we were able to fix
 			// by returning error/redirect page, nothing left to do here
 			return

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -84,10 +84,11 @@ test_expect_success "GET IPFS nonexistent file returns code expected (404)" '
   test_curl_resp_http_code "http://127.0.0.1:$port/ipfs/$HASH2/pleaseDontAddMe" "HTTP/1.1 404 Not Found"
 '
 
-test_expect_success "GET /ipfs/ipfs/{cid} returns redirect to the valid path" "
-  curl -sI -o response_with_double_ipfs_ns \"http://127.0.0.1:$port/ipfs/ipfs/bafkqaaa?query=to-remember\"  &&
-  test_should_contain \"Location: /ipfs/bafkqaaa?query=to-remember\" response_with_double_ipfs_ns
-"
+test_expect_success "GET /ipfs/ipfs/{cid} returns redirect to the valid path" '
+  curl -sD - "http://127.0.0.1:$port/ipfs/ipfs/bafkqaaa?query=to-remember" > response_with_double_ipfs_ns &&
+  test_should_contain "<meta http-equiv=\"refresh\" content=\"10;url=/ipfs/bafkqaaa?query=to-remember\" />" response_with_double_ipfs_ns &&
+  test_should_contain "<link rel=\"canonical\" href=\"/ipfs/bafkqaaa?query=to-remember\" />" response_with_double_ipfs_ns
+'
 
 test_expect_failure "GET IPNS path succeeds" '
   ipfs name publish --allow-offline "$HASH" &&
@@ -102,8 +103,9 @@ test_expect_failure "GET IPNS path output looks good" '
 
 test_expect_success "GET /ipfs/ipns/{peerid} returns redirect to the valid path" '
   PEERID=$(ipfs config Identity.PeerID) &&
-  curl -sI -o response_with_ipfs_ipns_ns "http://127.0.0.1:$port/ipfs/ipns/${PEERID}?query=to-remember" &&
-  test_should_contain "Location: /ipns/${PEERID}?query=to-remember" response_with_ipfs_ipns_ns
+  curl -sD - "http://127.0.0.1:$port/ipfs/ipns/${PEERID}?query=to-remember" > response_with_ipfs_ipns_ns &&
+  test_should_contain "<meta http-equiv=\"refresh\" content=\"10;url=/ipns/${PEERID}?query=to-remember\" />" response_with_ipfs_ipns_ns &&
+  test_should_contain "<link rel=\"canonical\" href=\"/ipns/${PEERID}?query=to-remember\" />" response_with_ipfs_ipns_ns
 '
 
 test_expect_success "GET invalid IPFS path errors" '

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -84,6 +84,11 @@ test_expect_success "GET IPFS nonexistent file returns code expected (404)" '
   test_curl_resp_http_code "http://127.0.0.1:$port/ipfs/$HASH2/pleaseDontAddMe" "HTTP/1.1 404 Not Found"
 '
 
+test_expect_success "GET /ipfs/ipfs/{cid} returns redirect to the valid path" "
+  curl -sI -o response_with_double_ipfs_ns \"http://127.0.0.1:$port/ipfs/ipfs/bafkqaaa?query=to-remember\"  &&
+  test_should_contain \"Location: /ipfs/bafkqaaa?query=to-remember\" response_with_double_ipfs_ns
+"
+
 test_expect_failure "GET IPNS path succeeds" '
   ipfs name publish --allow-offline "$HASH" &&
   PEERID=$(ipfs config Identity.PeerID) &&
@@ -93,6 +98,12 @@ test_expect_failure "GET IPNS path succeeds" '
 
 test_expect_failure "GET IPNS path output looks good" '
   test_cmp expected actual
+'
+
+test_expect_success "GET /ipfs/ipns/{peerid} returns redirect to the valid path" '
+  PEERID=$(ipfs config Identity.PeerID) &&
+  curl -sI -o response_with_ipfs_ipns_ns "http://127.0.0.1:$port/ipfs/ipns/${PEERID}?query=to-remember" &&
+  test_should_contain "Location: /ipns/${PEERID}?query=to-remember" response_with_ipfs_ipns_ns
 '
 
 test_expect_success "GET invalid IPFS path errors" '


### PR DESCRIPTION
This PR enables Gateways to recover from invalid paths like  `/ipfs/ipfs/{cid}`  and redirect them to proper one, when possible.

_raison d'être_  is to 
- smooth out unforeseen addressing issues during initial adoption, and fix cosmetic mistakes like the value in `image` tag [here](https://dweb.link/ipfs/bafybeien3m7mdn6imm425vc2s22erzyhbvk5n3ofzgikkhmdkh5cuqbpbq/metadata.json)  :cat2::rainbow_flag:  
-  make broken URIs resolve in Brave and Opera (because thats where most of people will paste those broken `ipfs://` URI to address bar)
- provide hint to developers on what should be fixed


cc @autonome 