### PR TITLE
docs: fix DNSLink gw recipe

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -730,7 +730,7 @@ Below is a list of the most common public gateway setups.
 
 * Public [DNSLink](https://dnslink.io/) gateway resolving every hostname passed in `Host` header.
   ```console
-  $ ipfs config --json Gateway.NoDNSLink true
+  $ ipfs config --json Gateway.NoDNSLink false
   ```
   * Note that `NoDNSLink: false` is the default (it works out of the box unless set to `true` manually)
 


### PR DESCRIPTION
# :see_no_evil: 

@aschmahmann  this PR fixes unfortunate typo due to additional negation and my lack of coffee I guess.