### PR TITLE
chore: bump minimum go version to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.14.4
+      - image: circleci/golang:1.15.8
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -60,7 +60,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer:
     docker:
-      - image: circleci/golang:1.14.4
+      - image: circleci/golang:1.15.8
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.15.8
+      - image: circleci/golang:1.15.2
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -60,7 +60,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer:
     docker:
-      - image: circleci/golang:1.15.8
+      - image: circleci/golang:1.15.2
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
-FROM golang:1.15.8-buster
+FROM golang:1.15.2-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
-FROM golang:1.14.4-buster 
+FROM golang:1.15.8-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ PS> scoop install go-ipfs
 
 ### Build from Source
 
-go-ipfs's build system requires Go 1.14.4 and some standard POSIX build tools:
+go-ipfs's build system requires Go 1.15.8 and some standard POSIX build tools:
 
 * GNU make
 * Git
@@ -170,7 +170,7 @@ To build without GCC, build with `CGO_ENABLED=0` (e.g., `make build CGO_ENABLED=
 
 #### Install Go
 
-The build process for ipfs requires Go 1.14.4 or higher. If you don't have it: [Download Go 1.14+](https://golang.org/dl/).
+The build process for ipfs requires Go 1.15.8 or higher. If you don't have it: [Download Go 1.15+](https://golang.org/dl/).
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ PS> scoop install go-ipfs
 
 ### Build from Source
 
-go-ipfs's build system requires Go 1.15.8 and some standard POSIX build tools:
+go-ipfs's build system requires Go 1.15.2 and some standard POSIX build tools:
 
 * GNU make
 * Git
@@ -170,7 +170,7 @@ To build without GCC, build with `CGO_ENABLED=0` (e.g., `make build CGO_ENABLED=
 
 #### Install Go
 
-The build process for ipfs requires Go 1.15.8 or higher. If you don't have it: [Download Go 1.15+](https://golang.org/dl/).
+The build process for ipfs requires Go 1.15.2 or higher. If you don't have it: [Download Go 1.15+](https://golang.org/dl/).
 
 You'll need to add Go's bin directories to your `$PATH` environment variable e.g., by adding these lines to your `/etc/profile` (for a system-wide installation) or `$HOME/.profile`:
 

--- a/go.mod
+++ b/go.mod
@@ -108,4 +108,4 @@ require (
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6
 )
 
-go 1.14
+go 1.15

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.14.4
+GO_MIN_VERSION = 1.15.8
 export GO111MODULE=on
 
 

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -1,5 +1,5 @@
 # golang utilities
-GO_MIN_VERSION = 1.15.8
+GO_MIN_VERSION = 1.15.2
 export GO111MODULE=on
 
 


### PR DESCRIPTION
bumping minimum version to 1.15 to indicate we are no longer explicitly supporting 1.14, and bumping CI testing to use 1.15.