### PR TITLE
fix some sharness-in-CI issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
         GOPATH: /home/circleci/go
         TEST_VERBOSE: 1
     steps:
-    - run: sudo apt install socat
+    - run: sudo apt install socat net-tools
     - checkout
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
         GOPATH: /home/circleci/go
         TEST_VERBOSE: 1
     steps:
+    - run: sudo apt update
     - run: sudo apt install socat net-tools
     - checkout
 

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -175,12 +175,12 @@ ipfs key rm key_ed25519
     test_cmp rsa_key_id roundtrip_rsa_key_id
   '
 
-  test_must_fail "online export rsa key" '
-    ipfs key export generated_rsa_key
+  test_expect_success "online export rsa key" '
+    test_must_fail ipfs key export generated_rsa_key
   '
 
-  test_must_fail "online rotate rsa key" '
-    ipfs key rotate
+  test_expect_success "online rotate rsa key" '
+    test_must_fail ipfs key rotate
   '
   
   test_kill_ipfs_daemon


### PR DESCRIPTION
1. We need netstat and sharness seems to silently fail when we don't have it.
2. `test_must_fail` still needs to go inside a `test_expect_success`.