### PR TITLE
test(sharness): pass correct timeout format to go-timeout

### DIFF
--- a/test/sharness/t0275-cid-security.sh
+++ b/test/sharness/t0275-cid-security.sh
@@ -78,7 +78,7 @@ test_expect_success "add block linking to insecure" '
 '
 
 test_expect_success "ipfs cat fails with code 1 and not timeout" '
-  test_expect_code 1 go-timeout 1s ipfs cat QmVpsktzNeJdfWEpyeix93QJdQaBSgRNxebSbYSo9SQPGx
+  test_expect_code 1 go-timeout 1 ipfs cat QmVpsktzNeJdfWEpyeix93QJdQaBSgRNxebSbYSo9SQPGx
 '
 
 test_kill_ipfs_daemon


### PR DESCRIPTION
It takes a number, not a duration. Unfortunately, it will _also_ exit with a status of 1 in this case so the test passes.