### PR TITLE
Feat: Re-import InitializeKeyspace code from go-namesys

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -15,7 +15,8 @@ import (
 	core "github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/commands"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
-	namesys "github.com/ipfs/go-namesys"
+	path "github.com/ipfs/go-path"
+	unixfs "github.com/ipfs/go-unixfs"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	config "github.com/ipfs/go-ipfs-config"
@@ -245,5 +246,19 @@ func initializeIpnsKeyspace(repoRoot string) error {
 	}
 	defer nd.Close()
 
-	return namesys.InitializeKeyspace(ctx, nd.Namesys, nd.Pinning, nd.PrivateKey)
+	emptyDir := unixfs.EmptyDirNode()
+
+	// pin recursively because this might already be pinned
+	// and doing a direct pin would throw an error in that case
+	err = nd.Pinning.Pin(ctx, emptyDir, true)
+	if err != nil {
+		return err
+	}
+
+	err = nd.Pinning.Flush(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nd.Namesys.Publish(ctx, nd.PrivateKey, path.FromCid(emptyDir.Cid()))
 }


### PR DESCRIPTION
The InitializeKeyspace functionality is go-ipfs specific but lives in the
go-namesys repo.

It is only called from initializeIpnsKeyspace, and therefore the code is
directly added to this function. The original function will be removed from
go-namesys.