### PR TITLE
chore: deprecate Gateway.PathPrefixes

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -677,6 +677,10 @@ func serveHTTPGateway(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, e
 		opts = append(opts, corehttp.RedirectOption("", cfg.Gateway.RootRedirect))
 	}
 
+	if len(cfg.Gateway.PathPrefixes) > 0 {
+		log.Error("Support for X-Ipfs-Gateway-Prefix and Gateway.PathPrefixes is deprecated and will be removed in the next release. Please comment on the issue if you're using this feature: https://github.com/ipfs/go-ipfs/issues/7702")
+	}
+
 	node, err := cctx.ConstructNode()
 	if err != nil {
 		return nil, fmt.Errorf("serveHTTPGateway: ConstructNode() failed: %s", err)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -159,6 +159,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	// If the gateway is behind a reverse proxy and mounted at a sub-path,
 	// the prefix header can be set to signal this sub-path.
 	// It will be prepended to links in directory listings and the index.html redirect.
+	// TODO: this feature is deprecated and will be removed  (https://github.com/ipfs/go-ipfs/issues/7702)
 	prefix := ""
 	if prfx := r.Header.Get("X-Ipfs-Gateway-Prefix"); len(prfx) > 0 {
 		for _, p := range i.config.PathPrefixes {

--- a/docs/config.md
+++ b/docs/config.md
@@ -559,6 +559,9 @@ Type: `bool`
 
 ### `Gateway.PathPrefixes`
 
+**DEPRECATED:** see [go-ipfs#7702](https://github.com/ipfs/go-ipfs/issues/7702)
+
+<!--
 Array of acceptable url paths that a client can specify in X-Ipfs-Path-Prefix
 header.
 
@@ -584,6 +587,8 @@ location /blog/ {
   proxy_pass http://127.0.0.1:8080;
 }
 ```
+
+-->
 
 Default: `[]`
 


### PR DESCRIPTION
Context: https://github.com/ipfs/go-ipfs/issues/7702 and @Stebalien comments there 

This PR deprecates `Gateway.PathPrefixes` and `X-Ipfs-Gateway-Prefix` header:
- marks `Gateway.PathPrefixes` as deprecated in `docs/config.md`
-  logs error during startup if `Gateway.PathPrefixes` is used  (not empty)
   - I went with log because it prints red ERROR that makes it hard to miss (but lmk if should be regular stderr instead):
     > ![2021-03-20--01-05-06](https://user-images.githubusercontent.com/157609/111852739-67e1be00-8918-11eb-8671-437bec710c09.png)

