### PR TITLE
docs: cosmetic fixes of help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ SUBCOMMANDS
   DATA STRUCTURE COMMANDS
     dag           Interact with IPLD DAG nodes
     files         Interact with files as if they were a unix filesystem
-    object        Interact with objects (deprecated, use 'dag' or 'files')
+    object        Interact with dag-pb objects (deprecated, use 'dag' or 'files')
     block         Interact with raw blocks in the datastore
 
   ADVANCED COMMANDS

--- a/README.md
+++ b/README.md
@@ -296,18 +296,23 @@ SUBCOMMANDS
     refs <ref>    List hashes of links from an object
 
   DATA STRUCTURE COMMANDS
+    dag           Interact with IPLD DAG nodes
+    files         Interact with files as if they were a unix filesystem
+    object        Interact with objects (deprecated, use 'dag' or 'files')
     block         Interact with raw blocks in the datastore
-    object        Interact with raw dag nodes
-    files         Interact with objects as if they were a unix filesystem
 
   ADVANCED COMMANDS
     daemon        Start a long-running daemon process
     mount         Mount an IPFS read-only mount point
     resolve       Resolve any type of name
-    name          Publish or resolve IPNS names
+    name          Publish and resolve IPNS names
+    key           Create and list IPNS name keypairs
     dns           Resolve DNS links
     pin           Pin objects to local storage
-    repo          Manipulate an IPFS repository
+    repo          Manipulate the IPFS repository
+    stats         Various operational stats
+    p2p           Libp2p stream mounting
+    filestore     Manage the filestore (experimental)
 
   NETWORK COMMANDS
     id            Show info about IPFS peers
@@ -322,6 +327,8 @@ SUBCOMMANDS
     version       Show IPFS version information
     update        Download and apply go-ipfs updates
     commands      List all available commands
+    cid           Convert and discover properties of CIDs
+    log           Manage and show logs of running daemon
 
   Use 'ipfs <command> --help' to learn more about each command.
 

--- a/README.md
+++ b/README.md
@@ -288,10 +288,10 @@ Basic proof of 'ipfs working' locally:
 
 SUBCOMMANDS
   BASIC COMMANDS
-    init          Initialize ipfs local configuration
-    add <path>    Add a file to ipfs
-    cat <ref>     Show ipfs object data
-    get <ref>     Download ipfs objects
+    init          Initialize local IPFS configuration
+    add <path>    Add a file to IPFS
+    cat <ref>     Show IPFS object data
+    get <ref>     Download IPFS objects
     ls <ref>      List links from an object
     refs <ref>    List hashes of links from an object
 
@@ -302,7 +302,7 @@ SUBCOMMANDS
 
   ADVANCED COMMANDS
     daemon        Start a long-running daemon process
-    mount         Mount an ipfs read-only mount point
+    mount         Mount an IPFS read-only mount point
     resolve       Resolve any type of name
     name          Publish or resolve IPNS names
     dns           Resolve DNS links
@@ -310,7 +310,7 @@ SUBCOMMANDS
     repo          Manipulate an IPFS repository
 
   NETWORK COMMANDS
-    id            Show info about ipfs peers
+    id            Show info about IPFS peers
     bootstrap     Add or remove bootstrap peers
     swarm         Manage connections to the p2p network
     dht           Query the DHT for values or peers
@@ -319,7 +319,7 @@ SUBCOMMANDS
 
   TOOL COMMANDS
     config        Manage configuration
-    version       Show ipfs version information
+    version       Show IPFS version information
     update        Download and apply go-ipfs updates
     commands      List all available commands
 

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -51,13 +51,13 @@ const adderOutChanSize = 8
 
 var AddCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Add a file or directory to ipfs.",
+		Tagline: "Add a file or directory to IPFS.",
 		ShortDescription: `
-Adds contents of <path> to ipfs. Use -r to add directories (recursively).
+Adds contents of <path> to IPFS. Use -r to add directories (recursively).
 `,
 		LongDescription: `
-Adds contents of <path> to ipfs. Use -r to add directories.
-Note that directories are added recursively, to form the ipfs
+Adds contents of <path> to IPFS. Use -r to add directories.
+Note that directories are added recursively, to form the IPFS
 MerkleDAG.
 
 If the daemon is not running, it will just add locally.
@@ -115,7 +115,7 @@ only-hash, and progress/status related flags) will change the final hash.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.FileArg("path", true, true, "The path to a file to be added to ipfs.").EnableRecursive().EnableStdin(),
+		cmds.FileArg("path", true, true, "The path to a file to be added to IPFS.").EnableRecursive().EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.OptionRecursivePath, // a builtin option that allows recursive paths (-r, --recursive)

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -53,10 +53,10 @@ var AddCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Add a file or directory to IPFS.",
 		ShortDescription: `
-Adds contents of <path> to IPFS. Use -r to add directories (recursively).
+Adds the content of <path> to IPFS. Use -r to add directories (recursively).
 `,
 		LongDescription: `
-Adds contents of <path> to IPFS. Use -r to add directories.
+Adds the content of <path> to IPFS. Use -r to add directories.
 Note that directories are added recursively, to form the IPFS
 MerkleDAG.
 

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -38,10 +38,10 @@ const (
 
 var ConfigCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Get and set ipfs config values.",
+		Tagline: "Get and set IPFS config values.",
 		ShortDescription: `
 'ipfs config' controls configuration variables. It works like 'git config'.
-The configuration values are stored in a config file inside your ipfs
+The configuration values are stored in a config file inside your IPFS_PATH
 repository.`,
 		LongDescription: `
 'ipfs config' controls configuration variables. It works

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -41,12 +41,11 @@ var ConfigCmd = &cmds.Command{
 		Tagline: "Get and set IPFS config values.",
 		ShortDescription: `
 'ipfs config' controls configuration variables. It works like 'git config'.
-The configuration values are stored in a config file inside your IPFS_PATH
-repository.`,
+The configuration values are stored in a config file inside your IPFS_PATH.`,
 		LongDescription: `
 'ipfs config' controls configuration variables. It works
 much like 'git config'. The configuration values are stored in a config
-file inside your IPFS repository.
+file inside your IPFS repository (IPFS_PATH).
 
 Examples:
 

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -24,9 +24,9 @@ const (
 // DagCmd provides a subset of commands for interacting with ipld dag objects
 var DagCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Interact with ipld dag objects.",
+		Tagline: "Interact with IPLD DAG objects.",
 		ShortDescription: `
-'ipfs dag' is used for creating and manipulating dag objects/hierarchies.
+'ipfs dag' is used for creating and manipulating DAG objects/hierarchies.
 
 This subcommand is currently an experimental feature, but it is intended
 to deprecate and replace the existing 'ipfs object' command moving forward.
@@ -67,7 +67,7 @@ type RootMeta struct {
 // DagPutCmd is a command for adding a dag node
 var DagPutCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Add a dag node to ipfs.",
+		Tagline: "Add a DAG node to IPFS.",
 		ShortDescription: `
 'ipfs dag put' accepts input from a file or stdin and parses it
 into an object of the specified format.
@@ -99,9 +99,9 @@ into an object of the specified format.
 // DagGetCmd is a command for getting a dag node from IPFS
 var DagGetCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Get a dag node from ipfs.",
+		Tagline: "Get a DAG node from IPFS.",
 		ShortDescription: `
-'ipfs dag get' fetches a dag node from ipfs and prints it out in the specified
+'ipfs dag get' fetches a DAG node from IPFS and prints it out in the specified
 format.
 `,
 	},
@@ -114,9 +114,9 @@ format.
 // DagResolveCmd returns address of highest block within a path and a path remainder
 var DagResolveCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Resolve ipld block",
+		Tagline: "Resolve IPLD block.",
 		ShortDescription: `
-'ipfs dag resolve' fetches a dag node from ipfs, prints its address and remaining path.
+'ipfs dag resolve' fetches a DAG node from IPFS, prints its address and remaining path.
 `,
 	},
 	Arguments: []cmds.Argument{
@@ -230,7 +230,7 @@ var DagExportCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Streams the selected DAG as a .car stream on stdout.",
 		ShortDescription: `
-'ipfs dag export' fetches a dag and streams it out as a well-formed .car file.
+'ipfs dag export' fetches a DAG and streams it out as a well-formed .car file.
 Note that at present only single root selections / .car files are supported.
 The output of blocks happens in strict DAG-traversal, first-seen, order.
 `,
@@ -260,9 +260,9 @@ func (s *DagStat) String() string {
 // DagStatCmd is a command for getting size information about an ipfs-stored dag
 var DagStatCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Gets stats for a DAG",
+		Tagline: "Gets stats for a DAG.",
 		ShortDescription: `
-'ipfs dag stat' fetches a dag and returns various statistics about the DAG.
+'ipfs dag stat' fetches a DAG and returns various statistics about it.
 Statistics include size and number of blocks.
 
 Note: This command skips duplicate blocks in reporting both size and the number of blocks

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
-	"github.com/dustin/go-humanize"
 	bservice "github.com/ipfs/go-blockservice"
 	cid "github.com/ipfs/go-cid"
 	cidenc "github.com/ipfs/go-cidutil/cidenc"
@@ -22,7 +22,7 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	dag "github.com/ipfs/go-merkledag"
-	"github.com/ipfs/go-mfs"
+	mfs "github.com/ipfs/go-mfs"
 	ft "github.com/ipfs/go-unixfs"
 	iface "github.com/ipfs/interface-go-ipfs-core"
 	path "github.com/ipfs/interface-go-ipfs-core/path"
@@ -943,9 +943,9 @@ are run with the '--flush=false'.
 
 var filesChcidCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Change the cid version or hash function of the root node of a given path.",
+		Tagline: "Change the CID version or hash function of the root node of a given path.",
 		ShortDescription: `
-Change the cid version or hash function of the root node of a given path.
+Change the CID version or hash function of the root node of a given path.
 `,
 	},
 	Arguments: []cmds.Argument{

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -48,7 +48,7 @@ const (
 
 var IDCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Show ipfs node id info.",
+		Tagline: "Show IPFS node id info.",
 		ShortDescription: `
 Prints out information about the specified peer.
 If no peer is specified, prints out information for local peers.

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -300,7 +300,7 @@ var keyImportCmd = &cmds.Command{
 
 var keyListCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "List all local keypairs",
+		Tagline: "List all local keypairs.",
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("l", "Show extra information about keys."),
@@ -345,7 +345,7 @@ const (
 
 var keyRenameCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Rename a keypair",
+		Tagline: "Rename a keypair.",
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("name", true, false, "name of key to rename"),
@@ -396,7 +396,7 @@ var keyRenameCmd = &cmds.Command{
 
 var keyRmCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Remove a keypair",
+		Tagline: "Remove a keypair.",
 	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("name", true, true, "names of keys to remove").EnableStdin(),
@@ -440,7 +440,7 @@ var keyRmCmd = &cmds.Command{
 
 var keyRotateCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Rotates the ipfs identity.",
+		Tagline: "Rotates the IPFS identity.",
 		ShortDescription: `
 Generates a new ipfs identity and saves it to the ipfs config file.
 Your existing identity key will be backed up in the Keystore.

--- a/core/commands/name/ipnsps.go
+++ b/core/commands/name/ipnsps.go
@@ -43,7 +43,7 @@ Note: this command is experimental and subject to change as the system is refine
 
 var ipnspsStateCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Query the state of IPNS pubsub",
+		Tagline: "Query the state of IPNS pubsub.",
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		n, err := cmdenv.GetNode(env)
@@ -71,7 +71,7 @@ var ipnspsStateCmd = &cmds.Command{
 
 var ipnspsSubsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Show current name subscriptions",
+		Tagline: "Show current name subscriptions.",
 	},
 	Options: []cmds.Option{
 		ke.OptionIPNSBase,
@@ -115,7 +115,7 @@ var ipnspsSubsCmd = &cmds.Command{
 
 var ipnspsCancelCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Cancel a name subscription",
+		Tagline: "Cancel a name subscription.",
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		n, err := cmdenv.GetNode(env)

--- a/core/commands/object/diff.go
+++ b/core/commands/object/diff.go
@@ -21,7 +21,7 @@ type Changes struct {
 
 var ObjectDiffCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Display the diff between two ipfs objects.",
+		Tagline: "Display the diff between two IPFS objects.",
 		ShortDescription: `
 'ipfs object diff' is a command used to show the differences between
 two IPFS objects.`,

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -48,10 +48,10 @@ const (
 
 var ObjectCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Interact with IPFS objects.",
+		Tagline: "Interact with objects (deprecated, use 'dag' or 'files')",
 		ShortDescription: `
-'ipfs object' is a plumbing command used to manipulate DAG objects
-directly.`,
+'ipfs object' is a legacy plumbing command used to manipulate DAG objects
+directly. Deprecated, use more modern 'ipfs dag' and 'ipfs files' instead.`,
 	},
 
 	Subcommands: map[string]*cmds.Command{

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -48,9 +48,9 @@ const (
 
 var ObjectCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Interact with objects (deprecated, use 'dag' or 'files')",
+		Tagline: "Interact with dag-pb objects (deprecated, use generic 'dag')",
 		ShortDescription: `
-'ipfs object' is a legacy plumbing command used to manipulate DAG objects
+'ipfs object' is a legacy plumbing command used to manipulate dag-pb objects
 directly. Deprecated, use more modern 'ipfs dag' and 'ipfs files' instead.`,
 	},
 
@@ -69,14 +69,14 @@ directly. Deprecated, use more modern 'ipfs dag' and 'ipfs files' instead.`,
 // ObjectDataCmd object data command
 var ObjectDataCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Output the raw bytes of an IPFS object.",
+		Tagline: "Output the raw bytes of a dag-pb object.",
 		ShortDescription: `
 'ipfs object data' is a plumbing command for retrieving the raw bytes stored
-in a DAG node. It outputs to stdout, and <key> is a base58 encoded multihash.
+in a dag-pb node. It outputs to stdout, and <key> is a base58 encoded multihash.
 `,
 		LongDescription: `
 'ipfs object data' is a plumbing command for retrieving the raw bytes stored
-in a DAG node. It outputs to stdout, and <key> is a base58 encoded multihash.
+in a dag-pb node. It outputs to stdout, and <key> is a base58 encoded multihash.
 
 Note that the "--encoding" option does not affect the output, since the output
 is the raw data of the object.
@@ -106,16 +106,16 @@ is the raw data of the object.
 // ObjectLinksCmd object links command
 var ObjectLinksCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Output the links pointed to by the specified object.",
+		Tagline: "Output the links pointed to by the specified dag-pb object.",
 		ShortDescription: `
 'ipfs object links' is a plumbing command for retrieving the links from
-a DAG node. It outputs to stdout, and <key> is a base58 encoded
+a dag-pb node. It outputs to stdout, and <key> is a base58 encoded
 multihash.
 `,
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format.").EnableStdin(),
+		cmds.StringArg("key", true, false, "Key of the dag-pb object to retrieve, in base58-encoded multihash format.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(headersOptionName, "v", "Print table headers (Hash, Size, Name)."),
@@ -180,14 +180,14 @@ multihash.
 // ObjectGetCmd object get command
 var ObjectGetCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Get and serialize the DAG node named by <key>.",
+		Tagline: "Get and serialize the dag-pb node named by <key>.",
 		ShortDescription: `
-'ipfs object get' is a plumbing command for retrieving DAG nodes.
+'ipfs object get' is a plumbing command for retrieving dag-pb nodes.
 It serializes the DAG node to the format specified by the "--encoding"
 flag. It outputs to stdout, and <key> is a base58 encoded multihash.
 `,
 		LongDescription: `
-'ipfs object get' is a plumbing command for retrieving DAG nodes.
+'ipfs object get' is a plumbing command for retrieving dag-pb nodes.
 It serializes the DAG node to the format specified by the "--encoding"
 flag. It outputs to stdout, and <key> is a base58 encoded multihash.
 
@@ -207,7 +207,7 @@ Supported values are:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format.").EnableStdin(),
+		cmds.StringArg("key", true, false, "Key of the dag-pb object to retrieve, in base58-encoded multihash format.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.StringOption(encodingOptionName, "Encoding type of the data field, either \"text\" or \"base64\".").WithDefault("text"),
@@ -287,9 +287,9 @@ Supported values are:
 // ObjectStatCmd object stat command
 var ObjectStatCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Get stats for the DAG node named by <key>.",
+		Tagline: "Get stats for the dag-pb node named by <key>.",
 		ShortDescription: `
-'ipfs object stat' is a plumbing command to print DAG node statistics.
+'ipfs object stat' is a plumbing command to print dag-pb node statistics.
 <key> is a base58 encoded multihash. It outputs to stdout:
 
 	NumLinks        int number of links in link table
@@ -360,13 +360,13 @@ var ObjectStatCmd = &cmds.Command{
 // ObjectPutCmd object put command
 var ObjectPutCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Store input as a DAG object, print its key.",
+		Tagline: "Store input as a dag-pb object, print its key.",
 		ShortDescription: `
-'ipfs object put' is a plumbing command for storing DAG nodes.
+'ipfs object put' is a plumbing command for storing dag-pb nodes.
 It reads from stdin, and the output is a base58 encoded multihash.
 `,
 		LongDescription: `
-'ipfs object put' is a plumbing command for storing DAG nodes.
+'ipfs object put' is a plumbing command for storing dag-pb nodes.
 It reads from stdin, and the output is a base58 encoded multihash.
 
 Data should be in the format specified by the --inputenc flag.
@@ -397,7 +397,7 @@ And then run:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.FileArg("data", true, false, "Data to be stored as a DAG object.").EnableStdin(),
+		cmds.FileArg("data", true, false, "Data to be stored as a dag-pb object.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.StringOption(inputencOptionName, "Encoding type of input data. One of: {\"protobuf\", \"json\"}.").WithDefault("json"),
@@ -466,12 +466,12 @@ And then run:
 // ObjectNewCmd object new command
 var ObjectNewCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Create a new object from an IPFS template.",
+		Tagline: "Create a new dag-pb object from a template.",
 		ShortDescription: `
-'ipfs object new' is a plumbing command for creating new DAG nodes.
+'ipfs object new' is a plumbing command for creating new dag-pb nodes.
 `,
 		LongDescription: `
-'ipfs object new' is a plumbing command for creating new DAG nodes.
+'ipfs object new' is a plumbing command for creating new dag-pb nodes.
 By default it creates and returns a new empty merkledag node, but
 you may pass an optional template argument to create a preformatted
 node.

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -8,11 +8,11 @@ import (
 	"io/ioutil"
 	"text/tabwriter"
 
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipfs-cmds"
 	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
 	"github.com/ipfs/interface-go-ipfs-core/options"
@@ -466,7 +466,7 @@ And then run:
 // ObjectNewCmd object new command
 var ObjectNewCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Create a new object from an ipfs template.",
+		Tagline: "Create a new object from an IPFS template.",
 		ShortDescription: `
 'ipfs object new' is a plumbing command for creating new DAG nodes.
 `,

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
-	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/ipfs/interface-go-ipfs-core/path"
 )
@@ -31,7 +31,7 @@ result. This is the Merkle-DAG version of modifying an object.
 
 var patchAppendDataCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Append data to the data segment of a dag node.",
+		Tagline: "Append data to the data segment of a DAG node.",
 		ShortDescription: `
 Append data to what already exists in the data segment in the given object.
 

--- a/core/commands/p2p.go
+++ b/core/commands/p2p.go
@@ -79,7 +79,7 @@ are refined`,
 
 var p2pForwardCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Forward connections to libp2p service",
+		Tagline: "Forward connections to libp2p service.",
 		ShortDescription: `
 Forward connections made to <listen-address> to <target-address>.
 
@@ -180,7 +180,7 @@ func parseIpfsAddr(addr string) (*peer.AddrInfo, error) {
 
 var p2pListenCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Create libp2p service",
+		Tagline: "Create libp2p service.",
 		ShortDescription: `
 Create libp2p service and forward connections made to <target-address>.
 

--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -523,7 +523,7 @@ const (
 
 var updatePinCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Update a recursive pin",
+		Tagline: "Update a recursive pin.",
 		ShortDescription: `
 Efficiently pins a new object based on differences from an existing one and,
 by default, removes the old pin.

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -32,7 +32,7 @@ var Root = &cmds.Command{
 		Synopsis: "ipfs [--config=<config> | -c] [--debug | -D] [--help] [-h] [--api=<api>] [--offline] [--cid-base=<base>] [--upgrade-cidv0-in-output] [--encoding=<encoding> | --enc] [--timeout=<timeout>] <command> ...",
 		Subcommands: `
 BASIC COMMANDS
-  init          Initialize ipfs local configuration
+  init          Initialize local IPFS configuration
   add <path>    Add a file to IPFS
   cat <ref>     Show IPFS object data
   get <ref>     Download IPFS objects
@@ -40,10 +40,10 @@ BASIC COMMANDS
   refs <ref>    List hashes of links from an object
 
 DATA STRUCTURE COMMANDS
+  dag           Interact with IPLD DAG nodes
+  files         Interact with files as if they were a unix filesystem
+  object        Interact with objects (deprecated, use 'dag' or 'files')
   block         Interact with raw blocks in the datastore
-  object        Interact with raw dag nodes
-  files         Interact with objects as if they were a unix filesystem
-  dag           Interact with IPLD documents (experimental)
 
 ADVANCED COMMANDS
   daemon        Start a long-running daemon process

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -42,7 +42,7 @@ BASIC COMMANDS
 DATA STRUCTURE COMMANDS
   dag           Interact with IPLD DAG nodes
   files         Interact with files as if they were a unix filesystem
-  object        Interact with objects (deprecated, use 'dag' or 'files')
+  object        Interact with dag-pb objects (deprecated, use 'dag' or 'files')
   block         Interact with raw blocks in the datastore
 
 ADVANCED COMMANDS

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -68,7 +68,7 @@ NETWORK COMMANDS
 
 TOOL COMMANDS
   config        Manage configuration
-  version       Show ipfs version information
+  version       Show IPFS version information
   update        Download and apply go-ipfs updates
   commands      List all available commands
   cid           Convert and discover properties of CIDs

--- a/core/commands/shutdown.go
+++ b/core/commands/shutdown.go
@@ -1,14 +1,13 @@
 package commands
 
 import (
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
-
-	"github.com/ipfs/go-ipfs-cmds"
 )
 
 var daemonShutdownCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Shut down the ipfs daemon",
+		Tagline: "Shut down the IPFS daemon.",
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		nd, err := cmdenv.GetNode(env)

--- a/core/commands/stat.go
+++ b/core/commands/stat.go
@@ -42,7 +42,7 @@ const (
 
 var statBwCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Print ipfs bandwidth information.",
+		Tagline: "Print IPFS bandwidth information.",
 		ShortDescription: `'ipfs stats bw' prints bandwidth information for the ipfs daemon.
 It displays: TotalIn, TotalOut, RateIn, RateOut.
 		`,

--- a/core/commands/stat_dht.go
+++ b/core/commands/stat_dht.go
@@ -35,7 +35,7 @@ type dhtBucket struct {
 
 var statDhtCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Returns statistics about the node's DHT(s)",
+		Tagline: "Returns statistics about the node's DHT(s).",
 		ShortDescription: `
 Returns statistics about the DHT(s) the node is participating in.
 

--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"io"
 
+	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	tar "github.com/ipfs/go-ipfs/tar"
 
-	"github.com/ipfs/go-ipfs-cmds"
 	dag "github.com/ipfs/go-merkledag"
 	path "github.com/ipfs/interface-go-ipfs-core/path"
 )
@@ -25,7 +25,7 @@ var TarCmd = &cmds.Command{
 
 var tarAddCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Import a tar file into ipfs.",
+		Tagline: "Import a tar file into IPFS.",
 		ShortDescription: `
 'ipfs tar add' will parse a tar file and create a merkledag structure to
 represent it.

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -30,8 +30,8 @@ const (
 
 var VersionCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline:          "Show ipfs version information.",
-		ShortDescription: "Returns the current version of ipfs and exits.",
+		Tagline:          "Show IPFS version information.",
+		ShortDescription: "Returns the current version of IPFS and exits.",
 	},
 	Subcommands: map[string]*cmds.Command{
 		"deps": depsVersionCommand,
@@ -105,7 +105,7 @@ const pkgVersionFmt = "%s@%s"
 
 var depsVersionCommand = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Shows information about dependencies used for build",
+		Tagline: "Shows information about dependencies used for build.",
 		ShortDescription: `
 Print out all dependencies and their versions.`,
 	},


### PR DESCRIPTION
People fixed a bunch of style issues in https://docs.ipfs.io/reference/http/api/

Unfortunately, those API docs are generated from go-ipfs sources via https://github.com/ipfs/http-api-docs tool,  so it all gets lost when API docs for new version are re-generated.

This PR:

-  Re-applies manual fixes from https://docs.ipfs.io/reference/http/api/  to `--help` text in go-ipfs.
   This way the next time http-api-docs are re-generated, those changes stay.

- Updates and reorders  operations on `ipfs --help`  to prioritize 'dag' and 'files' over legacy 'object'
  Context: https://github.com/ipfs/go-ipfs/issues/7936

- Clarifies that `ipfs object` only works with `dag-pb` ([multiformats/table.csv#L42](https://github.com/multiformats/multicodec/blob/909e183da65818ecd1e672904980e53711da8780/table.csv#L42))  – closes https://github.com/ipfs/go-ipfs/issues/7396


cc @aschmahmann – potential candidate for inclusion in 0.8.1
cc @johnnymatthews  for general awareness