### PR TITLE
fix: omit empty pins slice when reporting pin progress

### DIFF
--- a/core/commands/pin/pin.go
+++ b/core/commands/pin/pin.go
@@ -44,8 +44,8 @@ type PinOutput struct {
 }
 
 type AddPinOutput struct {
-	Pins     []string
-	Progress int `json:",omitempty"`
+	Pins     []string `json:",omitempty"`
+	Progress int      `json:",omitempty"`
 }
 
 const (


### PR DESCRIPTION
Otherwise, we get messages of the form `{Pins: null, Progress: 100}`. After this change, we'll get `{Progress: 100}`.