### PR TITLE
Update migration sharness tests for new migrations

### DIFF
--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -57,7 +57,6 @@ test_expect_success "output looks good" '
   grep "Success: fs-repo migrated to version 11" true_out > /dev/null
 '
 
-# Daemon exits with 1 after the prompt gets "n" when asking to migrate. 
 test_expect_success "'ipfs daemon' prompts to auto migrate" '
   test_expect_code 1 ipfs daemon > daemon_out 2> daemon_err
 '

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -59,7 +59,7 @@ test_expect_success "output looks good" '
 
 # Daemon exits with 1 after the prompt gets "n" when asking to migrate. 
 test_expect_success "'ipfs daemon' prompts to auto migrate" '
-  test_expect_code 1 bash -c "echo n | ipfs daemon > daemon_out 2> daemon_err"
+  test_expect_code 1 ipfs daemon > daemon_out 2> daemon_err
 '
 
 test_expect_success "output looks good" '

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -10,16 +10,27 @@ test_description="Test migrations auto update prompt"
 
 test_init_ipfs
 
+# Create fake migration binaries instead of letting ipfs download from network
+# To test downloading and running actual binaries, comment out this test.
 test_expect_success "setup mock migrations" '
   mkdir bin &&
-  echo "#!/bin/bash" > bin/fs-repo-migrations &&
-  echo "echo 5" >> bin/fs-repo-migrations &&
-  chmod +x bin/fs-repo-migrations &&
+  echo "#!/bin/bash" > bin/fs-repo-7-to-8 &&
+  echo "echo fake applying 7-to-8 repo migration" >> bin/fs-repo-7-to-8 &&
+  chmod +x bin/fs-repo-7-to-8 &&
+  echo "#!/bin/bash" > bin/fs-repo-8-to-9 &&
+  echo "echo fake applying 8-to-9 repo migration" >> bin/fs-repo-8-to-9 &&
+  chmod +x bin/fs-repo-8-to-9 &&
+  echo "#!/bin/bash" > bin/fs-repo-9-to-10 &&
+  echo "echo fake applying 9-to-10 repo migration" >> bin/fs-repo-9-to-10 &&
+  chmod +x bin/fs-repo-9-to-10 &&
+  echo "#!/bin/bash" > bin/fs-repo-10-to-11 &&
+  echo "echo fake applying 10-to-11 repo migration" >> bin/fs-repo-10-to-11 &&
+  chmod +x bin/fs-repo-10-to-11 &&
   export PATH="$(pwd)/bin":$PATH
 '
 
-test_expect_success "manually reset repo version to 3" '
-  echo "3" > "$IPFS_PATH"/version
+test_expect_success "manually reset repo version to 7" '
+  echo "7" > "$IPFS_PATH"/version
 '
 
 test_expect_success "ipfs daemon --migrate=false fails" '
@@ -30,17 +41,25 @@ test_expect_success "output looks good" '
   grep "Please get fs-repo-migrations from https://dist.ipfs.io" false_out
 '
 
+# The migrations will succeed, but the daemon will still exit with 1 because
+# the fake migrations do not update the repo version number.
+#
+# If run with real migrations, the daemon continues running and must be killed.
 test_expect_success "ipfs daemon --migrate=true runs migration" '
-  test_expect_code 1 ipfs daemon --migrate=true > true_out
+  test_expect_code 1 ipfs daemon --migrate=true > true_out 2>&1
 '
 
-test_expect_failure "output looks good" '
-  grep "Running: " true_out > /dev/null &&
-  grep "Success: fs-repo has been migrated to version 5." true_out > /dev/null
+test_expect_success "output looks good" '
+  grep "applying 7-to-8 repo migration" true_out > /dev/null &&
+  grep "applying 8-to-9 repo migration" true_out > /dev/null &&
+  grep "applying 9-to-10 repo migration" true_out > /dev/null &&
+  grep "applying 10-to-11 repo migration" true_out > /dev/null &&
+  grep "Success: fs-repo migrated to version 11" true_out > /dev/null
 '
 
+# Daemon exits with 1 after the prompt gets "n" when asking to migrate. 
 test_expect_success "'ipfs daemon' prompts to auto migrate" '
-  test_expect_code 1 ipfs daemon > daemon_out 2> daemon_err
+  test_expect_code 1 bash -c "echo n | ipfs daemon > daemon_out 2> daemon_err"
 '
 
 test_expect_success "output looks good" '

--- a/test/sharness/t0066-migration.sh
+++ b/test/sharness/t0066-migration.sh
@@ -46,7 +46,7 @@ test_expect_success "output looks good" '
 #
 # If run with real migrations, the daemon continues running and must be killed.
 test_expect_success "ipfs daemon --migrate=true runs migration" '
-  test_expect_code 1 ipfs daemon --migrate=true > true_out 2>&1
+  test_expect_code 1 ipfs daemon --migrate=true > true_out
 '
 
 test_expect_success "output looks good" '


### PR DESCRIPTION
With the new migrations, go-ipfs no longer uses `fs-repo-migrations` to do repo migrations, and was downloading real migration binaries from the network and running them.  This caused failure, but was not caught because the test was expecting `ipfs daemon --migrate` to fail for other reasons.

This PR fixes the migration tests by creating the appropriate fake migration binaries in the `PATH` so that those are run instead of downloading the real ones.  This also fixes a test that was previously marked broken.