### PR TITLE
chore: dont docker tag rc as latest

### DIFF
--- a/bin/push-docker-tags.sh
+++ b/bin/push-docker-tags.sh
@@ -6,7 +6,7 @@
 # A bit like dockerhub autobuild config, but somewhere we can version control it.
 # 
 # The `docker-build` job in .circleci/config.yml builds the current commit
-# in docker and tags it as ipfs/go-ipfs:wip
+# in docker and tags it as ipfs/go-ipfs:wip
 #
 # Then the `docker-publish` job runs this script to decide what tag, if any,
 # to publish to dockerhub.
@@ -59,9 +59,13 @@ pushTag () {
   fi
 }
 
-if [[ $GIT_TAG =~ ^v[0-9]+ ]]; then
+if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc ]]; then
+  pushTag "$GIT_TAG"
+
+elif [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   pushTag "$GIT_TAG"
   pushTag "latest"
+  pushTag "release" # see: https://github.com/ipfs/go-ipfs/issues/3999#issuecomment-742228981
 
 elif [ "$GIT_BRANCH" = "feat/stabilize-dht" ]; then
   pushTag "bifrost-${BUILD_NUM}-${GIT_SHA1_SHORT}"


### PR DESCRIPTION
- add guard for rc releases; publish them to docker hub with the matching git tag
- make the semver regex stricter and only publish as latest when a full semver tag with no pre-release suffix is the name of the git tag.
- add `release` tag as an alias of `latest` as per https://github.com/ipfs/go-ipfs/issues/3999#issuecomment-742228981

Tested manually as the push-docker-tag.sh script is set up for it:
```shell
./push-docker-tags.sh $(date -u +%F) testingsha release v0.9.0-test dry
Nothing to do. No docker tag defined for branch: release, tag: v0.9.0-test

./push-docker-tags.sh $(date -u +%F) testingsha release v0.9.0-rc1 dry
DRY RUN! I would have tagged and pushed the following...
docker tag ipfs/go-ipfs:wip ipfs/go-ipfs:v0.9.0-rc1
docker push ipfs/go-ipfs:v0.9.0-rc1

./push-docker-tags.sh $(date -u +%F) testingsha release v0.9.0 dry
DRY RUN! I would have tagged and pushed the following...
docker tag ipfs/go-ipfs:wip ipfs/go-ipfs:v0.9.0
docker push ipfs/go-ipfs:v0.9.0
DRY RUN! I would have tagged and pushed the following...
docker tag ipfs/go-ipfs:wip ipfs/go-ipfs:latest
docker push ipfs/go-ipfs:latest
DRY RUN! I would have tagged and pushed the following...
docker tag ipfs/go-ipfs:wip ipfs/go-ipfs:release
docker push ipfs/go-ipfs:release
```

fixes #3999

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>