### PR TITLE
go-namesys v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/ipfs/go-metrics-interface v0.0.1
 	github.com/ipfs/go-metrics-prometheus v0.0.2
 	github.com/ipfs/go-mfs v0.1.2
-	github.com/ipfs/go-namesys v0.1.0
+	github.com/ipfs/go-namesys v0.1.1
 	github.com/ipfs/go-path v0.0.9
 	github.com/ipfs/go-pinning-service-http-client v0.1.0
 	github.com/ipfs/go-unixfs v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/ipfs/go-metrics-prometheus v0.0.2 h1:9i2iljLg12S78OhC6UAiXi176xvQGiZa
 github.com/ipfs/go-metrics-prometheus v0.0.2/go.mod h1:ELLU99AQQNi+zX6GCGm2lAgnzdSH3u5UVlCdqSXnEks=
 github.com/ipfs/go-mfs v0.1.2 h1:DlelNSmH+yz/Riy0RjPKlooPg0KML4lXGdLw7uZkfAg=
 github.com/ipfs/go-mfs v0.1.2/go.mod h1:T1QBiZPEpkPLzDqEJLNnbK55BVKVlNi2a+gVm4diFo0=
-github.com/ipfs/go-namesys v0.1.0 h1:3wTIZ7oD9X9clmA+9cpZF6I7tZky24ahUvq0Oz7FD4c=
-github.com/ipfs/go-namesys v0.1.0/go.mod h1:JITpuwDgYYh84sXxw8bQXY3aTlEdyJqkbzvE12YzXgM=
+github.com/ipfs/go-namesys v0.1.1 h1:HwJWd1h0Z4oALjdOz8aP/38SHgyOfh0MUUaanvEUUn8=
+github.com/ipfs/go-namesys v0.1.1/go.mod h1:JITpuwDgYYh84sXxw8bQXY3aTlEdyJqkbzvE12YzXgM=
 github.com/ipfs/go-path v0.0.7/go.mod h1:6KTKmeRnBXgqrTvzFrPV3CamxcgvXX/4z79tfAd2Sno=
 github.com/ipfs/go-path v0.0.9 h1:BIi831cNED8YnIlIKo9y1SI3u+E+FwQQD+rIIw8PwFA=
 github.com/ipfs/go-path v0.0.9/go.mod h1:VpDkSBKQ9EFQOUgi54Tq/O/tGi8n1RfYNks13M3DEs8=


### PR DESCRIPTION
The new version has an improved resolve error and fixes #8000 

Changelog: https://github.com/ipfs/go-namesys/releases/tag/v0.1.1