### PR TITLE
fix(gw): remove hardcoded hostnames

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -23,12 +23,7 @@ import (
 	nsopts "github.com/ipfs/interface-go-ipfs-core/options/namesys"
 )
 
-var defaultPaths = []string{"/ipfs/", "/ipns/", "/api/", "/p2p/", "/version"}
-
-var pathGatewaySpec = &config.GatewaySpec{
-	Paths:         defaultPaths,
-	UseSubdomains: false,
-}
+var defaultPaths = []string{"/ipfs/", "/ipns/", "/api/", "/p2p/"}
 
 var subdomainGatewaySpec = &config.GatewaySpec{
 	Paths:         defaultPaths,
@@ -36,10 +31,7 @@ var subdomainGatewaySpec = &config.GatewaySpec{
 }
 
 var defaultKnownGateways = map[string]*config.GatewaySpec{
-	"localhost":       subdomainGatewaySpec,
-	"ipfs.io":         pathGatewaySpec,
-	"gateway.ipfs.io": pathGatewaySpec,
-	"dweb.link":       subdomainGatewaySpec,
+	"localhost": subdomainGatewaySpec,
 }
 
 // Label's max length in DNS (https://tools.ietf.org/html/rfc1034#page-7)


### PR DESCRIPTION
This PR closes #7317 by removing hard-coded PL hostnames from the default config, making the localhost the only implicit gateway hostname defined out-of-the-box.

@mburns to double-check if `dweb.link` uses explicit [`Gateway.PublicGateways`](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#gatewaypublicgateways-usesubdomains) config so it is not impacted by this change.