### PR TITLE
disable-last-modified-behaviour-ipns-routes

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -299,8 +299,9 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	// set these headers _after_ the error, for we may just not have it
 	// and don't want the client to cache a 500 response...
 	// and only if it's /ipfs!
-	// TODO: break this out when we split /ipfs /ipns routes.
-	modtime := time.Now()
+
+	// ipns routes do not require LastModified header, disable by passing zero date to ServeContent
+	modtime := time.Time{}
 
 	if f, ok := dr.(files.File); ok {
 		if strings.HasPrefix(urlPath, ipfsPathPrefix) {


### PR DESCRIPTION
[7968](https://github.com/ipfs/go-ipfs/issues/7968) `Webgateway: sets 'last-modified' header to now() `

@RubenKelevra @Stebalien 

As per the [documentation](https://golang.org/pkg/net/http/#ServeContent):

`If modtime is not zero time, ServeContent includes it in the Last-Modified header in the response. If the request includes an If-Modified-Since header, ServeContent uses modtime to determine whether the content needs to be sent at all.`

To disable this behaviour, pass a "zero" date to ServeContent.

This change only effects `ipns` routes not `ipfs` routes.


