### PR TITLE
Move dag import and export into the local node CoreAPI implementation

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -2,6 +2,7 @@ package dagcmd
 
 import (
 	"fmt"
+	"github.com/ipfs/go-ipfs/core/coreapi"
 	"io"
 
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
@@ -55,13 +56,7 @@ type ResolveOutput struct {
 
 // CarImportOutput is the output type of the 'dag import' commands
 type CarImportOutput struct {
-	Root RootMeta
-}
-
-// RootMeta is the metadata for a root pinning response
-type RootMeta struct {
-	Cid         cid.Cid
-	PinErrorMsg string
+	Root coreapi.RootMeta
 }
 
 // DagPutCmd is a command for adding a dag node
@@ -154,11 +149,6 @@ var DagResolveCmd = &cmds.Command{
 		}),
 	},
 	Type: ResolveOutput{},
-}
-
-type importResult struct {
-	roots map[cid.Cid]struct{}
-	err   error
 }
 
 // DagImportCmd is a command for importing a car to ipfs

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -1,28 +1,21 @@
 package dagcmd
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"io"
-
-	cid "github.com/ipfs/go-cid"
 	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
-	ipld "github.com/ipfs/go-ipld-format"
-	iface "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/ipfs/go-ipfs/core/coreapi"
 	"github.com/ipfs/interface-go-ipfs-core/options"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
-	gocar "github.com/ipld/go-car"
 )
 
+type dagImportAPI interface {
+	ImportMany(ctx context.Context, directory files.Directory, pinRoots bool) (<-chan coreapi.RootMeta, <-chan error)
+}
+
 func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-
-	node, err := cmdenv.GetNode(env)
-	if err != nil {
-		return err
-	}
-
 	api, err := cmdenv.GetApi(env, req)
 	if err != nil {
 		return err
@@ -36,166 +29,44 @@ func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 		return err
 	}
 
-	// grab a pinlock ( which doubles as a GC lock ) so that regardless of the
-	// size of the streamed-in cars nothing will disappear on us before we had
-	// a chance to roots that may show up at the very end
-	// This is especially important for use cases like dagger:
-	//    ipfs dag import $( ... | ipfs-dagger --stdout=carfifos )
-	//
-	unlocker := node.Blockstore.PinLock()
-	defer unlocker.Unlock()
+	dagapi, ok := api.Dag().(dagImportAPI)
+	if !ok {
+		return fmt.Errorf("API does not support DAG import")
+	}
 
 	doPinRoots, _ := req.Options[pinRootsOptionName].(bool)
 
-	retCh := make(chan importResult, 1)
-	go importWorker(req, res, api, retCh)
+	resCh, errCh := dagapi.ImportMany(req.Context, req.Files, doPinRoots)
 
-	done := <-retCh
-	if done.err != nil {
-		return done.err
+	err = <-errCh
+	if err != nil {
+		return err
 	}
 
-	// It is not guaranteed that a root in a header is actually present in the same ( or any )
-	// .car file. This is the case in version 1, and ideally in further versions too
-	// Accumulate any root CID seen in a header, and supplement its actual node if/when encountered
-	// We will attempt a pin *only* at the end in case all car files were well formed
-	//
-	// The boolean value indicates whether we have encountered the root within the car file's
-	roots := done.roots
+	if !doPinRoots {
+		return nil
+	}
 
-	// opportunistic pinning: try whatever sticks
-	if doPinRoots {
+	var failedPins, totalRoots int
 
-		var failedPins int
-		for c := range roots {
-
-			// We need to re-retrieve a block, convert it to ipld, and feed it
-			// to the Pinning interface, sigh...
-			//
-			// If we didn't have the problem of inability to take multiple pinlocks,
-			// we could use the api directly like so (though internally it does the same):
-			//
-			// // not ideal, but the pinning api takes only paths :(
-			// rp := path.NewResolvedPath(
-			// 	ipfspath.FromCid(c),
-			// 	c,
-			// 	c,
-			// 	"",
-			// )
-			//
-			// if err := api.Pin().Add(req.Context, rp, options.Pin.Recursive(true)); err != nil {
-
-			ret := RootMeta{Cid: c}
-
-			if block, err := node.Blockstore.Get(c); err != nil {
-				ret.PinErrorMsg = err.Error()
-			} else if nd, err := ipld.Decode(block); err != nil {
-				ret.PinErrorMsg = err.Error()
-			} else if err := node.Pinning.Pin(req.Context, nd, true); err != nil {
-				ret.PinErrorMsg = err.Error()
-			} else if err := node.Pinning.Flush(req.Context); err != nil {
-				ret.PinErrorMsg = err.Error()
-			}
-
-			if ret.PinErrorMsg != "" {
-				failedPins++
-			}
-
-			if err := res.Emit(&CarImportOutput{Root: ret}); err != nil {
-				return err
-			}
+	for ret := range resCh {
+		if ret.PinErrorMsg != "" {
+			failedPins++
 		}
+		totalRoots++
 
-		if failedPins > 0 {
-			return fmt.Errorf(
-				"unable to pin all roots: %d out of %d failed",
-				failedPins,
-				len(roots),
-			)
+		if err := res.Emit(&CarImportOutput{Root: ret}); err != nil {
+			return err
 		}
+	}
+
+	if doPinRoots && failedPins > 0 {
+		return fmt.Errorf(
+			"unable to pin all roots: %d out of %d failed",
+			failedPins,
+			totalRoots,
+		)
 	}
 
 	return nil
-}
-
-func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI, ret chan importResult) {
-
-	// this is *not* a transaction
-	// it is simply a way to relieve pressure on the blockstore
-	// similar to pinner.Pin/pinner.Flush
-	batch := ipld.NewBatch(req.Context, api.Dag())
-
-	roots := make(map[cid.Cid]struct{})
-
-	it := req.Files.Entries()
-	for it.Next() {
-
-		file := files.FileFromEntry(it)
-		if file == nil {
-			ret <- importResult{err: errors.New("expected a file handle")}
-			return
-		}
-
-		// wrap a defer-closer-scope
-		//
-		// every single file in it() is already open before we start
-		// just close here sooner rather than later for neatness
-		// and to surface potential errors writing on closed fifos
-		// this won't/can't help with not running out of handles
-		err := func() error {
-			defer file.Close()
-
-			car, err := gocar.NewCarReader(file)
-			if err != nil {
-				return err
-			}
-
-			// Be explicit here, until the spec is finished
-			if car.Header.Version != 1 {
-				return errors.New("only car files version 1 supported at present")
-			}
-
-			for _, c := range car.Header.Roots {
-				roots[c] = struct{}{}
-			}
-
-			for {
-				block, err := car.Next()
-				if err != nil && err != io.EOF {
-					return err
-				} else if block == nil {
-					break
-				}
-
-				// the double-decode is suboptimal, but we need it for batching
-				nd, err := ipld.Decode(block)
-				if err != nil {
-					return err
-				}
-
-				if err := batch.Add(req.Context, nd); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}()
-
-		if err != nil {
-			ret <- importResult{err: err}
-			return
-		}
-	}
-
-	if err := it.Err(); err != nil {
-		ret <- importResult{err: err}
-		return
-	}
-
-	if err := batch.Commit(); err != nil {
-		ret <- importResult{err: err}
-		return
-	}
-
-	ret <- importResult{roots: roots}
 }

--- a/core/coreapi/dag.go
+++ b/core/coreapi/dag.go
@@ -2,11 +2,15 @@ package coreapi
 
 import (
 	"context"
+	"errors"
+	"io"
 
 	cid "github.com/ipfs/go-cid"
+	files "github.com/ipfs/go-ipfs-files"
 	"github.com/ipfs/go-ipfs-pinner"
 	ipld "github.com/ipfs/go-ipld-format"
 	dag "github.com/ipfs/go-merkledag"
+	gocar "github.com/ipld/go-car"
 )
 
 type dagAPI struct {
@@ -54,6 +58,200 @@ func (api *dagAPI) Pinning() ipld.NodeAdder {
 
 func (api *dagAPI) Session(ctx context.Context) ipld.NodeGetter {
 	return dag.NewSession(ctx, api.DAGService)
+}
+
+// RootMeta is the metadata for a root pinning response
+type RootMeta struct {
+	Cid         cid.Cid
+	PinErrorMsg string
+}
+
+// ImportMany imports CAR files into the blockstore and returns the root CIDs. If pinning was requested errors that
+// occurred when importing each root will be returned as well.
+//
+// This function's API is not yet stable
+func (api *dagAPI) ImportMany(ctx context.Context, directory files.Directory, doPinRoots bool) (<-chan RootMeta, <-chan error) {
+	// grab a pinlock ( which doubles as a GC lock ) so that regardless of the
+	// size of the streamed-in cars nothing will disappear on us before we had
+	// a chance to roots that may show up at the very end
+	// This is especially important for use cases like dagger:
+	//    ipfs dag import $( ... | ipfs-dagger --stdout=carfifos )
+	//
+	unlocker := api.core.blockstore.PinLock()
+	defer unlocker.Unlock()
+
+	retCh := make(chan importResult, 1)
+	go api.importWorker(ctx, directory, retCh)
+
+	rootsCh := make(chan RootMeta, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(errCh)
+		defer close(rootsCh)
+
+		done := <-retCh
+		if done.err != nil {
+			errCh <- done.err
+			return
+		}
+
+		// It is not guaranteed that a root in a header is actually present in the same ( or any )
+		// .car file. This is the case in version 1, and ideally in further versions too
+		// Accumulate any root CID seen in a header, and supplement its actual node if/when encountered
+		// We will attempt a pin *only* at the end in case all car files were well formed
+		//
+		// The boolean value indicates whether we have encountered the root within the car file's
+		roots := done.roots
+
+		// If we are not pinning roots then just return all the roots
+		if !doPinRoots {
+			for r := range roots {
+				select {
+				case rootsCh <- RootMeta{Cid: r}:
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				}
+			}
+			return
+		}
+
+		// opportunistic pinning: try whatever sticks
+		if doPinRoots {
+
+			var failedPins int
+			for c := range roots {
+
+				// We need to re-retrieve a block, convert it to ipld, and feed it
+				// to the Pinning interface, sigh...
+				//
+				// If we didn't have the problem of inability to take multiple pinlocks,
+				// we could use the api directly like so (though internally it does the same):
+				//
+				// // not ideal, but the pinning api takes only paths :(
+				// rp := path.NewResolvedPath(
+				// 	ipfspath.FromCid(c),
+				// 	c,
+				// 	c,
+				// 	"",
+				// )
+				//
+				// if err := api.Pin().Add(req.Context, rp, options.Pin.Recursive(true)); err != nil {
+
+				ret := RootMeta{Cid: c}
+
+				if block, err := api.core.blockstore.Get(c); err != nil {
+					ret.PinErrorMsg = err.Error()
+				} else if nd, err := ipld.Decode(block); err != nil {
+					ret.PinErrorMsg = err.Error()
+				} else if err := api.core.pinning.Pin(ctx, nd, true); err != nil {
+					ret.PinErrorMsg = err.Error()
+				} else if err := api.core.pinning.Flush(ctx); err != nil {
+					ret.PinErrorMsg = err.Error()
+				}
+
+				if ret.PinErrorMsg != "" {
+					failedPins++
+				}
+
+				select {
+				case rootsCh <- ret:
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				}
+			}
+		}
+	}()
+
+	return rootsCh, errCh
+}
+
+type importResult struct {
+	roots map[cid.Cid]struct{}
+	err   error
+}
+
+func (api *dagAPI) importWorker(ctx context.Context, dir files.Directory, ret chan importResult) {
+	// this is *not* a transaction
+	// it is simply a way to relieve pressure on the blockstore
+	// similar to pinner.Pin/pinner.Flush
+	batch := ipld.NewBatch(ctx, api)
+
+	roots := make(map[cid.Cid]struct{})
+
+	it := dir.Entries()
+	for it.Next() {
+
+		file := files.FileFromEntry(it)
+		if file == nil {
+			ret <- importResult{err: errors.New("expected a file handle")}
+			return
+		}
+
+		// wrap a defer-closer-scope
+		//
+		// every single file in it() is already open before we start
+		// just close here sooner rather than later for neatness
+		// and to surface potential errors writing on closed fifos
+		// this won't/can't help with not running out of handles
+		err := func() error {
+			defer file.Close()
+
+			car, err := gocar.NewCarReader(file)
+			if err != nil {
+				return err
+			}
+
+			// Be explicit here, until the spec is finished
+			if car.Header.Version != 1 {
+				return errors.New("only car files version 1 supported at present")
+			}
+
+			for _, c := range car.Header.Roots {
+				roots[c] = struct{}{}
+			}
+
+			for {
+				block, err := car.Next()
+				if err != nil && err != io.EOF {
+					return err
+				} else if block == nil {
+					break
+				}
+
+				// the double-decode is suboptimal, but we need it for batching
+				nd, err := ipld.Decode(block)
+				if err != nil {
+					return err
+				}
+
+				if err := batch.Add(ctx, nd); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}()
+
+		if err != nil {
+			ret <- importResult{err: err}
+			return
+		}
+	}
+
+	if err := it.Err(); err != nil {
+		ret <- importResult{err: err}
+		return
+	}
+
+	if err := batch.Commit(); err != nil {
+		ret <- importResult{err: err}
+		return
+	}
+
+	ret <- importResult{roots: roots}
 }
 
 var (


### PR DESCRIPTION
This is an attempt to make importing/exporting CAR files into go-ipfs generally more usable before we extend the CoreAPI to include it.

The immediate use is to just unlock making it possible to do CAR import/export without going through the commands lib and either the CLI or HTTP API.