### PR TITLE
Monitor tool: query CIDs in BitSwap localhost

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -29,6 +29,7 @@ import (
 	migrate "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
 	sockets "github.com/libp2p/go-socket-activation"
 
+	logging "github.com/ipfs/go-log"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	mprome "github.com/ipfs/go-metrics-prometheus"
 	options "github.com/ipfs/interface-go-ipfs-core/options"
@@ -207,6 +208,13 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	// let the user know we're going.
 	fmt.Printf("Initializing daemon...\n")
+
+	if level := os.Getenv("BS_LOG"); level != "" {
+		logging.SetAllLoggers(logging.LevelWarn)
+		logging.SetLogLevel("bitswap", level)
+		logging.SetLogLevel("engine", level)
+		logging.SetLogLevel("bs:peermgr", level)
+	}
 
 	defer func() {
 		if _err != nil {

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -209,11 +209,14 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	// let the user know we're going.
 	fmt.Printf("Initializing daemon...\n")
 
-	if level := os.Getenv("BS_CFG_LOG"); level != "" {
+	bsLogLevel := os.Getenv("BS_CFG_LOG");
+	if  bsLogLevel == "" {
+		panic("BS_CFG_LOG not set, recommended to set to INFO")
+	} else {
 		logging.SetAllLoggers(logging.LevelWarn)
-		logging.SetLogLevel("bitswap", level)
-		logging.SetLogLevel("engine", level)
-		logging.SetLogLevel("bs:peermgr", level)
+		logging.SetLogLevel("bitswap", bsLogLevel)
+		logging.SetLogLevel("engine", bsLogLevel)
+		logging.SetLogLevel("bs:peermgr", bsLogLevel)
 	}
 
 	defer func() {

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -211,13 +211,11 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 	bsLogLevel := os.Getenv("BS_CFG_LOG");
 	if  bsLogLevel == "" {
-		panic("BS_CFG_LOG not set, recommended to set to INFO")
-	} else {
-		logging.SetAllLoggers(logging.LevelWarn)
-		logging.SetLogLevel("bitswap", bsLogLevel)
-		logging.SetLogLevel("engine", bsLogLevel)
-		logging.SetLogLevel("bs:peermgr", bsLogLevel)
+		bsLogLevel = "info"
 	}
+	logging.SetLogLevel("bitswap", bsLogLevel)
+	logging.SetLogLevel("engine", bsLogLevel)
+	logging.SetLogLevel("bs:peermgr", bsLogLevel)
 
 	defer func() {
 		if _err != nil {

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -209,7 +209,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	// let the user know we're going.
 	fmt.Printf("Initializing daemon...\n")
 
-	if level := os.Getenv("BS_LOG"); level != "" {
+	if level := os.Getenv("BS_CFG_LOG"); level != "" {
 		logging.SetAllLoggers(logging.LevelWarn)
 		logging.SetLogLevel("bitswap", level)
 		logging.SetLogLevel("engine", level)

--- a/core/node/core.go
+++ b/core/node/core.go
@@ -115,7 +115,7 @@ func OnlineExchange(provide bool) interface{} {
 						checkBitswapResponse(testContext, host.ID())
 
 						select {
-						case <-ctx.Done():
+						case <-helpers.LifecycleCtx(mctx, lc).Done():
 							return
 						case <-testContext.Done():
 						}

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -262,7 +262,7 @@ func Online(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 	shouldBitswapProvide := !cfg.Experimental.StrategicProviding
 
 	return fx.Options(
-		fx.Provide(OnlineExchange(shouldBitswapProvide)),
+		fx.Provide(OnlineExchange(shouldBitswapProvide, cfg.Internal.Bitswap)),
 		maybeProvide(Graphsync, cfg.Experimental.GraphsyncEnabled),
 		fx.Provide(Namesys(ipnsCacheSize)),
 		fx.Provide(Peering),

--- a/go.mod
+++ b/go.mod
@@ -112,3 +112,7 @@ require (
 )
 
 go 1.14
+
+// Only works with: GOPROXY=direct (https://github.com/golang/go/issues/32955#issuecomment-509318558)
+// Still, the branch name will get rewritten with the commit..
+replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap monitor/data-stall

--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,9 @@ require (
 
 go 1.14
 
+replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap v0.3.4-0.20210423195404-77774fa11f7a
+
+// Dev: To point to the (not fixed) branch (instead of fixed commit):
+// replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap monitor/data-stall
 // Only works with: GOPROXY=direct (https://github.com/golang/go/issues/32955#issuecomment-509318558)
-// Still, the branch name will get rewritten with the commit..
-replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap monitor/data-stall
+// Still, the branch name will get rewritten with the commit during first build.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/ipfs/go-bitswap v0.3.3
+	github.com/ipfs/go-bitswap v0.3.4-0.20210423224948-36c782e793b7
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4
 	github.com/ipfs/go-cid v0.0.7
@@ -112,8 +112,6 @@ require (
 )
 
 go 1.14
-
-replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap v0.3.4-0.20210423195404-77774fa11f7a
 
 // Dev: To point to the (not fixed) branch (instead of fixed commit):
 // replace github.com/ipfs/go-bitswap => github.com/ipfs/go-bitswap monitor/data-stall

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-cmds v0.6.0
-	github.com/ipfs/go-ipfs-config v0.12.0
+	github.com/ipfs/go-ipfs-config v0.16.1-0.20210830194616-e846165ea1ca
 	github.com/ipfs/go-ipfs-ds-help v0.1.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSA
 github.com/ipfs/go-bitswap v0.1.2/go.mod h1:qxSWS4NXGs7jQ6zQvoPY3+NmOfHHG47mhkiLzBpJQIs=
 github.com/ipfs/go-bitswap v0.1.3/go.mod h1:YEQlFy0kkxops5Vy+OxWdRSEZIoS7I7KDIwoa5Chkps=
 github.com/ipfs/go-bitswap v0.1.8/go.mod h1:TOWoxllhccevbWFUR2N7B1MTSVVge1s6XSMiCSA4MzM=
-github.com/ipfs/go-bitswap v0.3.3 h1:CrTO3OiOYFBcdliw074/C7T2QYHEOsPClgvR6RIYcO4=
-github.com/ipfs/go-bitswap v0.3.3/go.mod h1:AyWWfN3moBzQX0banEtfKOfbXb3ZeoOeXnZGNPV9S6w=
+github.com/ipfs/go-bitswap v0.3.4-0.20210423224948-36c782e793b7 h1:qvEpDDr627LazJ50POzYz52qlybNa5pDSc1wlKao0Rg=
+github.com/ipfs/go-bitswap v0.3.4-0.20210423224948-36c782e793b7/go.mod h1:AyWWfN3moBzQX0banEtfKOfbXb3ZeoOeXnZGNPV9S6w=
 github.com/ipfs/go-block-format v0.0.1/go.mod h1:DK/YYcsSUIVAFNwo/KZCdIIbpN0ROH/baNLgayt4pFc=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
@@ -330,8 +330,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.6.0 h1:yAxdowQZzoFKjcLI08sXVNnqVj3jnABbf9smrPQmBsw=
 github.com/ipfs/go-ipfs-cmds v0.6.0/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
-github.com/ipfs/go-ipfs-config v0.12.0 h1:wxqN3ohBlis1EkhkzIKuF+XLx4YNn9rNpiSOYw3DFZc=
-github.com/ipfs/go-ipfs-config v0.12.0/go.mod h1:Ei/FLgHGTdPyqCPK0oPCwGTe8VSnsjJjx7HZqUb6Ry0=
+github.com/ipfs/go-ipfs-config v0.16.1-0.20210830194616-e846165ea1ca h1:w/Ze0GE/as69lAf5eoINYLe1aHkkfWpeM0gF9O6RkkU=
+github.com/ipfs/go-ipfs-config v0.16.1-0.20210830194616-e846165ea1ca/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/run-bs-monitor.bash
+++ b/run-bs-monitor.bash
@@ -1,4 +1,5 @@
 export GOPROXY=direct
-export BS_LOG=info
-export BITSWAP_LOG_PEER=12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN
+export BS_CFG_LOG=info
+export BS_CFG_TIMEOUT=5
+export BS_CFG_CID_REQ_NUM=10
 make build && ./cmd/ipfs/ipfs daemon

--- a/run-bs-monitor.bash
+++ b/run-bs-monitor.bash
@@ -1,0 +1,4 @@
+export GOPROXY=direct
+export BS_LOG=info
+export BITSWAP_LOG_PEER=12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN
+make build && ./cmd/ipfs/ipfs daemon


### PR DESCRIPTION
# Meta

Patch to track in the BitSwap engine a failure to respond to a requested CID, see https://github.com/ipfs/go-ipfs/issues/7972#issuecomment-819780004.

*This is a draft PR without actual intention of merging, ever.* It is only submitted in this format to streamline the review process. As such attention should not be on proficient Go code or alignment with `go-ipfs` intrinsics but only on what can be added to a production GW node to monitor and log activity related to this issue without disrupting normal operation.

Most of the actual logic is in https://github.com/ipfs/go-bitswap/pull/475.

We hook a task on the node constructor to make a request every X seconds of a list of CIDs to our own BitSwap engine and see if they are all accounted for within those same X seconds.

TODO:
- [x] Fix the interval X.
- [x] Fix the number of CIDs we request.
- [ ] Confirm the level of logs we can have without causing any disruption. Do we rotate them?
- [x] Make all these configuration options we can adjust on the fly without restarting the GW node.
- [ ] For a second iteration: see if we want to replicate this test from an external process outside localhost (to better test the transport layer such as QUIC) and refactor accordingly.
- [x] Fix `go-bitswap` dependency replace to a commit (commenting out the branch replace).

-------------------------------------------

# PR description

This PR tests the BitSwap (BS) response mechanism with the objective of checking for inconsistencies such as https://github.com/ipfs/go-ipfs/issues/7972#issuecomment-819780004. It modifies a [`v0.8.0`](https://github.com/ipfs/go-ipfs/releases/tag/v0.8.0) node to start a goroutine along the node startup process that will constantly request a list of CIDs to its own BS component. (Analogous to a localhost connection where we bypass part of the network stack, we connect here directly to the node's own `Host` peer.)

This injected goroutine runs a BS test utility derived from the [`vole`](https://github.com/aschmahmann/vole) tool to request CIDs and monitor that the BS response accounts for all of them (we don't focus at the moment on whether we have the CIDs or not but only on BS responding to *all* requests, see cited issue for more background). Most of the BS logic, including the `vole` request CID tool, lives in a separate PR in the BS repo: https://github.com/ipfs/go-bitswap/pull/475.

The previous architecture translates into the fact that we no longer have to run two separate processes to test BS (as in the original `vole`), one running a node and the other sending requests to it, but only one: the node itself functioning as usual and *also* running this constant check in the background requesting *itself* for a list of artificial CIDs (again, we don't focus on actual meaningful content right now). The rationale for this design is to be able to deploy this modified version *in place* of a production GW node (where the original issue was first spotted) that handles a meaningful load (making this test run in a more realistic scenario and with more chances of finding anything useful).

While developing this the original issue was *likely* fixed by https://github.com/ipfs/go-bitswap/pull/477 (cherry picked here), but we still finish and deploy it in case we can find any other related problems.

Along with the requests in this patch we include some extra logging (`LogTargetPeer`) in the BS code base targeting specifically the "fake" peer (in the goroutine inside the node itself) from where the requests originate to spot if at any point the pipeline of task creation and dispatching ("pushing" and "popping" in BS terminology) that leads to reporting back a requested CID is broken. We can very easily modify this log pattern to go deeper in the code flow of interest if needed. We err for now on the side of less verbosity to not flood the log in this first test. The modified node should be monitored to make sure this is not the case and that the logs are rotated properly.

## Configuration and use

There are 3 configuration variable that are added to this patch (in the form of environment variables for simplicity) that need to be set *before* running it and can also be modified on the fly without restarting the node (to minimize operation disruption in production).

* `BS_CFG_TIMEOUT`: the time we wait for the response of the requested CIDs. **This is probably the most sensitive configuration of all** that can make the test meaningful or meaningless, and will probably need to be experimented with before arriving at an acceptable value. It is probably important to take into account that the connection is in "localhost" mode with virtually zero latency so the timeout will mainly be derived from the node average load. (After the timeout elapses, either with all responses or not, we rerun the test in an infinite loop in the goroutine until the node stops.)

* `BS_CFG_CID_REQ_NUM`: Number of CIDs requested on each test. Not sure how critical this configuration is. Ideally we would want to mimic a typical client request.

* `BS_CFG_LOG`: Log level for the BS and related components. The rest is set to `WARN`. During tests it is recommended to set this to `INFO` (the level at which we added the extra logging). In any case the log levels can be adjusted on the fly through the standard `ipfs log` CLI.

(See more details in the [documentation](https://github.com/ipfs/go-ipfs/pull/8082/files#diff-4140a14426af9479ef5f4cbe610e3251f8a2425b1503811955c7ea81adc049cbR109-R125) of the code itself.)

A typical configuration run during local (non-production) testing of this patch can be seen in [`run-bs-monitor.bash`](https://github.com/ipfs/go-ipfs/pull/8082/files#diff-57368464713abdbde4a15be0881be9ea08b03628f018f64787aa6c0f7a8555d8).

Apart from these extra configurations the node should be run as it is normally configured in production. The added configurations shouldn't interfere with the rest of the node's operations.

## Log output

A typical log output of a test would be:

```
INFO	bitswap	connecting through TCP
INFO	engine	[TRACKING-BS-PEER] pushing task for CID [bafkqaaju]
INFO	engine	[TRACKING-BS-PEER] pushing task for CID [bafkrefclej3xpvg5d7dby34ij5egihicwtisduy]
INFO	engine	[TRACKING-BS-PEER] pushing task for CID [bafkqaajq]
[...]
INFO	engine	[TRACKING-BS-PEER] popped [10] tasks from queue
INFO	engine	[TRACKING-BS-PEER] popped task CID: [bafkrefdlq2zhh7zu7tqz224aj37vup2xi6w2j2q]
INFO	engine	[TRACKING-BS-PEER] popped task CID: [bafkrefclej3xpvg5d7dby34ij5egihicwtisduy]
[...]
INFO	engine	[TRACKING-BS-PEER] popped task CID: [bafkrefcoa5aikyv63ofwbtqfyhpm7y5nc23sema]
INFO	engine	[TRACKING-BS-PEER] popped task CID: [bafkqaajq]
INFO	engine	[TRACKING-BS-PEER] popped task CID: [bafkqaajt]
INFO	engine	[TRACKING-BS-PEER] message sent [map[blocks:[bafkqaajr bafkqaajq bafkqaajt bafkqaaju bafkqaajs] presences:[{bafkrefguonpdujs6c3xoap2zogfzwxidagoapwa DontHave} {bafkrefcoa5aikyv63ofwbtqfyhpm7y5nc23sema DontHave} {bafkrefdlq2zhh7zu7tqz224aj37vup2xi6w2j2q DontHave} {bafkrefclej3xpvg5d7dby34ij5egihicwtisduy DontHave} {bafkrefc75tvwn76in44nsutynrwws3dzyln4eoi DontHave}] wants:[]]]
```

What we need to look out for is an `ERROR` in the BS log like:

```
ERROR	bitswap	CheckBitswapCID: did not get HAVE/DONT-HAVE response on CIDs:
```
