### PR TITLE
Switch insecure hash function sharness test

### DIFF
--- a/test/sharness/t0275-cid-security.sh
+++ b/test/sharness/t0275-cid-security.sh
@@ -11,7 +11,7 @@ test_description="Cid Security"
 test_init_ipfs
 
 test_expect_success "adding using unsafe function fails with error" '
-  echo foo | test_must_fail ipfs add --hash murmur3-128 2>add_out
+  echo foo | test_must_fail ipfs add --hash shake-128 2>add_out
 '
 
 test_expect_success "error reason is pointed out" '


### PR DESCRIPTION
# Goals

Fix broken sharness in ipld-in-ipfs branch

# Implementation

The test was failing cause it was using murmer3-128 as an insecure hash function, which has been removed from go-multihash 0.15. (meaning it produces a different "unknown hash function" error). I switched to shake-128 which repeduces the correct error.