### PR TITLE
Fix/gateway: add more debug logs

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -581,7 +581,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		webError(w, "WritableGateway: empty path", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
+		webError(w, "WritableGateway", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
 		return
 	}
 	newDirectory, newFileName := gopath.Split(newPath)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -503,7 +503,7 @@ func (i *gatewayHandler) serveFile(w http.ResponseWriter, req *http.Request, nam
 			// Fixes https://github.com/ipfs/go-ipfs/issues/7252
 			mimeType, err := mimetype.DetectReader(content)
 			if err != nil {
-				webError(w,"cannot detect content-type", err, http.StatusInternalServerError)
+				webError(w, "cannot detect content-type", err, http.StatusInternalServerError)
 				return
 			}
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -673,7 +673,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		webError(w, "WritableGateway: empty path", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
+		webError(w, "WritableGateway", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
 		return
 	}
 	directory, filename := gopath.Split(newPath)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -687,7 +687,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rootNode, ok := rootNodeIPLD.(*dag.ProtoNode)
 	if !ok {
-		webError(w, "WritableGateway: empty path", errors.New("empty path"), http.StatusInternalServerError)
+		webError(w, "WritableGateway", errors.New("empty path"), http.StatusInternalServerError)
 		return
 	}
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -709,7 +709,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	parent, ok := parentNode.(*mfs.Directory)
 	if !ok {
-		webError(w, "WritableGateway: parent is not a directory", errors.New("parent is not a directory"), http.StatusInternalServerError)
+		webError(w, "WritableGateway", errors.New("parent is not a directory"), http.StatusInternalServerError)
 		return
 	}
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -2,6 +2,7 @@ package corehttp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -577,7 +578,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		http.Error(w, "WritableGateway: empty path", http.StatusBadRequest)
+		webError(w, "WritableGateway: empty path", errors.New(fmt.Sprintf("empty path: %s", newPath)), http.StatusBadRequest)
 		return
 	}
 	newDirectory, newFileName := gopath.Split(newPath)
@@ -669,7 +670,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		http.Error(w, "WritableGateway: empty path", http.StatusBadRequest)
+		webError(w, "WritableGateway: empty path", errors.New(fmt.Sprintf("empty path: %s", newPath)), http.StatusBadRequest)
 		return
 	}
 	directory, filename := gopath.Split(newPath)
@@ -683,7 +684,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rootNode, ok := rootNodeIPLD.(*dag.ProtoNode)
 	if !ok {
-		http.Error(w, "WritableGateway: empty path", http.StatusInternalServerError)
+		webError(w, "WritableGateway: empty path", errors.New("empty path"), http.StatusInternalServerError)
 		return
 	}
 
@@ -705,7 +706,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	parent, ok := parentNode.(*mfs.Directory)
 	if !ok {
-		http.Error(w, "WritableGateway: parent is not a directory", http.StatusInternalServerError)
+		webError(w, "WritableGateway: parent is not a directory", errors.New("parent is not a directory"), http.StatusInternalServerError)
 		return
 	}
 
@@ -751,7 +752,9 @@ func webError(w http.ResponseWriter, message string, err error, defaultCode int)
 func webErrorWithCode(w http.ResponseWriter, message string, err error, code int) {
 	http.Error(w, fmt.Sprintf("%s: %s", message, err), code)
 	if code >= 500 {
-		log.Warnf("server error: %s: %s", err)
+		log.Warnf("server error: %s: %s", message, err)
+	} else {
+		log.Debugf("web error: %s: %s", message, err)
 	}
 }
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -635,7 +635,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	dir, ok := dirNode.(*mfs.Directory)
 	if !ok {
-		webError(w, "WritableGateway: target directory is not a directory", errors.New("target is not a directory"), http.StatusBadRequest)
+		webError(w, "WritableGateway", errors.New("target is not a directory"), http.StatusBadRequest)
 		return
 	}
 	err = dir.Unlink(newFileName)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -581,7 +581,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		webError(w, "WritableGateway: empty path", errors.New(fmt.Sprintf("empty path: %s", newPath)), http.StatusBadRequest)
+		webError(w, "WritableGateway: empty path", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
 		return
 	}
 	newDirectory, newFileName := gopath.Split(newPath)
@@ -673,7 +673,7 @@ func (i *gatewayHandler) deleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if newPath == "" || newPath == "/" {
-		webError(w, "WritableGateway: empty path", errors.New(fmt.Sprintf("empty path: %s", newPath)), http.StatusBadRequest)
+		webError(w, "WritableGateway: empty path", fmt.Errorf("empty path: %s", newPath), http.StatusBadRequest)
 		return
 	}
 	directory, filename := gopath.Split(newPath)

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -482,7 +482,7 @@ func (i *gatewayHandler) serveFile(w http.ResponseWriter, req *http.Request, nam
 	log.Debugf("serving file: %s for request: %s", name, req.URL.Path)
 	size, err := file.Size()
 	if err != nil {
-		http.Error(w, "cannot serve files with unknown sizes", http.StatusBadGateway)
+		webError(w, "cannot serve files with unknown sizes", err, http.StatusBadGateway)
 		return
 	}
 
@@ -503,14 +503,14 @@ func (i *gatewayHandler) serveFile(w http.ResponseWriter, req *http.Request, nam
 			// Fixes https://github.com/ipfs/go-ipfs/issues/7252
 			mimeType, err := mimetype.DetectReader(content)
 			if err != nil {
-				http.Error(w, fmt.Sprintf("cannot detect content-type: %s", err.Error()), http.StatusInternalServerError)
+				webError(w,"cannot detect content-type", err, http.StatusInternalServerError)
 				return
 			}
 
 			ctype = mimeType.String()
 			_, err = content.Seek(0, io.SeekStart)
 			if err != nil {
-				http.Error(w, "seeker can't seek", http.StatusInternalServerError)
+				webError(w, "seeker can't seek", err, http.StatusInternalServerError)
 				return
 			}
 		}
@@ -635,7 +635,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	dir, ok := dirNode.(*mfs.Directory)
 	if !ok {
-		http.Error(w, "WritableGateway: target directory is not a directory", http.StatusBadRequest)
+		webError(w, "WritableGateway: target directory is not a directory", errors.New("target is not a directory"), http.StatusBadRequest)
 		return
 	}
 	err = dir.Unlink(newFileName)


### PR DESCRIPTION
This PR adds more logging at debug level for gateway_handler.go.
Fixes issue #7873 

- Wraps calls to `http.Redirect` in `redirect`, which logs request and status code
- Log errors in method `webErrorWithCode`, which wraps calls to `http.Error`
- Replaced all usages of `http.Error` with `webError`
- Added couple of log lines for when CID is mapped or file is served

