### PR TITLE
feat(gw): expose /api/v0/dag/export on gateway port

### DIFF
--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -26,6 +26,7 @@ func TestROCommands(t *testing.T) {
 		"/dag/get",
 		"/dag/resolve",
 		"/dag/stat",
+		"/dag/export",
 		"/dns",
 		"/get",
 		"/ls",

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -194,6 +194,7 @@ var rootROSubcommands = map[string]*cmds.Command{
 			"get":     dag.DagGetCmd,
 			"resolve": dag.DagResolveCmd,
 			"stat":    dag.DagStatCmd,
+			"export":  dag.DagExportCmd,
 		},
 	},
 	"resolve": ResolveCmd,

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -199,6 +199,8 @@ for cmd in add  \
            block/put \
            bootstrap \
            config \
+           dag/put \
+           dag/import \
            dht \
            diag \
            id \


### PR DESCRIPTION
- add dag/export to read-only root. it's ready only, so why the heck not!
- test that i didn't expose other dag subcommands


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>