### PR TITLE
feat: allow key export in online mode

### DIFF
--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -169,7 +169,7 @@ path can be specified with '--output=<path>' or '-o=<path>'.
 		if err != nil {
 			return err
 		}
-		if ver > fsrepo.RepoVersion {
+		if ver != fsrepo.RepoVersion {
 			return fmt.Errorf("key export expects repo version (%d) but found (%d)", fsrepo.RepoVersion, ver)
 		}
 

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-ipfs/core/commands/e"
 	ke "github.com/ipfs/go-ipfs/core/commands/keyencode"
 	fsrepo "github.com/ipfs/go-ipfs/repo/fsrepo"
+	migrations "github.com/ipfs/go-ipfs/repo/fsrepo/migrations"
 	options "github.com/ipfs/interface-go-ipfs-core/options"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -161,6 +162,15 @@ path can be specified with '--output=<path>' or '-o=<path>'.
 		cfgRoot, err := cmdenv.GetConfigRoot(env)
 		if err != nil {
 			return err
+		}
+
+		// Check repo version, and error out if not matching
+		ver, err := migrations.RepoVersion(cfgRoot)
+		if err != nil {
+			return err
+		}
+		if ver > fsrepo.RepoVersion {
+			return fmt.Errorf("key export expects repo version (%d) but found (%d)", fsrepo.RepoVersion, ver)
 		}
 
 		// Export is read-only: safe to read it without acquiring repo lock

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -175,6 +175,7 @@ ipfs key rm key_ed25519
     test_cmp rsa_key_id roundtrip_rsa_key_id
   '
 
+  # export works directly on the keystore present in IPFS_PATH
   test_expect_success "export and import ed25519 key while daemon is running" '
     edhash=$(ipfs key gen exported_ed25519_key --type=ed25519)
     echo $edhash > ed25519_key_id
@@ -184,10 +185,15 @@ ipfs key rm key_ed25519
     test_cmp ed25519_key_id roundtrip_ed25519_key_id
   '
 
+  test_expect_success "key export over HTTP /api/v0/key/export is not possible" '
+    ipfs key gen nohttpexporttest_key --type=ed25519 &&
+    test_curl_resp_http_code "http://127.0.0.1:$API_PORT/api/v0/key/export&arg=nohttpexporttest_key" "HTTP/1.1 404 Not Found"
+  '
+
   test_expect_success "online rotate rsa key" '
     test_must_fail ipfs key rotate
   '
-  
+
   test_kill_ipfs_daemon
 
 }

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -187,7 +187,7 @@ ipfs key rm key_ed25519
 
   test_expect_success "key export over HTTP /api/v0/key/export is not possible" '
     ipfs key gen nohttpexporttest_key --type=ed25519 &&
-    test_curl_resp_http_code "http://127.0.0.1:$API_PORT/api/v0/key/export&arg=nohttpexporttest_key" "HTTP/1.1 404 Not Found"
+    curl -X POST -sI "http://$API_ADDR/api/v0/key/export&arg=nohttpexporttest_key" | grep -q "^HTTP/1.1 404 Not Found"
   '
 
   test_expect_success "online rotate rsa key" '

--- a/test/sharness/t0165-keystore.sh
+++ b/test/sharness/t0165-keystore.sh
@@ -175,8 +175,13 @@ ipfs key rm key_ed25519
     test_cmp rsa_key_id roundtrip_rsa_key_id
   '
 
-  test_expect_success "online export rsa key" '
-    test_must_fail ipfs key export generated_rsa_key
+  test_expect_success "export and import ed25519 key while daemon is running" '
+    edhash=$(ipfs key gen exported_ed25519_key --type=ed25519)
+    echo $edhash > ed25519_key_id
+    ipfs key export exported_ed25519_key &&
+    ipfs key rm exported_ed25519_key &&
+    ipfs key import exported_ed25519_key exported_ed25519_key.key > roundtrip_ed25519_key_id &&
+    test_cmp ed25519_key_id roundtrip_ed25519_key_id
   '
 
   test_expect_success "online rotate rsa key" '


### PR DESCRIPTION
This PR enables apps like Brave browser to do import/export without stopping/starting daemon.

Export does not require repo lock, and afaik it is safe to do even when ipfs daemon is running. 

Ref. https://github.com/brave/brave-browser/issues/15422 (cc @spylogsster)