### PR TITLE
chore: switch CI to nodejs 14.x 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,13 @@ executors:
       TEST_VERBOSE: 1
   node:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
   node-browsers:
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment


### PR DESCRIPTION
12 is no longer supported, latest js-ipfs requires 14 (current LTS)
https://blog.ipfs.io/2021-05-11-js-ipfs-0-55/