### PR TITLE
update to Go 1.16.3 on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,11 @@ jobs:
         TEST_VERBOSE: 1
     steps:
     - run: sudo apt update
+    - run: |
+        mkdir ~/localgo && cd ~/localgo
+        wget https://golang.org/dl/go1.16.4.linux-amd64.tar.gz
+        tar xfz go1.16.4.linux-amd64.tar.gz
+        echo "export PATH=$(pwd)/go/bin:$PATH" >> $BASH_ENV
     - run: sudo apt install socat net-tools
     - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.15.2
+      - image: cimg/go:1.16.4
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -60,7 +60,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer:
     docker:
-      - image: circleci/golang:1.15.2
+      - image: cimg/go:1.16.4
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
         wget https://golang.org/dl/go1.16.4.linux-amd64.tar.gz
         tar xfz go1.16.4.linux-amd64.tar.gz
         echo "export PATH=$(pwd)/go/bin:$PATH" >> $BASH_ENV
+    - run: go version
     - run: sudo apt install socat net-tools
     - checkout
 
@@ -160,7 +161,9 @@ jobs:
     - run:
         echo DOCKER_HOST=$DOCKER_HOST &&
         make -O -j 3 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1 DOCKER_HOST=$DOCKER_HOST
-
+    - run:
+        when: always
+        command: which ipfs || true
     - run:
         when: always
         command: bash <(curl -s https://codecov.io/bash) -cF sharness -X search -f coverage/sharness_tests.coverprofile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
-FROM golang:1.15.2-buster
+FROM golang:1.16.3-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -140,7 +140,7 @@ To build out-of-tree plugins, use the plugin's Makefile if provided. Otherwise,
 you can manually build the plugin by running:
 
 ```bash
-myplugin$ go build -buildmode=plugin -i -o myplugin.so myplugin.go
+myplugin$ go build -buildmode=plugin -o myplugin.so myplugin.go
 ```
 
 Finally, as with in-tree plugins:

--- a/plugin/plugins/Rules.mk
+++ b/plugin/plugins/Rules.mk
@@ -12,7 +12,7 @@ $($(d)_plugins_main):
 
 $($(d)_plugins_so): %.so : %/main/main.go
 $($(d)_plugins_so): $$(DEPS_GO) ALWAYS
-	$(GOCC) build -buildmode=plugin -i -pkgdir "$(GOPATH)/pkg/linux_amd64_dynlink" $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$(basename $@))/main"
+	$(GOCC) build -buildmode=plugin -pkgdir "$(GOPATH)/pkg/linux_amd64_dynlink" $(go-flags-with-tags) -o "$@" "$(call go-pkg-name,$(basename $@))/main"
 	chmod +x "$@"
 
 CLEAN += $($(d)_plugins_so)


### PR DESCRIPTION
Unfortunately, CircleCI doesn't provide a 1.16.4 image, although that version was released 10 days ago. This PR uses 1.16.3 instead.