### PR TITLE
fix(peering_test) : Fix the peering_test to check the connection explicitly added

### DIFF
--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -66,7 +66,7 @@ func TestPeeringService(t *testing.T) {
 	t.Logf("waiting for h1's connection to h3 to work")
 	require.NoError(t, h1.Connect(ctx, peer.AddrInfo{ID: h3.ID(), Addrs: h3.Addrs()}))
 	require.Eventually(t, func() bool {
-		return h1.Network().Connectedness(h2.ID()) == network.Connected
+		return h1.Network().Connectedness(h3.ID()) == network.Connected
 	}, 30*time.Second, 100*time.Millisecond)
 
 	require.Len(t, h1.Network().Peers(), 3)


### PR DESCRIPTION
## Overview
This PR is intended to correct the test for `peering.PeeringService`.

## Detail
The current master code tests that `h1` is connected to `h2` on L69.
I have modified it to check `h3`.  
This test appeared to be intended to test that `host.Connect` is working correctly after the PeeringService has been started.

## Processing flow in the modified area
```
// h1 is now connected to h2 and h4
h1 -> [h2, h4]
// then explicitly connect to h3 
h1 -> [h2, h4, h3]
// now we want to test is h3
h1 -> h3
```

## Comment
This is the first time I'm commiting to this repository. Please point it out if this PR breaks any conventions.
I've read and respect [CONTRIBUTING.md](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md) and [CONTRIBUTING_GO](https://github.com/ipfs/community/blob/master/CONTRIBUTING_GO.md). Thank you. 