### PR TITLE
Improve peer hints for pin remote add

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -25,7 +24,6 @@ import (
 	path "github.com/ipfs/interface-go-ipfs-core/path"
 	"github.com/libp2p/go-libp2p-core/host"
 	peer "github.com/libp2p/go-libp2p-core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 )
 
 var log = logging.Logger("core/commands/cmdenv")
@@ -186,14 +184,7 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 			if err != nil {
 				return err
 			}
-
-			var filteredAddrs []ma.Multiaddr
-			for _, addr := range addrs {
-				if !isLoopbackAddr(addr) {
-					filteredAddrs = append(filteredAddrs, addr)
-				}
-			}
-			opts = append(opts, pinclient.PinOpts.WithOrigins(filteredAddrs...))
+			opts = append(opts, pinclient.PinOpts.WithOrigins(addrs...))
 		}
 
 		// Execute remote pin request
@@ -253,12 +244,6 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 			return nil
 		}),
 	},
-}
-
-func isLoopbackAddr(addr ma.Multiaddr) bool {
-	// IP is located at the second index: /ip4/127.0.0.1/tcp/8080
-	ip := net.ParseIP(strings.Split(addr.String(), "/")[2])
-	return ip.IsLoopback()
 }
 
 var listRemotePinCmd = &cmds.Command{

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -187,14 +187,9 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 				return err
 			}
 
-			cfg, err := cmdenv.GetConfig(env)
-			if err != nil {
-				return err
-			}
-
 			var filteredAddrs []ma.Multiaddr
 			for _, addr := range addrs {
-				if isOriginAddr(addr, cfg.Addresses.NoAnnounce) {
+				if !isLoopbackAddr(addr) {
 					filteredAddrs = append(filteredAddrs, addr)
 				}
 			}
@@ -260,20 +255,10 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 	},
 }
 
-func isOriginAddr(addr ma.Multiaddr, noAnnounceAddrs []string) bool {
+func isLoopbackAddr(addr ma.Multiaddr) bool {
 	// IP is located at the second index: /ip4/127.0.0.1/tcp/8080
 	ip := net.ParseIP(strings.Split(addr.String(), "/")[2])
-	if ip.IsLoopback() {
-		return false
-	}
-
-	for _, noAnnounceAddr := range noAnnounceAddrs {
-		if strings.HasPrefix(addr.String(), noAnnounceAddr) {
-			return false
-		}
-	}
-
-	return true
+	return ip.IsLoopback()
 }
 
 var listRemotePinCmd = &cmds.Command{


### PR DESCRIPTION
Closes #7915. When running `ipfs pin remote add <cid>`,
1. If CID isn't in blockstore, local node isn't origin, so send `Pin.origins = []`
2. <del>If address is loopback, remove address from `Pin.origins`</del>
3. <del>If address is in [`NoAnnounce`](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#addressesnoannounce), remove address from `Pin.origins`</del>