### PR TITLE
fix: webui-2.12.3

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,7 +1,7 @@
 package corehttp
 
 // TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeifuexpvt6g4bkbmsrlb7rnudskfakn6vdrtoja4ml4zbxne2hu6bq" // v2.12.2
+const WebUIPath = "/ipfs/bafybeid26vjplsejg7t3nrh7mxmiaaxriebbm4xxrxxdunlk7o337m5sqq" // v2.12.3
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{


### PR DESCRIPTION
This PR bumps ipfs-webui to the bugfix release based on feedback from 0.9.0-rc1:
https://github.com/ipfs/ipfs-webui/releases/tag/v2.12.3

@aschmahmann fixed bugs are pretty annoying, so we really should include this in 0.9.0-rc2 (https://github.com/ipfs/go-ipfs/issues/8058) :)