### PR TITLE
feat: add a text output encoding for the stats provide command

### DIFF
--- a/core/commands/stat_provide.go
+++ b/core/commands/stat_provide.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"text/tabwriter"
+	"time"
 
 	humanize "github.com/dustin/go-humanize"
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -56,14 +57,18 @@ This interface is not stable and may change from release to release.
 
 			tp := float64(s.TotalProvides)
 			fmt.Fprintf(wtr, "TotalProvides:\t%s\t(%s)\n", humanSI(tp, 0), humanFull(tp, 0))
-			fmt.Fprintf(wtr, "AvgProvideDuration:\t%v\n", s.AvgProvideDuration)
-			fmt.Fprintf(wtr, "LastReprovideDuration:\t%v\n", s.LastReprovideDuration)
+			fmt.Fprintf(wtr, "AvgProvideDuration:\t%v\n", humanDuration(s.AvgProvideDuration))
+			fmt.Fprintf(wtr, "LastReprovideDuration:\t%v\n", humanDuration(s.LastReprovideDuration))
 			lrbs := float64(s.LastReprovideBatchSize)
 			fmt.Fprintf(wtr, "LastReprovideBatchSize:\t%s\t(%s)\n", humanSI(lrbs, 0), humanFull(lrbs, 0))
 			return nil
 		}),
 	},
 	Type: batched.BatchedProviderStats{},
+}
+
+func humanDuration(val time.Duration) string {
+	return val.Truncate(time.Microsecond).String()
 }
 
 func humanSI(val float64, decimals int) string {

--- a/core/commands/stat_provide.go
+++ b/core/commands/stat_provide.go
@@ -55,12 +55,10 @@ This interface is not stable and may change from release to release.
 			wtr := tabwriter.NewWriter(w, 1, 2, 1, ' ', 0)
 			defer wtr.Flush()
 
-			tp := float64(s.TotalProvides)
-			fmt.Fprintf(wtr, "TotalProvides:\t%s\t(%s)\n", humanSI(tp, 0), humanFull(tp, 0))
-			fmt.Fprintf(wtr, "AvgProvideDuration:\t%v\n", humanDuration(s.AvgProvideDuration))
-			fmt.Fprintf(wtr, "LastReprovideDuration:\t%v\n", humanDuration(s.LastReprovideDuration))
-			lrbs := float64(s.LastReprovideBatchSize)
-			fmt.Fprintf(wtr, "LastReprovideBatchSize:\t%s\t(%s)\n", humanSI(lrbs, 0), humanFull(lrbs, 0))
+			fmt.Fprintf(wtr, "TotalProvides:\t%s\n", humanNumber(s.TotalProvides))
+			fmt.Fprintf(wtr, "AvgProvideDuration:\t%s\n", humanDuration(s.AvgProvideDuration))
+			fmt.Fprintf(wtr, "LastReprovideDuration:\t%s\n", humanDuration(s.LastReprovideDuration))
+			fmt.Fprintf(wtr, "LastReprovideBatchSize:\t%s\n", humanNumber(s.LastReprovideBatchSize))
 			return nil
 		}),
 	},
@@ -71,9 +69,19 @@ func humanDuration(val time.Duration) string {
 	return val.Truncate(time.Microsecond).String()
 }
 
+func humanNumber(n int) string {
+	nf := float64(n)
+	str := humanSI(nf, 0)
+	fullStr := humanFull(nf, 0)
+	if str != fullStr {
+		return fmt.Sprintf("%s\t(%s)", str, fullStr)
+	}
+	return str
+}
+
 func humanSI(val float64, decimals int) string {
 	v, unit := humanize.ComputeSI(val)
-	return humanize.SIWithDigits(v, decimals, unit)
+	return fmt.Sprintf("%s%s", humanFull(v, decimals), unit)
 }
 
 func humanFull(val float64, decimals int) string {

--- a/core/commands/stat_provide.go
+++ b/core/commands/stat_provide.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"text/tabwriter"
 
+	humanize "github.com/dustin/go-humanize"
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
@@ -50,15 +51,26 @@ This interface is not stable and may change from release to release.
 	},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, s *batched.BatchedProviderStats) error {
-			wtr := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+			wtr := tabwriter.NewWriter(w, 1, 2, 1, ' ', 0)
 			defer wtr.Flush()
 
-			fmt.Fprintf(wtr, "TotalProvides: %d\n", s.TotalProvides)
-			fmt.Fprintf(wtr, "AvgProvideDuration: %v\n", s.AvgProvideDuration)
-			fmt.Fprintf(wtr, "LastReprovideDuration: %v\n", s.LastReprovideDuration)
-			fmt.Fprintf(wtr, "LastReprovideBatchSize: %d\n", s.LastReprovideBatchSize)
+			tp := float64(s.TotalProvides)
+			fmt.Fprintf(wtr, "TotalProvides:\t%s\t(%s)\n", humanSI(tp, 0), humanFull(tp, 0))
+			fmt.Fprintf(wtr, "AvgProvideDuration:\t%v\n", s.AvgProvideDuration)
+			fmt.Fprintf(wtr, "LastReprovideDuration:\t%v\n", s.LastReprovideDuration)
+			lrbs := float64(s.LastReprovideBatchSize)
+			fmt.Fprintf(wtr, "LastReprovideBatchSize:\t%s\t(%s)\n", humanSI(lrbs, 0), humanFull(lrbs, 0))
 			return nil
 		}),
 	},
 	Type: batched.BatchedProviderStats{},
+}
+
+func humanSI(val float64, decimals int) string {
+	v, unit := humanize.ComputeSI(val)
+	return humanize.SIWithDigits(v, decimals, unit)
+}
+
+func humanFull(val float64, decimals int) string {
+	return humanize.CommafWithDigits(val, decimals)
 }

--- a/core/commands/stat_provide.go
+++ b/core/commands/stat_provide.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"text/tabwriter"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
@@ -46,6 +48,17 @@ This interface is not stable and may change from release to release.
 
 		return nil
 	},
-	Encoders: cmds.EncoderMap{},
-	Type:     batched.BatchedProviderStats{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, s *batched.BatchedProviderStats) error {
+			wtr := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+			defer wtr.Flush()
+
+			fmt.Fprintf(wtr, "TotalProvides: %d\n", s.TotalProvides)
+			fmt.Fprintf(wtr, "AvgProvideDuration: %v\n", s.AvgProvideDuration)
+			fmt.Fprintf(wtr, "LastReprovideDuration: %v\n", s.LastReprovideDuration)
+			fmt.Fprintf(wtr, "LastReprovideBatchSize: %d\n", s.LastReprovideBatchSize)
+			return nil
+		}),
+	},
+	Type: batched.BatchedProviderStats{},
 }


### PR DESCRIPTION
This adds a text output encoding to the `ipfs stats provide` command for easier glance value

It looks something like:
```
❯ ipfs stats provide
TotalProvides: 7084
AvgProvideDuration: 15.358954ms
LastReprovideDuration: 58.3776802s
LastReprovideBatchSize: 3542
```

It could be a little prettier, but here's a first stab so at least we have something.