### PR TITLE
feat: print error on bootstrap failure

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -515,6 +515,16 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 	// Give the user heads up if daemon running in online mode has no peers after 1 minute
 	if !offline {
 		time.AfterFunc(1*time.Minute, func() {
+			cfg, err := cctx.GetConfig()
+			if err != nil {
+				log.Errorf("failed to access config: %s", err)
+			}
+			if len(cfg.Bootstrap) == 0 && len(cfg.Peering.Peers) == 0 {
+				// Skip peer check if Bootstrap and Peering lists are empty
+				// (means user disabled them on purpose)
+				log.Warn("skipping bootstrap: empty Bootstrap and Peering lists")
+				return
+			}
 			ipfs, err := coreapi.NewCoreAPI(node)
 			if err != nil {
 				log.Errorf("failed to access CoreAPI: %v", err)

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"sync"
+	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
 
@@ -22,6 +23,7 @@ import (
 	oldcmds "github.com/ipfs/go-ipfs/commands"
 	"github.com/ipfs/go-ipfs/core"
 	commands "github.com/ipfs/go-ipfs/core/commands"
+	"github.com/ipfs/go-ipfs/core/coreapi"
 	corehttp "github.com/ipfs/go-ipfs/core/corehttp"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
 	libp2p "github.com/ipfs/go-ipfs/core/node/libp2p"
@@ -509,6 +511,23 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		fmt.Println("Received interrupt signal, shutting down...")
 		fmt.Println("(Hit ctrl-c again to force-shutdown the daemon.)")
 	}()
+
+	// Give the user heads up if daemon running in online mode has no peers after 1 minute
+	if !offline {
+		time.AfterFunc(1*time.Minute, func() {
+			ipfs, err := coreapi.NewCoreAPI(node)
+			if err != nil {
+				log.Errorf("failed to access CoreAPI: %v", err)
+			}
+			peers, err := ipfs.Swarm().Peers(cctx.Context())
+			if err != nil {
+				log.Errorf("failed to read swarm peers: %v", err)
+			}
+			if len(peers) == 0 {
+				log.Error("failed to bootstrap (no peers found): consider updating Bootstrap or Peering section of your config")
+			}
+		})
+	}
 
 	// collect long-running errors and block for shutdown
 	// TODO(cryptix): our fuse currently doesn't follow this pattern for graceful shutdown


### PR DESCRIPTION
This PR aims to improve UX when bootstrap fails.

It will print ERROR to log if daemon running in online mode has no peers after one minute since start:

```console 
$ ipfs daemon
...
Daemon is ready
2021-05-31T15:28:34.403+0200	ERROR	cmd/ipfs	ipfs/daemon.go:527	failed to bootstrap (no peers found): consider updating Bootstrap or Peering section of your config
```

