### PR TITLE
feat: dag import --stats (#8237)

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -55,8 +55,8 @@ type ResolveOutput struct {
 
 // CarImportOutput is the output type of the 'dag import' commands
 type CarImportOutput struct {
-	BlockCount uint64
-	Root       *RootMeta
+	BlockCount *uint64   `json:",omitempty"`
+	Root       *RootMeta `json:",omitempty"`
 }
 
 // RootMeta is the metadata for a root pinning response
@@ -208,9 +208,17 @@ Maximum supported CAR version: 1
 				return nil
 			}
 
+			// event should have only one of `Root` or `BlockCount` set, not both
 			if event.Root == nil {
-				fmt.Fprintf(w, "Imported %d blocks\n", event.BlockCount)
+				if event.BlockCount == nil {
+					return fmt.Errorf("Unexpected message from DAG import")
+				}
+				fmt.Fprintf(w, "Imported %d blocks\n", *event.BlockCount)
 				return nil
+			}
+
+			if event.BlockCount != nil {
+				return fmt.Errorf("Unexpected message from DAG import")
 			}
 
 			enc, err := cmdenv.GetLowLevelCidEncoder(req)

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -55,8 +55,8 @@ type ResolveOutput struct {
 }
 
 type CarImportStats struct {
-	BlockCount        uint64
-	PayloadBytesCount uint64
+	BlockCount      uint64
+	BlockBytesCount uint64
 }
 
 // CarImportOutput is the output type of the 'dag import' commands
@@ -167,10 +167,10 @@ var DagResolveCmd = &cmds.Command{
 }
 
 type importResult struct {
-	blockCount        uint64
-	payloadBytesCount uint64
-	roots             map[cid.Cid]struct{}
-	err               error
+	blockCount      uint64
+	blockBytesCount uint64
+	roots           map[cid.Cid]struct{}
+	err             error
 }
 
 // DagImportCmd is a command for importing a car to ipfs
@@ -223,7 +223,7 @@ Maximum supported CAR version: 1
 				}
 				stats, _ := req.Options[statsOptionName].(bool)
 				if stats {
-					fmt.Fprintf(w, "Imported %d blocks (%d bytes)\n", event.Stats.BlockCount, event.Stats.PayloadBytesCount)
+					fmt.Fprintf(w, "Imported %d blocks (%d bytes)\n", event.Stats.BlockCount, event.Stats.BlockBytesCount)
 				}
 				return nil
 			}

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -55,7 +55,8 @@ type ResolveOutput struct {
 }
 
 type CarImportStats struct {
-	BlockCount uint64
+	BlockCount        uint64
+	PayloadBytesCount uint64
 }
 
 // CarImportOutput is the output type of the 'dag import' commands
@@ -166,9 +167,10 @@ var DagResolveCmd = &cmds.Command{
 }
 
 type importResult struct {
-	blockCount uint64
-	roots      map[cid.Cid]struct{}
-	err        error
+	blockCount        uint64
+	payloadBytesCount uint64
+	roots             map[cid.Cid]struct{}
+	err               error
 }
 
 // DagImportCmd is a command for importing a car to ipfs
@@ -221,7 +223,7 @@ Maximum supported CAR version: 1
 				}
 				stats, _ := req.Options[statsOptionName].(bool)
 				if stats {
-					fmt.Fprintf(w, "Imported %d blocks\n", event.Stats.BlockCount)
+					fmt.Fprintf(w, "Imported %d blocks (%d bytes)\n", event.Stats.BlockCount, event.Stats.PayloadBytesCount)
 				}
 				return nil
 			}

--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -55,7 +55,8 @@ type ResolveOutput struct {
 
 // CarImportOutput is the output type of the 'dag import' commands
 type CarImportOutput struct {
-	Root RootMeta
+	BlockCount uint64
+	Root       *RootMeta
 }
 
 // RootMeta is the metadata for a root pinning response
@@ -160,8 +161,9 @@ var DagResolveCmd = &cmds.Command{
 }
 
 type importResult struct {
-	roots map[cid.Cid]struct{}
-	err   error
+	blockCount uint64
+	roots      map[cid.Cid]struct{}
+	err        error
 }
 
 // DagImportCmd is a command for importing a car to ipfs
@@ -203,6 +205,11 @@ Maximum supported CAR version: 1
 
 			silent, _ := req.Options[silentOptionName].(bool)
 			if silent {
+				return nil
+			}
+
+			if event.Root == nil {
+				fmt.Fprintf(w, "Imported %d blocks\n", event.BlockCount)
 				return nil
 			}
 

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -55,7 +55,7 @@ func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 		return done.err
 	}
 
-	if err := res.Emit(&CarImportOutput{BlockCount: done.blockCount}); err != nil {
+	if err := res.Emit(&CarImportOutput{BlockCount: &done.blockCount}); err != nil {
 		return err
 	}
 

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -55,10 +55,6 @@ func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 		return done.err
 	}
 
-	if err := res.Emit(&CarImportOutput{BlockCount: &done.blockCount}); err != nil {
-		return err
-	}
-
 	// It is not guaranteed that a root in a header is actually present in the same ( or any )
 	// .car file. This is the case in version 1, and ideally in further versions too
 	// Accumulate any root CID seen in a header, and supplement its actual node if/when encountered
@@ -116,6 +112,17 @@ func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 				failedPins,
 				len(roots),
 			)
+		}
+	}
+
+	stats, _ := req.Options[statsOptionName].(bool)
+	if stats {
+		if err := res.Emit(&CarImportOutput{
+			Stats: &CarImportStats{
+				BlockCount: done.blockCount,
+			},
+		}); err != nil {
+			return err
 		}
 	}
 

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -191,7 +191,7 @@ func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI,
 					return err
 				}
 				blockCount++
-				blockBytesCount += uint64(len(nd.RawData()))
+				blockBytesCount += uint64(len(block.RawData()))
 			}
 
 			return nil

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -119,8 +119,8 @@ func dagImport(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment
 	if stats {
 		err = res.Emit(&CarImportOutput{
 			Stats: &CarImportStats{
-				BlockCount:        done.blockCount,
-				PayloadBytesCount: done.payloadBytesCount,
+				BlockCount:      done.blockCount,
+				BlockBytesCount: done.blockBytesCount,
 			},
 		})
 		if err != nil {
@@ -139,7 +139,7 @@ func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI,
 	batch := ipld.NewBatch(req.Context, api.Dag())
 
 	roots := make(map[cid.Cid]struct{})
-	var blockCount, payloadBytesCount uint64
+	var blockCount, blockBytesCount uint64
 
 	it := req.Files.Entries()
 	for it.Next() {
@@ -192,7 +192,7 @@ func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI,
 				}
 				blockCount++
 				ndSize, _ := nd.Size()
-				payloadBytesCount += ndSize
+				blockBytesCount += ndSize
 			}
 
 			return nil
@@ -215,7 +215,7 @@ func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI,
 	}
 
 	ret <- importResult{
-		blockCount:        blockCount,
-		payloadBytesCount: payloadBytesCount,
-		roots:             roots}
+		blockCount:      blockCount,
+		blockBytesCount: blockBytesCount,
+		roots:           roots}
 }

--- a/core/commands/dag/import.go
+++ b/core/commands/dag/import.go
@@ -191,8 +191,7 @@ func importWorker(req *cmds.Request, re cmds.ResponseEmitter, api iface.CoreAPI,
 					return err
 				}
 				blockCount++
-				ndSize, _ := nd.Size()
-				blockBytesCount += ndSize
+				blockBytesCount += uint64(len(nd.RawData()))
 			}
 
 			return nil

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -269,7 +269,7 @@ test_launch_ipfs_daemon() {
 
   # wait for api file to show up
   test_expect_success "api file shows up" '
-    test_wait_for_file 50 100ms "$IPFS_PATH/api"
+    test_wait_for_file 50 200ms "$IPFS_PATH/api"
   '
 
   test_set_address_vars actual_daemon

--- a/test/sharness/t0041-ping.sh
+++ b/test/sharness/t0041-ping.sh
@@ -43,7 +43,7 @@ test_expect_success "test ping 0" '
 '
 
 test_expect_success "test ping offline" '
-  iptb stop 1 &&
+  iptb stop 1 && sleep 2 &&
   ! ipfsi 0 ping -n2 -- "$PEERID_1"
 '
 

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -56,14 +56,16 @@ run_online_imp_exp_tests() {
   reset_blockstore 1
 
   cat > basic_import_expected <<EOE
+Imported 1198 blocks
 Pinned root${tab}bafkqaaa${tab}success
 Pinned root${tab}bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u${tab}success
 Pinned root${tab}bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy${tab}success
 EOE
 
   cat >naked_root_import_json_expected <<EOE
-{"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
-{"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
+{"BlockCount":0,"Root":null}
+{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
+{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
 EOE
 
 
@@ -170,9 +172,10 @@ test_expect_success "correct error" '
 
 
 cat >multiroot_import_json_expected <<EOE
-{"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
-{"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
-{"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
+{"BlockCount":2825,"Root":null}
+{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
+{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
+{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
 EOE
 test_expect_success "multiroot import works" '
   ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
@@ -182,14 +185,17 @@ test_expect_success "multiroot import expected output" '
 '
 
 
+cat >pin_import_expected << EOE
+{"BlockCount":1198,"Root":null}
+EOE
 test_expect_success "pin-less import works" '
   ipfs dag import --enc=json --pin-roots=false \
   ../t0054-dag-car-import-export-data/lotus_devnet_genesis.car \
   ../t0054-dag-car-import-export-data/lotus_testnet_export_128.car \
     > no-pin_import_actual
 '
-test_expect_success "expected silence on --pin-roots=false" '
-  test_cmp /dev/null no-pin_import_actual
+test_expect_success "expected no pins on --pin-roots=false" '
+  test_cmp pin_import_expected no-pin_import_actual
 '
 
 

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -63,9 +63,9 @@ Pinned root${tab}bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy$
 EOE
 
   cat >naked_root_import_json_expected <<EOE
-{"BlockCount":0,"Root":null}
-{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
-{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
+{"BlockCount":0}
+{"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
+{"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
 EOE
 
 
@@ -172,10 +172,10 @@ test_expect_success "correct error" '
 
 
 cat >multiroot_import_json_expected <<EOE
-{"BlockCount":2825,"Root":null}
-{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
-{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
-{"BlockCount":0,"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
+{"BlockCount":2825}
+{"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
+{"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
+{"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
 EOE
 test_expect_success "multiroot import works" '
   ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
@@ -186,7 +186,7 @@ test_expect_success "multiroot import expected output" '
 
 
 cat >pin_import_expected << EOE
-{"BlockCount":1198,"Root":null}
+{"BlockCount":1198}
 EOE
 test_expect_success "pin-less import works" '
   ipfs dag import --enc=json --pin-roots=false \

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -41,7 +41,7 @@ do_import() {
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
 
-      ipfsi "$node" dag import --stats "$@" 2>&1 && ipfsi "$node" repo verify &>/dev/null
+      ipfsi "$node" dag import "$@" 2>&1 && ipfsi "$node" repo verify &>/dev/null
       result=$?
 
       rm -f spin.gc &>/dev/null
@@ -55,19 +55,24 @@ run_online_imp_exp_tests() {
   reset_blockstore 0
   reset_blockstore 1
 
-  cat > basic_import_expected <<EOE
+  cat > basic_import_stats_expected <<EOE
 Imported 1198 blocks (468513 bytes)
 Pinned root${tab}bafkqaaa${tab}success
 Pinned root${tab}bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u${tab}success
 Pinned root${tab}bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy${tab}success
 EOE
+  # output without the --stats line at the top
+  tail -n +2 basic_import_stats_expected > basic_import_expected
 
+  # Explainer:
+  # naked_root_import_json_expected output is produced by dag import of combined_naked_roots_genesis_and_128.car
+  # executed when roots are already present in the repo - thus the BlockCount=0
+  # (if blocks were not present in the repo, blockstore: block not found would be returned)
   cat >naked_root_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
 {"Stats":{"BlockCount":0,"BlockBytesCount":0}}
 EOE
-
 
   test_expect_success "basic import" '
     do_import 0 \
@@ -79,6 +84,18 @@ EOE
 
   test_expect_success "basic import output as expected" '
     test_cmp_sorted basic_import_expected basic_import_actual
+  '
+
+  test_expect_success "basic import with --stats" '
+    do_import 0 --stats \
+      ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
+      ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car \
+      ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car \
+    > basic_import_actual
+  '
+
+  test_expect_success "basic import output with --stats as expected" '
+    test_cmp_sorted basic_import_stats_expected basic_import_actual
   '
 
   test_expect_success "basic fetch+export 1" '
@@ -119,7 +136,7 @@ EOE
         cat ../t0054-dag-car-import-export-data/lotus_testnet_export_128_shuffled_nulroot.car > pipe_testnet &
         cat ../t0054-dag-car-import-export-data/lotus_devnet_genesis_shuffled_nulroot.car > pipe_devnet &
 
-        do_import 0 \
+        do_import 0 --stats \
           pipe_testnet \
           pipe_devnet \
           ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
@@ -136,7 +153,7 @@ EOE
   '
 
   test_expect_success "fifo-import output as expected" '
-    test_cmp_sorted basic_import_expected basic_fifo_import_actual
+    test_cmp_sorted basic_import_stats_expected basic_fifo_import_actual
   '
 }
 
@@ -170,18 +187,27 @@ test_expect_success "correct error" '
   test_cmp_sorted offline_fetch_error_expected offline_fetch_error_actual
 '
 
-
-cat >multiroot_import_json_expected <<EOE
+cat >multiroot_import_json_stats_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
 {"Stats":{"BlockCount":2825,"BlockBytesCount":1339709}}
 EOE
-test_expect_success "multiroot import works" '
-  ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
+# output without --stats line
+head -3 multiroot_import_json_stats_expected > multiroot_import_json_expected
+
+test_expect_success "multiroot import works (--enc=json)" '
+  ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
 '
 test_expect_success "multiroot import expected output" '
   test_cmp_sorted multiroot_import_json_expected multiroot_import_json_actual
+'
+
+test_expect_success "multiroot import works with --stats" '
+  ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
+'
+test_expect_success "multiroot import expected output" '
+  test_cmp_sorted multiroot_import_json_stats_expected multiroot_import_json_actual
 '
 
 

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -56,7 +56,7 @@ run_online_imp_exp_tests() {
   reset_blockstore 1
 
   cat > basic_import_expected <<EOE
-Imported 1198 blocks
+Imported 1198 blocks (468513 bytes)
 Pinned root${tab}bafkqaaa${tab}success
 Pinned root${tab}bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u${tab}success
 Pinned root${tab}bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy${tab}success
@@ -65,7 +65,7 @@ EOE
   cat >naked_root_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
-{"Stats":{"BlockCount":0}}
+{"Stats":{"BlockCount":0,"PayloadBytesCount":0}}
 EOE
 
 
@@ -175,7 +175,7 @@ cat >multiroot_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
-{"Stats":{"BlockCount":2825}}
+{"Stats":{"BlockCount":2825,"PayloadBytesCount":1339709}}
 EOE
 test_expect_success "multiroot import works" '
   ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
@@ -186,7 +186,7 @@ test_expect_success "multiroot import expected output" '
 
 
 cat >pin_import_expected << EOE
-{"Stats":{"BlockCount":1198}}
+{"Stats":{"BlockCount":1198,"PayloadBytesCount":468513}}
 EOE
 test_expect_success "pin-less import works" '
   ipfs dag import --stats --enc=json --pin-roots=false \

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -41,7 +41,7 @@ do_import() {
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
       while [[ -e spin.gc ]]; do ipfsi "$node" repo gc &>/dev/null; done &
 
-      ipfsi "$node" dag import "$@" 2>&1 && ipfsi "$node" repo verify &>/dev/null
+      ipfsi "$node" dag import --stats "$@" 2>&1 && ipfsi "$node" repo verify &>/dev/null
       result=$?
 
       rm -f spin.gc &>/dev/null
@@ -63,9 +63,9 @@ Pinned root${tab}bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy$
 EOE
 
   cat >naked_root_import_json_expected <<EOE
-{"BlockCount":0}
 {"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
+{"Stats":{"BlockCount":0}}
 EOE
 
 
@@ -100,7 +100,7 @@ EOE
   '
 
   test_expect_success "import/pin naked roots only, relying on local blockstore having all the data" '
-    ipfsi 1 dag import --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
+    ipfsi 1 dag import --stats --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
       > naked_import_result_json_actual
   '
 
@@ -172,13 +172,13 @@ test_expect_success "correct error" '
 
 
 cat >multiroot_import_json_expected <<EOE
-{"BlockCount":2825}
 {"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
+{"Stats":{"BlockCount":2825}}
 EOE
 test_expect_success "multiroot import works" '
-  ipfs dag import --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
+  ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
 '
 test_expect_success "multiroot import expected output" '
   test_cmp_sorted multiroot_import_json_expected multiroot_import_json_actual
@@ -186,10 +186,10 @@ test_expect_success "multiroot import expected output" '
 
 
 cat >pin_import_expected << EOE
-{"BlockCount":1198}
+{"Stats":{"BlockCount":1198}}
 EOE
 test_expect_success "pin-less import works" '
-  ipfs dag import --enc=json --pin-roots=false \
+  ipfs dag import --stats --enc=json --pin-roots=false \
   ../t0054-dag-car-import-export-data/lotus_devnet_genesis.car \
   ../t0054-dag-car-import-export-data/lotus_testnet_export_128.car \
     > no-pin_import_actual
@@ -200,7 +200,7 @@ test_expect_success "expected no pins on --pin-roots=false" '
 
 
 test_expect_success "naked root import works" '
-  ipfs dag import --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
+  ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/combined_naked_roots_genesis_and_128.car \
     > naked_root_import_json_actual
 '
 test_expect_success "naked root import expected output" '

--- a/test/sharness/t0054-dag-car-import-export.sh
+++ b/test/sharness/t0054-dag-car-import-export.sh
@@ -65,7 +65,7 @@ EOE
   cat >naked_root_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceaxm23epjsmh75yvzcecsrbavlmkcxnva66bkdebdcnyw3bjrc74u"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzaced4ueelaegfs5fqu4tzsh6ywbbpfk3cxppupmxfdhbpbhzawfw5oy"},"PinErrorMsg":""}}
-{"Stats":{"BlockCount":0,"PayloadBytesCount":0}}
+{"Stats":{"BlockCount":0,"BlockBytesCount":0}}
 EOE
 
 
@@ -175,7 +175,7 @@ cat >multiroot_import_json_expected <<EOE
 {"Root":{"Cid":{"/":"bafy2bzaceb55n7uxyfaelplulk3ev2xz7gnq6crncf3ahnvu46hqqmpucizcw"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacebedrc4n2ac6cqdkhs7lmj5e4xiif3gu7nmoborihajxn3fav3vdq"},"PinErrorMsg":""}}
 {"Root":{"Cid":{"/":"bafy2bzacede2hsme6hparlbr4g2x6pylj43olp4uihwjq3plqdjyrdhrv7cp4"},"PinErrorMsg":""}}
-{"Stats":{"BlockCount":2825,"PayloadBytesCount":1339709}}
+{"Stats":{"BlockCount":2825,"BlockBytesCount":1339709}}
 EOE
 test_expect_success "multiroot import works" '
   ipfs dag import --stats --enc=json ../t0054-dag-car-import-export-data/lotus_testnet_export_256_multiroot.car > multiroot_import_json_actual
@@ -186,7 +186,7 @@ test_expect_success "multiroot import expected output" '
 
 
 cat >pin_import_expected << EOE
-{"Stats":{"BlockCount":1198,"PayloadBytesCount":468513}}
+{"Stats":{"BlockCount":1198,"BlockBytesCount":468513}}
 EOE
 test_expect_success "pin-less import works" '
   ipfs dag import --stats --enc=json --pin-roots=false \


### PR DESCRIPTION
I'm just taking a stab at this and am unsure if I'm following the right pattern here so feedback would be appreciated.

Currently `dag import` only reports pinned CIDs and an error on pinning. If you `pin-roots=false` then you get nothing. I'm working on the JS version of this, including the HTTP client, and I'd really like to get a bit more information out of this process. The minimum I think is simply a report of how many blocks were imported (although in the current form it's not counting unique blocks, just total processed blocks).

So we end up with this slightly awkward event: `{BlockCount:uint64, Root:*RootMeta}` - where the first one is expected to be `Root==nil` and `BlockCount` telling you how many blocks, and any remaining should have `Root!=nil` and reporting pin status if you asked for pinning.

Is there a better pattern to follow than this? Can I make two separate event types? Can I clean up the struct a bit somehow or maybe use two separate structs rather than overloading one?