### PR TITLE
Disambiguate online/offline naming in sharness tests

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -280,6 +280,11 @@ test_launch_ipfs_daemon() {
   '
 }
 
+test_launch_ipfs_daemon_without_network() {
+  test_launch_ipfs_daemon --offline "$@"
+  # FIXME: Check if this is the right way to concatenate arguments.
+}
+
 do_umount() {
   if [ "$(uname -s)" = "Linux" ]; then
   fusermount -u "$1"

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -282,7 +282,6 @@ test_launch_ipfs_daemon() {
 
 test_launch_ipfs_daemon_without_network() {
   test_launch_ipfs_daemon --offline "$@"
-  # FIXME: Check if this is the right way to concatenate arguments.
 }
 
 do_umount() {

--- a/test/sharness/t0023-shutdown.sh
+++ b/test/sharness/t0023-shutdown.sh
@@ -24,7 +24,7 @@ test_expect_success "daemon no longer running" '
   done
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "shutdown succeeds" '
   ipfs shutdown

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -842,7 +842,7 @@ test_add_named_pipe
 test_add_pwd_is_symlink
 
 # Test daemon in offline mode
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_add_cat_file
 

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -312,7 +312,7 @@ test_expect_success "'ipfs ls --resolve-type=true --size=false' fails" '
   test_must_fail ipfs ls --resolve-type=true --size=false $DIR
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "'ipfs ls --resolve-type=false --size=false' ok" '
   ipfs ls --resolve-type=false --size=false $DIR > /dev/null

--- a/test/sharness/t0061-daemon-opts.sh
+++ b/test/sharness/t0061-daemon-opts.sh
@@ -25,7 +25,7 @@ test_expect_success SOCAT 'transport should be unencrypted ( needs socat )' '
 
 test_kill_ipfs_daemon
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 gwyaddr=$GWAY_ADDR
 apiaddr=$API_ADDR

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -9,7 +9,7 @@ test_description="Test ipfs repo operations"
 . lib/test-lib.sh
 
 test_init_ipfs
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "'ipfs repo gc' succeeds" '
   ipfs repo gc >gc_out_actual
@@ -63,7 +63,7 @@ test_expect_success "ipfs repo gc fully reverse ipfs add (part 2)" '
   test_cmp expected_blocks actual_blocks
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "file no longer pinned" '
   ipfs pin ls --type=recursive --quiet >actual2 &&

--- a/test/sharness/t0081-repo-pinning.sh
+++ b/test/sharness/t0081-repo-pinning.sh
@@ -237,7 +237,7 @@ test_expect_success "some are no longer there" '
   test_must_fail ipfs ls "$HASH_DIR3"
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 test_expect_success "recursive pin fails without objects" '
   test_must_fail ipfs pin add -r "$HASH_DIR1" 2>err_expected8 &&
   grep "pin: merkledag: not found" err_expected8 ||

--- a/test/sharness/t0085-pins.sh
+++ b/test/sharness/t0085-pins.sh
@@ -180,7 +180,7 @@ test_pin_dag --raw-leaves
 
 test_pin_progress
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_pins '' '' ''
 test_pins --progress '' ''

--- a/test/sharness/t0087-repo-robust-gc.sh
+++ b/test/sharness/t0087-repo-robust-gc.sh
@@ -157,7 +157,7 @@ test_init_ipfs
 test_gc_robust_part1
 test_gc_robust_part2
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_gc_robust_part1
 test_gc_robust_part2

--- a/test/sharness/t0095-refs.sh
+++ b/test/sharness/t0095-refs.sh
@@ -9,7 +9,7 @@ test_description="Test 'ipfs refs' command"
 . lib/test-lib.sh
 
 test_init_ipfs
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # This file performs tests with the following directory
 # structure.

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -228,7 +228,7 @@ test_name_with_self() {
         test_kill_ipfs_daemon
 
         # Test daemon in offline mode
-        test_launch_ipfs_daemon --offline
+        test_launch_ipfs_daemon_without_network
 
         test_expect_success "'ipfs name publish' fails offline mode" '
         test_expect_code 1 ipfs name publish "/ipfs/$HASH_WELCOME_DOCS"

--- a/test/sharness/t0114-gateway-subdomains.sh
+++ b/test/sharness/t0114-gateway-subdomains.sh
@@ -89,7 +89,7 @@ test_expect_success "ipfs init" '
   ipfs init --profile=test > /dev/null
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # CIDv0to1 is necessary because raw-leaves are enabled by default during
 # "ipfs add" with CIDv1 and disabled with CIDv0
@@ -141,7 +141,7 @@ test_expect_success "Publish test text file to IPNS using ED25519 keys" '
 test_expect_success 'start daemon with empty config for Gateway.PublicGateways' '
   test_kill_ipfs_daemon &&
   ipfs config --json Gateway.PublicGateways "{}" &&
-  test_launch_ipfs_daemon --offline
+  test_launch_ipfs_daemon_without_network
 '
 
 ## ============================================================================
@@ -337,7 +337,7 @@ ipfs config --json Gateway.PublicGateways '{
 }' || exit 1
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 
 # example.com/ip(f|n)s/*
@@ -519,7 +519,7 @@ ipfs config --json Gateway.PublicGateways '{
 }' || exit 1
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # not mounted at the root domain
 test_hostname_gateway_response_should_contain \
@@ -632,7 +632,7 @@ ipfs config --json Gateway.PublicGateways '{
 }' || exit 1
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # refuse requests to Paths that were not explicitly whitelisted for the hostname
 test_hostname_gateway_response_should_contain \
@@ -661,7 +661,7 @@ ipfs config --json Gateway.PublicGateways '{
 
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # example.com/ip(f|n)s/* smoke-tests
 # =============================================================================
@@ -834,7 +834,7 @@ ipfs config --json Gateway.PublicGateways '{
 }' || exit 1
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "request for http://fake.domain.com/ipfs/{CID} doesn't match the example.com gateway" "
   curl -H \"Host: fake.domain.com\" -sD - \"http://127.0.0.1:$GWAY_PORT/ipfs/$CIDv1\" > response &&
@@ -876,7 +876,7 @@ ipfs config --json Gateway.PublicGateways '{
 }' || exit 1
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 # *.example1.com
 
@@ -945,7 +945,7 @@ ipfs config --json Gateway.PublicGateways '{
 
 # restart daemon to apply config changes
 test_kill_ipfs_daemon
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_localhost_gateway_response_should_contain \
   "request for localhost/ipfs/{CID} stays on path when subdomain gw is explicitly disabled" \

--- a/test/sharness/t0115-gateway-dir-listing.sh
+++ b/test/sharness/t0115-gateway-dir-listing.sh
@@ -16,7 +16,7 @@ test_expect_success "ipfs init" '
   ipfs init --profile=test > /dev/null
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "Add the test directory" '
   mkdir -p rootDir/ipfs &&

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -786,7 +786,7 @@ test_expect_success "enable sharding in config" '
   ipfs config --json Experimental.ShardingEnabled true
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 SHARD_HASH=QmPkwLJTYZRGPJ8Lazr9qPdrLmswPtUjaDbEpmR9jEh1se
 test_sharding "(cidv0)"

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -498,8 +498,12 @@ test_files_api() {
     echo "testing" | ipfs files write $ARGS $RAW_LEAVES -f=false -e /cats/walrus
   '
 
+  # Skip this test if the commands are not being run through the daemon
+  # ($WITH_DAEMON not set) as standalone commands will *always* flush
+  # after being done and the 'no-flush' call from the previous test will
+  # not be enforced.
   test_expect_success "root hash not bubbled up yet $EXTRA" '
-    test -z "$ONLINE" ||
+    test -z "$WITH_DAEMON" ||
     (ipfs refs local > refsout &&
     test_expect_code 1 grep $ROOT_HASH refsout)
   '
@@ -693,8 +697,10 @@ test_files_api() {
   '
 }
 
-# test offline and online
-
+# test with and without the daemon (EXTRA="with-daemon" and EXTRA="no-daemon"
+# respectively).
+# FIXME: Check if we are correctly using the "no-daemon" flag in these test
+# combinations.
 tests_for_files_api() {
   local EXTRA
   EXTRA=$1
@@ -712,7 +718,7 @@ tests_for_files_api() {
     create_files --raw-leaves
   '
 
-  if [ "$EXTRA" = "offline" ]; then
+  if [ "$EXTRA" = "with-daemon" ]; then
     ROOT_HASH=QmTpKiKcAj4sbeesN6vrs5w3QeVmd4QmGpxRL81hHut4dZ
     CATS_HASH=QmPhPkmtUGGi8ySPHoPu1qbfryLJKKq1GYxpgLyyCruvGe
     test_files_api "($EXTRA, partial raw-leaves)"
@@ -728,7 +734,7 @@ tests_for_files_api() {
   CATS_HASH=bafybeig4cpvfu2qwwo3u4ffazhqdhyynfhnxqkzvbhrdbamauthf5mfpuq
   FILE_HASH=bafybeibkrazpbejqh3qun7xfnsl7yofl74o4jwhxebpmtrcpavebokuqtm
   TRUNC_HASH=bafybeigwhb3q36yrm37jv5fo2ap6r6eyohckqrxmlejrenex4xlnuxiy3e
-  if [ "$EXTRA" = "offline" ]; then
+  if [ "$EXTRA" = "with-daemon" ]; then
     test_files_api "($EXTRA, cidv1)" --cid-version=1
   fi
 
@@ -742,7 +748,7 @@ tests_for_files_api() {
   ROOT_HASH=bafybeifxnoetaa2jetwmxubv3gqiyaknnujwkkkhdeua63kulm63dcr5wu
     test_files_api "($EXTRA, cidv1 root)"
 
-  if [ "$EXTRA" = "offline" ]; then
+  if [ "$EXTRA" = "with-daemon" ]; then
     test_expect_success "can update root hash to blake2b-256" '
     ipfs files chcid --hash=blake2b-256 / &&
       echo bafykbzacebugfutjir6qie7apo5shpry32ruwfi762uytd5g3u2gk7tpscndq > hash_expect &&
@@ -764,15 +770,17 @@ tests_for_files_api() {
   '
 }
 
-tests_for_files_api "online"
+tests_for_files_api "no-daemon"
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
-ONLINE=1 # set online flag so tests can easily tell
+WITH_DAEMON=1
+# FIXME: Used only on a specific test inside `test_files_api` but we should instead
+# propagate the `"with-daemon"` argument in its caller `tests_for_files_api`.
 
-tests_for_files_api "offline"
+tests_for_files_api "with-daemon"
 
-test_kill_ipfs_daemon --offline
+test_kill_ipfs_daemon
 
 test_expect_success "enable sharding in config" '
   ipfs config --json Experimental.ShardingEnabled true

--- a/test/sharness/t0271-filestore-utils.sh
+++ b/test/sharness/t0271-filestore-utils.sh
@@ -187,7 +187,7 @@ test_init
 
 # must be in offline mode so tests that retrieve non-existent blocks
 # doesn't hang
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_filestore_adds
 
@@ -251,7 +251,7 @@ test_init
 
 # must be in offline mode so tests that retrieve non-existent blocks
 # doesn't hang
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_filestore_adds
 

--- a/test/sharness/t0272-urlstore.sh
+++ b/test/sharness/t0272-urlstore.sh
@@ -26,7 +26,7 @@ test_urlstore() {
     HASH3a=$(ipfs add -q --trickle --raw-leaves=false file3)
   '
   
-  test_launch_ipfs_daemon --offline
+  test_launch_ipfs_daemon_without_network
   
   test_expect_success "make sure files can be retrieved via the gateway" '
     curl http://127.0.0.1:$GWAY_PORT/ipfs/$HASH1a -o file1.actual &&
@@ -48,7 +48,7 @@ test_urlstore() {
     ipfs config --json Experimental.UrlstoreEnabled true
   '
   
-  test_launch_ipfs_daemon --offline
+  test_launch_ipfs_daemon_without_network
   
   test_expect_success "add files using gateway address via url store using $ADD_CMD" '
     HASH1=$(ipfs $ADD_CMD --pin=false http://127.0.0.1:$GWAY_PORT/ipfs/$HASH1a) &&

--- a/test/sharness/t0600-issues-and-regressions-online.sh
+++ b/test/sharness/t0600-issues-and-regressions-online.sh
@@ -59,7 +59,7 @@ test_expect_success "ipfs daemon --offline --mount fails - #2995" '
   test_fsh cat daemon_err
 '
 
-test_launch_ipfs_daemon --offline
+test_launch_ipfs_daemon_without_network
 
 test_expect_success "'ipfs name resolve' succeeds after ipfs id when daemon offline" '
   PEERID=`ipfs key list --ipns-base=base36 -l | grep self | cut -d " " -f1` &&


### PR DESCRIPTION
In connection with #8131.

_Does not have any change in logic, just naming. The commits should be reviewed separately; we can drop the second one if too invasive._

Do not use online/offline naming system when starting the daemon in tests but the more specific "with network".

Particularly in the files tests (`t0250`) the online/offline names were _also_ being used to signal if the daemon was running or not. They were even used what appears to be incorrectly as `"online"` meant `"no-daemon"` (now renamed as such) so the internal logic of `tests_for_files_api` should be reviewed (left a `FIXME` note for that).
