### PR TITLE
fix dag test fixtures for go-ipld-prime codecs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,3 +116,4 @@ require (
 )
 
 go 1.14
+replace github.com/ipld/go-ipld-prime => ./../../ipld/go-ipld-prime/

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	github.com/ipfs/go-verifcid v0.0.1
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/ipld/go-car v0.3.1
-	github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2
-	github.com/ipld/go-ipld-prime v0.10.1-0.20210701102120-b7347f196aa5
+	github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2 // indirect
+	github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4
 	github.com/jbenet/go-is-domain v1.0.5
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
@@ -116,4 +116,3 @@ require (
 )
 
 go 1.14
-replace github.com/ipld/go-ipld-prime => ./../../ipld/go-ipld-prime/

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	github.com/ipfs/go-verifcid v0.0.1
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/ipld/go-car v0.3.1
-	github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2 // indirect
-	github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4
+	github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2
+	github.com/ipld/go-ipld-prime v0.10.1-0.20210721023048-333be0f75cff
 	github.com/jbenet/go-is-domain v1.0.5
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -499,10 +499,8 @@ github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2 h1:m/ZZEoOds
 github.com/ipld/go-codec-dagpb v1.2.1-0.20210405170603-d0b86f7623c2/go.mod h1:GMLfso6KSkYJlIbd2cGKdGMe/hM5/IukeXRQ+u6zTrQ=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
-github.com/ipld/go-ipld-prime v0.10.1-0.20210701102120-b7347f196aa5 h1:hlKWs60jv1TN1WqYS4RueP9+MS2RRCFqj7CgJ+uDFQc=
-github.com/ipld/go-ipld-prime v0.10.1-0.20210701102120-b7347f196aa5/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
-github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4 h1:P0193tWVYBZqARh+uaGbI1xvuJbuzQDSS6GWlxDnPuA=
-github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
+github.com/ipld/go-ipld-prime v0.10.1-0.20210721023048-333be0f75cff h1:lq3003BnMXgz+sqwv2RBBalILy0AnY3TbXeyTBa34ww=
+github.com/ipld/go-ipld-prime v0.10.1-0.20210721023048-333be0f75cff/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,8 @@ github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/j
 github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.10.1-0.20210701102120-b7347f196aa5 h1:hlKWs60jv1TN1WqYS4RueP9+MS2RRCFqj7CgJ+uDFQc=
 github.com/ipld/go-ipld-prime v0.10.1-0.20210701102120-b7347f196aa5/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
+github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4 h1:P0193tWVYBZqARh+uaGbI1xvuJbuzQDSS6GWlxDnPuA=
+github.com/ipld/go-ipld-prime v0.10.1-0.20210716061152-019d85c21ab4/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/test/sharness/t0275-cid-security.sh
+++ b/test/sharness/t0275-cid-security.sh
@@ -11,7 +11,7 @@ test_description="Cid Security"
 test_init_ipfs
 
 test_expect_success "adding using unsafe function fails with error" '
-  echo foo | test_must_fail ipfs add --hash murmur3-128 2>add_out
+  echo foo | test_must_fail ipfs add --hash md5 2>add_out
 '
 
 test_expect_success "error reason is pointed out" '


### PR DESCRIPTION
Pending https://github.com/ipld/go-ipld-prime/pull/202 and https://github.com/ipld/go-ipld-prime/pull/203

* I've massaged one of the main fixtures so that it's pre-sorted according to DAG-CBOR rules since go-ipld-prime as yet doesn't apply any sorting, I didn't want to treat that as a blocker for this PR but it may have to be treated as a blocker for release (similar change to https://github.com/ipld/go-ipld-prime/pull/203, but there's deep background here ... cans of worms).
* `dag get` doesn't print a newline now, which I think is the right behaviour since it can now do any codec and newlines are going to be a problem for the stricter binary formats than dag-json, so I've adapted the fixtures.
* The proper DAG-PB `Data` / `Links` changes show up here and are now correct, as are the new (proper) rules for showing bytes with DAG-JSON.
* There's a change near the bottom for `dag stat`, this comes from go-ipld-cbor doing always-64-bit integers, but we're now doing always-smallest-possible now across all our codecs, so go-ipld-cbor is the odd one out (old and new JS codecs do this, and spec says it).