### PR TITLE
Rename DOCKER_HOST to TEST_DOCKER_HOST to avoid conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,10 @@ jobs:
     - run:
         name: Setup Environment Variables
         # we need the docker host IP; all ports exported by child containers can be accessed there.
-        command: echo "export DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')" >> $BASH_ENV
+        command: echo "export TEST_DOCKER_HOST=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')" >> $BASH_ENV
     - run:
-        echo DOCKER_HOST=$DOCKER_HOST &&
-        make -O -j 3 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1 DOCKER_HOST=$DOCKER_HOST
+        echo TEST_DOCKER_HOST=$TEST_DOCKER_HOST &&
+        make -O -j 3 coverage/sharness_tests.coverprofile test/sharness/test-results/sharness.xml TEST_GENERATE_JUNIT=1 CONTINUE_ON_S_FAILURE=1 TEST_DOCKER_HOST=$TEST_DOCKER_HOST
 
     - run:
         when: always

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -4,9 +4,9 @@ test_description="Test ipfs remote pinning operations"
 
 . lib/test-lib.sh
 
-if [ -z ${DOCKER_HOST+x} ]; then
+if [ -z ${TEST_DOCKER_HOST+x} ]; then
   # TODO: set up instead of skipping?
-  skip_all='Skipping pinning service integration tests: missing DOCKER_HOST, remote pinning service not available'
+  skip_all='Skipping pinning service integration tests: missing TEST_DOCKER_HOST, remote pinning service not available'
   test_done
 fi
 
@@ -15,7 +15,7 @@ test_init_ipfs
 test_launch_ipfs_daemon
 
 # create user on pinning service
-TEST_PIN_SVC="http://${DOCKER_HOST}:5000/api/v1"
+TEST_PIN_SVC="http://${TEST_DOCKER_HOST}:5000/api/v1"
 TEST_PIN_SVC_KEY=$(curl -s -X POST "$TEST_PIN_SVC/users" -d email="go-ipfs-sharness@ipfs.example.com" | jq --raw-output .access_token)
 
 # pin remote service  add|ls|rm


### PR DESCRIPTION
DOCKER_HOST is a special environment variable of the Docker CLI
so there's risk of creating conflicts whenever attempting to use `docker`
in the test suite; it also makes it difficult to run the same full suite
locally using the same setup since DOCKER_HOST is a fixed variable in
t0700-remotepin.sh