### PR TITLE
(ipld-prime) Use mh.Set() for "hash" -> mhType & Make git plugin test work again

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -80,7 +80,7 @@ into an object of the specified format.
 		cmds.StringOption("format", "f", "Format that the object will be added as.").WithDefault("dag-cbor"),
 		cmds.StringOption("input-enc", "Format that the input object will be.").WithDefault("dag-json"),
 		cmds.BoolOption("pin", "Pin this object when adding."),
-		cmds.StringOption("hash", "Hash function to use").WithDefault(""),
+		cmds.StringOption("hash", "Hash function to use").WithDefault("sha2-256"),
 	},
 	Run:  dagPut,
 	Type: OutputObject{},

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-ipld-format v0.2.0
-	github.com/ipfs/go-ipld-git v0.0.4-0.20210326054912-6be33ddcbecc
+	github.com/ipfs/go-ipld-git v0.0.4-0.20210722115044-0436bc7c4a27
 	github.com/ipfs/go-ipld-legacy v0.0.0-20210325015318-9799f2cffab0
 	github.com/ipfs/go-ipns v0.0.2
 	github.com/ipfs/go-log v1.0.4

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-dns v0.2.0
 	github.com/multiformats/go-multibase v0.0.3
-	github.com/multiformats/go-multicodec v0.2.1-0.20210718225951-a237c4436b76
+	github.com/multiformats/go-multicodec v0.2.1-0.20210723011827-52a3ac546597
 	github.com/multiformats/go-multihash v0.0.15
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/ipfs/go-ipld-format v0.0.1/go.mod h1:kyJtbkDALmFHv3QR6et67i35QzO3S0dC
 github.com/ipfs/go-ipld-format v0.0.2/go.mod h1:4B6+FM2u9OJ9zCV+kSbgFAZlOrv1Hqbf0INGQgiKf9k=
 github.com/ipfs/go-ipld-format v0.2.0 h1:xGlJKkArkmBvowr+GMCX0FEZtkro71K1AwiKnL37mwA=
 github.com/ipfs/go-ipld-format v0.2.0/go.mod h1:3l3C1uKoadTPbeNfrDi+xMInYKlx2Cvg1BuydPSdzQs=
-github.com/ipfs/go-ipld-git v0.0.4-0.20210326054912-6be33ddcbecc h1:57luC/Oc36sZBp4BAJ74MJGsAULBeQ5NLLRpTL6YJwI=
-github.com/ipfs/go-ipld-git v0.0.4-0.20210326054912-6be33ddcbecc/go.mod h1:jtK6vhzvHtNm2YhKRxKMR8IQJAoZRtYoWqf8RnDeaIA=
+github.com/ipfs/go-ipld-git v0.0.4-0.20210722115044-0436bc7c4a27 h1:ziq9+3WwmgmSRmyquYdIXECGHUk9B+hEshIGMV1Kkp4=
+github.com/ipfs/go-ipld-git v0.0.4-0.20210722115044-0436bc7c4a27/go.mod h1:jtK6vhzvHtNm2YhKRxKMR8IQJAoZRtYoWqf8RnDeaIA=
 github.com/ipfs/go-ipld-legacy v0.0.0-20210325015318-9799f2cffab0 h1:PXjRvJkxqQ2EbwviF5GEURYqvhS/ulee/ZdVsVgVtHM=
 github.com/ipfs/go-ipld-legacy v0.0.0-20210325015318-9799f2cffab0/go.mod h1:86f5P/srAmh9GcIcWQR9lfFLZPrIyyXQeVlOWeeWEuI=
 github.com/ipfs/go-ipns v0.0.2 h1:oq4ErrV4hNQ2Eim257RTYRgfOSV/s8BDaf9iIl4NwFs=

--- a/go.sum
+++ b/go.sum
@@ -942,8 +942,8 @@ github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
-github.com/multiformats/go-multicodec v0.2.1-0.20210718225951-a237c4436b76 h1:VD/M8CCDR5uOoNpeCSejcHp3MY7XaQYqLr3ANrDDRxQ=
-github.com/multiformats/go-multicodec v0.2.1-0.20210718225951-a237c4436b76/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
+github.com/multiformats/go-multicodec v0.2.1-0.20210723011827-52a3ac546597 h1:ULcqjrvbMRf7TiRiXlmXprupBxpeUkL8q2N8Xq+bNi4=
+github.com/multiformats/go-multicodec v0.2.1-0.20210723011827-52a3ac546597/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/plugin/plugins/git/git.go
+++ b/plugin/plugins/git/git.go
@@ -31,9 +31,9 @@ func (*gitPlugin) Version() string {
 }
 
 func (*gitPlugin) Init(_ *plugin.Environment) error {
-	// register a custom identifier for import of "zlib-incoded git objects."
+	// register a custom identifier in the reserved range for import of "zlib-encoded git objects."
 	// TODO: give this a name.
-	multicodec.RegisterDecoder(uint64(0x10000000+mc.GitRaw), decodeZlibGit)
+	multicodec.RegisterDecoder(uint64(0x300000+mc.GitRaw), decodeZlibGit)
 	return nil
 }
 

--- a/plugin/plugins/git/git.go
+++ b/plugin/plugins/git/git.go
@@ -33,7 +33,7 @@ func (*gitPlugin) Version() string {
 func (*gitPlugin) Init(_ *plugin.Environment) error {
 	// register a custom identifier in the reserved range for import of "zlib-encoded git objects."
 	// TODO: give this a name.
-	multicodec.RegisterDecoder(uint64(0x300000+mc.GitRaw), decodeZlibGit)
+	multicodec.RegisterDecoder(uint64(mc.ReservedStart+mc.GitRaw), decodeZlibGit)
 	return nil
 }
 

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -130,7 +130,7 @@ test_object_cmd() {
   '
 
   test_expect_failure "'ipfs object put --inputenc=xml' output looks good" '
-    echo "added $HASH" >expected &&
+    echo "added $HASH\n" >expected &&
     test_cmp expected actual
   '
 

--- a/test/sharness/t0280-plugin-git.sh
+++ b/test/sharness/t0280-plugin-git.sh
@@ -17,19 +17,19 @@ test_expect_success "prepare test data" '
 
 test_dag_git() {
   test_expect_success "add objects via dag put" '
-    find objects -type f -exec ipfs dag put --format=git-raw --input-enc=268435576 {} \; -exec echo \; > hashes
+    find objects -type f -exec ipfs dag put --format=git-raw --input-enc=3145848 --hash=sha1 {} \; -exec echo -n \; > hashes
   '
 
-  test_expect_failure "successfully get added objects" '
+  test_expect_success "successfully get added objects" '
     cat hashes | xargs -I {} ipfs dag get -- {} > /dev/null
   '
 
-  test_expect_failure "path traversals work" '
-    echo \"YmxvYiA3ACcsLnB5Zgo=\" > file1 &&
-    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/object/parents/0/tree/dir2/hash/f3/hash > out1
+  test_expect_success "path traversals work" '
+    echo -n "{\"/\":{\"bytes\":\"YmxvYiA3ACcsLnB5Zgo=\"}}" > file1 &&
+    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/Object/Parents/0/GitTree/1/Hash/0/Hash > out1
   '
 
-  test_expect_failure "outputs look correct" '
+  test_expect_success "outputs look correct" '
     test_cmp file1 out1
   '
 }

--- a/test/sharness/t0280-plugin-git.sh
+++ b/test/sharness/t0280-plugin-git.sh
@@ -17,7 +17,7 @@ test_expect_success "prepare test data" '
 
 test_dag_git() {
   test_expect_success "add objects via dag put" '
-    find objects -type f -exec ipfs dag put --format=git-raw --input-enc=3145848 --hash=sha1 {} \; -exec echo -n \; > hashes
+    find objects -type f -exec ipfs dag put --format=git-raw --input-enc=0x300078 --hash=sha1 {} \; -exec echo -n \; > hashes
   '
 
   test_expect_success "successfully get added objects" '

--- a/test/sharness/t0280-plugin-git.sh
+++ b/test/sharness/t0280-plugin-git.sh
@@ -26,7 +26,7 @@ test_dag_git() {
 
   test_expect_success "path traversals work" '
     echo -n "{\"/\":{\"bytes\":\"YmxvYiA3ACcsLnB5Zgo=\"}}" > file1 &&
-    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/Object/Parents/0/GitTree/1/Hash/0/Hash > out1
+    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/object/parents/0/tree/dir2/hash/f3/hash > out1
   '
 
   test_expect_success "outputs look correct" '


### PR DESCRIPTION
@mvdan this extends your last commit to the branch to do `mh.Set()` for `hash` as well.

It also revives t0280 for the git-plugin. The diff with master is the most interesting bit now:

```diff
diff --git a/test/sharness/t0280-plugin-git.sh b/test/sharness/t0280-plugin-git.sh
index e7bc06427..d90df46bc 100755
--- a/test/sharness/t0280-plugin-git.sh
+++ b/test/sharness/t0280-plugin-git.sh
@@ -17,7 +17,7 @@ test_expect_success "prepare test data" '

 test_dag_git() {
   test_expect_success "add objects via dag put" '
-    find objects -type f -exec ipfs dag put --format=git --input-enc=zlib {} \; -exec echo \; > hashes
+    find objects -type f -exec ipfs dag put --format=git-raw --input-enc=3145848 --hash=sha1 {} \; -exec echo -n \; > hashes
   '

   test_expect_success "successfully get added objects" '
@@ -25,8 +25,8 @@ test_dag_git() {
   '

   test_expect_success "path traversals work" '
-    echo \"YmxvYiA3ACcsLnB5Zgo=\" > file1 &&
-    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/object/parents/0/tree/dir2/hash/f3/hash > out1
+    echo -n "{\"/\":{\"bytes\":\"YmxvYiA3ACcsLnB5Zgo=\"}}" > file1 &&
+    ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/Object/Parents/0/GitTree/1/Hash/0/Hash > out1
   '

   test_expect_success "outputs look correct" '
```

Note the pathing through the git object at the bottom there. I wouldn't mind getting that addressed - don't CamelCase, at least one rename, and maybe turn those arrays into maps so we can do it by name. It'd be nice to maintain consistency of forms.