### PR TITLE
fix: avoid out of bounds error when rendering short hashes

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -391,11 +391,12 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 			size = humanize.Bytes(uint64(s))
 		}
 
-		hash := ""
-		if r, err := i.api.ResolvePath(r.Context(), ipath.Join(resolvedPath, dirit.Name())); err == nil {
-			// Path may not be resolved. Continue anyways.
-			hash = r.Cid().String()
+		resolved, err := i.api.ResolvePath(r.Context(), ipath.Join(resolvedPath, dirit.Name()))
+		if err != nil {
+			internalWebError(w, err)
+			return
 		}
+		hash := resolved.Cid().String()
 
 		// See comment above where originalUrlPath is declared.
 		di := directoryItem{

--- a/core/corehttp/gateway_indexPage.go
+++ b/core/corehttp/gateway_indexPage.go
@@ -75,6 +75,9 @@ func breadcrumbs(urlPath string, dnslinkOrigin bool) []breadcrumb {
 }
 
 func shortHash(hash string) string {
+	if len(hash) <= 8 {
+		return hash
+	}
 	return (hash[0:4] + "\u2026" + hash[len(hash)-4:])
 }
 


### PR DESCRIPTION
The panic is caught higher up the stack so it can't crash the node, but it's still "not good".