### PR TITLE
Docker override config from env variables

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -2,6 +2,7 @@
 set -e
 user=ipfs
 repo="$IPFS_PATH"
+ipfsEnvPrefix="IPFSCONFIG"
 
 if [ `id -u` -eq 0 ]; then
   echo "Changing user to $user"
@@ -24,6 +25,27 @@ else
   ipfs init $INIT_ARGS
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+
+  # Set config from ENV variables
+  # Some examples are:
+  # 
+  # IPFSCONFIG_Swarm_EnableAutoRelay=true
+  # IPFSCONFIG_Addresses_Swarm=[\"/ip4/0.0.0.0/tcp/4001\",\"/ip6/::/tcp/4001\"]
+  env | \
+  while IFS='=' read -r name value; do
+    # Since we don't have extended pattern in busybox, will use grep
+    if echo $name | grep -qxwE "${ipfsEnvPrefix}(_[a-zA-Z0-9]+)+" ; then
+      removePrefix=${name#$ipfsEnvPrefix*}
+      replaceToDot=${removePrefix//_/.}
+      ipfsConfigArg=${replaceToDot:1}
+      
+      # Inform user what we are doing, since it could be
+      # a potential vector for command injections
+      set -x
+      ipfs config --json $ipfsConfigArg $value
+      { set +x; } 2>/dev/null
+    fi
+  done
 
   # Set up the swarm key, if provided
 


### PR DESCRIPTION
Hello,

It seems a old problem without a clear patch to support it. I've tried to do it as much simple/clean as possible.

With this patch, anyone can override the config with env variable such as:

 - IPFSCONFIG_Swarm_EnableAutoRelay=true
 - IPFSCONFIG_Addresses_Swarm=[\\"/ip4/0.0.0.0/tcp/4001\\",\\"/ip6/::/tcp/4001\\"]

Take in account that:
 - Is case sensitive. Is not the same `IPFSCONFIG_FooBar` than `IPFSCONFIG_FOOBAR`
 - A valid syntax will be accepted even if the path is wrong (`ipfs config` stuff). Something like `IPFSCONFIG_Swarm_EnableAutoRealy=true` will be accepted and written to the config even if it does nothing. So typos could make you loose a lot of hours here :)

Hope it helps you. IPFS is really awesome stuff and now it should be more flexible in container environments

/cc #251 #387 #6325

PS: Docker docs should be updated if is finally merged