### PR TITLE
Fix: Use a pointer type on IpfsNode.Peering

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -85,7 +85,7 @@ type IpfsNode struct {
 
 	// Online
 	PeerHost      p2phost.Host            `optional:"true"` // the network host (server+client)
-	Peering       peering.PeeringService  `optional:"true"`
+	Peering       *peering.PeeringService `optional:"true"`
 	Filters       *ma.Filters             `optional:"true"`
 	Bootstrapper  io.Closer               `optional:"true"` // the periodic bootstrapper
 	Routing       routing.Routing         `optional:"true"` // the routing system. recommend ipfs-dht


### PR DESCRIPTION
# The problem

The current type of `IpfsNode.Peering` is `PeeringService`.
It is different from the type `*PeeringService` returned from `node.Peering` provided in core/node/groups.go:270 .
This difference prevents fx from injecting `IpfsNode.Peering`.
The current `node.PeeringService` on the daemon is a zero value.

I also cannot get the valid `PeeringService` on `SwarmAddCommand` in  https://github.com/ipfs/go-ipfs/pull/8147 due to this problem.


# Proposal

I propose to fix the type of `IpfsNode.PeeringService` from `PeeringService` to `*PeeringService`.