### PR TITLE
feat: register first block metric by default

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -28,6 +28,7 @@ import (
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	routing "github.com/libp2p/go-libp2p-core/routing"
+	prometheus "github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -62,6 +63,8 @@ type redirectTemplateData struct {
 type gatewayHandler struct {
 	config GatewayConfig
 	api    coreiface.CoreAPI
+
+	unixfsGetMetric *prometheus.SummaryVec
 }
 
 // StatusResponseWriter enables us to override HTTP Status Code passed to
@@ -84,9 +87,27 @@ func (sw *statusResponseWriter) WriteHeader(code int) {
 }
 
 func newGatewayHandler(c GatewayConfig, api coreiface.CoreAPI) *gatewayHandler {
+	unixfsGetMetric := prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "ipfs",
+			Subsystem: "http",
+			Name:      "unixfs_get_latency_seconds",
+			Help:      "The time till the first block is received when 'getting' a file from the gateway.",
+		},
+		[]string{"gateway"},
+	)
+	if err := prometheus.Register(unixfsGetMetric); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			unixfsGetMetric = are.ExistingCollector.(*prometheus.SummaryVec)
+		} else {
+			log.Errorf("failed to register unixfsGetMetric: %v", err)
+		}
+	}
+
 	i := &gatewayHandler{
-		config: c,
-		api:    api,
+		config:          c,
+		api:             api,
+		unixfsGetMetric: unixfsGetMetric,
 	}
 	return i
 }
@@ -271,7 +292,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	unixfsGetMetric.WithLabelValues(parsedPath.Namespace()).Observe(time.Since(begin).Seconds())
+	i.unixfsGetMetric.WithLabelValues(parsedPath.Namespace()).Observe(time.Since(begin).Seconds())
 
 	defer dr.Close()
 

--- a/core/corehttp/metrics.go
+++ b/core/corehttp/metrics.go
@@ -14,7 +14,7 @@ import (
 	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// This adds the scraping endpoint which Prometheus uses to fetch metrics.
+// MetricsScrapingOption adds the scraping endpoint which Prometheus uses to fetch metrics.
 func MetricsScrapingOption(path string) ServeOption {
 	return func(n *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.Handle(path, promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
@@ -51,7 +51,7 @@ func MetricsOpenCensusCollectionOption() ServeOption {
 	}
 }
 
-// This adds collection of net/http-related metrics
+// MetricsCollectionOption adds collection of net/http-related metrics.
 func MetricsCollectionOption(handlerName string) ServeOption {
 	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		// Adapted from github.com/prometheus/client_golang/prometheus/http.go
@@ -130,14 +130,10 @@ func MetricsCollectionOption(handlerName string) ServeOption {
 var (
 	peersTotalMetric = prometheus.NewDesc(
 		prometheus.BuildFQName("ipfs", "p2p", "peers_total"),
-		"Number of connected peers", []string{"transport"}, nil)
-
-	unixfsGetMetric = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace: "ipfs",
-		Subsystem: "http",
-		Name:      "unixfs_get_latency_seconds",
-		Help:      "The time till the first block is received when 'getting' a file from the gateway.",
-	}, []string{"namespace"})
+		"Number of connected peers",
+		[]string{"transport"},
+		nil,
+	)
 )
 
 type IpfsNodeCollector struct {


### PR DESCRIPTION
This is an important performance metric that PL uses for gateway monitoring, so enabling it by default.

This is cherry-picked from 44fcc1558a65de37cbc74fd383cedfc6f29979fd