### PR TITLE
fix: macos notarized fs-repo-migrations

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -77,10 +77,11 @@ Defaults: 2048
 
 ## `IPFS_DIST_PATH`
 
-URL from which go-ipfs fetches repo migrations (when the daemon is launched with
-the `--migrate` flag).
+IPFS Content Path from which go-ipfs fetches repo migrations (when the daemon
+is launched with the `--migrate` flag).
 
-Default: https://ipfs.io/ipfs/$something (depends on the IPFS version)
+Default: `/ipfs/<cid>` (the exact path is hardcoded in
+`migrations.CurrentIpfsDist`, depends on the IPFS version)
 
 ## `IPFS_NS_MAP`
 

--- a/repo/fsrepo/migrations/fetcher.go
+++ b/repo/fsrepo/migrations/fetcher.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Current dirstibution to fetch migrations from
-	CurrentIpfsDist = "/ipfs/QmVxxcTSuryJYdQJGcS8SyhzN7NBNLTqVPAxpu6gp2ZcrR"
+	CurrentIpfsDist = "/ipfs/QmP7tLxzhLU1KauTRX3jkVkF93pCv4skcceyUYMhf4AKJR" // fs-repo-migrations v2.0.2
 	// Latest distribution path.  Default for fetchers.
 	LatestIpfsDist = "/ipns/dist.ipfs.io"
 


### PR DESCRIPTION
This PR updates go-ipfs to use signed migrations on macOS.

Uses: https://github.com/ipfs/fs-repo-migrations/releases/tag/v2.0.2 signed in https://github.com/ipfs/distributions/pull/381
Closes #8240

cc @autonome @bbondy @spylogsster  – fysa the plan is for this to land in go-ipfs 0.10

# Smoke-test passed ok :+1: 

All good,  confirmed this works as expected in Brave (without fs-repo-10-to-11 signed by Brave):

### Unsigned binary blocked by macOS 

> ![vtQC6sJ](https://user-images.githubusercontent.com/157609/128773383-11e359c6-d104-48c9-9631-776a66f28ee8.png)

> ![wfCj33T](https://user-images.githubusercontent.com/157609/128773451-cecc48d4-2629-478a-ab4c-46963984c43b.png)


### With signed migrations from this PR

`IPFS_DIST_PATH=/ipfs/QmP7tLxzhLU1KauTRX3jkVkF93pCv4skcceyUYMhf4AKJR` works fine:

> ![XS2BOv6](https://user-images.githubusercontent.com/157609/128772043-4a16cac9-72d0-4c66-9b0a-9353542e608a.png)


