### PR TITLE
Add support for scripts during initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainer="Steven Allen <steven@stebalien.com>"
 RUN apt-get update && apt-get install -y \
   libssl-dev \
   ca-certificates \
-  fuse
+  fuse \
+  bash-static
 
 ENV SRC_DIR /go-ipfs
 
@@ -71,6 +72,9 @@ COPY --from=0 /lib/*-linux-gnu*/libdl.so.2 /lib/
 # Copy over SSL libraries.
 COPY --from=0 /usr/lib/*-linux-gnu*/libssl.so* /usr/lib/
 COPY --from=0 /usr/lib/*-linux-gnu*/libcrypto.so* /usr/lib/
+
+# Bash shell for ERR signals
+COPY --from=0 /bin/bash-static /bin/bash
 
 # Swarm TCP; should be exposed to the public
 EXPOSE 4001

--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -1,7 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 user=ipfs
 repo="$IPFS_PATH"
+
+init_scripts() {
+  trap 'kill $$' ERR # Kill parent if init fail
+  local scripts_path=$1
+
+  if [ -d ${scripts_path} ]; then
+    for script in ${scripts_path}/*.sh; do
+      echo "==== Running $script"
+      # Prevent failure if no +x is set on file
+      cat $script | sh -e
+    done
+  fi
+
+}
 
 if [ `id -u` -eq 0 ]; then
   echo "Changing user to $user"
@@ -50,6 +64,12 @@ else
 
   # Unset the swarm key file variable
   unset IPFS_SWARM_KEY_FILE
+
+  # Pre-hook init with scripts
+  init_scripts /docker-prehook.d
+
+  # Post-hook init scripts
+  { sleep 10; init_scripts /docker-posthook.d ; } &
 
 fi
 


### PR DESCRIPTION
This functionality was suggested by https://github.com/ipfs/go-ipfs/issues/387#issuecomment-517340629
I saw @Caian PR https://github.com/ipfs/go-ipfs/pull/6577 after, so I publish my suggestion anyway


This patch will enable more complex init patterns during the IPFS first initialization. The scripts under */docker-prehook.d* directory will be executed just after all env initialization and **BEFORE** running ipfs daemon. If there were no errors, it will execute the ipfs daemon. **AFTER** running ipfs daemon (10 seconds) it will execute all scripts under */docker-posthook.d* and kill the main ipfs process if any script failed.

Btw, I'm not sure if the documentation of this functionality should go to the README.md or to https://github.com/ipfs/ipfs-docs/