### PR TITLE
ci: use Go 1.16.7 in .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ jobs:
     - run: sudo apt update
     - run: |
         mkdir ~/localgo && cd ~/localgo
-        wget https://golang.org/dl/go1.16.6.linux-amd64.tar.gz
-        tar xfz go1.16.6.linux-amd64.tar.gz
+        wget https://golang.org/dl/go1.16.7.linux-amd64.tar.gz
+        tar xfz go1.16.7.linux-amd64.tar.gz
         echo "export PATH=$(pwd)/go/bin:\$PATH" >> ~/.bashrc
     - run: go version
     - run: sudo apt install socat net-tools


### PR DESCRIPTION
followup to https://github.com/ipfs/go-ipfs/pull/8324, missed the 1.16.6 -> 1.16.7 change in the CircliCI config