### PR TITLE
[wip] initial bitswap monitor/checker

### DIFF
--- a/core/commands/bitswap.go
+++ b/core/commands/bitswap.go
@@ -1,17 +1,28 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
+	"strconv"
+	"time"
 
+	cid "github.com/ipfs/go-cid"
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	e "github.com/ipfs/go-ipfs/core/commands/e"
+	mh "github.com/multiformats/go-multihash"
 
 	humanize "github.com/dustin/go-humanize"
 	bitswap "github.com/ipfs/go-bitswap"
 	decision "github.com/ipfs/go-bitswap/decision"
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	bsmsgpb "github.com/ipfs/go-bitswap/message/pb"
+	bsnet "github.com/ipfs/go-bitswap/network"
 	cidutil "github.com/ipfs/go-cidutil"
 	cmds "github.com/ipfs/go-ipfs-cmds"
+	nrouting "github.com/ipfs/go-ipfs-routing/none"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -26,6 +37,7 @@ var BitswapCmd = &cmds.Command{
 		"wantlist":  showWantlistCmd,
 		"ledger":    ledgerCmd,
 		"reprovide": reprovideCmd,
+		"sanity":    bitswapSanityCheckCmd,
 	},
 }
 
@@ -240,4 +252,161 @@ Trigger reprovider to announce our data to network.
 
 		return nil
 	},
+}
+
+var bitswapSanityCheckCmd = &cmds.Command{
+	Arguments: []cmds.Argument{
+		cmds.StringArg("timeout", false, false, "test timeout"),
+		cmds.StringArg("num", false, false, "CID count"),
+		cmds.StringArg("target", true, false, "target AddrInfo string"),
+	},
+	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
+		timeout, err := time.ParseDuration(req.Arguments[0])
+		if err != nil {
+			return fmt.Errorf("timeout must be time duration. %w", err)
+		}
+		cidNum, err := strconv.Atoi(req.Arguments[1])
+		if err != nil {
+			return fmt.Errorf("cidNum must be an integer")
+		}
+
+		nd, err := cmdenv.GetNode(env)
+		if err != nil {
+			return err
+		}
+
+		if !nd.IsOnline {
+			return ErrNotOnline
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		target, err := peer.AddrInfoFromString(req.Arguments[2])
+		if err != nil {
+			return err
+		}
+		err = nd.PeerHost.Connect(ctx, *target)
+		if err != nil {
+			return err
+		}
+
+		nilRouter, err := nrouting.ConstructNilRouting(nil, nil, nil, nil)
+		if err != nil {
+			return err
+		}
+		c := make(chan interface{})
+		rcv := &bsReceiver{
+			target: target.ID,
+			result: c,
+		}
+		bn := bsnet.NewFromIpfsHost(nd.PeerHost, nilRouter)
+		bn.SetDelegate(rcv)
+
+		testCids := createCids(cidNum)
+		msg := createMsg(testCids)
+		if err := bn.SendMessage(ctx, target.ID, msg); err != nil {
+			return nil
+		}
+		cmds.EmitChan(res, c)
+		return nil
+	},
+	Type: msgOrErr{},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *msgOrErr) error {
+			_, err := fmt.Fprintf(w, "%v\n", out)
+			return err
+		}),
+	},
+}
+
+type bsReceiver struct {
+	target peer.ID
+	result chan interface{}
+}
+
+type msgOrErr struct {
+	msg bsmsg.BitSwapMessage
+	err error
+}
+
+func (r *bsReceiver) ReceiveMessage(ctx context.Context, sender peer.ID, incoming bsmsg.BitSwapMessage) {
+	fmt.Println(incoming)
+	if r.target != sender {
+		select {
+		case <-ctx.Done():
+		case r.result <- &msgOrErr{err: fmt.Errorf("expected peerID %v, got %v", r.target, sender)}:
+		}
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+	case r.result <- &msgOrErr{msg: incoming}:
+	}
+}
+
+func (r *bsReceiver) ReceiveError(err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+	case r.result <- &msgOrErr{err: err}:
+	}
+}
+
+func (r *bsReceiver) PeerConnected(id peer.ID) {
+	return
+}
+
+func (r *bsReceiver) PeerDisconnected(id peer.ID) {
+	return
+}
+
+func createCids(cidNum int) map[cid.Cid]bool {
+	cids := make(map[cid.Cid]bool, cidNum)
+
+	v1RawIDPrefix := cid.Prefix{
+		Version: 1,
+		Codec:   cid.Raw,
+		MhType:  mh.IDENTITY,
+	}
+
+	v1RawSha256Prefix := cid.Prefix{
+		Version:  1,
+		Codec:    cid.Raw,
+		MhType:   mh.SHA2_256,
+		MhLength: 20, // To guarantee nonexistence shorten the 32-byte SHA length.
+	}
+
+	cidsPerGroup := int(math.Ceil(float64(cidNum) / 2))
+	for i := 0; i < cidsPerGroup; i++ {
+		c, err := v1RawIDPrefix.Sum([]byte(strconv.FormatUint(uint64(i), 10)))
+		if err != nil {
+			panic("error creating raw ID CID")
+		}
+		cids[c] = false
+		c, err = v1RawSha256Prefix.Sum([]byte(strconv.FormatUint(uint64(i), 10)))
+		if err != nil {
+			panic("error creating raw SHA-256 CID")
+		}
+		cids[c] = false
+	}
+	return cids
+}
+
+func createMsg(requestedCids map[cid.Cid]bool) bsmsg.BitSwapMessage {
+	msg := bsmsg.New(true)
+	// Creating a new full list to replace the previous one since each test
+	// is independent.
+	for c := range requestedCids {
+		wantType := bsmsgpb.Message_Wantlist_Have
+		if rand.Intn(2) == 1 {
+			wantType = bsmsgpb.Message_Wantlist_Block
+		}
+		msg.AddEntry(c, rand.Int31(), wantType, true)
+		// Priority is only local to peer so not relevant for this test, still
+		// keep it random just in case to avoid bias.
+	}
+	return msg
 }


### PR DESCRIPTION
This is a work in progress. Adds a command to watch bitswap activity. This was written as a response to https://github.com/ipfs/go-ipfs/issues/8157 and might not be merged.