### PR TITLE
DisplayCLI for `stat bw` CLI command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/ipfs/go-graphsync v0.8.0
 	github.com/ipfs/go-ipfs-blockstore v0.1.6
 	github.com/ipfs/go-ipfs-chunker v0.0.5
-	github.com/ipfs/go-ipfs-cmds v0.6.0
 	github.com/ipfs/go-ipfs-config v0.14.0
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
@@ -59,6 +58,7 @@ require (
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
+	github.com/jbouwman/go-ipfs-cmds v0.6.1-0.20210819183735-7ee6142a5f12 // indirect
 	github.com/libp2p/go-doh-resolver v0.3.1
 	github.com/libp2p/go-libp2p v0.14.4
 	github.com/libp2p/go-libp2p-circuit v0.4.0
@@ -108,3 +108,5 @@ require (
 )
 
 go 1.15
+
+// replace github.com/ipfs/go-ipfs-cmds => ../go-ipfs-cmds

--- a/go.sum
+++ b/go.sum
@@ -537,6 +537,8 @@ github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsj
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
+github.com/jbouwman/go-ipfs-cmds v0.6.1-0.20210819183735-7ee6142a5f12 h1:Fpq4JqaVM4/7R+iHwT5vWdsxHGjZabzqBuWkAyqTcc8=
+github.com/jbouwman/go-ipfs-cmds v0.6.1-0.20210819183735-7ee6142a5f12/go.mod h1:g6wLI6iRb7guDxPSbVzhAHdhsIhn7ggvyKc0by6SR+U=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Replace PostRun with DisplayCLI

Initial test PR to shake out issues related to https://github.com/ipfs/go-ipfs-cmds/pull/215 according to recommendation in https://github.com/ipfs/go-ipfs-cmds/issues/115

- Distinguishes polled/non polled output cases in text-specific DisplayCLI output mode.
- Certainly breaks `&encoding=text` API output - to be explored
- Closes #5594 by exposing json and xml output via global `--encoding` flag
- go.mod points to a specific commit in a fork of go-ipfs-cmds, which will probably fail some sharness tests