### PR TITLE
--config option would take file instead of repo directory

### DIFF
--- a/plugin/loader/loader.go
+++ b/plugin/loader/loader.go
@@ -94,10 +94,10 @@ type PluginLoader struct {
 }
 
 // NewPluginLoader creates new plugin loader
-func NewPluginLoader(repo string) (*PluginLoader, error) {
+func NewPluginLoader(repo string, conf string) (*PluginLoader, error) {
 	loader := &PluginLoader{plugins: make(map[string]plugin.Plugin, len(preloadPlugins)), repo: repo}
-	if repo != "" {
-		cfg, err := cserialize.Load(filepath.Join(repo, config.DefaultConfigFile))
+	if conf != "" {
+		cfg, err := cserialize.Load(filepath.Join(conf, config.DefaultConfigFile))
 		switch err {
 		case cserialize.ErrNotInitialized:
 		case nil:

--- a/repo/fsrepo/config_test.go
+++ b/repo/fsrepo/config_test.go
@@ -75,7 +75,7 @@ var measureConfig = []byte(`{
 }`)
 
 func TestDefaultDatastoreConfig(t *testing.T) {
-	loader, err := loader.NewPluginLoader("")
+	loader, err := loader.NewPluginLoader("","")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher_test.go
+++ b/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher_test.go
@@ -261,7 +261,7 @@ func setupPlugins() error {
 	}
 
 	// Load plugins. This will skip the repo if not available.
-	plugins, err := loader.NewPluginLoader(filepath.Join(defaultPath, "plugins"))
+	plugins, err := loader.NewPluginLoader(filepath.Join(defaultPath, "plugins"),defaultPath)
 	if err != nil {
 		return fmt.Errorf("error loading plugins: %w", err)
 	}


### PR DESCRIPTION
This PR addresses issue :  #8067

--config flag takes repo directory instead of the config file path
This addresses the config file path as a separate path(from the repo path) to check the config for the following command:-
`ipfs -config=path/to/ipfs.conf config show`
or whatever the name of the config file is

Thanks