### PR TITLE
fix(cli): object add-link: do not allow blocks over BS limit

### DIFF
--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -92,6 +92,10 @@ DEPRECATED and provided for legacy reasons. Use 'ipfs add' or 'ipfs files' inste
 			return err
 		}
 
+		if err := checkBlockSize(req, p.Cid(), api.Dag()); err != nil {
+			return err
+		}
+
 		return cmds.EmitOnce(res, &Object{Hash: p.Cid().String()})
 	},
 	Type: &Object{},
@@ -138,6 +142,10 @@ DEPRECATED and provided for legacy reasons. Use 'files cp' and 'dag put' instead
 			return err
 		}
 
+		if err := checkBlockSize(req, p.Cid(), api.Dag()); err != nil {
+			return err
+		}
+
 		return cmds.EmitOnce(res, &Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},
@@ -173,6 +181,10 @@ DEPRECATED and provided for legacy reasons. Use 'files rm' instead.
 		name := req.Arguments[1]
 		p, err := api.Object().RmLink(req.Context, root, name)
 		if err != nil {
+			return err
+		}
+
+		if err := checkBlockSize(req, p.Cid(), api.Dag()); err != nil {
 			return err
 		}
 

--- a/core/commands/object/patch.go
+++ b/core/commands/object/patch.go
@@ -232,6 +232,21 @@ Use MFS and 'files' commands instead:
 			return err
 		}
 
+		// We do not allow producing blocks bigger than 1 MiB to avoid errors
+		// when transmitting them over BitSwap. The 1 MiB constant is an
+		// unenforced and undeclared rule of thumb hard-coded here.
+		modifiedNode, err := api.Dag().Get(req.Context, p.Cid())
+		if err != nil {
+			return err
+		}
+		modifiedNodeSize, err := modifiedNode.Size()
+		if err != nil {
+			return err
+		}
+		if modifiedNodeSize > 1024 * 1024 {
+			return fmt.Errorf("object API does not support HAMT-sharding. To create big directories, please use the files API (MFS)")
+		}
+		
 		return cmds.EmitOnce(res, &Object{Hash: p.Cid().String()})
 	},
 	Type: Object{},

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -227,14 +227,18 @@ test_object_cmd() {
     DIR=$(ipfs object new unixfs-dir)
     for i in {1..13}
     do
-       DIR=$(ipfs object patch --force-block-size=false "$DIR" add-link "$DIR.jpg" "$DIR")
+       DIR=$(ipfs object patch "$DIR" add-link "$DIR.jpg" "$DIR")
     done
-    # This one will fail as it goes over the BS limit of 1MB.
-    test_expect_code 1 ipfs object patch --force-block-size=false "$DIR" add-link "$DIR.jpg" "$DIR"  >patch_out 2>&1
+    # Fail when new block goes over the BS limit of 1MB, but allow manual override
+    test_expect_code 1 ipfs object patch "$DIR" add-link "$DIR.jpg" "$DIR"  >patch_out 2>&1
   '
 
   test_expect_success "ipfs object patch add-link output has the correct error" '
-    grep "Error: object API does not support HAMT-sharding. To create big directories, please use the files API (MFS)" patch_out
+    grep "produced block is over 1MB, object API is deprecated and does not support HAMT-sharding: to create big directories, please use the files API (MFS)" patch_out
+  '
+
+  test_expect_success "ipfs object patch --allow-big-block=true add-link works" '
+    test_expect_code 0 ipfs object patch --allow-big-block=true "$DIR" add-link "$DIR.jpg" "$DIR"
   '
 
   test_expect_success "'ipfs object new foo' shouldn't crash" '

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -223,6 +223,20 @@ test_object_cmd() {
     ipfs object stat $OUTPUT
   '
 
+  test_expect_success "'ipfs object patch' check output block size" '
+    DIR=$(ipfs object new unixfs-dir)
+    for i in {1..13}
+    do
+       DIR=$(ipfs object patch --force-block-size=false "$DIR" add-link "$DIR.jpg" "$DIR")
+    done
+    # This one will fail as it goes over the BS limit of 1MB.
+    test_expect_code 1 ipfs object patch --force-block-size=false "$DIR" add-link "$DIR.jpg" "$DIR"  >patch_out 2>&1
+  '
+
+  test_expect_success "ipfs object patch add-link output has the correct error" '
+    grep "Error: object API does not support HAMT-sharding. To create big directories, please use the files API (MFS)" patch_out
+  '
+
   test_expect_success "'ipfs object new foo' shouldn't crash" '
     test_expect_code 1 ipfs object new foo
   '


### PR DESCRIPTION
Trying not to be too invasive as this is just an ad-hoc check for a deprected command I have added the check at the CLI level; otherwise I can go deeper in the `ObjectAPI`.

If the placement of the check is correct will add a test as a sharness. If instead the check should go deeper in the stack then the test should likely be written in Go. Waiting on an initial review to decide course.

Optional additional proposals to the current PR:
* Add the same check for the (less common) `set-data` and `append-data` commands which can potentially go over the BS limit just as well.
* Add the check to `rm-link` _but only as a warning_ to flag if the current block being manipulated is already over the limit.

Fixes https://github.com/ipfs/go-ipfs/issues/7421.