### PR TITLE
Deprecate input-enc, add input-format, handle graceful upgrade

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -78,7 +78,8 @@ into an object of the specified format.
 	},
 	Options: []cmds.Option{
 		cmds.StringOption("format", "f", "Format that the object will be added as.").WithDefault("dag-cbor"),
-		cmds.StringOption("input-enc", "Format that the input object will be.").WithDefault("dag-json"),
+		cmds.StringOption("input-format", "Format that the input object will be."),
+		cmds.StringOption("input-enc", "Format that the input object will be (DEPRECATED)."),
 		cmds.BoolOption("pin", "Pin this object when adding."),
 		cmds.StringOption("hash", "Hash function to use").WithDefault("sha2-256"),
 	},


### PR DESCRIPTION
Ref: https://github.com/ipfs/go-ipfs/issues/8415

Here's a proposal for handling a graceful transition for input-enc behaviour for 0.10.0.

Ideally I'd like `input-enc` to not be shown on the `help` output but in lieu of that I thought adding a "DEPRECATED" notice might be a good idea.

The behaviour here is:

1. If you supply `input-format` then use that, ignoring `input-enc`
2. if you don't supply an `input-format` or an `input-enc` then default `input-format` to `dag-json`
3. If you don't supply an `input-format` but do supply an `input-enc` then map as per current behaviour in https://github.com/ipfs/go-ipfs/blob/master/core/coredag/dagtransl.go - which is essentially accepting input as bytes presumed to be in `format` codec except in the case of `json` where we switch to `dag-json`.

There is some laxity around `input-enc` that doesn't currently exist - it'll accept any valid codec too and just push that into `input-format` so it can be used as an alias for `input-format` in that case (I mainly did this to get the proper error output for a bad value).

This makes https://github.com/ipfs/js-ipfs/blob/870d446f/packages/ipfs-http-client/test/dag.spec.js pass except for the missing `cid-version` and new default of CIDv1.

So, `ipfs dag put --input-enc=raw --format=dag-pb` works as per previous versions in that it's going to assume you're giving it bytes of a valid dag-pb block. This would be `ipfs dag put --input-format=dag-pb --format=dag-pb` in the new style, whereas `ipfs dag put --input-format=raw --format=dag-pb` is not going to work because you can't just stick a single byte array into a dag-pb codec, that's invalid.

For another example, `ipfs dag put --input-enc=raw --format=dag-cbor` is going to be the same as `ipfs dag put --input-enc=raw --format=dag-cbor`, but `ipfs dag put --input-format=raw --format=dag-cbor` is entirely different and would encode your incoming bytes as a single terminal CBOR with the "byte string" prefix.