### PR TITLE
feat(cli): add daemon option --agent-version-suffix

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -67,6 +67,7 @@ const (
 	enablePubSubKwd           = "enable-pubsub-experiment"
 	enableIPNSPubSubKwd       = "enable-namesys-pubsub"
 	enableMultiplexKwd        = "enable-mplex-experiment"
+	agentVersionSuffix        = "agent-version-suffix"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
 )
@@ -180,6 +181,7 @@ Headers.
 		cmds.BoolOption(enablePubSubKwd, "Instantiate the ipfs daemon with the experimental pubsub feature enabled."),
 		cmds.BoolOption(enableIPNSPubSubKwd, "Enable IPNS record distribution through pubsub; enables pubsub."),
 		cmds.BoolOption(enableMultiplexKwd, "DEPRECATED"),
+		cmds.StringOption(agentVersionSuffix, "Optional suffix to the AgentVersion presented by `ipfs id` and also advertised through BitSwap."),
 
 		// TODO: add way to override addresses. tricky part: updating the config if also --init.
 		// cmds.StringOption(apiAddrKwd, "Address for the daemon rpc API (overrides config)"),
@@ -408,6 +410,11 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 		ncfg.Routing = libp2p.NilRouterOption
 	default:
 		return fmt.Errorf("unrecognized routing option: %s", routingOption)
+	}
+
+	agentVersionSuffixString, _ := req.Options[agentVersionSuffix].(string)
+	if agentVersionSuffixString != "" {
+		version.SetUserAgentSuffix(agentVersionSuffixString)
 	}
 
 	node, err := core.NewNode(req.Context, ncfg)

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -223,6 +223,6 @@ func printSelf(keyEnc ke.KeyEncoder, node *core.IpfsNode) (interface{}, error) {
 		sort.Strings(info.Protocols)
 	}
 	info.ProtocolVersion = identify.LibP2PVersion
-	info.AgentVersion = version.UserAgent
+	info.AgentVersion = version.GetUserAgentVersion()
 	return info, nil
 }

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -104,7 +104,7 @@ func VersionOption() ServeOption {
 	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
 		mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "Commit: %s\n", version.CurrentCommit)
-			fmt.Fprintf(w, "Client Version: %s\n", version.UserAgent)
+			fmt.Fprintf(w, "Client Version: %s\n", version.GetUserAgentVersion())
 			fmt.Fprintf(w, "Protocol Version: %s\n", id.LibP2PVersion)
 		})
 		return mux, nil

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -732,7 +732,7 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("response doesn't contain commit:\n%s", s)
 	}
 
-	if !strings.Contains(s, "Client Version: "+version.UserAgent) {
+	if !strings.Contains(s, "Client Version: "+version.GetUserAgentVersion()) {
 		t.Fatalf("response doesn't contain client version:\n%s", s)
 	}
 

--- a/core/node/libp2p/libp2p.go
+++ b/core/node/libp2p/libp2p.go
@@ -25,8 +25,7 @@ type Libp2pOpts struct {
 }
 
 // Misc options
-
-var UserAgent = simpleOpt(libp2p.UserAgent(version.UserAgent))
+var UserAgent = simpleOpt(libp2p.UserAgent(version.GetUserAgentVersion()))
 
 func ConnectionManager(low, high int, grace time.Duration) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {

--- a/test/sharness/t0026-id.sh
+++ b/test/sharness/t0026-id.sh
@@ -17,7 +17,12 @@ test_id_compute_agent() {
         AGENT_COMMIT="${AGENT_COMMIT##$AGENT_VERSION-}"
     fi
     AGENT_VERSION="go-ipfs/$AGENT_VERSION/$AGENT_COMMIT"
-    test -z "$AGENT_SUFFIX" || AGENT_VERSION="$AGENT_VERSION/$AGENT_SUFFIX"
+    if test -n "$AGENT_SUFFIX"; then
+      if test -n "$AGENT_COMMIT"; then
+        AGENT_VERSION="$AGENT_VERSION/"
+      fi
+      AGENT_VERSION="$AGENT_VERSION$AGENT_SUFFIX"
+    fi
     echo "$AGENT_VERSION"
 }
 

--- a/test/sharness/t0026-id.sh
+++ b/test/sharness/t0026-id.sh
@@ -7,6 +7,8 @@ test_description="Test to make sure our identity information looks sane"
 test_init_ipfs
 
 test_id_compute_agent() {
+    local AGENT_SUFFIX
+    AGENT_SUFFIX=$1
     AGENT_VERSION="$(ipfs version --number)" || return 1
     AGENT_COMMIT="$(ipfs version --number --commit)" || return 1
     if test "$AGENT_COMMIT" = "$AGENT_VERSION"; then
@@ -14,7 +16,9 @@ test_id_compute_agent() {
     else
         AGENT_COMMIT="${AGENT_COMMIT##$AGENT_VERSION-}"
     fi
-    echo "go-ipfs/$AGENT_VERSION/$AGENT_COMMIT"
+    AGENT_VERSION="go-ipfs/$AGENT_VERSION/$AGENT_COMMIT"
+    test -z "$AGENT_SUFFIX" || AGENT_VERSION="$AGENT_VERSION/$AGENT_SUFFIX"
+    echo "$AGENT_VERSION"
 }
 
 test_expect_success "checking AgentVersion" '
@@ -22,6 +26,16 @@ test_expect_success "checking AgentVersion" '
   ipfs id -f "<aver>\n" > actual-agent-version &&
   test_cmp expected-agent-version actual-agent-version
 '
+
+test_launch_ipfs_daemon_without_network --agent-version-suffix=test-suffix
+
+test_expect_success "checking AgentVersion with suffix (daemon running)" '
+  test_id_compute_agent test-suffix > expected-agent-version &&
+  ipfs id -f "<aver>\n" > actual-agent-version &&
+  test_cmp expected-agent-version actual-agent-version
+'
+
+test_kill_ipfs_daemon
 
 test_expect_success "checking ProtocolVersion" '
   echo "ipfs/0.1.0" > expected-protocol-version &&

--- a/version.go
+++ b/version.go
@@ -8,7 +8,22 @@ const CurrentVersionNumber = "0.11.0-dev"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"
 
-// UserAgent is the libp2p user agent used by go-ipfs.
+// GetUserAgentVersion is the libp2p user agent used by go-ipfs.
 //
 // Note: This will end in `/` when no commit is available. This is expected.
-var UserAgent = "go-ipfs/" + CurrentVersionNumber + "/" + CurrentCommit
+func GetUserAgentVersion() string {
+	userAgent := "go-ipfs/" + CurrentVersionNumber + "/" + CurrentCommit
+	if userAgentSuffix != "" {
+		if CurrentCommit != "" {
+			userAgent += "/"
+		}
+		userAgent += userAgentSuffix
+	}
+	return userAgent
+}
+
+var userAgentSuffix string
+
+func SetUserAgentSuffix(suffix string) {
+	userAgentSuffix = suffix
+}


### PR DESCRIPTION
Preliminary design for feedback to add the option storing it inside the `IpfsNode` structure.

(Test and minor fixes will follow after this design is validated.)

Closes https://github.com/ipfs/go-ipfs/issues/7898.