### PR TITLE
ci: drop unit tests make jobs back to 1

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -104,7 +104,7 @@ jobs:
     - *restore_gomod
 
     - run: |
-        make -j << pipeline.parameters.make_jobs >> test/unit/gotest.junit.xml \
+        make -j 1 test/unit/gotest.junit.xml \
         && [[ ! $(jq -s -c 'map(select(.Action == "fail")) | .[]' test/unit/gotest.json) ]]
     - run:
         when: always


### PR DESCRIPTION
This was accidentally bumped up, but it doesn't need to be and slows
things down rather than helps.