### PR TITLE
change ipfs dag get flag name from format to output-codec

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -116,7 +116,7 @@ format.
 		cmds.StringArg("ref", true, false, "The object to get").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption("format", "f", "Format that the object will be serialized as.").WithDefault("dag-json"),
+		cmds.StringOption("output-codec", "Format that the object will be encoded as.").WithDefault("dag-json"),
 	},
 	Run: dagGet,
 }

--- a/core/commands/dag/get.go
+++ b/core/commands/dag/get.go
@@ -22,9 +22,9 @@ func dagGet(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) e
 		return err
 	}
 
-	format, _ := req.Options["format"].(string)
-	var fCodec mc.Code
-	if err := fCodec.Set(format); err != nil {
+	codecStr, _ := req.Options["output-codec"].(string)
+	var codec mc.Code
+	if err := codec.Set(codecStr); err != nil {
 		return err
 	}
 
@@ -54,9 +54,9 @@ func dagGet(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) e
 		}
 	}
 
-	encoder, err := multicodec.LookupEncoder(uint64(fCodec))
+	encoder, err := multicodec.LookupEncoder(uint64(codec))
 	if err != nil {
-		return fmt.Errorf("invalid encoding: %s - %s", format, err)
+		return fmt.Errorf("invalid encoding: %s - %s", codec, err)
 	}
 
 	r, w := io.Pipe()

--- a/test/sharness/t0053-dag.sh
+++ b/test/sharness/t0053-dag.sh
@@ -165,6 +165,18 @@ test_dag_cmd() {
     ipfs dag get $IPLDPBHASH >& dag-get-pb
   '
 
+  test_expect_success "can get dag-pb block transcoded as dag-cbor" '
+    ipfs dag get --output-codec=dag-cbor $IPLDPBHASH >& dag-get-dagpb-transcoded-to-dagcbor &&
+    echo "122082a2e4c892e7dcf1d491b30d68aa73ba76bec94f87d4e1a887596ce0730a534a" >sha2_dagpb_to_dagcbor_expected &&
+    multihash -a=sha2-256 -e=hex dag-get-dagpb-transcoded-to-dagcbor >sha2_dagpb_to_dagcbor_actual &&
+    test_cmp sha2_dagpb_to_dagcbor_expected sha2_dagpb_to_dagcbor_actual
+  '
+
+  test_expect_success "dag put and dag get transcodings match" '
+    ROUNDTRIPDAGCBOR=$(ipfs dag put --input-codec=dag-cbor --store-codec=dag-cbor dag-get-dagpb-transcoded-to-dagcbor) &&
+    test $ROUNDTRIPDAGCBOR = $IPLDCBORHASH
+  '
+
   # this doesn't tell us if they are correct, we test that better below
   test_expect_success "outputs are the same" '
     test_cmp dag-get-cbor dag-get-json &&


### PR DESCRIPTION
Change `ipfs dag get --format` to `ipfs dag get --output-codec` to be closer to https://github.com/ipfs/go-ipfs/pull/8439.

TODO: Merge to master after #8439 