### PR TITLE
Make variadic false for `ipfs files rm`

### DIFF
--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -1033,7 +1033,7 @@ Remove files or directories.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("path", true, true, "File to remove."),
+		cmds.StringArg("path", true, false, "File to remove."),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(recursiveOptionName, "r", "Recursively remove directories."),


### PR DESCRIPTION
Because it's actually handles only one argument, and I am not sure that
it should actually support multiple files.
If we want to make it support multiple arguments in the future -- we need to handle
error for each file from a list separately somehow, as unix `rm` does.

#8395