### PR TITLE
feat: add gateway histogram metrics

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -62,7 +62,8 @@ type gatewayHandler struct {
 	config GatewayConfig
 	api    coreiface.CoreAPI
 
-	unixfsGetMetric *prometheus.SummaryVec
+	unixfsGetMetric     *prometheus.SummaryVec
+	unixfsGetHistMetric *prometheus.HistogramVec
 }
 
 // StatusResponseWriter enables us to override HTTP Status Code passed to
@@ -104,10 +105,29 @@ func newGatewayHandler(c GatewayConfig, api coreiface.CoreAPI) *gatewayHandler {
 		}
 	}
 
+	unixfsGetHistMetric := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ipfs",
+			Subsystem: "http",
+			Name:      "unixfs_get_latency_hist_seconds",
+			Help:      "The time till the first block is received when 'getting' a file from the gateway.",
+			Buckets:   []float64{0.1, 0.5, 1, 2, 3, 5, 8, 13},
+		},
+		[]string{"gateway"},
+	)
+	if err := prometheus.Register(unixfsGetHistMetric); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			unixfsGetHistMetric = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			log.Errorf("failed to register unixfsGetMetric: %v", err)
+		}
+	}
+
 	i := &gatewayHandler{
-		config:          c,
-		api:             api,
-		unixfsGetMetric: unixfsGetMetric,
+		config:              c,
+		api:                 api,
+		unixfsGetMetric:     unixfsGetMetric,
+		unixfsGetHistMetric: unixfsGetHistMetric,
 	}
 	return i
 }
@@ -291,7 +311,9 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		webError(w, "ipfs block get "+resolvedPath.Cid().String(), err, http.StatusInternalServerError)
 		return
 	}
-	i.unixfsGetMetric.WithLabelValues(contentPath.Namespace()).Observe(time.Since(begin).Seconds())
+	timeToGetFirstContentBlock := time.Since(begin).Seconds()
+	i.unixfsGetMetric.WithLabelValues(contentPath.Namespace()).Observe(timeToGetFirstContentBlock)
+	i.unixfsGetHistMetric.WithLabelValues(contentPath.Namespace()).Observe(timeToGetFirstContentBlock)
 
 	// HTTP Headers
 	i.addUserHeaders(w) // ok, _now_ write user's headers.

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -116,7 +116,7 @@ func newGatewaySummaryMetric(name string, help string) *prometheus.SummaryVec {
 func newGatewayHistogramMetric(name string, help string) *prometheus.HistogramVec {
 	// We can add buckets as a parameter in the future, but for now using static defaults
 	// suggested in https://github.com/ipfs/go-ipfs/issues/8441
-	defaultBuckets := []float64{0.1, 0.5, 1, 2, 3, 5, 8, 13}
+	defaultBuckets := []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60}
 	histogramMetric := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "ipfs",

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -155,22 +155,22 @@ func newGatewayHandler(c GatewayConfig, api coreiface.CoreAPI) *gatewayHandler {
 		// UnixFS: time it takes to return a file
 		unixfsFileGetMetric: newGatewayHistogramMetric(
 			"gw_unixfs_file_get_duration_seconds",
-			"The time it takes till the entire file is served on GET from the gateway.",
+			"The time to serve an entire UnixFS file from the gateway.",
 		),
 		// UnixFS: time it takes to generate static HTML with directory listing
 		unixfsGenDirGetMetric: newGatewayHistogramMetric(
 			"gw_unixfs_gen_dir_listing_get_duration_seconds",
-			"The time it takes till generated HTML with directory listing is served on GET from the gateway.",
+			"The time to serve a generated UnixFS HTML directory listing from the gateway.",
 		),
 		// CAR: time it takes to return requested CAR stream
 		carStreamGetMetric: newGatewayHistogramMetric(
 			"gw_car_stream_get_duration_seconds",
-			"The time it takes to get entire CAR stream on GET from the gateway.",
+			"The time to GET an entire CAR stream from the gateway.",
 		),
 		// Block: time it takes to return requested Block
 		rawBlockGetMetric: newGatewayHistogramMetric(
 			"gw_raw_block_get_duration_seconds",
-			"The time it takes to get entire raw Block on GET from the gateway.",
+			"The time to GET an entire raw Block from the gateway.",
 		),
 
 		// Legacy Metrics
@@ -178,7 +178,7 @@ func newGatewayHandler(c GatewayConfig, api coreiface.CoreAPI) *gatewayHandler {
 		unixfsGetMetric: newGatewaySummaryMetric( // TODO: remove?
 			// (deprecated, use firstContentBlockGetMetric instead)
 			"unixfs_get_latency_seconds",
-			"The time till the first unixfs node is received on GET from the gateway.",
+			"The time to receive the first UnixFS node on a GET from the gateway.",
 		),
 	}
 	return i

--- a/core/corehttp/gateway_handler_car.go
+++ b/core/corehttp/gateway_handler_car.go
@@ -3,6 +3,7 @@ package corehttp
 import (
 	"context"
 	"net/http"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -13,7 +14,7 @@ import (
 )
 
 // serveCar returns a CAR stream for specific DAG+selector
-func (i *gatewayHandler) serveCar(w http.ResponseWriter, r *http.Request, rootCid cid.Cid, contentPath ipath.Path) {
+func (i *gatewayHandler) serveCar(w http.ResponseWriter, r *http.Request, rootCid cid.Cid, contentPath ipath.Path, begin time.Time) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -59,6 +60,9 @@ func (i *gatewayHandler) serveCar(w http.ResponseWriter, r *http.Request, rootCi
 		w.Header().Set("X-Stream-Error", err.Error())
 		return
 	}
+
+	// Update metrics
+	i.carStreamGetMetric.WithLabelValues(contentPath.Namespace()).Observe(time.Since(begin).Seconds())
 }
 
 type dagStore struct {

--- a/core/corehttp/gateway_handler_unixfs.go
+++ b/core/corehttp/gateway_handler_unixfs.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"time"
 
 	files "github.com/ipfs/go-ipfs-files"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	"go.uber.org/zap"
 )
 
-func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, logger *zap.SugaredLogger) {
+func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, begin time.Time, logger *zap.SugaredLogger) {
 	// Handling UnixFS
 	dr, err := i.api.Unixfs().Get(r.Context(), resolvedPath)
 	if err != nil {
@@ -22,7 +23,7 @@ func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, res
 	// Handling Unixfs file
 	if f, ok := dr.(files.File); ok {
 		logger.Debugw("serving unixfs file", "path", contentPath)
-		i.serveFile(w, r, contentPath, resolvedPath.Cid(), f)
+		i.serveFile(w, r, contentPath, resolvedPath.Cid(), f, begin)
 		return
 	}
 
@@ -33,5 +34,5 @@ func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, res
 		return
 	}
 	logger.Debugw("serving unixfs directory", "path", contentPath)
-	i.serveDirectory(w, r, resolvedPath, contentPath, dir, logger)
+	i.serveDirectory(w, r, resolvedPath, contentPath, dir, begin, logger)
 }


### PR DESCRIPTION
fixes #8441

@gmasgras did you want both the summary and histogram exposed, or should I just switch the summary over to a histogram?

Any preference on the metric name? For example, if replacing the summary metric we may still want a different name so infra that's running the older version and the newer version can have the metrics play together a little nicer.