### PR TITLE
ci: trigger continuation on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,14 @@ version: 2.1
 setup: true
 orbs:
   continuation: circleci/continuation@0.2.0
+
+aliases:
+  only-version-tags: &only-version-tags
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
 jobs:
   generate-params:
     executor: continuation/default
@@ -35,3 +43,9 @@ workflows:
   setup-workflow:
     jobs:
       - generate-params
+
+  # NOTE: CircleCI only builds tags if you explicitly filter for them.
+  setup-workflow-tag:
+    jobs:
+      - generate-params:
+          filters: *only-version-tags

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -442,7 +442,6 @@ workflows:
               # the bifrost-* branches are used for deploying code that hasn't hit master yet (e.g. for testing)
               - /^bifrost-.*/
 
-
   # NOTE: CircleCI only builds tags if you explicitly filter for them. That
   # also means tag-based jobs can only depend on other tag-based jobs, so we
   # use a separate workflow because every job needs to be tagged together.


### PR DESCRIPTION
When the config was wrapped in a continuation so that params could be
dynamically generated, this broke tag workflows since there was no
explicit tag filter anymore in config.yml. This attempts to fix that.

I may have gotten this wrong, since this is intrinsically hard to
test. We'll see next time we tag something.