### PR TITLE
ci: move Docker image build to Actions

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -24,11 +24,6 @@ aliases:
         paths:
           - ~/go/pkg/mod
           - ~/.cache/go-build/
-  only-version-tags: &only-version-tags
-    tags:
-      only: /^v[0-9].*/
-    branches:
-      ignore: /.*/
 
 default_environment: &default_environment
   SERVICE: circle-ci
@@ -331,6 +326,8 @@ jobs:
           key: v1-ipfs-webui-{{ checksum "~/ipfs/go-ipfs/ipfs-webui/package-lock.json" }}
           paths:
             - ~/ipfs/go-ipfs/ipfs-webui/node_modules
+  # We only run build as a test here. DockerHub images are built and published
+  # by Github Action now: https://github.com/ipfs/go-ipfs/pull/8467
   docker-build:
     executor: dockerizer
     steps:
@@ -341,62 +338,6 @@ jobs:
           name: Build Docker image
           command: |
             docker build -t $IMAGE_NAME:$WIP_IMAGE_TAG .
-      - run:
-          name: Archive Docker image
-          command: docker save -o go-ipfs-image.tar $IMAGE_NAME
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./go-ipfs-image.tar
-  docker-build-extras:
-    executor: dockerizer
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "19.03.13"
-      - run:
-          name: Build Docker Extras image
-          command: |
-            docker build --build-arg IPFS_PLUGINS="peerlog" -t "$IMAGE_NAME-extras:$WIP_IMAGE_TAG" .
-      - run:
-          name: Archive Docker Extras image
-          command: docker save -o go-ipfs-extras-image.tar $IMAGE_NAME
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./go-ipfs-extras-image.tar
-  docker-push:
-    executor: dockerizer
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "19.03.13"
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Load archived Docker image
-          command: docker load -i /tmp/workspace/go-ipfs-image.tar
-      - run:
-          name: Publish Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            ./bin/push-docker-tags.sh $(date -u +%F) "$CIRCLE_SHA1" "$CIRCLE_BRANCH" "$CIRCLE_TAG"
-  docker-push-extras:
-    executor: dockerizer
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: "19.03.13"
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Load archived Docker Extras image
-          command: docker load -i /tmp/workspace/go-ipfs-extras-image.tar
-      - run:
-          name: Publish Docker Extras Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            ./bin/push-docker-tags.sh $(date -u +%F) "$CIRCLE_SHA1" "$CIRCLE_BRANCH" "extras"
 
 workflows:
   version: 2
@@ -423,36 +364,3 @@ workflows:
         requires:
           - build
     - docker-build
-    - docker-push:
-        # Requires dockerhub credentials, from circleci context.
-        context: dockerhub
-        requires:
-          - docker-build
-          - golint
-          - gotest
-          - sharness
-          - interop
-          - go-ipfs-api
-          - go-ipfs-http-client
-          - ipfs-webui
-        filters:
-          branches:
-            only:
-              - master
-              # the bifrost-* branches are used for deploying code that hasn't hit master yet (e.g. for testing)
-              - /^bifrost-.*/
-
-
-  # NOTE: CircleCI only builds tags if you explicitly filter for them. That
-  # also means tag-based jobs can only depend on other tag-based jobs, so we
-  # use a separate workflow because every job needs to be tagged together.
-  # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
-  docker-on-tag:
-    jobs:
-      - docker-build:
-          filters: *only-version-tags
-      - docker-push:
-          context: dockerhub
-          filters: *only-version-tags
-          requires:
-            - docker-build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - 'bifrost-*'
+    tags:
+      - 'v*'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ipfs/go-ipfs
+      WIP_IMAGE_TAG: wip
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Build wip Docker image
+        run: docker build -t $IMAGE_NAME:$WIP_IMAGE_TAG .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Publish Docker Image to Docker Hub
+        run: ./bin/push-docker-tags.sh $(date -u +%F)
+

--- a/bin/push-docker-tags.sh
+++ b/bin/push-docker-tags.sh
@@ -29,18 +29,18 @@
 #
 set -euo pipefail
 
-if [[ $# -lt 3 ]] ; then
-  echo 'At least 3 args required. Pass 5 args for a dry run.'
+if [[ $# -lt 1 ]] ; then
+  echo 'At least 1 arg required. Pass 5 args for a dry run.'
   echo 'Usage:'
-  echo './push-docker-tags.sh <build number> <git commit sha1> <git branch name> [git tag name] [dry run]'
+  echo './push-docker-tags.sh <build number> [git commit sha1] [git branch name] [git tag name] [dry run]'
   exit 1
 fi
 
 BUILD_NUM=$1
-GIT_SHA1=$2
+GIT_SHA1=${2:-$(git rev-parse HEAD)}
 GIT_SHA1_SHORT=$(echo "$GIT_SHA1" | cut -c 1-7)
-GIT_BRANCH=$3
-GIT_TAG=${4:-""}
+GIT_BRANCH=${3:-$(git symbolic-ref -q --short HEAD || echo "unknown")}
+GIT_TAG=${4:-$(git describe --tags --exact-match || echo "")}
 DRY_RUN=${5:-false}
 
 WIP_IMAGE_TAG=${WIP_IMAGE_TAG:-wip}


### PR DESCRIPTION
This PR aims to close #8330 and unblock 0.10.0-rc2


## TODO
- [x] add github action workflow and reuse `bin/push-docker-tags.sh` (so we get same image names)
- [x] set up docker hub secrets for publishing (`DOCKER_USERNAME` & `DOCKER_PASSWORD`)
  - using temporary credentials for testing, need to switch to ones from `ipfsbot` but we can do that later this week
- [x] remove docker publishing from circleci scripts