### PR TITLE
feat: add endpoint for enabling block profiling

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -647,6 +647,7 @@ func serveHTTPApi(req *cmds.Request, cctx *oldcmds.Context) (<-chan error, error
 		defaultMux("/debug/vars"),
 		defaultMux("/debug/pprof/"),
 		corehttp.MutexFractionOption("/debug/pprof-mutex/"),
+		corehttp.BlockProfileRateOption("/debug/pprof-block/"),
 		corehttp.MetricsScrapingOption("/debug/metrics/prometheus"),
 		corehttp.LogOption(),
 	}

--- a/core/corehttp/mutex_profile.go
+++ b/core/corehttp/mutex_profile.go
@@ -41,3 +41,38 @@ func MutexFractionOption(path string) ServeOption {
 		return mux, nil
 	}
 }
+
+// BlockProfileRateOption allows to set runtime.SetBlockProfileRate via HTTP
+// using POST request with parameter 'rate'.
+// The profiler tries to sample 1 event every <rate> nanoseconds.
+// If rate == 1, then the profiler samples every blocking event.
+// To disable, set rate = 0.
+func BlockProfileRateOption(path string) ServeOption {
+	return func(_ *core.IpfsNode, _ net.Listener, mux *http.ServeMux) (*http.ServeMux, error) {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "only POST allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			rateStr := r.Form.Get("rate")
+			if len(rateStr) == 0 {
+				http.Error(w, "parameter 'rate' must be set", http.StatusBadRequest)
+				return
+			}
+
+			rate, err := strconv.Atoi(rateStr)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			log.Infof("Setting BlockProfileRate to %d", rate)
+			runtime.SetBlockProfileRate(rate)
+		})
+		return mux, nil
+	}
+}

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -163,6 +163,19 @@ test_expect_success "test failure conditions of mutex pprof endpoint" '
     test_must_fail curl -f -X GET "http://127.0.0.1:$apiport/debug/pprof-mutex/?fraction=-1"
 '
 
+curl_pprofblock() {
+  curl -f -X POST "http://127.0.0.1:$apiport/debug/pprof-block/?rate=$1"
+}
+
+test_expect_success "set blocking profiler rate for pprof (0 so it doesn't enable)" '
+  curl_pprofblock 0
+'
+
+test_expect_success "test failure conditions of mutex block endpoint" '
+  test_must_fail curl_pprofblock &&
+  test_must_fail curl_pprofblock that_is_string &&
+  test_must_fail curl -f -X GET "http://127.0.0.1:$apiport/debug/pprof-block/?rate=0"
+'
 
 test_expect_success "setup index hash" '
   mkdir index &&


### PR DESCRIPTION
After this is added I'll go back and add it to `bin/collect-profiles.sh` and `docs/debug-guide.md`