### PR TITLE
add more logging to TestPeersTotal

### DIFF
--- a/core/corehttp/metrics_test.go
+++ b/core/corehttp/metrics_test.go
@@ -46,7 +46,7 @@ func TestPeersTotal(t *testing.T) {
 	collector := IpfsNodeCollector{Node: node}
 	actual := collector.PeersTotalValues()
 	if len(actual) != 1 {
-		t.Fatalf("expected 1 peers transport, got %d", len(actual))
+		t.Fatalf("expected 1 peers transport, got %d, transport map %v", len(actual), actual)
 	}
 	if actual["/ip4/tcp"] != float64(3) {
 		t.Fatalf("expected 3 peers, got %f", actual["/ip4/tcp"])


### PR DESCRIPTION
Attempting to address https://github.com/ipfs/go-ipfs/issues/8135.

It unclear why in unsuccessful tests, we observe two transport types and what they are, so we are logging this now to see what is going on.