### PR TITLE
chore: set agent-version-suffix in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,4 +107,4 @@ ENV IPFS_LOGGING ""
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/start_ipfs"]
 
 # Execute the daemon subcommand by default
-CMD ["daemon", "--migrate=true"]
+CMD ["daemon", "--migrate=true", "--agent-version-suffix=docker"]


### PR DESCRIPTION
- [go-ipfs 0.10.0 shipped](https://github.com/ipfs/go-ipfs/releases/tag/v0.10.0) with support for running  `ipfs daemon` with custom `--agent-version-suffix`  (https://github.com/ipfs/go-ipfs/pull/8419)
- Docker image already produces custom AgentVersion, this makes it explicit and easier to reason about.


FYSA I filled similar PRs in  https://github.com/brave/brave-browser/issues/18505 and https://github.com/ipfs/ipfs-desktop/pull/1914 