### PR TITLE
fix(cli): ipfs add with multiple files of same name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipfs/go-graphsync v0.11.0
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
 	github.com/ipfs/go-ipfs-chunker v0.0.5
-	github.com/ipfs/go-ipfs-cmds v0.7.0
+	github.com/ipfs/go-ipfs-cmds v0.8.0
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.2.0
 	github.com/ipfs/go-ipfs-files v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtL
 github.com/ipfs/go-ipfs-chunker v0.0.1/go.mod h1:tWewYK0we3+rMbOh7pPFGDyypCtvGcBFymgY4rSDLAw=
 github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7NapWLY8=
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
-github.com/ipfs/go-ipfs-cmds v0.7.0 h1:0lEldmB7C83RxIOer38Sv1ob6wIoCAIEOaxiYgcv7wA=
-github.com/ipfs/go-ipfs-cmds v0.7.0/go.mod h1:y0bflH6m4g6ary4HniYt98UqbrVnRxmRarzeMdLIUn0=
+github.com/ipfs/go-ipfs-cmds v0.8.0 h1:M7apkPxhGe7I3rcKuQ8xRJLIPdaEqaZhJz0uPZEE8EU=
+github.com/ipfs/go-ipfs-cmds v0.8.0/go.mod h1:y0bflH6m4g6ary4HniYt98UqbrVnRxmRarzeMdLIUn0=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -345,6 +345,27 @@ test_add_cat_file() {
     echo "added Qmf35k66MZNW2GijohUmXQEWKZU4cCGTCwK6idfnt152wJ hello2.txt" >> expected &&
     test_cmp expected actual
   '
+
+  test_expect_success "ipfs add with multiple files of same name succeeds" '
+    mkdir -p mountdir/same-file/ &&
+    cp mountdir/hello.txt mountdir/same-file/hello.txt &&
+    ipfs add mountdir/hello.txt mountdir/same-file/hello.txt >actual &&
+    rm mountdir/same-file/hello.txt  &&
+    rmdir mountdir/same-file
+  '
+
+  test_expect_success "ipfs add with multiple files of same name output looks good" '
+    echo "added QmVr26fY1tKyspEJBniVhqxQeEjhF78XerGiqWAwraVLQH hello.txt" >expected &&
+    test_cmp expected actual
+  '
+
+    test_must_fail "ipfs add with multiple files of same name but different dirs fails" '
+      mkdir -p mountdir/same-file/ &&
+      cp mountdir/hello.txt mountdir/same-file/hello.txt &&
+      ipfs add mountdir/hello.txt mountdir/same-file/hello.txt >actual &&
+      rm mountdir/same-file/hello.txt  &&
+      rmdir mountdir/same-file
+    '
 }
 
 test_add_cat_5MB() {


### PR DESCRIPTION
This PR incorporates the `go-ipfs-cmds` [fix](https://github.com/ipfs/go-ipfs-cmds/pull/220) that makes the `ipfs add` command not ignore repeated entries. This fix conflicts with another bug in the `ipfs add -w` variant of the command which can't correctly process files with the same name (I think this was uncovered here and we don't have a specific issue for it). This is shown by the shanress test failing (see more details below). We need to first fix the `ipfs add -w` issue before landing this so we can be confident this is the correct fix.

---------------------------------------------------

#### Detail of the `ipfs add -w` bug and the [test](https://github.com/ipfs/go-ipfs/blob/2a871ef0184da3b021209881dfa48e3cfdaa9d26/test/sharness/t0043-add-w.sh#L131-L142) that [fails](https://app.circleci.com/pipelines/github/ipfs/go-ipfs/5975/workflows/fd82d174-de6f-43cf-ad3c-8102b908e81f/jobs/65050) (uncovering it)

The `ipfs add -w (repeats)` test now fails. This is expected because:
* we repeatedly add the `m/4r93` file
* ignored before, these extra/repeated files are now sent to the core UnixFS API `Add()`
* this API uses a [fake (disposable) MFS root directory](https://github.com/ipfs/go-ipfs/blob/52a747763f6c4e85b33ca051cda9cc4b75c815f9/core/coreunix/add.go#L84-L96) as a way to interact with the underlying DAG service (repo)
* with the "wrapped" option `-w` we group all the entries being added in a [single directory](https://github.com/ipfs/go-ipfs/blob/52a747763f6c4e85b33ca051cda9cc4b75c815f9/core/commands/add.go#L194-L199)
* the MFS directory, not intended for this ephemeral abuse, correctly refuses to add two entries with the same name (with the resulting error in sharness of a failed command: `Error: directory already has entry by that name`)

We are abusing the MFS API, see related and broader issue for more details on this general topic: [Decouple MFS from UnixFS](https://github.com/ipfs/go-ipfs/issues/8541).

Also note that this issue might not happen with *any* kind of repeated entry in the `ipfs add -w` command as empty directories seem to be ignored when constructing the path and only files within those repeated directories will trigger the error, like `ipfs add -w -r dir/file dir/file`. There is some undocumented logic around path manipulation related to this:

https://github.com/ipfs/go-ipfs/blob/52a747763f6c4e85b33ca051cda9cc4b75c815f9/core/coreunix/add.go#L411-L424

--------------------------------------------------

Fixes https://github.com/ipfs/go-ipfs/issues/8264.

cc @guseggert
