### PR TITLE
feat: Swarm.EnableHolePunching flag

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -154,6 +154,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled, cfg.Discovery.MDNS.Interval)),
 		fx.Provide(libp2p.ForceReachability(cfg.Internal.Libp2pForceReachability)),
 		fx.Provide(libp2p.StaticRelays(cfg.Swarm.RelayClient.StaticRelays)),
+		fx.Provide(libp2p.HolePunching(cfg.Swarm.EnableHolePunching, cfg.Swarm.RelayClient.Enabled.WithDefault(false))),
 
 		fx.Provide(libp2p.Security(!bcfg.DisableEncryptedConnections, cfg.Swarm.Transports)),
 

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -73,7 +73,10 @@ func AutoRelay(addDefaultRelays bool) func() (opts Libp2pOpts, err error) {
 
 func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		if flag.WithDefault(false) hasRelayClient {
+		if flag.WithDefault(false) {
+			if !hasRelayClient {
+				log.Fatal("To enable `Swarm.EnableHolePunching` requires `Swarm.RelayClient.Enabled` to be enabled.")
+			}
 			opts.Opts = append(opts.Opts, libp2p.EnableHolePunching())
 		}
 		return

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -70,3 +70,12 @@ func AutoRelay(addDefaultRelays bool) func() (opts Libp2pOpts, err error) {
 		return
 	}
 }
+
+func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts, err error) {
+	return func() (opts Libp2pOpts, err error) {
+		if flag.WithDefault(false) hasRelayClient {
+			opts.Opts = append(opts.Opts, libp2p.EnableHolePunching())
+		}
+		return
+	}
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -99,6 +99,7 @@ config file at runtime.
     - [`Swarm.AddrFilters`](#swarmaddrfilters)
     - [`Swarm.DisableBandwidthMetrics`](#swarmdisablebandwidthmetrics)
     - [`Swarm.DisableNatPortMap`](#swarmdisablenatportmap)
+    - [`Swarm.EnableHolePunching`](#swarmenableholepunching)
     - [`Swarm.EnableAutoRelay`](#swarmenableautorelay)
     - [`Swarm.RelayClient`](#swarmrelayclient)
       - [`Swarm.RelayClient.Enabled`](#swarmrelayclientenabled)
@@ -1278,6 +1279,21 @@ go-ipfs node accessible from the public internet.
 Default: `false`
 
 Type: `bool`
+
+### `Swarm.EnableHolePunching`
+
+Enable hole punching for NAT traversal
+when port forwarding is not possible.
+
+When enabled, go-ipfs will coordinate with the counterparty using
+a [relayed connection](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md),
+to [upgrade to a direct connection](https://github.com/libp2p/specs/blob/master/relay/DCUtR.md)
+through a NAT/firewall whenever possible.
+For good results, use with `RelayClient.Enabled` set to `true`.
+
+Default: `false`
+
+Type: `flag`
 
 ### `Swarm.EnableAutoRelay`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1289,7 +1289,7 @@ When enabled, go-ipfs will coordinate with the counterparty using
 a [relayed connection](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md),
 to [upgrade to a direct connection](https://github.com/libp2p/specs/blob/master/relay/DCUtR.md)
 through a NAT/firewall whenever possible.
-This feature requires `Swarm.RelayClient.Enabled` set to `true`.
+This feature requires `Swarm.RelayClient.Enabled` to be set to `true`.
 
 Default: `false`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1289,7 +1289,7 @@ When enabled, go-ipfs will coordinate with the counterparty using
 a [relayed connection](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md),
 to [upgrade to a direct connection](https://github.com/libp2p/specs/blob/master/relay/DCUtR.md)
 through a NAT/firewall whenever possible.
-For good results, use with `RelayClient.Enabled` set to `true`.
+This feature requires `Swarm.RelayClient.Enabled` set to `true`.
 
 Default: `false`
 


### PR DESCRIPTION
This PR won't build. It needs rebasing once #8522 or https://github.com/ipfs/go-ipfs/pull/8563 is merged.
Opening it now so we don't forget it for the v0.11 release.

- [x] rebase on #8522 or https://github.com/ipfs/go-ipfs/pull/8563
- [x] add `Swarm.EnableHolePunching` docs in `docs/config.md`