### PR TITLE
feat: hard deprecation of IPFS_REUSEPORT

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -559,6 +559,12 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 				log.Error("failed to bootstrap (no peers found): consider updating Bootstrap or Peering section of your config")
 			}
 		})
+
+	}
+
+	// Hard deprecation notice if someone still uses IPFS_REUSEPORT
+	if flag := os.Getenv("IPFS_REUSEPORT"); flag != "" {
+		log.Fatal("Support for IPFS_REUSEPORT was removed. Use LIBP2P_TCP_REUSEPORT instead.")
 	}
 
 	// collect long-running errors and block for shutdown

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,12 +1,10 @@
 # go-ipfs environment variables
 
-## `LIBP2P_TCP_REUSEPORT` (`IPFS_REUSEPORT`)
+## `LIBP2P_TCP_REUSEPORT`
 
 go-ipfs tries to reuse the same source port for all connections to improve NAT
 traversal. If this is an issue, you can disable it by setting
 `LIBP2P_TCP_REUSEPORT` to false.
-
-This variable was previously `IPFS_REUSEPORT`.
 
 Default: true
 


### PR DESCRIPTION
This PR ensures hard deprecation.
`IPFS_REUSEPORT=false ipfs daemon`  refuses to start:

```
Daemon is ready
2021-11-23T20:49:02.160+0100	FATAL	cmd/ipfs	ipfs/daemon.go:567	Support for IPFS_REUSEPORT was removed. Use LIBP2P_TCP_REUSEPORT instead.
```