### PR TITLE
fix(cmds): use ipld multicodecs for cmds block put and cid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # go-ipfs changelog
 
+## v0.13 (DRAFT)
+
+### BREAKING CHANGES
+
+- `ipfs block put` command produces CIDv1 with `raw` codec by default now
+    - `ipfs block put --cid-codec` makes `block put` return CID with alternative codec
+       - this impacts only the returned CID, it does  not trigger any validation or data transformation
+       - codec names are validated against tables from https://github.com/multiformats/go-multicodec
+    - `ipfs block put --format` is deprecated. It used incorrect codec names and should be avoided for new deployments. Use it only if you need the old, invalid behavior, namely:
+      - `ipfs block put --format=v0` will produce CIDv0 (implicit dag-pb)
+      - `ipfs block put --format=cbor` will produce CIDv1 with dag-cbor (!)
+      - `ipfs block put --format=protobuf` will produce CIDv1 with dag-pb (!)
+- `ipfs cid codecs` command
+  - it now lists codecs from https://github.com/multiformats/go-multicodec
+  - `ipfs cid codecs --supported` can be passed to only show codecs supported in various go-ipfs commands
+
+
 ## v0.12.2 and v0.11.1 2022-04-08
 
 This patch release fixes a security issue wherein traversing some malformed DAGs can cause the node to panic.

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -142,7 +142,7 @@ only for backward compatibility when a legacy CIDv0 is required (--format=v0).
 		cmds.FileArg("data", true, true, "The data to be stored as an IPFS block.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption(blockCidCodecOptionName, "Multicodec to use in returned CID. Default: raw"),
+		cmds.StringOption(blockCidCodecOptionName, "Multicodec to use in returned CID").WithDefault("raw"),
 		cmds.StringOption(mhtypeOptionName, "Multihash hash function").WithDefault("sha2-256"),
 		cmds.IntOption(mhlenOptionName, "Multihash hash length").WithDefault(-1),
 		cmds.BoolOption(pinOptionName, "Pin added blocks recursively").WithDefault(false),
@@ -168,8 +168,13 @@ only for backward compatibility when a legacy CIDv0 is required (--format=v0).
 
 		cidCodec, _ := req.Options[blockCidCodecOptionName].(string)
 		format, _ := req.Options[blockFormatOptionName].(string) // deprecated
-		if format != "" && cidCodec != "" {
-			return fmt.Errorf("unable to use %q (deprecated) with %q at the same time", blockFormatOptionName, blockCidCodecOptionName)
+
+		// use of legacy 'format' needs to supress 'cid-codec'
+		if format != "" {
+			if cidCodec != "" && cidCodec != "raw" {
+				return fmt.Errorf("unable to use %q (deprecated) and a custom %q at the same time", blockFormatOptionName, blockCidCodecOptionName)
+			}
+			cidCodec = "" // makes it no-op
 		}
 
 		pin, _ := req.Options[pinOptionName].(bool)

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -31,8 +31,8 @@ var BlockCmd = &cmds.Command{
 		Tagline: "Interact with raw IPFS blocks.",
 		ShortDescription: `
 'ipfs block' is a plumbing command used to manipulate raw IPFS blocks.
-Reads from stdin or writes to stdout, and <key> is a base58 encoded
-multihash.
+Reads from stdin or writes to stdout. A block is identified by a Multihash
+passed with a valid CID.
 `,
 	},
 
@@ -51,14 +51,14 @@ var blockStatCmd = &cmds.Command{
 'ipfs block stat' is a plumbing command for retrieving information
 on raw IPFS blocks. It outputs the following to stdout:
 
-	Key  - the base58 encoded multihash
+	Key  - the CID of the block
 	Size - the size of the block in bytes
 
 `,
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to stat.").EnableStdin(),
+		cmds.StringArg("cid", true, false, "The CID of an existing block to stat.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -90,12 +90,12 @@ var blockGetCmd = &cmds.Command{
 		Tagline: "Get a raw IPFS block.",
 		ShortDescription: `
 'ipfs block get' is a plumbing command for retrieving raw IPFS blocks.
-It outputs to stdout, and <key> is a base58 encoded multihash.
+It takes a <cid>, and outputs the block to stdout.
 `,
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to get.").EnableStdin(),
+		cmds.StringArg("cid", true, false, "The CID of an existing block to get.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -113,10 +113,10 @@ It outputs to stdout, and <key> is a base58 encoded multihash.
 }
 
 const (
-	blockFormatOptionName = "format"
-	blockStoreCodecOptionName = "store-codec"
-	mhtypeOptionName      = "mhtype"
-	mhlenOptionName       = "mhlen"
+	blockFormatOptionName   = "format"
+	blockCidCodecOptionName = "cid-codec"
+	mhtypeOptionName        = "mhtype"
+	mhlenOptionName         = "mhlen"
 )
 
 var blockPutCmd = &cmds.Command{
@@ -124,10 +124,17 @@ var blockPutCmd = &cmds.Command{
 		Tagline: "Store input as an IPFS block.",
 		ShortDescription: `
 'ipfs block put' is a plumbing command for storing raw IPFS blocks.
-It reads from stdin, and outputs the block's CID to stdout.
+It reads data from stdin, and outputs the block's CID to stdout.
 
-Unless specified, this command returns dag-pb CIDv0 CIDs. Setting 'mhtype' to anything
-other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1.
+Unless cid-codec is specified, this command returns raw (0x55) CIDv1 CIDs.
+
+Passing alternative --cid-codec does not modify imported data, nor run any
+validation. It is provided solely for convenience for users who create blocks
+in userland.
+
+NOTE:
+Do not use --format for any new code. It got superseded by --cid-codec and left
+only for backward compatibility when a legacy CIDv0 is required (--format=v0).
 `,
 	},
 
@@ -135,12 +142,12 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 		cmds.FileArg("data", true, true, "The data to be stored as an IPFS block.").EnableStdin(),
 	},
 	Options: []cmds.Option{
-		cmds.StringOption(blockFormatOptionName, "f", "cid format for blocks to be created with."),
-		cmds.StringOption(blockStoreCodecOptionName, "s", "multicodec name for blocks to be stored with"),
-		cmds.StringOption(mhtypeOptionName, "multihash hash function").WithDefault("sha2-256"),
-		cmds.IntOption(mhlenOptionName, "multihash hash length").WithDefault(-1),
-		cmds.BoolOption(pinOptionName, "pin added blocks recursively").WithDefault(false),
+		cmds.StringOption(blockCidCodecOptionName, "Multicodec to use in returned CID. Default: raw"),
+		cmds.StringOption(mhtypeOptionName, "Multihash hash function").WithDefault("sha2-256"),
+		cmds.IntOption(mhlenOptionName, "Multihash hash length").WithDefault(-1),
+		cmds.BoolOption(pinOptionName, "Pin added blocks recursively").WithDefault(false),
 		cmdutils.AllowBigBlockOption,
+		cmds.StringOption(blockFormatOptionName, "f", "Use legacy format for returned CID (DEPRECATED)"),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -159,8 +166,11 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 			return errors.New("missing option \"mhlen\"")
 		}
 
-		format, _ := req.Options[blockFormatOptionName].(string)
-		storeCodec, _ := req.Options[blockStoreCodecOptionName].(string)
+		cidCodec, _ := req.Options[blockCidCodecOptionName].(string)
+		format, _ := req.Options[blockFormatOptionName].(string) // deprecated
+		if format != "" && cidCodec != "" {
+			return fmt.Errorf("unable to use %q (deprecated) with %q at the same time", blockFormatOptionName, blockCidCodecOptionName)
+		}
 
 		pin, _ := req.Options[pinOptionName].(bool)
 
@@ -173,8 +183,8 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 
 			p, err := api.Block().Put(req.Context, file,
 				options.Block.Hash(mhtval, mhlen),
+				options.Block.CidCodec(cidCodec),
 				options.Block.Format(format),
-				options.Block.StoreCodec(storeCodec),
 				options.Block.Pin(pin))
 			if err != nil {
 				return err
@@ -216,14 +226,14 @@ type removedBlock struct {
 
 var blockRmCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Remove IPFS block(s).",
+		Tagline: "Remove IPFS block(s) from the local datastore.",
 		ShortDescription: `
 'ipfs block rm' is a plumbing command for removing raw ipfs blocks.
-It takes a list of base58 encoded multihashes to remove.
+It takes a list of CIDs to remove from the local datastore..
 `,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("hash", true, true, "Bash58 encoded multihash of block(s) to remove."),
+		cmds.StringArg("cid", true, true, "CIDs of block(s) to remove."),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(forceOptionName, "f", "Ignore nonexistent blocks."),

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -114,6 +114,7 @@ It outputs to stdout, and <key> is a base58 encoded multihash.
 
 const (
 	blockFormatOptionName = "format"
+	blockStoreCodecOptionName = "store-codec"
 	mhtypeOptionName      = "mhtype"
 	mhlenOptionName       = "mhlen"
 )
@@ -135,6 +136,7 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 	},
 	Options: []cmds.Option{
 		cmds.StringOption(blockFormatOptionName, "f", "cid format for blocks to be created with."),
+		cmds.StringOption(blockStoreCodecOptionName, "s", "multicodec name for blocks to be stored with"),
 		cmds.StringOption(mhtypeOptionName, "multihash hash function").WithDefault("sha2-256"),
 		cmds.IntOption(mhlenOptionName, "multihash hash length").WithDefault(-1),
 		cmds.BoolOption(pinOptionName, "pin added blocks recursively").WithDefault(false),
@@ -157,14 +159,8 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 			return errors.New("missing option \"mhlen\"")
 		}
 
-		format, formatSet := req.Options[blockFormatOptionName].(string)
-		if !formatSet {
-			if mhtval != mh.SHA2_256 || (mhlen != -1 && mhlen != 32) {
-				format = "protobuf"
-			} else {
-				format = "v0"
-			}
-		}
+		format, _ := req.Options[blockFormatOptionName].(string)
+		storeCodec, _ := req.Options[blockStoreCodecOptionName].(string)
 
 		pin, _ := req.Options[pinOptionName].(bool)
 
@@ -178,6 +174,7 @@ other than 'sha2-256' or format to anything other than 'v0' will result in CIDv1
 			p, err := api.Block().Put(req.Context, file,
 				options.Block.Hash(mhtval, mhlen),
 				options.Block.Format(format),
+				options.Block.StoreCodec(storeCodec),
 				options.Block.Pin(pin))
 			if err != nil {
 				return err

--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -330,6 +330,8 @@ var codecsCmd = &cmds.Command{
 			for _, code := range multicodec.ListDecoders() {
 				supportedCodecs[code] = struct{}{}
 			}
+			// add libp2p-key
+			supportedCodecs[uint64(mc.Libp2pKey)] = struct{}{}
 		}
 
 		var res []CodeAndName

--- a/core/commands/cid.go
+++ b/core/commands/cid.go
@@ -48,7 +48,7 @@ The optional format string is a printf style format string:
 ` + cidutil.FormatRef,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("cid", true, true, "Cids to format.").EnableStdin(),
+		cmds.StringArg("cid", true, true, "CIDs to format.").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.StringOption(cidFormatOptionName, "Printf style format string.").WithDefault("%s"),
@@ -65,14 +65,14 @@ The optional format string is a printf style format string:
 		opts := cidFormatOpts{}
 
 		if strings.IndexByte(fmtStr, '%') == -1 {
-			return fmt.Errorf("invalid format string: %s", fmtStr)
+			return fmt.Errorf("invalid format string: %q", fmtStr)
 		}
 		opts.fmtStr = fmtStr
 
 		if codecStr != "" {
 			codec, ok := cid.Codecs[codecStr]
 			if !ok {
-				return fmt.Errorf("unknown IPLD codec: %s", codecStr)
+				return fmt.Errorf("unknown IPLD codec: %q", codecStr)
 			}
 			opts.newCodec = codec
 		} // otherwise, leave it as 0 (not a valid IPLD codec)
@@ -82,13 +82,13 @@ The optional format string is a printf style format string:
 			// noop
 		case "0":
 			if opts.newCodec != 0 && opts.newCodec != cid.DagProtobuf {
-				return fmt.Errorf("cannot convert to CIDv0 with any codec other than DagPB")
+				return fmt.Errorf("cannot convert to CIDv0 with any codec other than dag-pb")
 			}
 			opts.verConv = toCidV0
 		case "1":
 			opts.verConv = toCidV1
 		default:
-			return fmt.Errorf("invalid cid version: %s", verStr)
+			return fmt.Errorf("invalid cid version: %q", verStr)
 		}
 
 		if baseStr != "" {
@@ -125,9 +125,13 @@ type CidFormatRes struct {
 var base32Cmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Convert CIDs to Base32 CID version 1.",
+		ShortDescription: `
+'ipfs cid base32' normalizes passes CIDs to their canonical case-insensitive encoding.
+Useful when processing third-party CIDs which could come with arbitrary formats.
+`,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("cid", true, true, "Cids to convert.").EnableStdin(),
+		cmds.StringArg("cid", true, true, "CIDs to convert.").EnableStdin(),
 	},
 	Run: func(req *cmds.Request, resp cmds.ResponseEmitter, env cmds.Environment) error {
 		opts := cidFormatOpts{
@@ -234,7 +238,7 @@ func emitCids(req *cmds.Request, resp cmds.ResponseEmitter, opts cidFormatOpts) 
 
 func toCidV0(c cid.Cid) (cid.Cid, error) {
 	if c.Type() != cid.DagProtobuf {
-		return cid.Cid{}, fmt.Errorf("can't convert non-protobuf nodes to cidv0")
+		return cid.Cid{}, fmt.Errorf("can't convert non-dag-pb nodes to cidv0")
 	}
 	return cid.NewCidV0(c.Hash()), nil
 }
@@ -256,6 +260,9 @@ const (
 var basesCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List available multibase encodings.",
+		ShortDescription: `
+'ipfs cid bases' relies on https://github.com/multiformats/go-multibase
+`,
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(prefixOptionName, "also include the single letter prefixes in addition to the code"),
@@ -305,6 +312,9 @@ const (
 var codecsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List available CID codecs.",
+		ShortDescription: `
+'ipfs cid codecs' relies on https://github.com/multiformats/go-multicodec
+`,
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(codecsNumericOptionName, "n", "also include numeric codes"),
@@ -355,6 +365,9 @@ var codecsCmd = &cmds.Command{
 var hashesCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "List available multihashes.",
+		ShortDescription: `
+'ipfs cid hashes' relies on https://github.com/multiformats/go-multihash
+`,
 	},
 	Options: codecsCmd.Options,
 	Run: func(req *cmds.Request, resp cmds.ResponseEmitter, env cmds.Environment) error {

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -31,7 +31,7 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 	ctx, span := tracing.Span(ctx, "CoreAPI.BlockAPI", "Put")
 	defer span.End()
 
-	settings, pref, err := caopts.BlockPutOptions(opts...)
+	settings, err := caopts.BlockPutOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 		return nil, err
 	}
 
-	bcid, err := pref.Sum(data)
+	bcid, err := settings.CidPrefix.Sum(data)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multibase v0.0.3
-	github.com/multiformats/go-multicodec v0.4.0
+	github.com/multiformats/go-multicodec v0.4.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.1.3
 	github.com/ipfs/go-verifcid v0.0.1
-	github.com/ipfs/interface-go-ipfs-core v0.6.2
+	github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953
 	github.com/ipfs/tar-utils v0.0.2
 	github.com/ipld/go-car v0.3.2
 	github.com/ipld/go-car/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.1.3
 	github.com/ipfs/go-verifcid v0.0.1
-	github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703
+	github.com/ipfs/interface-go-ipfs-core v0.7.0
 	github.com/ipfs/tar-utils v0.0.2
 	github.com/ipld/go-car v0.3.2
 	github.com/ipld/go-car/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.1.3
 	github.com/ipfs/go-verifcid v0.0.1
-	github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953
+	github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703
 	github.com/ipfs/tar-utils v0.0.2
 	github.com/ipld/go-car v0.3.2
 	github.com/ipld/go-car/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -1188,8 +1188,8 @@ github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPw
 github.com/multiformats/go-multicodec v0.2.0/go.mod h1:/y4YVwkfMyry5kFbMTbLJKErhycTIftytRV+llXdyS4=
 github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multicodec v0.3.1-0.20210902112759-1539a079fd61/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
-github.com/multiformats/go-multicodec v0.4.0 h1:fbqb6ky7erjdD+/zaEBJgZWu1i8D6i/wmPywGK7sdow=
-github.com/multiformats/go-multicodec v0.4.0/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
+github.com/multiformats/go-multicodec v0.4.1 h1:BSJbf+zpghcZMZrwTYBGwy0CPcVZGWiC72Cp8bBd4R4=
+github.com/multiformats/go-multicodec v0.4.1/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/go.sum
+++ b/go.sum
@@ -605,8 +605,8 @@ github.com/ipfs/go-unixfsnode v1.1.3/go.mod h1:ZZxUM5wXBC+G0Co9FjrYTOm+UlhZTjxLf
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/interface-go-ipfs-core v0.4.0/go.mod h1:UJBcU6iNennuI05amq3FQ7g0JHUkibHFAfhfUIy927o=
-github.com/ipfs/interface-go-ipfs-core v0.6.2 h1:nnkq9zhb5O8lPzkZeynEymc83RqkTRqfYH4x5JNUkT4=
-github.com/ipfs/interface-go-ipfs-core v0.6.2/go.mod h1:h3NuO3wzv2KuKazt0zDF2/i8AFRqiKHusyh5DUQQdPA=
+github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953 h1:0jHj/vY8khomu6mCvmRlJT0RNMWM2f108uYoMGsqyX0=
+github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
 github.com/ipfs/tar-utils v0.0.2 h1:UNgHB4x/PPzbMkmJi+7EqC9LNMPDztOVSnx1HAqSNg4=
 github.com/ipfs/tar-utils v0.0.2/go.mod h1:4qlnRWgTVljIMhSG2SqRYn66NT+3wrv/kZt9V+eqxDM=
 github.com/ipld/go-car v0.3.2 h1:V9wt/80FNfbMRWSD98W5br6fyjUAyVgI2lDOTZX16Lg=

--- a/go.sum
+++ b/go.sum
@@ -607,6 +607,8 @@ github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZ
 github.com/ipfs/interface-go-ipfs-core v0.4.0/go.mod h1:UJBcU6iNennuI05amq3FQ7g0JHUkibHFAfhfUIy927o=
 github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953 h1:0jHj/vY8khomu6mCvmRlJT0RNMWM2f108uYoMGsqyX0=
 github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
+github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703 h1:HAdB02slFC+/zxf3szFvXqdtRrwvE7xBKxCRxzFrOFc=
+github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
 github.com/ipfs/tar-utils v0.0.2 h1:UNgHB4x/PPzbMkmJi+7EqC9LNMPDztOVSnx1HAqSNg4=
 github.com/ipfs/tar-utils v0.0.2/go.mod h1:4qlnRWgTVljIMhSG2SqRYn66NT+3wrv/kZt9V+eqxDM=
 github.com/ipld/go-car v0.3.2 h1:V9wt/80FNfbMRWSD98W5br6fyjUAyVgI2lDOTZX16Lg=

--- a/go.sum
+++ b/go.sum
@@ -605,10 +605,8 @@ github.com/ipfs/go-unixfsnode v1.1.3/go.mod h1:ZZxUM5wXBC+G0Co9FjrYTOm+UlhZTjxLf
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipfs/interface-go-ipfs-core v0.4.0/go.mod h1:UJBcU6iNennuI05amq3FQ7g0JHUkibHFAfhfUIy927o=
-github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953 h1:0jHj/vY8khomu6mCvmRlJT0RNMWM2f108uYoMGsqyX0=
-github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220412233708-a6eb01527953/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
-github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703 h1:HAdB02slFC+/zxf3szFvXqdtRrwvE7xBKxCRxzFrOFc=
-github.com/ipfs/interface-go-ipfs-core v0.6.3-0.20220413011532-7e14e1e09703/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
+github.com/ipfs/interface-go-ipfs-core v0.7.0 h1:7tb+2upz8oCcjIyjo1atdMk+P+u7wPmI+GksBlLE8js=
+github.com/ipfs/interface-go-ipfs-core v0.7.0/go.mod h1:lF27E/nnSPbylPqKVXGZghal2hzifs3MmjyiEjnc9FY=
 github.com/ipfs/tar-utils v0.0.2 h1:UNgHB4x/PPzbMkmJi+7EqC9LNMPDztOVSnx1HAqSNg4=
 github.com/ipfs/tar-utils v0.0.2/go.mod h1:4qlnRWgTVljIMhSG2SqRYn66NT+3wrv/kZt9V+eqxDM=
 github.com/ipld/go-car v0.3.2 h1:V9wt/80FNfbMRWSD98W5br6fyjUAyVgI2lDOTZX16Lg=

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -39,6 +39,15 @@ test_expect_success "'ipfs block put' output looks good" '
   test_cmp expected_out actual_out
 '
 
+test_expect_success "can set cid store codec on block put" '
+  CODEC_HASH=$(ipfs block put --store-codec=dag-pb ../t0051-object-data/testPut.pb)
+'
+
+test_expect_success "block get output looks right" '
+  ipfs block get $CODEC_HASH > pb_block_out &&
+  test_cmp pb_block_out ../t0051-object-data/testPut.pb
+'
+
 #
 # "block get" tests
 #
@@ -236,13 +245,17 @@ test_expect_success "no panic in output" '
   test_expect_code 1 grep "panic" stat_out
 '
 
-test_expect_success "can set multihash type and length on block put without format" '
-  HASH=$(echo "foooo" | ipfs block put --mhtype=sha3 --mhlen=20)
-'
+# FIXME: FAILING. This should work once 'protobuf' is added back in
+#  the default in https://github.com/ipfs/interface-go-ipfs-core/pull/80
+#  (after the first round of review passes).
 
-test_expect_success "output looks good" '
-  test "bafybifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
-'
+#test_expect_success "can set multihash type and length on block put without format" '
+#  HASH=$(echo "foooo" | ipfs block put --mhtype=sha3 --mhlen=20)
+#'
+#
+#test_expect_success "output looks good" '
+#  test "bafybifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
+#'
 
 test_expect_success "put with sha3 and cidv0 fails" '
   echo "foooo" | test_must_fail ipfs block put --mhtype=sha3 --mhlen=20 --format=v0

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -247,6 +247,11 @@ test_expect_success "output looks good" '
   test "bafkrifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
 '
 
+test_expect_success "can't use both legacy format and custom cid-codec at the same time" '
+  test_expect_code 1 ipfs block put --format=dag-cbor --cid-codec=dag-json < ../t0051-object-data/testPut.pb 2> output &&
+  test_should_contain "unable to use \"format\" (deprecated) and a custom \"cid-codec\" at the same time" output
+'
+
 test_expect_success "can read block with different hash" '
   ipfs block get $HASH > blk_get_out &&
   echo "foooo" > blk_get_exp &&
@@ -260,6 +265,7 @@ test_expect_success "'ipfs block stat' with nothing from stdin doesn't crash" '
   test_expect_code 1 ipfs block stat < /dev/null 2> stat_out
 '
 
+# lol
 test_expect_success "no panic in output" '
   test_expect_code 1 grep "panic" stat_out
 '

--- a/test/sharness/t0050-block.sh
+++ b/test/sharness/t0050-block.sh
@@ -10,16 +10,18 @@ test_description="Test block command"
 
 test_init_ipfs
 
-HASH="QmRKqGMAM6EZngbpjSqrvYzq5Qd8b1bSWymjSUY9zQSNDk"
-HASHB="QmdnpnsaEj69isdw5sNzp3h3HkaDz7xKq7BmvFFBzNr5e7"
+HASH="bafkreibmlvvgdyihetgocpof6xk64kjjzdeq2e4c7hqs3krdheosk4tgj4"
+HASHB="bafkreihfsphazrk2ilejpekyltjeh5k4yvwgjuwg26ueafohqioeo3sdca"
 
-#
+HASHV0="QmRKqGMAM6EZngbpjSqrvYzq5Qd8b1bSWymjSUY9zQSNDk"
+HASHBV0="QmdnpnsaEj69isdw5sNzp3h3HkaDz7xKq7BmvFFBzNr5e7"
+
 # "block put tests"
 #
 
 test_expect_success "'ipfs block put' succeeds" '
   echo "Hello Mars!" >expected_in &&
-  ipfs block put <expected_in >actual_out
+  ipfs block put <expected_in | tee actual_out
 '
 
 test_expect_success "'ipfs block put' output looks good" '
@@ -30,7 +32,7 @@ test_expect_success "'ipfs block put' output looks good" '
 test_expect_success "'ipfs block put' with 2 files succeeds" '
   echo "Hello Mars!" > a &&
   echo "Hello Venus!" > b &&
-  ipfs block put a b >actual_out
+  ipfs block put a b | tee actual_out
 '
 
 test_expect_success "'ipfs block put' output looks good" '
@@ -39,8 +41,8 @@ test_expect_success "'ipfs block put' output looks good" '
   test_cmp expected_out actual_out
 '
 
-test_expect_success "can set cid store codec on block put" '
-  CODEC_HASH=$(ipfs block put --store-codec=dag-pb ../t0051-object-data/testPut.pb)
+test_expect_success "can set cid codec on block put" '
+  CODEC_HASH=$(ipfs block put --cid-codec=dag-pb ../t0051-object-data/testPut.pb)
 '
 
 test_expect_success "block get output looks right" '
@@ -205,7 +207,9 @@ test_expect_success "multi-block 'ipfs block rm -q' produces no output" '
   test ! -s block_rm_out
 '
 
-test_expect_success "can set cid format on block put" '
+# --format used 'protobuf' for 'dag-pb' which was invalid, but we keep
+# for backward-compatibility
+test_expect_success "can set deprecated --format=protobuf on block put" '
   HASH=$(ipfs block put --format=protobuf ../t0051-object-data/testPut.pb)
 '
 
@@ -220,7 +224,22 @@ test_expect_success "block get output looks right" '
   test_cmp pb_block_out ../t0051-object-data/testPut.pb
 '
 
-test_expect_success "can set multihash type and length on block put" '
+test_expect_success "can set --cid-codec=dag-pb on block put" '
+  HASH=$(ipfs block put --cid-codec=dag-pb ../t0051-object-data/testPut.pb)
+'
+
+test_expect_success "created an object correctly!" '
+  ipfs object get $HASH > obj_out &&
+  echo "{\"Links\":[],\"Data\":\"test json for sharness test\"}" > obj_exp &&
+  test_cmp obj_out obj_exp
+'
+
+test_expect_success "block get output looks right" '
+  ipfs block get $HASH > pb_block_out &&
+  test_cmp pb_block_out ../t0051-object-data/testPut.pb
+'
+
+test_expect_success "can set multihash type and length on block put with --format=raw (deprecated)" '
   HASH=$(echo "foooo" | ipfs block put --format=raw --mhtype=sha3 --mhlen=20)
 '
 
@@ -245,17 +264,21 @@ test_expect_success "no panic in output" '
   test_expect_code 1 grep "panic" stat_out
 '
 
-# FIXME: FAILING. This should work once 'protobuf' is added back in
-#  the default in https://github.com/ipfs/interface-go-ipfs-core/pull/80
-#  (after the first round of review passes).
+test_expect_success "can set multihash type and length on block put without format or cid-codec" '
+  HASH=$(echo "foooo" | ipfs block put --mhtype=sha3 --mhlen=20)
+'
 
-#test_expect_success "can set multihash type and length on block put without format" '
-#  HASH=$(echo "foooo" | ipfs block put --mhtype=sha3 --mhlen=20)
-#'
-#
-#test_expect_success "output looks good" '
-#  test "bafybifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
-#'
+test_expect_success "output looks good" '
+  test "bafkrifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
+'
+
+test_expect_success "can set multihash type and length on block put with cid-codec=dag-pb" '
+  HASH=$(echo "foooo" | ipfs block put --mhtype=sha3 --mhlen=20 --cid-codec=dag-pb)
+'
+
+test_expect_success "output looks good" '
+  test "bafybifctrq4xazzixy2v4ezymjcvzpskqdwlxra" = "$HASH"
+'
 
 test_expect_success "put with sha3 and cidv0 fails" '
   echo "foooo" | test_must_fail ipfs block put --mhtype=sha3 --mhlen=20 --format=v0

--- a/test/sharness/t0110-gateway.sh
+++ b/test/sharness/t0110-gateway.sh
@@ -262,7 +262,7 @@ test_expect_success "try fetching it from gateway" '
 
 test_expect_success "Add compact blocks" '
   ipfs block put ../t0110-gateway-data/foo.block &&
-  FOO2_HASH=$(ipfs block put ../t0110-gateway-data/foofoo.block) &&
+  FOO2_HASH=$(ipfs block put --cid-codec=dag-pb ../t0110-gateway-data/foofoo.block) &&
   printf "foofoo" > expected
 '
 

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -103,11 +103,19 @@ Z    90  base58flickr
 EOF
 
 cat <<EOF > codecs_expect
+   81  cbor
    85  raw
-  112  protobuf
-  113  cbor
+  112  dag-pb
+  113  dag-cbor
+  114  libp2p-key
   120  git-raw
+  123  torrent-info
+  124  torrent-file
+  129  leofcoin-block
+  130  leofcoin-tx
+  131  leofcoin-pr
   133  dag-jose
+  134  dag-cose
   144  eth-block
   145  eth-block-list
   146  eth-tx-trie
@@ -117,16 +125,34 @@ cat <<EOF > codecs_expect
   150  eth-state-trie
   151  eth-account-snapshot
   152  eth-storage-trie
+  153  eth-receipt-log-trie
+  154  eth-reciept-log
   176  bitcoin-block
   177  bitcoin-tx
+  178  bitcoin-witness-commitment
   192  zcash-block
   193  zcash-tx
+  208  stellar-block
+  209  stellar-tx
   224  decred-block
   225  decred-tx
   240  dash-block
   241  dash-tx
-61697  fil-commitment-unsealed
-61698  fil-commitment-sealed
+  250  swarm-manifest
+  251  swarm-feed
+  297  dag-json
+  496  swhid-1-snp
+  512  json
+EOF
+
+cat <<EOF > supported_codecs_expect
+   81  cbor
+   85  raw
+  112  dag-pb
+  113  dag-cbor
+  120  git-raw
+  297  dag-json
+  512  json
 EOF
 
 cat <<EOF > hashes_expect
@@ -230,6 +256,17 @@ test_expect_success "cid codecs" '
 test_expect_success "cid codecs --numeric" '
   ipfs cid codecs --numeric > actual &&
   test_cmp codecs_expect actual
+'
+
+test_expect_success "cid codecs --supported" '
+  cut -c 8- supported_codecs_expect > expect &&
+  ipfs cid codecs --supported > actual
+  test_cmp expect actual
+'
+
+test_expect_success "cid codecs --supported --numeric" '
+  ipfs cid codecs --supported --numeric > actual &&
+  test_cmp supported_codecs_expect actual
 '
 
 test_expect_success "cid hashes" '

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -150,6 +150,7 @@ cat <<EOF > supported_codecs_expect
    85  raw
   112  dag-pb
   113  dag-cbor
+  114  libp2p-key
   120  git-raw
   133  dag-jose
   297  dag-json

--- a/test/sharness/t0290-cid.sh
+++ b/test/sharness/t0290-cid.sh
@@ -151,6 +151,7 @@ cat <<EOF > supported_codecs_expect
   112  dag-pb
   113  dag-cbor
   120  git-raw
+  133  dag-jose
   297  dag-json
   512  json
 EOF


### PR DESCRIPTION
## @lidel's blurb for Release Notes

- This PR requires https://github.com/ipfs/interface-go-ipfs-core/pull/80 to land first. Go there first.

### BREAKING CHANGES
- `ipfs block` commands
  - `ipfs block put` now produces CIDv1 with `raw` codec by default now
    - `ipfs block put --cid-codec` makes `block put` return CID with alternative codec
       -  this impacts only the returned CID, it does  not trigger any validation or data transformation
       - codec names are validated against tables from https://github.com/multiformats/go-multicodec
    - `ipfs block put --format` is deprecated. It used incorrect codec names and should be avoided for new deployments. Use it only if you need the old, invalid behavior, namely:
      - `ipfs block put --format=v0` will produce CIDv0 (implicit dag-pb)
      - `ipfs block put --format=cbor` will produce CIDv1 with dag-cbor (!)
      - `ipfs block put --format=protobuf` will produce CIDv1 with dag-pb (!)
- `ipfs cid codecs`
  - it now lists codecs from https://github.com/multiformats/go-multicodec
  - `ipfs cid codecs --supported` can be passed to only show codecs supported in various go-ipfs commands


----


Depends on:
* [x] https://github.com/ipfs/interface-go-ipfs-core/pull/80 (need to be merged and released before we can merge this PR)
* [x] https://github.com/multiformats/go-multicodec/pull/59
* [x] <del>https://github.com/ipfs/go-cid/pull/137 </del> 
  - not a dependency, we can use old version for now, only aciton here was to remove use of maps that will be removed when the go-cid PR is merged.

TODO:
- [x] Add <del>`--store-codec`</del> `--cid-codec` sharness tests. 
- [x] update `block` and `cid` command helptext
- [x] Update `github.com/ipfs/interface-go-ipfs-core` dependency with version.
- [x] <del>Update `github.com/ipfs/go-cid` dependency with version that includes https://github.com/ipfs/go-ipfs/pull/8568</del>
  - this was descoped, as noted in "Depends on" above
- [x] Update `github.com/multiformats/go-multicodec` dependency with version that includes  https://github.com/multiformats/go-multicodec/pull/59
- [x] Fix sharness test `"can set multihash type and length on block put without format"` once `interface-go-ipfs-core` is reviewed and the `--format=protobuf` backward-compatibility is  added back.


Closes https://github.com/ipfs/go-ipfs/issues/8471 