### PR TITLE
fix(corehttp): adjust peer counting metrics

### DIFF
--- a/core/corehttp/metrics_test.go
+++ b/core/corehttp/metrics_test.go
@@ -44,11 +44,13 @@ func TestPeersTotal(t *testing.T) {
 
 	node := &core.IpfsNode{PeerHost: hosts[0]}
 	collector := IpfsNodeCollector{Node: node}
-	actual := collector.PeersTotalValues()
-	if len(actual) != 1 {
-		t.Fatalf("expected 1 peers transport, got %d, transport map %v", len(actual), actual)
+	peersTransport := collector.PeersTotalValues()
+	if len(peersTransport) > 2 {
+		t.Fatalf("expected at most 2 peers transport (tcp and upd/quic), got %d, transport map %v",
+			len(peersTransport), peersTransport)
 	}
-	if actual["/ip4/tcp"] != float64(3) {
-		t.Fatalf("expected 3 peers, got %f", actual["/ip4/tcp"])
+	totalPeers := peersTransport["/ip4/tcp"] + peersTransport["/ip4/udp/quic"]
+	if totalPeers != 3 {
+		t.Fatalf("expected 3 peers in either tcp or upd/quic transport, got %f", totalPeers)
 	}
 }


### PR DESCRIPTION
Following upstream fix in https://github.com/libp2p/go-libp2p-swarm/commit/0538806be79cf321e79253cecaec8c9b0d2a7167.

Fixes https://github.com/ipfs/go-ipfs/issues/8135.