### PR TITLE
fix(ci): dist.ipfs.io sync preserving binaries

### DIFF
--- a/.github/workflows/sync-release-assets.yml
+++ b/.github/workflows/sync-release-assets.yml
@@ -107,14 +107,17 @@ jobs:
               for (const file of missing_files) {
                 console.log("fetching", file, "from dist.ipfs.io")
                 await exec.exec('ipfs', ['get', p + '/' + file])
-                const data = await fs.readFile(file, "binary")
                 console.log("uploading", file, "to github release", release.tag_name)
                 resp = await github.repos.uploadReleaseAsset({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   release_id: release.id,
+                  headers: {
+                    "content-type": "application/octet-stream",
+                    "content-length": `${(await fs.stat(file)).size}`
+                    },
                   name: file,
-                  data: data,
+                  data: await fs.readFile(file),
                 })
               }
               // summary of assets on both sides


### PR DESCRIPTION
This is a quick fix for #8494  

- `tar.gz`s got mangled because of reasons known to github and nodejs (had no bandwidth to dig why)
- this does the correct upload every time by reading file as Buffer and forcing github to interpret payload as an opaque stream of bytes of a known length without anything fancy – makes this as future-proof as possible
- I confirmed this fix works in https://github.com/libp2p/go-libp2p-relay-daemon/releases/tag/v0.1.0  (reuploaded `_linux-amd64.tar.gz` was the same as on dist.ipfs.io)

