### PR TITLE
chore: bump Go version to 1.16.12

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: cimg/go:1.16.11
+      - image: cimg/go:1.16.12
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -61,7 +61,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer:
     docker:
-      - image: cimg/go:1.16.11
+      - image: cimg/go:1.16.12
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip
@@ -150,8 +150,8 @@ jobs:
     - run: sudo apt update
     - run: |
         mkdir ~/localgo && cd ~/localgo
-        wget https://golang.org/dl/go1.16.11.linux-amd64.tar.gz
-        tar xfz go1.16.11.linux-amd64.tar.gz
+        wget https://golang.org/dl/go1.16.12.linux-amd64.tar.gz
+        tar xfz go1.16.12.linux-amd64.tar.gz
         echo "export PATH=$(pwd)/go/bin:\$PATH" >> ~/.bashrc
     - run: go version
     - run: sudo apt install socat net-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
-FROM golang:1.16.11-buster
+FROM golang:1.16.12-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps


### PR DESCRIPTION
Waiting on https://github.com/CircleCI-Public/cimg-go/pull/142