### PR TITLE
feat: DNS.MaxCacheTTL for DNS-over-HTTPS resolvers

### DIFF
--- a/core/node/dns.go
+++ b/core/node/dns.go
@@ -2,7 +2,9 @@ package node
 
 import (
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	config "github.com/ipfs/go-ipfs-config"
 	doh "github.com/libp2p/go-doh-resolver"
@@ -16,17 +18,22 @@ var defaultResolvers = map[string]string{
 	"crypto.": "https://resolver.cloudflare-eth.com/dns-query",
 }
 
-func newResolver(url string) (madns.BasicResolver, error) {
+func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {
 	if !strings.HasPrefix(url, "https://") {
 		return nil, fmt.Errorf("invalid resolver url: %s", url)
 	}
 
-	return doh.NewResolver(url), nil
+	return doh.NewResolver(url, opts...), nil
 }
 
 func DNSResolver(cfg *config.Config) (*madns.Resolver, error) {
 	var opts []madns.Option
 	var err error
+
+	var dohOpts []doh.Option
+	if !cfg.DNS.MaxCacheTTL.IsDefault() {
+		dohOpts = append(dohOpts, doh.WithMaxCacheTTL(cfg.DNS.MaxCacheTTL.WithDefault(time.Duration(math.MaxUint32)*time.Second)))
+	}
 
 	domains := make(map[string]struct{})           // to track overridden default resolvers
 	rslvrs := make(map[string]madns.BasicResolver) // to reuse resolvers for the same URL
@@ -44,7 +51,7 @@ func DNSResolver(cfg *config.Config) (*madns.Resolver, error) {
 
 		rslv, ok := rslvrs[url]
 		if !ok {
-			rslv, err = newResolver(url)
+			rslv, err = newResolver(url, dohOpts...)
 			if err != nil {
 				return nil, fmt.Errorf("bad resolver for %s: %w", domain, err)
 			}

--- a/core/node/dns.go
+++ b/core/node/dns.go
@@ -23,7 +23,7 @@ func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {
 		return nil, fmt.Errorf("invalid resolver url: %s", url)
 	}
 
-	return doh.NewResolver(url, opts...), nil
+	return doh.NewResolver(url, opts...)
 }
 
 func DNSResolver(cfg *config.Config) (*madns.Resolver, error) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -140,7 +140,8 @@ config file at runtime.
     - [`Swarm.Transports.Multiplexers.Yamux`](#swarmtransportsmultiplexersyamux)
     - [`Swarm.Transports.Multiplexers.Mplex`](#swarmtransportsmultiplexersmplex)
   - [`DNS`](#dns)
-  - [`DNS.Resolvers`](#dnsresolvers)
+    - [`DNS.Resolvers`](#dnsresolvers)
+    - [`DNS.MaxCacheTTL`](#dnsmaxcachettl)
 
 
 
@@ -1757,7 +1758,7 @@ Type: `priority`
 
 Options for configuring DNS resolution for [DNSLink](https://docs.ipfs.io/concepts/dnslink/) and `/dns*` [Multiaddrs](https://github.com/multiformats/multiaddr/).
 
-## `DNS.Resolvers`
+### `DNS.Resolvers`
 
 Map of [FQDNs](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) to custom resolver URLs.
 
@@ -1793,3 +1794,17 @@ Be mindful that:
 Default: `{}`
 
 Type: `object[string -> string]`
+
+### `DNS.MaxCacheTTL`
+
+Maximum duration entries are valid in the cache.
+
+This allows to cap the Time-To-Live suggested by the DNS response. This includes resolution of DNSLink captured by the custom resolver URLs.
+
+**Examples:**
+* `"5m"` DNS entries are kept for 5 minutes or less.
+* `"0s"` DNS entries expire as soon as they are retrieved.
+
+Default: Respect DNS Response TTL
+
+Type: `optionalDuration`

--- a/docs/config.md
+++ b/docs/config.md
@@ -1797,12 +1797,12 @@ Type: `object[string -> string]`
 
 ### `DNS.MaxCacheTTL`
 
-Maximum duration entries are valid in the DoH cache.
+Maximum duration for which entries are valid in the DoH cache.
 
-This allows to cap the Time-To-Live suggested by the DNS response ([RFC2181](https://datatracker.ietf.org/doc/html/rfc2181#section-8)).
+This allows you to cap the Time-To-Live suggested by the DNS response ([RFC2181](https://datatracker.ietf.org/doc/html/rfc2181#section-8)).
 If present, the upper bound is applied to DoH resolvers in [`DNS.Resolvers`](#dnsresolvers).
 
-Note: This does NOT work with OS-level resolver. To make this a global setting, add `.` entry to `DNS.Resolvers` first.
+Note: this does NOT work with Go's default DNS resolver. To make this a global setting, add a `.` entry to `DNS.Resolvers` first.
 
 **Examples:**
 * `"5m"` DNS entries are kept for 5 minutes or less.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1773,7 +1773,7 @@ Example:
       "eth.": "https://eth.link/dns-query",
       "crypto.": "https://resolver.unstoppable.io/dns-query",
       "libre.": "https://ns1.iriseden.fr/dns-query",
-      ".": "https://doh-ch.blahdns.com:4443/dns-query"
+      ".": "https://cloudflare-dns.com/dns-query"
     }
   }
 }
@@ -1786,7 +1786,7 @@ Be mindful that:
   ```json
   {
     "eth.": "https://resolver.cloudflare-eth.com/dns-query",
-    "crypto.": "https://resolver.cloudflare-eth.com/dns-query
+    "crypto.": "https://resolver.cloudflare-eth.com/dns-query"
   }
   ```
   To get all the benefits of a decentralized naming system we strongly suggest setting DoH endpoint to an empty string and running own decentralized resolver as catch-all one on localhost.
@@ -1797,9 +1797,12 @@ Type: `object[string -> string]`
 
 ### `DNS.MaxCacheTTL`
 
-Maximum duration entries are valid in the cache.
+Maximum duration entries are valid in the DoH cache.
 
-This allows to cap the Time-To-Live suggested by the DNS response. This includes resolution of DNSLink captured by the custom resolver URLs.
+This allows to cap the Time-To-Live suggested by the DNS response ([RFC2181](https://datatracker.ietf.org/doc/html/rfc2181#section-8)).
+If present, the upper bound is applied to DoH resolvers in [`DNS.Resolvers`](#dnsresolvers).
+
+Note: This does NOT work with OS-level resolver. To make this a global setting, add `.` entry to `DNS.Resolvers` first.
 
 **Examples:**
 * `"5m"` DNS entries are kept for 5 minutes or less.

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v1.1.2
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-cmds v0.6.0
-	github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398
+	github.com/ipfs/go-ipfs-config v0.19.0
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1
 	github.com/ipfs/go-ipfs-files v0.0.9

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
-	github.com/libp2p/go-doh-resolver v0.3.1
+	github.com/libp2p/go-doh-resolver v0.0.0-20211210150402-67a10ef63bf3
 	github.com/libp2p/go-libp2p v0.16.0
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.11.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v1.1.2
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-cmds v0.6.0
-	github.com/ipfs/go-ipfs-config v0.18.0
+	github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1
 	github.com/ipfs/go-ipfs-files v0.0.9
@@ -65,7 +65,7 @@ require (
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
-	github.com/libp2p/go-doh-resolver v0.0.0-20211210150402-67a10ef63bf3
+	github.com/libp2p/go-doh-resolver v0.4.0
 	github.com/libp2p/go-libp2p v0.16.0
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.6.0 h1:yAxdowQZzoFKjcLI08sXVNnqVj3jnABbf9smrPQmBsw=
 github.com/ipfs/go-ipfs-cmds v0.6.0/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
-github.com/ipfs/go-ipfs-config v0.18.0 h1:Ta1aNGNEq6RIvzbw7dqzCVZJKb7j+Dd35JFnAOCpT8g=
-github.com/ipfs/go-ipfs-config v0.18.0/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
+github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398 h1:/nmcZ+JtMNjjGNzthIdfHu51bI7wOBIy5tvUfGg7NPA=
+github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
@@ -673,9 +673,8 @@ github.com/libp2p/go-conn-security-multistream v0.2.0/go.mod h1:hZN4MjlNetKD3Rq5
 github.com/libp2p/go-conn-security-multistream v0.2.1/go.mod h1:cR1d8gA0Hr59Fj6NhaTpFhJZrjSYuNmhpT2r25zYR70=
 github.com/libp2p/go-conn-security-multistream v0.3.0 h1:9UCIKlBL1hC9u7nkMXpD1nkc/T53PKMAn3/k9ivBAVc=
 github.com/libp2p/go-conn-security-multistream v0.3.0/go.mod h1:EEP47t4fw/bTelVmEzIDqSe69hO/ip52xBEhZMLWAHM=
-github.com/libp2p/go-doh-resolver v0.0.0-20211210150402-67a10ef63bf3/go.mod h1:v1/jwsFusgsWIGX/c6vCRrnJ60x7bhTiq/fs2qt0cAg=
-github.com/libp2p/go-doh-resolver v0.3.1 h1:1wbVGkB4Tdj4WEvjAuYknOPyt4vSSDn9thnj13pKPaY=
-github.com/libp2p/go-doh-resolver v0.3.1/go.mod h1:y5go1ZppAq9N2eppbX0xON01CyPBeUg2yS6BTssssog=
+github.com/libp2p/go-doh-resolver v0.4.0 h1:gUBa1f1XsPwtpE1du0O+nnZCUqtG7oYi7Bb+0S7FQqw=
+github.com/libp2p/go-doh-resolver v0.4.0/go.mod h1:v1/jwsFusgsWIGX/c6vCRrnJ60x7bhTiq/fs2qt0cAg=
 github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=
 github.com/libp2p/go-eventbus v0.2.1 h1:VanAdErQnpTioN2TowqNcOijf6YwhuODe4pPKSDpxGc=
 github.com/libp2p/go-eventbus v0.2.1/go.mod h1:jc2S4SoEVPP48H9Wpzm5aiGwUCBMfGhVhhBjyhhCJs8=

--- a/go.sum
+++ b/go.sum
@@ -673,6 +673,7 @@ github.com/libp2p/go-conn-security-multistream v0.2.0/go.mod h1:hZN4MjlNetKD3Rq5
 github.com/libp2p/go-conn-security-multistream v0.2.1/go.mod h1:cR1d8gA0Hr59Fj6NhaTpFhJZrjSYuNmhpT2r25zYR70=
 github.com/libp2p/go-conn-security-multistream v0.3.0 h1:9UCIKlBL1hC9u7nkMXpD1nkc/T53PKMAn3/k9ivBAVc=
 github.com/libp2p/go-conn-security-multistream v0.3.0/go.mod h1:EEP47t4fw/bTelVmEzIDqSe69hO/ip52xBEhZMLWAHM=
+github.com/libp2p/go-doh-resolver v0.0.0-20211210150402-67a10ef63bf3/go.mod h1:v1/jwsFusgsWIGX/c6vCRrnJ60x7bhTiq/fs2qt0cAg=
 github.com/libp2p/go-doh-resolver v0.3.1 h1:1wbVGkB4Tdj4WEvjAuYknOPyt4vSSDn9thnj13pKPaY=
 github.com/libp2p/go-doh-resolver v0.3.1/go.mod h1:y5go1ZppAq9N2eppbX0xON01CyPBeUg2yS6BTssssog=
 github.com/libp2p/go-eventbus v0.1.0/go.mod h1:vROgu5cs5T7cv7POWlWxBaVLxfSegC5UGQf8A2eEmx4=

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.6.0 h1:yAxdowQZzoFKjcLI08sXVNnqVj3jnABbf9smrPQmBsw=
 github.com/ipfs/go-ipfs-cmds v0.6.0/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
-github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398 h1:/nmcZ+JtMNjjGNzthIdfHu51bI7wOBIy5tvUfGg7NPA=
-github.com/ipfs/go-ipfs-config v0.18.1-0.20220120190453-0a6e6d171398/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
+github.com/ipfs/go-ipfs-config v0.19.0 h1:OuKIL+BkOZgJ+hb4Wg/9ynCtE/BaZBWcGy8hgdMepAo=
+github.com/ipfs/go-ipfs-config v0.19.0/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-delay v0.0.1 h1:r/UXYyRcddO6thwOnhiznIAiSvxMECGgtv35Xs1IeRQ=
 github.com/ipfs/go-ipfs-delay v0.0.1/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=


### PR DESCRIPTION
Expose `WithMaxCacheTTL` option of go-doh-resolver within IPFS node config.
This allows to cap the Time-To-Live suggested by the DNS response. This includes resolution of DNSLink captured by the custom resolver URLs.

This change relies on [go-ipfs.config](https://github.com/ipfs/go-ipfs-config/pull/161) change. The change of go.mod and go.sum would have to be updated accordingly at this time.

Before merging, both go-doh-resolver and go-ipfs-config have to be updated.

Tagging @vyzo and @marten-seemann , as they reviewed the [go-doh-resolver change](https://github.com/libp2p/go-doh-resolver/pull/12).