### PR TITLE
feat: warn user when 'pin remote add' while offline

### DIFF
--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -185,6 +186,8 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 				return err
 			}
 			opts = append(opts, pinclient.PinOpts.WithOrigins(addrs...))
+		} else if isInBlockstore && node.PeerHost == nil {
+			fmt.Fprintf(os.Stdout, "Warning: the local node is offline and remote pinning may fail if there is no other provider\n")
 		}
 
 		// Execute remote pin request

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -186,7 +186,7 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 				return err
 			}
 			opts = append(opts, pinclient.PinOpts.WithOrigins(addrs...))
-		} else if isInBlockstore && node.PeerHost == nil {
+		} else if isInBlockstore && !node.IsOnline {
 			fmt.Fprintf(os.Stdout, "Warning: the local node is offline and remote pinning may fail if there is no other provider\n")
 		}
 

--- a/core/commands/pin/remotepin.go
+++ b/core/commands/pin/remotepin.go
@@ -186,8 +186,8 @@ NOTE: a comma-separated notation is supported in CLI for convenience:
 				return err
 			}
 			opts = append(opts, pinclient.PinOpts.WithOrigins(addrs...))
-		} else if isInBlockstore && !node.IsOnline {
-			fmt.Fprintf(os.Stdout, "Warning: the local node is offline and remote pinning may fail if there is no other provider\n")
+		} else if isInBlockstore && !node.IsOnline && cmds.GetEncoding(req, cmds.Text) == cmds.Text {
+			fmt.Fprintf(os.Stdout, "WARNING: the local node is offline and remote pinning may fail if there is no other provider for this CID\n")
 		}
 
 		// Execute remote pin request

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -319,6 +319,14 @@ test_remote_pins() {
 test_remote_pins ""
 
 test_kill_ipfs_daemon
+
+test_expect_success "'ipfs pin remote add' shows the warning message while offline" '
+  test_expect_code 0 ipfs pin remote add --service=test_pin_svc --enc=json $BASE_ARGS --name=name_a $HASH_A > actual &&
+  echo "Warning: the local node is offline and remote pinning may fail if there is no other provider" > expected &&
+  echo "{\"Status\":\"pinned\",\"Cid\":\"$HASH_A\",\"Name\":\"name_a\"}" >> expected &&
+  test_cmp expected actual
+'
+
 test_done
 
 # vim: ts=2 sw=2 sts=2 et:

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -320,10 +320,10 @@ test_remote_pins ""
 
 test_kill_ipfs_daemon
 
-WARNINGMESSAGE="Warning: the local node is offline and remote pinning may fail if there is no other provider"
+WARNINGMESSAGE="WARNING: the local node is offline and remote pinning may fail if there is no other provider for this CID"
 
 test_expect_success "'ipfs pin remote add' shows the warning message while offline" '
-  test_expect_code 0 ipfs pin remote add --service=test_pin_svc --enc=json $BASE_ARGS --name=name_a $HASH_A > actual &&
+  test_expect_code 0 ipfs pin remote add --service=test_pin_svc --background $BASE_ARGS --name=name_a  $HASH_A > actual &&
   test_expect_code 0 grep -q "$WARNINGMESSAGE" actual
 '
 

--- a/test/sharness/t0700-remotepin.sh
+++ b/test/sharness/t0700-remotepin.sh
@@ -320,11 +320,11 @@ test_remote_pins ""
 
 test_kill_ipfs_daemon
 
+WARNINGMESSAGE="Warning: the local node is offline and remote pinning may fail if there is no other provider"
+
 test_expect_success "'ipfs pin remote add' shows the warning message while offline" '
   test_expect_code 0 ipfs pin remote add --service=test_pin_svc --enc=json $BASE_ARGS --name=name_a $HASH_A > actual &&
-  echo "Warning: the local node is offline and remote pinning may fail if there is no other provider" > expected &&
-  echo "{\"Status\":\"pinned\",\"Cid\":\"$HASH_A\",\"Name\":\"name_a\"}" >> expected &&
-  test_cmp expected actual
+  test_expect_code 0 grep -q "$WARNINGMESSAGE" actual
 '
 
 test_done


### PR DESCRIPTION
Resolves #8418 

The warning is printed only when being online matters (if CID to be pinned remotely is in a local store)