### PR TITLE
ipfs files add

### DIFF
--- a/core/commands/commands_test.go
+++ b/core/commands/commands_test.go
@@ -129,6 +129,7 @@ func TestCommands(t *testing.T) {
 		"/file",
 		"/file/ls",
 		"/files",
+		"/files/add",
 		"/files/chcid",
 		"/files/cp",
 		"/files/flush",

--- a/core/commands/files.go
+++ b/core/commands/files.go
@@ -1456,7 +1456,7 @@ likewise, files can be seen with human-readable names in the MFS.
 				src := p.String()
 				dst := dstBase
 				if dst[len(dst)-1] == '/' {
-					dst += gopath.Base(src)
+					dst += gopath.Base(addit.Name())
 				}
 
 				node, err := getNodeFromPath(req.Context, nd, api, src)

--- a/test/sharness/t0411-add-files-add.sh
+++ b/test/sharness/t0411-add-files-add.sh
@@ -13,23 +13,23 @@ test_launch_ipfs_daemon
 # Verify CIDS are the same
 test_expect_success "files add CID matches add CID" '
   DIR="/test-${RANDOM}"
-	ipfs files mkdir $DIR
+  ipfs files mkdir $DIR
 
   echo "hi" > f1
-	ADDCID=$(ipfs add -q f1)
-	FILESADDCID=$(ipfs files add -q $DIR/ f1)
-	test $ADDCID = $FILESADDCID
+  ADDCID=$(ipfs add -q f1)
+  FILESADDCID=$(ipfs files add -q $DIR/ f1)
+  test $ADDCID = $FILESADDCID
 '
 
 # verify files add does not result in a pin.
 test_expect_code 1 '
   DIR="/test-${RANDOM}"
-	ipfs files mkdir $DIR
+  ipfs files mkdir $DIR
 
-	echo "${RANDOM}" > f2
-	CID=$(ipfs files add -q $DIR/ f2)
+  echo "${RANDOM}" > f2
+  CID=$(ipfs files add -q $DIR/ f2)
 
-	ipfs pin ls | grep $CID
+  ipfs pin ls | grep $CID
 '
 test_kill_ipfs_daemon
 

--- a/test/sharness/t0411-add-files-add.sh
+++ b/test/sharness/t0411-add-files-add.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2016 Tom O'Donnell
-# MIT Licensed; see the LICENSE file in this repository.
-#
 
 test_description="Test files add and add commands"
 
@@ -20,8 +17,8 @@ test_expect_success "files add CID matches add CID" '
 
   echo "hi" > f1
 	ADDCID=$(ipfs add -q f1)
-	FILESADDCID=$(ipfs files add -q $DIR f1)
-	test_cmp ADDCID FILESADDCID
+	FILESADDCID=$(ipfs files add -q $DIR/ f1)
+	test $ADDCID = $FILESADDCID
 '
 
 # verify files add does not result in a pin.
@@ -37,3 +34,4 @@ test_expect_code 1 '
 test_kill_ipfs_daemon
 
 test_done
+

--- a/test/sharness/t0411-add-files-add.sh
+++ b/test/sharness/t0411-add-files-add.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2016 Tom O'Donnell
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test files add and add commands"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+
+test_launch_ipfs_daemon
+
+# Verify CIDS are the same
+test_expect_success "files add CID matches add CID" '
+  DIR="/test-${RANDOM}"
+	ipfs files mkdir $DIR
+
+  echo "hi" > f1
+	ADDCID=$(ipfs add -q f1)
+	FILESADDCID=$(ipfs files add -q $DIR f1)
+	test_cmp ADDCID FILESADDCID
+'
+
+# verify files add does not result in a pin.
+test_expect_code 1 '
+  DIR="/test-${RANDOM}"
+	ipfs files mkdir $DIR
+
+	echo "${RANDOM}" > f2
+	CID=$(ipfs files add -q $DIR/ f2)
+
+	ipfs pin ls | grep $CID
+'
+test_kill_ipfs_daemon
+
+test_done


### PR DESCRIPTION
fixes: https://github.com/ipfs/go-ipfs/issues/8504

adds command `ipfs files add` using mostly the same parameters as in `ipfs add`

This is functionally equivilent to running `ipfs add` followed by `ifps files cp` with some slightly different defautls.

* IPFS pinning is not enabled by default, although it is an option.
* Keeping with the pattern established for other files command, `-p` is for parent creation. The progress bar is moved to `-P` (capital) instead. Seems unfortunate; if this doesnt make sense, let me know what would be better.

* There is no wrap option. Although, I could be convinced that it should be included here. When adding a directory recursively, files are "wrapped" implicitly by the MFS directory that contains them. 

* Following the convention from cp command, if the destination ends in a forward slash, files are added under an MFS directory such that many files can be added like this:

```
ipfs files add /mfs/path/ file1 file2 file3...
```

The two encantations, although similar, result in a different dag for the containing directory. This is a subtle difference that might be confusing, maybe there is a better way to go about it.


Recursive adds
```
Ξ ~ → ipfs files add -rp /d1 website 
added QmeEte3ZFyKA4yhiQTnBP2x2XTxdDfZzivUiX86xqGT42X website/image.jpg
added QmdXozHCMxfsps9exhLPCzoJq2VeVRkZtuD6KLev7JhfSB website/index.html
added QmfGCw7KQkYGnVbz2h7d3T4TGCpDNza32NqUyoV8zqhWFr website
```

Adding several files with implicit directory creation
```
Ξ ~ → ipfs files add -p /d2/ website/*
added QmeEte3ZFyKA4yhiQTnBP2x2XTxdDfZzivUiX86xqGT42X image.jpg
added QmdXozHCMxfsps9exhLPCzoJq2VeVRkZtuD6KLev7JhfSB index.html
```

Results:
```
Ξ ~ → ipfs files ls -l /
d1/	QmfGCw7KQkYGnVbz2h7d3T4TGCpDNza32NqUyoV8zqhWFr	0
d2/	bafybeih3om227lpu74wyc7zl3f4sddq4atwyv4b3abq6oowgoynkdyygce	0
Ξ ~ → ipfs files ls -l /d1
image.jpg	QmeEte3ZFyKA4yhiQTnBP2x2XTxdDfZzivUiX86xqGT42X	5
index.html	QmdXozHCMxfsps9exhLPCzoJq2VeVRkZtuD6KLev7JhfSB	48
Ξ ~ → ipfs files ls -l /d2
image.jpg	QmeEte3ZFyKA4yhiQTnBP2x2XTxdDfZzivUiX86xqGT42X	5
index.html	QmdXozHCMxfsps9exhLPCzoJq2VeVRkZtuD6KLev7JhfSB	48
```
