### PR TITLE
fix(ci): interop test parallelism

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -219,7 +219,7 @@ jobs:
     docker:
       - image: cimg/node:16.13.2
     parallelism: 4
-    resource_class: 2xlarge
+    resource_class: large
     steps:
       - *make_out_dirs
       - attach_workspace:
@@ -336,6 +336,7 @@ jobs:
           name: Installing dependencies
           command: |
             npm install
+            npx playwright install
           working_directory: ~/ipfs/go-ipfs/ipfs-webui
       - run:
           name: Running upstream tests (finish early if they fail)
@@ -351,6 +352,7 @@ jobs:
       - save_cache:
           key: v1-ipfs-webui-{{ checksum "~/ipfs/go-ipfs/ipfs-webui/package-lock.json" }}
           paths:
+            - ~/.cache/ms-playwright
             - ~/ipfs/go-ipfs/ipfs-webui/node_modules
   # We only run build as a test here. DockerHub images are built and published
   # by Github Action now: https://github.com/ipfs/go-ipfs/pull/8467

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -226,9 +226,9 @@ jobs:
           at: /tmp/circleci-workspace
       - restore_cache:
           keys:
-            - v1-ipfs-interop-{{ .Branch }}-{{ .Revision }}
-            - v1-ipfs-interop-{{ .Branch }}-
-            - v1-ipfs-interop-
+            - v1-interop-{{ .Branch }}-{{ .Revision }}
+            - v1-interop-{{ .Branch }}-
+            - v1-interop-
       - run:
           name: Installing dependencies
           command: |
@@ -251,7 +251,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
       - save_cache:
-          key: v1-ipfs-interop-{{ .Branch }}-{{ .Revision }}
+          key: v1-interop-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/ipfs/go-ipfs/interop/node_modules
   go-ipfs-api:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -224,6 +224,11 @@ jobs:
       - *make_out_dirs
       - attach_workspace:
           at: /tmp/circleci-workspace
+      - restore_cache:
+          keys:
+            - v1-ipfs-interop-{{ .Branch }}-{{ .Revision }}
+            - v1-ipfs-interop-{{ .Branch }}-
+            - v1-ipfs-interop-
       - run:
           name: Installing dependencies
           command: |
@@ -245,6 +250,10 @@ jobs:
             IPFS_GO_EXEC: /tmp/circleci-workspace/bin/ipfs
       - store_test_results:
           path: /tmp/test-results
+      - save_cache:
+          key: v1-ipfs-interop-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/ipfs/go-ipfs/interop/node_modules
   go-ipfs-api:
     executor: golang
     steps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -236,7 +236,7 @@ jobs:
           command: |
             mkdir -p /tmp/test-results/interop/
             export MOCHA_FILE="$(mktemp /tmp/test-results/interop/unit.XXXXXX.xml)"
-            npx ipfs-interop -- -t node -f $(sed -n -e "s|^require('\(.*\)')$|test/\1|p" node_modules/ipfs-interop/test/node.js | circleci tests split) -- --reporter mocha-circleci-reporter
+            npx ipfs-interop -- -t node -f $(sed -n -e "s|^import '\(.*\)'$|test/\1|p" node_modules/ipfs-interop/test/node.js | circleci tests split --split-by=timings) -- --reporter mocha-circleci-reporter
           working_directory: ~/ipfs/go-ipfs/interop
           environment:
             LIBP2P_TCP_REUSEPORT: false

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -219,6 +219,7 @@ jobs:
     docker:
       - image: cimg/go:1.16-node
     parallelism: 4
+    resource_class: medium
     steps:
       - *make_out_dirs
       - attach_workspace:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -219,7 +219,7 @@ jobs:
     docker:
       - image: cimg/go:1.16-node
     parallelism: 4
-    resource_class: medium
+    resource_class: 2xlarge
     steps:
       - *make_out_dirs
       - attach_workspace:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -217,7 +217,7 @@ jobs:
       - *store_gomod
   interop:
     docker:
-      - image: cimg/go:1.16-node
+      - image: cimg/node:16.13.2
     parallelism: 4
     resource_class: 2xlarge
     steps:

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -217,7 +217,7 @@ jobs:
       - *store_gomod
   interop:
     docker:
-      - image: cimg/node:16.13.2
+      - image: cimg/go:1.16-node
     parallelism: 4
     resource_class: large
     steps:


### PR DESCRIPTION
## Main fix

`parallelism: 4` on circleci broke when require got replaced with modern import statement in [ipfs-interop//test/node.js](https://github.com/ipfs/interop/blob/v8.0.0/test/node.js)
Since then, CI run all tests four times.. every time, taking more than it should :upside_down_face: 

This fix also makes the split smarter – based on timing of previous runs: https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timing-data which should shave some time, if some files take way longer than others.


##  TODO

- [x] fix parallelism (run 1/4  instead of 4x everything)
- [x] fix ipfs-webui (playwright install was missing)
- [x] NPM cache for faster install
- [x] fix Noise issues  (main suspect: https://github.com/ChainSafe/js-libp2p-noise/pull/129)