### PR TITLE
fix(build): Recognize Go Beta versions in makefile

### DIFF
--- a/bin/check_go_version
+++ b/bin/check_go_version
@@ -39,6 +39,6 @@ type ${GOCC} >/dev/null 2>&1 || die_upgrade "go is not installed or not in the P
 
 VERS_STR=$(${GOCC} version 2>&1) || die "'go version' failed with output: $VERS_STR"
 
-GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
+GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version.* go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
 
 check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "${GOCC}"

--- a/bin/check_go_version
+++ b/bin/check_go_version
@@ -39,6 +39,6 @@ type ${GOCC} >/dev/null 2>&1 || die_upgrade "go is not installed or not in the P
 
 VERS_STR=$(${GOCC} version 2>&1) || die "'go version' failed with output: $VERS_STR"
 
-GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version.* go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
+GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version.* go\([^[:space:]]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
 
 check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "${GOCC}"


### PR DESCRIPTION
* Closes https://github.com/ipfs/go-ipfs/issues/8672

This allows using `make install` with beta versions of Golang.

```yaml
go-ipfs version: 0.13.0-dev-653dbff13-dirty
Repo version: 12
System version: amd64/linux
Golang version: devel go1.18-becaeea119 Tue Dec 14 17:43:51 2021 +0000
```