### PR TITLE
Serve subdomain requests on path gateways

### DIFF
--- a/core/corehttp/hostname.go
+++ b/core/corehttp/hostname.go
@@ -132,8 +132,8 @@ func HostnameOption() ServeOption {
 				// Assemble original path prefix.
 				pathPrefix := "/" + ns + "/" + rootID
 
-				// Does this gateway _handle_ subdomains AND this path?
-				if !(gw.UseSubdomains && hasPrefix(pathPrefix, gw.Paths...)) {
+				// Does this gateway handle this path?
+				if !hasPrefix(pathPrefix, gw.Paths...) {
 					// If not, resource does not exist, return 404
 					http.NotFound(w, r)
 					return


### PR DESCRIPTION
Enables serving origin isolated subdomains on path gateways (without redirects). This allows a smoother transition to subdomain gateways since they can be tested prior to redirecting all path gateway traffic.