### PR TITLE
feat(cmds): add command output option

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -165,7 +165,7 @@ func mainRet() int {
 		}, nil
 	}
 
-	err = cli.Run(ctx, Root, os.Args, os.Stdin, os.Stdout, os.Stderr, buildEnv, makeExecutor)
+	err = cli.Run(ctx, Root, os.Args, os.Stdin, os.Stderr, buildEnv, makeExecutor)
 	if err != nil {
 		return 1
 	}

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -110,6 +110,7 @@ The CLI will exit with one of the following values:
 		cmds.OptionEncodingType,
 		cmds.OptionStreamChannels,
 		cmds.OptionTimeout,
+		cmds.OptionOutputFile,
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ipfs/go-graphsync v0.11.0
 	github.com/ipfs/go-ipfs-blockstore v1.1.2
 	github.com/ipfs/go-ipfs-chunker v0.0.5
-	github.com/ipfs/go-ipfs-cmds v0.6.0
+	github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220118161130-e68b50b9648c
 	github.com/ipfs/go-ipfs-config v0.18.0
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.6.0 h1:yAxdowQZzoFKjcLI08sXVNnqVj3jnABbf9smrPQmBsw=
 github.com/ipfs/go-ipfs-cmds v0.6.0/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
+github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220118161130-e68b50b9648c h1:jTebhgb+LZlqdCc6z6jKlG+WFb9T89/Uzq4pv0knhk8=
+github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220118161130-e68b50b9648c/go.mod h1:y0bflH6m4g6ary4HniYt98UqbrVnRxmRarzeMdLIUn0=
 github.com/ipfs/go-ipfs-config v0.18.0 h1:Ta1aNGNEq6RIvzbw7dqzCVZJKb7j+Dd35JFnAOCpT8g=
 github.com/ipfs/go-ipfs-config v0.18.0/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=


### PR DESCRIPTION
Placeholder applying https://github.com/ipfs/go-ipfs-cmds/pull/223 to add a command option to save output to a file.

Example test (should work with or without the daemon running):
```
BLOCK_PATH=/ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme

ipfs block get $BLOCK_PATH > shell_redirected_out

ipfs block get $BLOCK_PATH --command-output option_redirected_out

cmp shell_redirected_out option_redirected_out
```

Fixes https://github.com/ipfs/go-ipfs/issues/8335.