### PR TITLE
fix(ci): faster gobuild job

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -69,6 +69,7 @@ executors:
 jobs:
   gobuild:
     executor: golang
+    resource_class: 2xlarge+
     steps:
     - checkout
     - *make_out_dirs


### PR DESCRIPTION
I noticed `gobuild` takes nearly as much time as sharness.

This PR runs `gobuild` job with more vCPUs (20 instead of 3) and shaves off some time (~5m instead of ~11m, both with cache) without  the need for rewriting logic behind `make cmd/ipfs-try-build`