### PR TITLE
fix(cmds): option for progress bar in cat/get

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -106,6 +106,7 @@ var CatCmd = &cmds.Command{
 						var bar *pb.ProgressBar
 						bar, reader = progressBarForReader(os.Stderr, val, int64(res.Length()))
 						bar.Start()
+						defer bar.Finish()
 					}
 
 					err = re.Emit(reader)

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
 
+	"github.com/cheggaaa/pb"
 	"github.com/ipfs/go-ipfs-cmds"
 	"github.com/ipfs/go-ipfs-files"
 	"github.com/ipfs/interface-go-ipfs-core"
@@ -32,6 +33,7 @@ var CatCmd = &cmds.Command{
 	Options: []cmds.Option{
 		cmds.Int64Option(offsetOptionName, "o", "Byte offset to begin reading from."),
 		cmds.Int64Option(lengthOptionName, "l", "Maximum number of bytes to read."),
+		cmds.BoolOption(progressOptionName, "p", "Stream progress data.").WithDefault(true),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
 		api, err := cmdenv.GetApi(env, req)
@@ -96,8 +98,15 @@ var CatCmd = &cmds.Command{
 
 				switch val := v.(type) {
 				case io.Reader:
-					bar, reader := progressBarForReader(os.Stderr, val, int64(res.Length()))
-					bar.Start()
+					reader := val
+
+					req := res.Request()
+					progress, _ := req.Options[progressOptionName].(bool)
+					if progress {
+						var bar *pb.ProgressBar
+						bar, reader = progressBarForReader(os.Stderr, val, int64(res.Length()))
+						bar.Start()
+					}
 
 					err = re.Emit(reader)
 					if err != nil {

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -54,6 +54,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 		cmds.BoolOption(archiveOptionName, "a", "Output a TAR archive."),
 		cmds.BoolOption(compressOptionName, "C", "Compress the output with GZIP compression."),
 		cmds.IntOption(compressionLevelOptionName, "l", "The level of compression (1-9)."),
+		cmds.BoolOption(progressOptionName, "p", "Stream progress data.").WithDefault(true),
 	},
 	PreRun: func(req *cmds.Request, env cmds.Environment) error {
 		_, err := getCompressOptions(req)
@@ -114,6 +115,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 			}
 
 			archive, _ := req.Options[archiveOptionName].(bool)
+			progress, _ := req.Options[progressOptionName].(bool)
 
 			gw := getWriter{
 				Out:         os.Stdout,
@@ -121,6 +123,7 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 				Archive:     archive,
 				Compression: cmplvl,
 				Size:        int64(res.Length()),
+				Progress:    progress,
 			}
 
 			return gw.Write(outReader, outPath)
@@ -181,6 +184,7 @@ type getWriter struct {
 	Archive     bool
 	Compression int
 	Size        int64
+	Progress    bool
 }
 
 func (gw *getWriter) Write(r io.Reader, fpath string) error {
@@ -213,22 +217,29 @@ func (gw *getWriter) writeArchive(r io.Reader, fpath string) error {
 	defer file.Close()
 
 	fmt.Fprintf(gw.Out, "Saving archive to %s\n", fpath)
-	bar, barR := progressBarForReader(gw.Err, r, gw.Size)
-	bar.Start()
-	defer bar.Finish()
+	if gw.Progress {
+		var bar *pb.ProgressBar
+		bar, r = progressBarForReader(gw.Err, r, gw.Size)
+		bar.Start()
+		defer bar.Finish()
+	}
 
-	_, err = io.Copy(file, barR)
+	_, err = io.Copy(file, r)
 	return err
 }
 
 func (gw *getWriter) writeExtracted(r io.Reader, fpath string) error {
 	fmt.Fprintf(gw.Out, "Saving file(s) to %s\n", fpath)
-	bar := makeProgressBar(gw.Err, gw.Size)
-	bar.Start()
-	defer bar.Finish()
-	defer bar.Set64(gw.Size)
+	var progressCb func(int64) int64
+	if gw.Progress {
+		bar := makeProgressBar(gw.Err, gw.Size)
+		bar.Start()
+		defer bar.Finish()
+		defer bar.Set64(gw.Size)
+		progressCb = bar.Add64
+	}
 
-	extractor := &tar.Extractor{Path: fpath, Progress: bar.Add64}
+	extractor := &tar.Extractor{Path: fpath, Progress: progressCb}
 	return extractor.Extract(r)
 }
 


### PR DESCRIPTION
Add a `-p=false` flag to not show the progress bar (true by default to keep the current behavior).

Closes https://github.com/ipfs/go-ipfs/issues/8470.