### PR TITLE
fix: allow ipfs-companion browser extension to access RPC API

### DIFF
--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -44,6 +44,9 @@ var defaultLocalhostOrigins = []string{
 	"https://[::1]:<port>",
 	"http://localhost:<port>",
 	"https://localhost:<port>",
+}
+
+var companionBrowserExtensionOrigins = []string{
 	"chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch", // ipfs-companion
 	"chrome-extension://hjoieblefckbooibpepigmacodalfndh", // ipfs-companion-beta
 }
@@ -86,10 +89,9 @@ func addHeadersFromConfig(c *cmdsHttp.ServerConfig, nc *config.Config) {
 }
 
 func addCORSDefaults(c *cmdsHttp.ServerConfig) {
-	// by default use localhost origins
-	if len(c.AllowedOrigins()) == 0 {
-		c.SetAllowedOrigins(defaultLocalhostOrigins...)
-	}
+	// always safelist certain origins
+	c.AppendAllowedOrigins(defaultLocalhostOrigins...)
+	c.AppendAllowedOrigins(companionBrowserExtensionOrigins...)
 
 	// by default, use GET, PUT, POST
 	if len(c.AllowedMethods()) == 0 {

--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -44,6 +44,8 @@ var defaultLocalhostOrigins = []string{
 	"https://[::1]:<port>",
 	"http://localhost:<port>",
 	"https://localhost:<port>",
+	"chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch", // ipfs-companion
+	"chrome-extension://hjoieblefckbooibpepigmacodalfndh", // ipfs-companion-beta
 }
 
 func addCORSFromEnv(c *cmdsHttp.ServerConfig) {

--- a/test/sharness/t0401-api-browser-security.sh
+++ b/test/sharness/t0401-api-browser-security.sh
@@ -39,17 +39,18 @@ test_expect_success "browser is able to access API if Origin is the API port on 
   grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
 '
 
-test_expect_success "Companion extension is unable to access API with invalid Origin" '
+test_expect_success "Random browser extension is unable to access RPC API due to invalid Origin" '
   curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://invalidextensionid" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
   grep "HTTP/1.1 403 Forbidden" curl_output
 '
 
-test_expect_success "Companion extension is able to access API if Origin is the API port on localhost (ipv4)" '
+test_expect_success "Companion extension is able to access RPC API on localhost" '
   curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
+  cat curl_output &&
   grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
 '
 
-test_expect_success "Companion beta extension is able to access API if Origin is the API port on localhost (ipv4)" '
+test_expect_success "Companion beta extension is able to access API on localhost" '
   curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://hjoieblefckbooibpepigmacodalfndh" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
   grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
 '
@@ -63,6 +64,14 @@ test_expect_success "setting CORS in API.HTTPHeaders works via CLI" "
 "
 
 test_launch_ipfs_daemon
+
+test_expect_success "Companion extension is able to access RPC API even when custom Access-Control-Allow-Origin is set" '
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin | grep -q valid.example.com  &&
+  curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
+  cat curl_output &&
+  grep "HTTP/1.1 200 OK" curl_output &&
+  grep "$PEERID" curl_output
+'
 
 # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
 test_expect_success "OPTIONS with preflight request to API with CORS allowlist succeeds" '

--- a/test/sharness/t0401-api-browser-security.sh
+++ b/test/sharness/t0401-api-browser-security.sh
@@ -39,6 +39,21 @@ test_expect_success "browser is able to access API if Origin is the API port on 
   grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
 '
 
+test_expect_success "Companion extension is unable to access API with invalid Origin" '
+  curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://invalidextensionid" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
+  grep "HTTP/1.1 403 Forbidden" curl_output
+'
+
+test_expect_success "Companion extension is able to access API if Origin is the API port on localhost (ipv4)" '
+  curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://nibjojkomfdiaoajekhjakgkdhaomnch" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
+  grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
+'
+
+test_expect_success "Companion beta extension is able to access API if Origin is the API port on localhost (ipv4)" '
+  curl -sD - -X POST -A "Mozilla" -H "Origin: chrome-extension://hjoieblefckbooibpepigmacodalfndh" "http://127.0.0.1:$API_PORT/api/v0/id" >curl_output &&
+  grep "HTTP/1.1 200 OK" curl_output && grep "$PEERID" curl_output
+'
+
 test_kill_ipfs_daemon
 
 test_expect_success "setting CORS in API.HTTPHeaders works via CLI" "


### PR DESCRIPTION
- fixes #8689
- Adds the chrome-extension ids for ipfs-companion and
ipfs-companion-beta to the allowed origins list, this
allows us to accesss ipfs api from a manifest v3 extension.
- added tests in t0401-api-browser-security.sh