### PR TITLE
feat(cmds): add command status

### DIFF
--- a/core/commands/object/diff.go
+++ b/core/commands/object/diff.go
@@ -85,6 +85,8 @@ Example:
 
 		return cmds.EmitOnce(res, &Changes{out})
 	},
+	Status: cmds.Deprecated,
+
 	Type: Changes{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *Changes) error {

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -103,6 +103,7 @@ is the raw data of the object.
 
 		return res.Emit(data)
 	},
+	Status: cmds.Deprecated,
 }
 
 // ObjectLinksCmd object links command
@@ -177,6 +178,8 @@ multihash. Provided for legacy reasons. Use 'ipfs dag get' instead.
 		}),
 	},
 	Type: &Object{},
+	Status: cmds.Experimental,
+
 }
 
 // ObjectGetCmd object get command
@@ -268,6 +271,8 @@ DEPRECATED and provided for legacy reasons. Use 'ipfs dag get' instead.
 			return err
 		}),
 	},
+	Status: cmds.Experimental,
+
 }
 
 // ObjectStatCmd object stat command

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ipfs/go-graphsync v0.11.0
 	github.com/ipfs/go-ipfs-blockstore v1.1.2
 	github.com/ipfs/go-ipfs-chunker v0.0.5
-	github.com/ipfs/go-ipfs-cmds v0.6.0
+	github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220201141850-01819a11065d
 	github.com/ipfs/go-ipfs-config v0.18.0
 	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ github.com/ipfs/go-ipfs-chunker v0.0.5 h1:ojCf7HV/m+uS2vhUGWcogIIxiO5ubl5O57Q7Na
 github.com/ipfs/go-ipfs-chunker v0.0.5/go.mod h1:jhgdF8vxRHycr00k13FM8Y0E+6BoalYeobXmUyTreP8=
 github.com/ipfs/go-ipfs-cmds v0.6.0 h1:yAxdowQZzoFKjcLI08sXVNnqVj3jnABbf9smrPQmBsw=
 github.com/ipfs/go-ipfs-cmds v0.6.0/go.mod h1:ZgYiWVnCk43ChwoH8hAmI1IRbuVtq3GSTHwtRB/Kqhk=
+github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220201141850-01819a11065d h1:FM5C1ZxLHZADZ/L0nHs6uaJq4MVgboNRvEtw07256Ns=
+github.com/ipfs/go-ipfs-cmds v0.6.1-0.20220201141850-01819a11065d/go.mod h1:y0bflH6m4g6ary4HniYt98UqbrVnRxmRarzeMdLIUn0=
 github.com/ipfs/go-ipfs-config v0.18.0 h1:Ta1aNGNEq6RIvzbw7dqzCVZJKb7j+Dd35JFnAOCpT8g=
 github.com/ipfs/go-ipfs-config v0.18.0/go.mod h1:wz2lKzOjgJeYJa6zx8W9VT7mz+iSd0laBMqS/9wmX6A=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=


### PR DESCRIPTION
Placeholder PR to visualize https://github.com/ipfs/go-ipfs-cmds/pull/225 for now.

```
$ ipfs object

[...]
EXPERIMENTAL SUBCOMMANDS
  ipfs object get <key>   - Deprecated way to get and serialize the dag-pb node. Use 'dag get' instead
  ipfs object links <key> - Deprecated way to output links in the specified dag-pb object: use 'dag get' instead.

DEPRECATED SUBCOMMANDS
  ipfs object data <key>           - Deprecated way to read the raw bytes of a dag-pb object: use 'dag get' instead.
  ipfs object diff <obj_a> <obj_b> - Display the diff between two IPFS objects.

$ ipfs object data --help

WARNING:   DEPRECATED

USAGE
  ipfs object data <key> - Deprecated way to read the raw bytes of a dag-pb object: use 'dag get' instead.
