### PR TITLE
feat: ipfs-webui v2.15

### DIFF
--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,7 +1,7 @@
 package corehttp
 
 // TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeiet6eoo4vjqev7cj5qczqwk6f7ao6pjtmj3uu3kfezldugi5eizei" // v2.14.0
+const WebUIPath = "/ipfs/bafybeiednzu62vskme5wpoj4bjjikeg3xovfpp4t7vxk5ty2jxdi4mv4bu" // v2.15.0
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{

--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,11 +1,12 @@
 package corehttp
 
 // TODO: move to IPNS
-const WebUIPath = "/ipfs/bafybeihcyruaeza7uyjd6ugicbcrqumejf6uf353e5etdkhotqffwtguva" // v2.13.0
+const WebUIPath = "/ipfs/bafybeiet6eoo4vjqev7cj5qczqwk6f7ao6pjtmj3uu3kfezldugi5eizei" // v2.14.0
 
 // this is a list of all past webUI paths.
 var WebUIPaths = []string{
 	WebUIPath,
+	"/ipfs/bafybeihcyruaeza7uyjd6ugicbcrqumejf6uf353e5etdkhotqffwtguva",
 	"/ipfs/bafybeiflkjt66aetfgcrgvv75izymd5kc47g6luepqmfq6zsf5w6ueth6y",
 	"/ipfs/bafybeid26vjplsejg7t3nrh7mxmiaaxriebbm4xxrxxdunlk7o337m5sqq",
 	"/ipfs/bafybeif4zkmu7qdhkpf3pnhwxipylqleof7rl6ojbe7mq3fzogz6m4xk3i",


### PR DESCRIPTION
This bumps webui to latest release 

Release Notes: 
- https://github.com/ipfs/ipfs-webui/releases/tag/v2.14.0 (small bugfixes + support for permanent peering via peers screen)
- https://github.com/ipfs/ipfs-webui/releases/tag/v2.15.0 (remote pinning that works with rate-limited services like Pinata)

