### PR TITLE
fix: installation without sudo

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -6,7 +6,7 @@
 INSTALL_DIR=$(dirname $0)
 
 bin="$INSTALL_DIR/ipfs"
-binpaths="/usr/local/bin /usr/bin"
+binpaths="$HOME/.local/bin /usr/local/bin /usr/bin"
 
 # This variable contains a nonzero length string in case the script fails
 # because of missing write permissions.

--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -6,13 +6,15 @@
 INSTALL_DIR=$(dirname $0)
 
 bin="$INSTALL_DIR/ipfs"
-binpaths="$HOME/.local/bin /usr/local/bin /usr/bin"
+binpaths='/usr/local/bin /usr/bin $HOME/.local/bin'
 
 # This variable contains a nonzero length string in case the script fails
 # because of missing write permissions.
 is_write_perm_missing=""
 
-for binpath in $binpaths; do
+for raw in $binpaths; do
+  # Expand the $HOME variable.
+  binpath=$(eval echo "$raw")
   if mv "$bin" "$binpath/ipfs" ; then
     echo "Moved $bin to $binpath"
     exit 0


### PR DESCRIPTION
I think it's good practice that users don't need to run `sudo`
to install something just to try it out. With this change, the
local bin directory is tried first, which usually is also in the
`PATH`. This way the installation script can be run without
`sudo` and should still work.