### PR TITLE
Allow setting config in Docker containers

### DIFF
--- a/bin/container_daemon
+++ b/bin/container_daemon
@@ -53,4 +53,20 @@ else
 
 fi
 
+config_file=/ipfs-config
+if [ -e $config_file ]; then
+  echo "Loading extra config"
+  # Copy config as it will be r/o if its a mounted file
+  cp $config_file /tmp/config
+  # Ensure it has a trailing newline
+  tail -n1 /tmp/config | read -r _ || echo >> /tmp/config
+  while read -r config; do
+    regex="([a-zA-Z\.]+):(.*)"
+    name=$(echo "$config" | sed -En "s/$regex/\1/p")
+    value=$(echo "$config" | sed -En "s/$regex/\2/p")
+    echo "Setting $name to $value"
+    ipfs config --json "$name" "$value"
+  done < /tmp/config
+fi
+
 exec ipfs "$@"


### PR DESCRIPTION
This allows injecting config via a file, each line is the name of the config item (letters and dots) then a colon followed by a single line line of valid JSON (we dont validate it, but the container won't start if `go-ipfs` rejects it)

We run for each line
```
ipfs config --json "$name" "$value"
```

If you have this saved as `ipfs-config` 
```
Gateway.PublicGateways:{ "dweb.link": { "UseSubdomains": true, "Paths": ["/ipfs", "/ipns"]}}
Gateway.NoFetch:true
Gateway.NoDNSLink:true
```
(from the examples page)


```
docker build . -t go-ipfs && docker run --mount type=bind,source=`pwd`/ipfs-config,target=/ipfs-config go-ipfs
```

You should see:

```
ipfs version 0.13.0-dev
generating ED25519 keypair...done
peer identity: 12D3KooWLzVVSP2SdWM1piTMKRRWZH2mYnGd98ujfxvq9AMGUAm8
initializing IPFS node at /data/ipfs
to get started, enter:

	ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme

Loading extra config
Setting Gateway.PublicGateways to { "dweb.link": { "UseSubdomains": true, "Paths": ["/ipfs", "/ipns"]}}
Setting Gateway.NoFetch to true
Setting Gateway.NoDNSLink to true
Initializing daemon...
```
