### PR TITLE
feat: log multifetcher errors

### DIFF
--- a/repo/fsrepo/migrations/fetcher.go
+++ b/repo/fsrepo/migrations/fetcher.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -39,7 +40,8 @@ type limitReadCloser struct {
 
 // NewMultiFetcher creates a MultiFetcher with the given Fetchers.  The
 // Fetchers are tried in order ther passed to this function.
-func NewMultiFetcher(f ...Fetcher) Fetcher {
+func NewMultiFetcher(f ...Fetcher) *MultiFetcher {
+
 	mf := &MultiFetcher{
 		fetchers: make([]Fetcher, len(f)),
 	}
@@ -56,6 +58,7 @@ func (f *MultiFetcher) Fetch(ctx context.Context, ipfsPath string) (io.ReadClose
 		if err == nil {
 			return rc, nil
 		}
+		fmt.Printf("Error fetching: %s\n", err.Error())
 		errs = multierror.Append(errs, err)
 	}
 	return nil, errs


### PR DESCRIPTION
This is to make it easier to understand why the multifetcher is falling back to a different fetcher.


Example output from unit test:

```
Fetching with HTTP: "bad-url/ipns/dist.ipfs.io/versions"
Error fetching: http.DefaultClient.Do error: Get "bad-url/ipns/dist.ipfs.io/versions": unsupported protocol scheme ""
Fetching with HTTP: "http://127.0.0.1:33923/ipns/dist.ipfs.io/versions"
```