### PR TITLE
fix(ci): testground workflow hanging indefinitely

### DIFF
--- a/.github/workflows/testground-on-push.yml
+++ b/.github/workflows/testground-on-push.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: testground run
-        uses: coryschwartz/testground-github-action@v1.1
+        # restore the mainline once https://github.com/coryschwartz/testground-github-action/pull/2 is released
+        uses: galargh/testground-github-action@6bdc2d4f12280a3e0ec654fd75fe170d4b7931df
         timeout-minutes: 5
         with:
           backend_addr: ${{ matrix.backend_addr }}

--- a/.github/workflows/testground-on-push.yml
+++ b/.github/workflows/testground-on-push.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: testground run
         uses: coryschwartz/testground-github-action@v1.1
+        timeout-minutes: 5
         with:
           backend_addr: ${{ matrix.backend_addr }}
           backend_proto: ${{ matrix.backend_proto }}


### PR DESCRIPTION
Closes   #8731

Fixes hanging builds problem with https://github.com/coryschwartz/testground-github-action/pull/2 (detailed description of the problem and testing performed).

Additionally, it adds a 5 minutes timeout on testground jobs - they finish in ~2 minutes if everything goes smoothly.

I'll reenable the workflow after the fix is in place.