### PR TITLE
docs(changelog): update v0.12.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ As usual, this release includes important fixes, some of which may be critical f
 
 - `ipfs refs local` will now list all blocks as if they were [raw]() CIDv1 instead of with whatever CID version and IPLD codecs they were stored with. All other functionality should remain the same.
 
+Note: This change also effects [ipfs-update](https://github.com/ipfs/ipfs-update) so if you use that tool to mange your go-ipfs installation then grab ipfs-update v1.8.0 from [dist](https://dist.ipfs.io/#ipfs-update).
+
 Keep reading to learn more details.
 
 #### 🔦 Highlights


### PR DESCRIPTION
Add line to the breaking changes section indicating that there's a new version of ipfs-update needed to install go-ipfs v0.12.0.

I added this to the tag + GH issue, but didn't get it into the release notes before the tag.