### PR TITLE
feat: EnableHolePunching by default

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -245,7 +245,7 @@ jobs:
           command: |
             npm init -y
             npm install ipfs@^0.61.0
-            npm install ipfs-interop@^8.0.0
+            npm install ipfs-interop@^8.0.10
             npm install mocha-circleci-reporter@0.0.3
           working_directory: ~/ipfs/go-ipfs/interop
       - run:

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -69,9 +69,10 @@ func AutoRelay(staticRelays []string, peerChan <-chan peer.AddrInfo) func() (opt
 
 func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts, err error) {
 	return func() (opts Libp2pOpts, err error) {
-		if flag.WithDefault(false) {
+		if flag.WithDefault(true) {
 			if !hasRelayClient {
-				log.Fatal("To enable `Swarm.EnableHolePunching` requires `Swarm.RelayClient.Enabled` to be enabled.")
+				log.Fatal("Failed to enable `Swarm.EnableHolePunching`, it requires `Swarm.RelayClient.Enabled` to be true.")
+				return
 			}
 			opts.Opts = append(opts.Opts, libp2p.EnableHolePunching())
 		}

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -71,7 +71,11 @@ func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts
 	return func() (opts Libp2pOpts, err error) {
 		if flag.WithDefault(true) {
 			if !hasRelayClient {
-				log.Fatal("Failed to enable `Swarm.EnableHolePunching`, it requires `Swarm.RelayClient.Enabled` to be true.")
+				// If hole punching is explicitly enabled but the relay client is disabled then panic,
+				// otherwise just silently disable hole punching
+				if flag != config.Default {
+					log.Fatal("Failed to enable `Swarm.EnableHolePunching`, it requires `Swarm.RelayClient.Enabled` to be true.")
+				}
 				return
 			}
 			opts.Opts = append(opts.Opts, libp2p.EnableHolePunching())

--- a/core/node/libp2p/relay.go
+++ b/core/node/libp2p/relay.go
@@ -75,6 +75,8 @@ func HolePunching(flag config.Flag, hasRelayClient bool) func() (opts Libp2pOpts
 				// otherwise just silently disable hole punching
 				if flag != config.Default {
 					log.Fatal("Failed to enable `Swarm.EnableHolePunching`, it requires `Swarm.RelayClient.Enabled` to be true.")
+				} else {
+					log.Info("HolePunching has been disabled due to the RelayClient being disabled.")
 				}
 				return
 			}

--- a/docs/config.md
+++ b/docs/config.md
@@ -1383,7 +1383,7 @@ to [upgrade to a direct connection](https://github.com/libp2p/specs/blob/master/
 through a NAT/firewall whenever possible.
 This feature requires `Swarm.RelayClient.Enabled` to be set to `true`.
 
-Default: `false`
+Default: `true`
 
 Type: `flag`
 

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/libp2p/go-doh-resolver v0.4.0
-	github.com/libp2p/go-libp2p v0.19.0
+	github.com/libp2p/go-libp2p v0.19.1
 	github.com/libp2p/go-libp2p-connmgr v0.3.2-0.20220115145817-a7820a5879c7 // indirect
 	github.com/libp2p/go-libp2p-core v0.15.1
 	github.com/libp2p/go-libp2p-discovery v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/libp2p/go-libp2p v0.13.0/go.mod h1:pM0beYdACRfHO1WcJlp65WXyG2A6NqYM+t
 github.com/libp2p/go-libp2p v0.14.3/go.mod h1:d12V4PdKbpL0T1/gsUNN8DfgMuRPDX8bS2QxCZlwRH0=
 github.com/libp2p/go-libp2p v0.14.4/go.mod h1:EIRU0Of4J5S8rkockZM7eJp2S0UrCyi55m2kJVru3rM=
 github.com/libp2p/go-libp2p v0.16.0/go.mod h1:ump42BsirwAWxKzsCiFnTtN1Yc+DuPu76fyMX364/O4=
-github.com/libp2p/go-libp2p v0.19.0 h1:zosskMbaobL7UDCVLEe1m5CGs1TaFNFoN/M5XLiKg0U=
-github.com/libp2p/go-libp2p v0.19.0/go.mod h1:Ki9jJXLO2YqrTIFxofV7Twyd3INWPT97+r8hGt7XPjI=
+github.com/libp2p/go-libp2p v0.19.1 h1:ysBA1vDxhvgy9WmXpDeuk082EakewbJAwfU+ApdTG6I=
+github.com/libp2p/go-libp2p v0.19.1/go.mod h1:Ki9jJXLO2YqrTIFxofV7Twyd3INWPT97+r8hGt7XPjI=
 github.com/libp2p/go-libp2p-asn-util v0.0.0-20200825225859-85005c6cf052/go.mod h1:nRMRTab+kZuk0LnKZpxhOVH/ndsdr2Nr//Zltc/vwgo=
 github.com/libp2p/go-libp2p-asn-util v0.1.0/go.mod h1:wu+AnM9Ii2KgO5jMmS1rz9dvzTdj8BXqsPR9HR0XB7I=
 github.com/libp2p/go-libp2p-asn-util v0.2.0 h1:rg3+Os8jbnO5DxkC7K/Utdi+DkY3q/d1/1q+8WeNAsw=


### PR DESCRIPTION
This PR continues epic from https://github.com/ipfs/go-ipfs/pull/8562:
- [x] changes the implicit default in ` Swarm.EnableHolePunching` to `true`.
  - This enables the  [Direct Connection Upgrade through Relay (DCUtR)](https://github.com/libp2p/specs/blob/master/relay/DCUtR.md) client (introduced in 0.11: https://github.com/ipfs/go-ipfs/pull/8562, [docs](https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#swarmenableholepunching)).
- [x] fix ipfs-interop to account for `EnableHolePunching` requiring `RelayClient` to be enabled
  -  needs https://github.com/ipfs/interop/pull/443
- [x] switch to go-libp2p with relay discovery logic
  - rebase on top of  https://github.com/ipfs/go-ipfs/pull/8868
- [x] fix panic in tests 
  ```
  ipfsfetcher_test.go
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1533fd9]
  ```
  - upstream bug: https://github.com/libp2p/go-libp2p/issues/1448
    - potential fix: https://github.com/libp2p/go-libp2p/pull/1467
