### PR TITLE
fix(fsrepo): deep merge when setting config

### DIFF
--- a/repo/common/common.go
+++ b/repo/common/common.go
@@ -21,7 +21,13 @@ func MapGetKV(v map[string]interface{}, key string) (interface{}, error) {
 
 		cursor, ok = mcursor[part]
 		if !ok {
-			return nil, fmt.Errorf("%s key has no attributes", sofar)
+			// Construct the current path traversed to print a nice error message
+			var path string
+			if len(sofar) > 0 {
+				path += sofar + "."
+			}
+			path += part
+			return nil, fmt.Errorf("%s not found", path)
 		}
 	}
 	return cursor, nil

--- a/repo/common/common.go
+++ b/repo/common/common.go
@@ -54,3 +54,33 @@ func MapSetKV(v map[string]interface{}, key string, value interface{}) error {
 	}
 	return nil
 }
+
+// Merges the right map into the left map, recursively traversing child maps
+// until a non-map value is found
+func MapMergeDeep(left, right map[string]interface{}) map[string]interface{} {
+	// We want to alter a copy of the map, not the original
+	result := make(map[string]interface{})
+	for k, v := range left {
+		result[k] = v
+	}
+
+	for key, rightVal := range right {
+		// If right value is a map
+		if rightMap, ok := rightVal.(map[string]interface{}); ok {
+			// If key is in left
+			if leftVal, found := result[key]; found {
+				// If left value is also a map
+				if leftMap, ok := leftVal.(map[string]interface{}); ok {
+					// Merge nested map
+					result[key] = MapMergeDeep(leftMap, rightMap)
+					continue
+				}
+			}
+		}
+
+		// Otherwise set new value to result
+		result[key] = rightVal
+	}
+
+	return result
+}

--- a/repo/common/common_test.go
+++ b/repo/common/common_test.go
@@ -1,0 +1,132 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-ipfs/thirdparty/assert"
+)
+
+func TestMapMergeDeepReturnsNew(t *testing.T) {
+	leftMap := make(map[string]interface{})
+	leftMap["A"] = "Hello World"
+
+	rightMap := make(map[string]interface{})
+	rightMap["A"] = "Foo"
+
+	MapMergeDeep(leftMap, rightMap)
+
+	assert.True(leftMap["A"] == "Hello World", t, "MapMergeDeep should return a new map instance")
+}
+
+func TestMapMergeDeepNewKey(t *testing.T) {
+	leftMap := make(map[string]interface{})
+	leftMap["A"] = "Hello World"
+	/*
+		leftMap
+		{
+			A: "Hello World"
+		}
+	*/
+
+	rightMap := make(map[string]interface{})
+	rightMap["B"] = "Bar"
+	/*
+		rightMap
+		{
+			B: "Bar"
+		}
+	*/
+
+	result := MapMergeDeep(leftMap, rightMap)
+	/*
+		expected
+		{
+			A: "Hello World"
+			B: "Bar"
+		}
+	*/
+
+	assert.True(result["B"] == "Bar", t, "New keys in right map should exist in resulting map")
+}
+
+func TestMapMergeDeepRecursesOnMaps(t *testing.T) {
+	leftMapA := make(map[string]interface{})
+	leftMapA["B"] = "A value!"
+	leftMapA["C"] = "Another value!"
+
+	leftMap := make(map[string]interface{})
+	leftMap["A"] = leftMapA
+	/*
+		leftMap
+		{
+			A: {
+				B: "A value!"
+				C: "Another value!"
+			}
+		}
+	*/
+
+	rightMapA := make(map[string]interface{})
+	rightMapA["C"] = "A different value!"
+
+	rightMap := make(map[string]interface{})
+	rightMap["A"] = rightMapA
+	/*
+		rightMap
+		{
+			A: {
+				C: "A different value!"
+			}
+		}
+	*/
+
+	result := MapMergeDeep(leftMap, rightMap)
+	/*
+		expected
+		{
+			A: {
+				B: "A value!"
+				C: "A different value!"
+			}
+		}
+	*/
+
+	resultA := result["A"].(map[string]interface{})
+	assert.True(resultA["B"] == "A value!", t, "Unaltered values should not change")
+	assert.True(resultA["C"] == "A different value!", t, "Nested values should be altered")
+}
+
+func TestMapMergeDeepRightNotAMap(t *testing.T) {
+	leftMapA := make(map[string]interface{})
+	leftMapA["B"] = "A value!"
+
+	leftMap := make(map[string]interface{})
+	leftMap["A"] = leftMapA
+	/*
+		origMap
+		{
+			A: {
+				B: "A value!"
+			}
+		}
+	*/
+
+	rightMap := make(map[string]interface{})
+	rightMap["A"] = "Not a map!"
+	/*
+		newMap
+		{
+			A: "Not a map!"
+		}
+	*/
+
+	result := MapMergeDeep(leftMap, rightMap)
+	/*
+		expected
+		{
+			A: "Not a map!"
+		}
+	*/
+
+	assert.True(result["A"] == "Not a map!", t, "Right values that are not a map should be set on the result")
+}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -559,10 +559,8 @@ func (r *FSRepo) setConfigUnsynced(updated *config.Config) error {
 	if err != nil {
 		return err
 	}
-	for k, v := range m {
-		mapconf[k] = v
-	}
-	if err := serialize.WriteConfigFile(configFilename, mapconf); err != nil {
+	mergedMap := common.MapMergeDeep(mapconf, m)
+	if err := serialize.WriteConfigFile(configFilename, mergedMap); err != nil {
 		return err
 	}
 	// Do not use `*r.config = ...`. This will modify the *shared* config

--- a/test/sharness/t0250-files-api.sh
+++ b/test/sharness/t0250-files-api.sh
@@ -876,7 +876,7 @@ test_expect_success "set up automatic sharding/unsharding data" '
 '
 
 # TODO: This does not need to report an error https://github.com/ipfs/go-ipfs/issues/8088
-test_expect_failure "reset automatic sharding" '
+test_expect_success "reset automatic sharding" '
   ipfs config --json Internal.UnixFSShardingSizeThreshold null
 '
 


### PR DESCRIPTION
## The Problem
Key retrieval for config keys that were flagged with the `omitempty` json encoding option would throw an error when setting/getting those keys when the values were considered empty.
```
$ ipfs config --json Swarm.DisableRelay true
$ ipfs config --json Swarm.DisableRelay false
Error: failed to get config value: "Swarm key has no attributes"
```
When a config key is set, a [config struct is being merged with a map read from disk](https://github.com/ipfs/go-ipfs/blob/v0.12.0/repo/fsrepo/fsrepo.go#L551-L564) to ensure user provided keys are not removed in the process of trying to write a valid config file. The merging implementation is only updating root keys, overwriting any child values in the map read from disk with the values in the map from the config struct. The problem with this being that the marshalling of a config struct to a map omits empty values. Upon retrieval, the key does not exist because the merge removes it.

From the [`encoding/json`](https://pkg.go.dev/encoding/json#Marshal) package in the Go docs: 
> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.

## The Solution
The merge when setting a config now does a deep merge of nested map properties. This ensures that nested properties that are flagged as 'omitempty' in the map created from the config struct are not touched, while all other values can be updated.

* Fixes #8088 
* Fixes #7482

## Additionally...
This PR includes a commit that improves the error response when a key is not found. Initially discussed in #8628, but ultimately including here.