### PR TITLE
fix prioritization of stream muxers

### DIFF
--- a/core/node/libp2p/libp2p.go
+++ b/core/node/libp2p/libp2p.go
@@ -58,7 +58,7 @@ type priorityOption struct {
 
 func prioritizeOptions(opts []priorityOption) libp2p.Option {
 	type popt struct {
-		priority int64
+		priority int64 // lower priority values mean higher priority
 		opt      libp2p.Option
 	}
 	enabledOptions := make([]popt, 0, len(opts))
@@ -71,7 +71,7 @@ func prioritizeOptions(opts []priorityOption) libp2p.Option {
 		}
 	}
 	sort.Slice(enabledOptions, func(i, j int) bool {
-		return enabledOptions[i].priority > enabledOptions[j].priority
+		return enabledOptions[i].priority < enabledOptions[j].priority
 	})
 	p2pOpts := make([]libp2p.Option, len(enabledOptions))
 	for i, opt := range enabledOptions {

--- a/core/node/libp2p/libp2p_test.go
+++ b/core/node/libp2p/libp2p_test.go
@@ -1,0 +1,58 @@
+package libp2p
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/libp2p/go-libp2p"
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrioritize(t *testing.T) {
+	// The option is encoded into the port number of a TCP multiaddr.
+	// By extracting the port numbers obtained from the applied option, we can make sure that
+	// prioritization sorted the options correctly.
+	newOption := func(num int) libp2p.Option {
+		return func(cfg *libp2p.Config) error {
+			cfg.ListenAddrs = append(cfg.ListenAddrs, ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", num)))
+			return nil
+		}
+	}
+
+	extractNums := func(cfg *libp2p.Config) []int {
+		addrs := cfg.ListenAddrs
+		nums := make([]int, 0, len(addrs))
+		for _, addr := range addrs {
+			_, comp := ma.SplitLast(addr)
+			num, err := strconv.Atoi(comp.Value())
+			require.NoError(t, err)
+			nums = append(nums, num)
+		}
+		return nums
+	}
+
+	t.Run("using default priorities", func(t *testing.T) {
+		opts := []priorityOption{
+			{defaultPriority: 200, opt: newOption(200)},
+			{defaultPriority: 1, opt: newOption(1)},
+			{defaultPriority: 300, opt: newOption(300)},
+		}
+		var cfg libp2p.Config
+		require.NoError(t, prioritizeOptions(opts)(&cfg))
+		require.Equal(t, extractNums(&cfg), []int{1, 200, 300})
+	})
+
+	t.Run("using custom priorities", func(t *testing.T) {
+		opts := []priorityOption{
+			{defaultPriority: 200, priority: 1, opt: newOption(1)},
+			{defaultPriority: 1, priority: 300, opt: newOption(300)},
+			{defaultPriority: 300, priority: 20, opt: newOption(20)},
+		}
+		var cfg libp2p.Config
+		require.NoError(t, prioritizeOptions(opts)(&cfg))
+		require.Equal(t, extractNums(&cfg), []int{1, 20, 300})
+	})
+}

--- a/core/node/libp2p/sec.go
+++ b/core/node/libp2p/sec.go
@@ -30,11 +30,11 @@ func Security(enabled bool, tptConfig config.Transports) interface{} {
 	return func() (opts Libp2pOpts) {
 		opts.Opts = append(opts.Opts, prioritizeOptions([]priorityOption{{
 			priority:        tptConfig.Security.TLS,
-			defaultPriority: 100,
+			defaultPriority: 200,
 			opt:             libp2p.Security(tls.ID, tls.New),
 		}, {
 			priority:        tptConfig.Security.Noise,
-			defaultPriority: 300,
+			defaultPriority: 100,
 			opt:             libp2p.Security(noise.ID, noise.New),
 		}}))
 		return opts


### PR DESCRIPTION
Looks like we've been prioritizing `mplex` over `yamux` since at least June 2020. This is really, really bad.