### PR TITLE
feat: add peer block filter option

### DIFF
--- a/core/node/bitswap.go
+++ b/core/node/bitswap.go
@@ -24,7 +24,7 @@ const (
 )
 
 // OnlineExchange creates new LibP2P backed block exchange (BitSwap)
-func OnlineExchange(cfg *config.Config, provide bool) interface{} {
+func OnlineExchange(cfg *config.Config, provide bool, pbrf bitswap.PeerBlockRequestFilter) interface{} {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host, rt routing.Routing, bs blockstore.GCBlockstore) exchange.Interface {
 		bitswapNetwork := network.NewFromIpfsHost(host, rt)
 
@@ -40,6 +40,11 @@ func OnlineExchange(cfg *config.Config, provide bool) interface{} {
 			bitswap.EngineTaskWorkerCount(int(internalBsCfg.EngineTaskWorkerCount.WithDefault(DefaultEngineTaskWorkerCount))),
 			bitswap.MaxOutstandingBytesPerPeer(int(internalBsCfg.MaxOutstandingBytesPerPeer.WithDefault(DefaultMaxOutstandingBytesPerPeer))),
 		}
+
+		if pbrf != nil {
+			opts = append(opts, bitswap.WithPeerBlockRequestFilter(pbrf))
+		}
+
 		exch := bitswap.New(helpers.LifecycleCtx(mctx, lc), bitswapNetwork, bs, opts...)
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {

--- a/core/node/builder.go
+++ b/core/node/builder.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/ipfs/go-bitswap"
 	"github.com/ipfs/go-ipfs/core/node/helpers"
 	"github.com/ipfs/go-ipfs/core/node/libp2p"
 	"github.com/ipfs/go-ipfs/repo"
@@ -40,6 +41,9 @@ type BuildCfg struct {
 	Routing libp2p.RoutingOption
 	Host    libp2p.HostOption
 	Repo    repo.Repo
+
+	// Bitswap
+	PeerBlockRequestFilter bitswap.PeerBlockRequestFilter
 }
 
 func (cfg *BuildCfg) getOpt(key string) bool {

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -281,9 +281,10 @@ func Online(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 
 	/* don't provide from bitswap when the strategic provider service is active */
 	shouldBitswapProvide := !cfg.Experimental.StrategicProviding
+	pbrf := bcfg.PeerBlockRequestFilter
 
 	return fx.Options(
-		fx.Provide(OnlineExchange(cfg, shouldBitswapProvide)),
+		fx.Provide(OnlineExchange(cfg, shouldBitswapProvide, pbrf)),
 		maybeProvide(Graphsync, cfg.Experimental.GraphsyncEnabled),
 		fx.Provide(DNSResolver),
 		fx.Provide(Namesys(ipnsCacheSize)),

--- a/docs/examples/go-ipfs-as-a-library/README.md
+++ b/docs/examples/go-ipfs-as-a-library/README.md
@@ -108,6 +108,6 @@ As a bonus, you can also find lines that show you how to spawn a node over your 
 - [Comment these lines](./main.go#L219-L223)
 - [Uncomment these lines](./main.go#L209-L216)
 
-## Voilá! You are now a go-ipfs hacker
+## Voilà! You are now a go-ipfs hacker
 
 You've learned how to spawn a go-ipfs node using the go-ipfs core API. There are many more [methods to experiment next](https://godoc.org/github.com/ipfs/interface-go-ipfs-core). Happy hacking!


### PR DESCRIPTION
This feature lets a user configure a filter to allow / deny bitswap requests according to the request's peer ID and the content id. For example, a user may use this option to implement a dynamic peer-based authorization.

Contributes to https://github.com/ipfs/go-ipfs/issues/8763,
Relates to https://github.com/ipfs/go-bitswap/pull/549

This PR adds the plumbing required to pass the peer-block filter option from ipfs down to go-bitswap.

- [ ] confirm with the team the way we pass the option is the right approach,
- [ ] confirm with the team where we want to document this,
   - we could advertise this as an experimental feature,
   - provide an example / demo of the feature in the docs/examples folder (like in [this demo](https://github.com/laurentsenta/go-ipfs/tree/feat/peer-block-filter-with-demo/docs/examples/go-ipfs-as-a-library))