### PR TITLE
feat: export rcmgr metrics to prometheus

### DIFF
--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -146,7 +146,6 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 
 		// Services (resource management)
 		fx.Provide(libp2p.ResourceManager(cfg.Swarm.ResourceMgr)),
-
 		fx.Provide(libp2p.AddrFilters(cfg.Swarm.AddrFilters)),
 		fx.Provide(libp2p.AddrsFactory(cfg.Addresses.Announce, cfg.Addresses.AppendAnnounce, cfg.Addresses.NoAnnounce)),
 		fx.Provide(libp2p.SmuxTransport(cfg.Swarm.Transports)),

--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -385,12 +385,12 @@ var (
 	rcmgrStreamBlocked       *prometheus.CounterVec
 	rcmgrPeerAllowed         prometheus.Counter
 	rcmgrPeerBlocked         prometheus.Counter
-	rcmgrProtocolAllowed     prometheus.Counter
-	rcmgrProtocolBlocked     prometheus.Counter
-	rcmgrProtocolPeerBlocked prometheus.Counter
-	rcmgrServiceAllowed      prometheus.Counter
-	rcmgrServiceBlocked      prometheus.Counter
-	rcmgrServicePeerBlocked  prometheus.Counter
+	rcmgrProtocolAllowed     *prometheus.CounterVec
+	rcmgrProtocolBlocked     *prometheus.CounterVec
+	rcmgrProtocolPeerBlocked *prometheus.CounterVec
+	rcmgrServiceAllowed      *prometheus.CounterVec
+	rcmgrServiceBlocked      *prometheus.CounterVec
+	rcmgrServicePeerBlocked  *prometheus.CounterVec
 	rcmgrMemoryAllowed       prometheus.Counter
 	rcmgrMemoryBlocked       prometheus.Counter
 )
@@ -399,6 +399,8 @@ func init() {
 	const (
 		direction = "direction"
 		usesFD    = "usesFD"
+		protocol  = "protocol"
+		service   = "service"
 	)
 
 	rcmgrConnAllowed = prometheus.NewCounterVec(
@@ -449,40 +451,58 @@ func init() {
 	})
 	prometheus.MustRegister(rcmgrPeerBlocked)
 
-	rcmgrProtocolAllowed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_protocols_allowed_total",
-		Help: "allowed streams attached to a protocol",
-	})
+	rcmgrProtocolAllowed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_protocols_allowed_total",
+			Help: "allowed streams attached to a protocol",
+		},
+		[]string{protocol},
+	)
 	prometheus.MustRegister(rcmgrProtocolAllowed)
 
-	rcmgrProtocolBlocked = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_protocols_blocked_total",
-		Help: "blocked streams attached to a protocol",
-	})
+	rcmgrProtocolBlocked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_protocols_blocked_total",
+			Help: "blocked streams attached to a protocol",
+		},
+		[]string{protocol},
+	)
 	prometheus.MustRegister(rcmgrProtocolBlocked)
 
-	rcmgrProtocolPeerBlocked = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_protocols_for_peer_blocked_total",
-		Help: "blocked streams attached to a protocol for a specific peer",
-	})
+	rcmgrProtocolPeerBlocked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_protocols_for_peer_blocked_total",
+			Help: "blocked streams attached to a protocol for a specific peer",
+		},
+		[]string{protocol},
+	)
 	prometheus.MustRegister(rcmgrProtocolPeerBlocked)
 
-	rcmgrServiceAllowed = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_services_allowed_total",
-		Help: "allowed streams attached to a service",
-	})
+	rcmgrServiceAllowed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_services_allowed_total",
+			Help: "allowed streams attached to a service",
+		},
+		[]string{service},
+	)
 	prometheus.MustRegister(rcmgrServiceAllowed)
 
-	rcmgrServiceBlocked = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_services_blocked_total",
-		Help: "blocked streams attached to a service",
-	})
+	rcmgrServiceBlocked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_services_blocked_total",
+			Help: "blocked streams attached to a service",
+		},
+		[]string{service},
+	)
 	prometheus.MustRegister(rcmgrServiceBlocked)
 
-	rcmgrServicePeerBlocked = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "libp2p_rcmgr_service_for_peer_blocked_total",
-		Help: "blocked streams attached to a service for a specific peer",
-	})
+	rcmgrServicePeerBlocked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "libp2p_rcmgr_service_for_peer_blocked_total",
+			Help: "blocked streams attached to a service for a specific peer",
+		},
+		[]string{service},
+	)
 	prometheus.MustRegister(rcmgrServicePeerBlocked)
 
 	rcmgrMemoryAllowed = prometheus.NewCounter(prometheus.CounterOpts{
@@ -535,28 +555,28 @@ func (r rcmgrMetrics) BlockPeer(_ peer.ID) {
 	rcmgrPeerBlocked.Add(1)
 }
 
-func (r rcmgrMetrics) AllowProtocol(_ protocol.ID) {
-	rcmgrProtocolAllowed.Add(1)
+func (r rcmgrMetrics) AllowProtocol(proto protocol.ID) {
+	rcmgrProtocolAllowed.WithLabelValues(string(proto)).Add(1)
 }
 
-func (r rcmgrMetrics) BlockProtocol(_ protocol.ID) {
-	rcmgrProtocolBlocked.Add(1)
+func (r rcmgrMetrics) BlockProtocol(proto protocol.ID) {
+	rcmgrProtocolBlocked.WithLabelValues(string(proto)).Add(1)
 }
 
-func (r rcmgrMetrics) BlockProtocolPeer(_ protocol.ID, _ peer.ID) {
-	rcmgrProtocolPeerBlocked.Add(1)
+func (r rcmgrMetrics) BlockProtocolPeer(proto protocol.ID, _ peer.ID) {
+	rcmgrProtocolPeerBlocked.WithLabelValues(string(proto)).Add(1)
 }
 
 func (r rcmgrMetrics) AllowService(svc string) {
-	rcmgrServiceAllowed.Add(1)
+	rcmgrServiceAllowed.WithLabelValues(svc).Add(1)
 }
 
 func (r rcmgrMetrics) BlockService(svc string) {
-	rcmgrServiceBlocked.Add(1)
+	rcmgrServiceBlocked.WithLabelValues(svc).Add(1)
 }
 
-func (r rcmgrMetrics) BlockServicePeer(_ string, _ peer.ID) {
-	rcmgrServicePeerBlocked.Add(1)
+func (r rcmgrMetrics) BlockServicePeer(svc string, _ peer.ID) {
+	rcmgrServicePeerBlocked.WithLabelValues(svc).Add(1)
 }
 
 func (r rcmgrMetrics) AllowMemory(_ int) {

--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -10,11 +10,15 @@ import (
 
 	config "github.com/ipfs/go-ipfs/config"
 	"github.com/ipfs/go-ipfs/repo"
+
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/fx"
 )
 
@@ -71,7 +75,7 @@ func ResourceManager(cfg config.ResourceMgr) func(fx.Lifecycle, repo.Repo) (netw
 
 			libp2p.SetDefaultServiceLimits(limiter)
 
-			var ropts []rcmgr.Option
+			ropts := []rcmgr.Option{rcmgr.WithMetrics(&rcmgrMetrics{})}
 			if os.Getenv("LIBP2P_DEBUG_RCMGR") != "" {
 				traceFilePath := filepath.Join(repoPath, NetLimitTraceFilename)
 				ropts = append(ropts, rcmgr.WithTrace(traceFilePath))
@@ -372,4 +376,141 @@ func NetSetLimit(mgr network.ResourceManager, scope string, limit config.Resourc
 	default:
 		return fmt.Errorf("invalid scope %q", scope)
 	}
+}
+
+var (
+	ServiceID, _  = tag.NewKey("svc")
+	ProtocolID, _ = tag.NewKey("proto")
+	Direction, _  = tag.NewKey("direction")
+	UseFD, _      = tag.NewKey("use_fd")
+	PeerID, _     = tag.NewKey("peer_id")
+)
+
+var (
+	RcmgrAllowConn      = stats.Int64("rcmgr/allow_conn", "Number of allowed connections", stats.UnitDimensionless)
+	RcmgrBlockConn      = stats.Int64("rcmgr/block_conn", "Number of blocked connections", stats.UnitDimensionless)
+	RcmgrAllowStream    = stats.Int64("rcmgr/allow_stream", "Number of allowed streams", stats.UnitDimensionless)
+	RcmgrBlockStream    = stats.Int64("rcmgr/block_stream", "Number of blocked streams", stats.UnitDimensionless)
+	RcmgrAllowPeer      = stats.Int64("rcmgr/allow_peer", "Number of allowed peer connections", stats.UnitDimensionless)
+	RcmgrBlockPeer      = stats.Int64("rcmgr/block_peer", "Number of blocked peer connections", stats.UnitDimensionless)
+	RcmgrAllowProto     = stats.Int64("rcmgr/allow_proto", "Number of allowed streams attached to a protocol", stats.UnitDimensionless)
+	RcmgrBlockProto     = stats.Int64("rcmgr/block_proto", "Number of blocked blocked streams attached to a protocol", stats.UnitDimensionless)
+	RcmgrBlockProtoPeer = stats.Int64("rcmgr/block_proto", "Number of blocked blocked streams attached to a protocol for a specific peer", stats.UnitDimensionless)
+	RcmgrAllowSvc       = stats.Int64("rcmgr/allow_svc", "Number of allowed streams attached to a service", stats.UnitDimensionless)
+	RcmgrBlockSvc       = stats.Int64("rcmgr/block_svc", "Number of blocked blocked streams attached to a service", stats.UnitDimensionless)
+	RcmgrBlockSvcPeer   = stats.Int64("rcmgr/block_svc", "Number of blocked blocked streams attached to a service for a specific peer", stats.UnitDimensionless)
+	RcmgrAllowMem       = stats.Int64("rcmgr/allow_mem", "Number of allowed memory reservations", stats.UnitDimensionless)
+	RcmgrBlockMem       = stats.Int64("rcmgr/block_mem", "Number of blocked memory reservations", stats.UnitDimensionless)
+)
+
+type rcmgrMetrics struct{}
+
+func (r rcmgrMetrics) AllowConn(dir network.Direction, usefd bool) {
+	ctx := context.Background()
+	if dir == network.DirInbound {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "inbound"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "outbound"))
+	}
+	if usefd {
+		ctx, _ = tag.New(ctx, tag.Upsert(UseFD, "true"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(UseFD, "false"))
+	}
+	stats.Record(ctx, RcmgrAllowConn.M(1))
+}
+
+func (r rcmgrMetrics) BlockConn(dir network.Direction, usefd bool) {
+	ctx := context.Background()
+	if dir == network.DirInbound {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "inbound"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "outbound"))
+	}
+	if usefd {
+		ctx, _ = tag.New(ctx, tag.Upsert(UseFD, "true"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(UseFD, "false"))
+	}
+	stats.Record(ctx, RcmgrBlockConn.M(1))
+}
+
+func (r rcmgrMetrics) AllowStream(p peer.ID, dir network.Direction) {
+	ctx := context.Background()
+	if dir == network.DirInbound {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "inbound"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "outbound"))
+	}
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrAllowStream.M(1))
+}
+
+func (r rcmgrMetrics) BlockStream(p peer.ID, dir network.Direction) {
+	ctx := context.Background()
+	if dir == network.DirInbound {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "inbound"))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(Direction, "outbound"))
+	}
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrBlockStream.M(1))
+}
+
+func (r rcmgrMetrics) AllowPeer(p peer.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrAllowPeer.M(1))
+}
+
+func (r rcmgrMetrics) BlockPeer(p peer.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrBlockPeer.M(1))
+}
+
+func (r rcmgrMetrics) AllowProtocol(proto protocol.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ProtocolID, string(proto)))
+	stats.Record(ctx, RcmgrAllowProto.M(1))
+}
+
+func (r rcmgrMetrics) BlockProtocol(proto protocol.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ProtocolID, string(proto)))
+	stats.Record(ctx, RcmgrBlockProto.M(1))
+}
+
+func (r rcmgrMetrics) BlockProtocolPeer(proto protocol.ID, p peer.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ProtocolID, string(proto)))
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrBlockProtoPeer.M(1))
+}
+
+func (r rcmgrMetrics) AllowService(svc string) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ServiceID, svc))
+	stats.Record(ctx, RcmgrAllowSvc.M(1))
+}
+
+func (r rcmgrMetrics) BlockService(svc string) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ServiceID, svc))
+	stats.Record(ctx, RcmgrBlockSvc.M(1))
+}
+
+func (r rcmgrMetrics) BlockServicePeer(svc string, p peer.ID) {
+	ctx := context.Background()
+	ctx, _ = tag.New(ctx, tag.Upsert(ServiceID, svc))
+	ctx, _ = tag.New(ctx, tag.Upsert(PeerID, p.Pretty()))
+	stats.Record(ctx, RcmgrBlockSvcPeer.M(1))
+}
+
+func (r rcmgrMetrics) AllowMemory(size int) {
+	stats.Record(context.Background(), RcmgrAllowMem.M(1))
+}
+
+func (r rcmgrMetrics) BlockMemory(size int) {
+	stats.Record(context.Background(), RcmgrBlockMem.M(1))
 }

--- a/go.mod
+++ b/go.mod
@@ -105,9 +105,6 @@ require (
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	go.opencensus.io v0.23.0
-	go.uber.org/dig v1.14.0
-	go.uber.org/fx v1.16.0
-	go.uber.org/zap v1.21.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.27.0
 	go.opentelemetry.io/otel v1.2.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.2.0
@@ -116,6 +113,9 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
 	go.opentelemetry.io/otel/trace v1.2.0
+	go.uber.org/dig v1.14.0
+	go.uber.org/fx v1.16.0
+	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211025112917-711f33c9992c


### PR DESCRIPTION
Part of #8761 

Adds basic metrics under `libp2p_rcmgr_*`


## Demo sample

````
# HELP libp2p_rcmgr_conns_allowed_total allowed connections
# TYPE libp2p_rcmgr_conns_allowed_total counter
libp2p_rcmgr_conns_allowed_total{direction="inbound",usesFD="false"} 682
libp2p_rcmgr_conns_allowed_total{direction="inbound",usesFD="true"} 614
libp2p_rcmgr_conns_allowed_total{direction="outbound",usesFD="false"} 7647
libp2p_rcmgr_conns_allowed_total{direction="outbound",usesFD="true"} 9107
# HELP libp2p_rcmgr_conns_blocked_total blocked connections
# TYPE libp2p_rcmgr_conns_blocked_total counter
libp2p_rcmgr_conns_blocked_total{direction="inbound",usesFD="false"} 2274
libp2p_rcmgr_conns_blocked_total{direction="inbound",usesFD="true"} 1938
libp2p_rcmgr_conns_blocked_total{direction="outbound",usesFD="false"} 15206
libp2p_rcmgr_conns_blocked_total{direction="outbound",usesFD="true"} 16344
# HELP libp2p_rcmgr_memory_allocations_allowed_total allowed memory allocations
# TYPE libp2p_rcmgr_memory_allocations_allowed_total counter
libp2p_rcmgr_memory_allocations_allowed_total 9808
# HELP libp2p_rcmgr_memory_allocations_blocked_total blocked memory allocations
# TYPE libp2p_rcmgr_memory_allocations_blocked_total counter
libp2p_rcmgr_memory_allocations_blocked_total 0
# HELP libp2p_rcmgr_peer_blocked_total blocked peers
# TYPE libp2p_rcmgr_peer_blocked_total counter
libp2p_rcmgr_peer_blocked_total 0
# HELP libp2p_rcmgr_peers_allowed_total allowed peers
# TYPE libp2p_rcmgr_peers_allowed_total counter
libp2p_rcmgr_peers_allowed_total 17416
# HELP libp2p_rcmgr_protocols_allowed_total allowed streams attached to a protocol
# TYPE libp2p_rcmgr_protocols_allowed_total counter
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/bitswap/1.1.0"} 23
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/bitswap/1.2.0"} 5065
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/id/1.0.0"} 6213
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/id/push/1.0.0"} 859
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/kad/1.0.0"} 4920
libp2p_rcmgr_protocols_allowed_total{protocol="/ipfs/ping/1.0.0"} 936
libp2p_rcmgr_protocols_allowed_total{protocol="/libp2p/autonat/1.0.0"} 11
libp2p_rcmgr_protocols_allowed_total{protocol="/libp2p/circuit/relay/0.1.0"} 29
libp2p_rcmgr_protocols_allowed_total{protocol="/p2p/id/delta/1.0.0"} 18
# HELP libp2p_rcmgr_services_allowed_total allowed streams attached to a service
# TYPE libp2p_rcmgr_services_allowed_total counter
libp2p_rcmgr_services_allowed_total{service="libp2p.autonat"} 11
libp2p_rcmgr_services_allowed_total{service="libp2p.identify"} 6247
libp2p_rcmgr_services_allowed_total{service="libp2p.ping"} 827
# HELP libp2p_rcmgr_services_blocked_total blocked streams attached to a service
# TYPE libp2p_rcmgr_services_blocked_total counter
libp2p_rcmgr_services_blocked_total{service="libp2p.ping"} 109
# HELP libp2p_rcmgr_streams_allowed_total allowed streams
# TYPE libp2p_rcmgr_streams_allowed_total counter
libp2p_rcmgr_streams_allowed_total{direction="inbound"} 9199
libp2p_rcmgr_streams_allowed_total{direction="outbound"} 9743
```