### PR TITLE
feat: rewrite dag stat to be awesomerer

### DIFF
--- a/core/commands/dag/dag.go
+++ b/core/commands/dag/dag.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	pinRootsOptionName = "pin-roots"
-	progressOptionName = "progress"
-	silentOptionName   = "silent"
-	statsOptionName    = "stats"
+	pinRootsOptionName      = "pin-roots"
+	progressOptionName      = "progress"
+	skipRawleavesOptionName = "skip-raw-leaves"
+	silentOptionName        = "silent"
+	statsOptionName         = "stats"
 )
 
 // DagCmd provides a subset of commands for interacting with ipld dag objects
@@ -305,6 +306,7 @@ Note: This command skips duplicate blocks in reporting both size and the number 
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption(progressOptionName, "p", "Return progressive data while reading through the DAG").WithDefault(true),
+		cmds.BoolOption(skipRawleavesOptionName, "s", "Skip raw leaves block when size is already known, faster but can lead to underestimating the size with malformed DAGs.").WithDefault(true),
 	},
 	Run:  dagStat,
 	Type: DagStat{},


### PR DESCRIPTION
Fixes #8794
Fixes #8791

Todo:
- [ ] Add tests!

This adds:
- skip-raw-leaves option, that avoids downloading raw leaves when you 
already know their size in the parrent block
- multithreaded download
- properly count blocks that show up multiple times with different 
multicodec
- do not count size of inlined blocks

Speed:
Way way faster (it's hard to make an objective number because that depends a lot on how much multithreading helps you and how many raw-leaves block you skip), in my case: `>100x` faster.