### PR TITLE
feat: re-enable docker sharness tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -154,7 +154,7 @@ jobs:
     working_directory: ~/ipfs/go-ipfs
     environment:
         <<: *default_environment
-        TEST_NO_DOCKER: 1
+        TEST_NO_DOCKER: 0
         TEST_NO_FUSE: 1
         TEST_VERBOSE: 1
     steps:

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ Dockerfile.fast
 !.git/refs/
 !.git/packed-refs
 test/sharness/lib/sharness/
+test/sharness/trash*
+rb-pinning-service-api/
 
 # The Docker client might not be running on Linux
 # so delete any compiled binaries

--- a/test/dependencies/pollEndpoint/main.go
+++ b/test/dependencies/pollEndpoint/main.go
@@ -2,7 +2,11 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"time"
 
@@ -15,6 +19,8 @@ var (
 	host    = flag.String("host", "/ip4/127.0.0.1/tcp/5001", "the multiaddr host to dial on")
 	tries   = flag.Int("tries", 10, "how many tries to make before failing")
 	timeout = flag.Duration("tout", time.Second, "how long to wait between attempts")
+	httpURL = flag.String("http-url", "", "HTTP URL to fetch")
+	httpOut = flag.Bool("http-out", false, "Print the HTTP response body to stdout")
 	verbose = flag.Bool("v", false, "verbose logging")
 )
 
@@ -37,18 +43,76 @@ func main() {
 	start := time.Now()
 	log.Debugf("starting at %s, tries: %d, timeout: %s, addr: %s", start, *tries, *timeout, addr)
 
-	for *tries > 0 {
+	connTries := *tries
+	for connTries > 0 {
 		c, err := manet.Dial(addr)
 		if err == nil {
 			log.Debugf("ok -  endpoint reachable with %d tries remaining, took %s", *tries, time.Since(start))
 			c.Close()
-			os.Exit(0)
+			break
 		}
 		log.Debug("connect failed: ", err)
 		time.Sleep(*timeout)
-		*tries--
+		connTries--
 	}
 
-	log.Error("failed.")
+	if err != nil {
+		goto Fail
+	}
+
+	if *httpURL != "" {
+		dialer := &connDialer{addr: addr}
+		httpClient := http.Client{Transport: &http.Transport{
+			DialContext: dialer.DialContext,
+		}}
+		reqTries := *tries
+		for reqTries > 0 {
+			try := (*tries - reqTries) + 1
+			log.Debugf("trying HTTP req %d: '%s'", try, *httpURL)
+			if tryHTTPGet(&httpClient, *httpURL) {
+				log.Debugf("HTTP req %d to '%s' succeeded", try, *httpURL)
+				goto Success
+			}
+			log.Debugf("HTTP req %d to '%s' failed", try, *httpURL)
+			time.Sleep(*timeout)
+			reqTries--
+		}
+		goto Fail
+	}
+
+Success:
+	os.Exit(0)
+
+Fail:
+	log.Error("failed")
 	os.Exit(1)
+}
+
+func tryHTTPGet(client *http.Client, url string) bool {
+	resp, err := client.Get(*httpURL)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return false
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	if *httpOut {
+		_, err := io.Copy(os.Stdout, resp.Body)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return true
+}
+
+type connDialer struct {
+	addr ma.Multiaddr
+}
+
+func (d connDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return (&manet.Dialer{}).DialContext(ctx, d.addr)
 }

--- a/test/ipfs-test-lib.sh
+++ b/test/ipfs-test-lib.sh
@@ -62,12 +62,7 @@ docker_run() {
 
 # This takes a docker ID and a command as arguments
 docker_exec() {
-    if test "$CIRCLE" = 1
-    then
-        sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' $1)" -- /bin/bash -c "$2"
-    else
-	docker exec -t "$1" /bin/bash -c "$2"
-    fi
+    docker exec -t "$1" /bin/sh -c "$2"
 }
 
 # This takes a docker ID as argument


### PR DESCRIPTION
The Docker sharness tests were disabled years ago when go-ipfs moved
from Travis to CircleCI. This makes the tweaks necessary to re-enable
them.

The Docker image has since moved to be based on BusyBox which doesn't
have the requisite wget version for the existing tests to work, so
this adds some functionality to the pollEndpoint program to support
polling HTTP endpoints as well.