### PR TITLE
CI: force running go-ipfs-http-client tests

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -292,7 +292,7 @@ jobs:
             - v1-go-api-{{ checksum "~/ipfs/go-ipfs/go-ipfs-api/go.sum" }}
             - v1-go-api-
       - run:
-          command: go test -v ./...
+          command: go test -count=1 -v ./...
           working_directory: ~/ipfs/go-ipfs/go-ipfs-api
       - save_cache:
           key: v1-go-api-{{ checksum "~/ipfs/go-ipfs/go-ipfs-api/go.sum" }}
@@ -318,10 +318,10 @@ jobs:
             - v1-http-client-{{ checksum "~/ipfs/go-ipfs/go-ipfs-http-client/go.sum" }}
             - v1-http-client-
       - run:
-          name: go test -v ./...
+          name: go test -count=1 -v ./...
           command: |
             export PATH=/tmp/circleci-workspace/bin:$PATH
-            go test -v ./...
+            go test -count=1 -v ./...
           working_directory: ~/ipfs/go-ipfs/go-ipfs-http-client
       - save_cache:
           key: v1-http-client-{{ checksum "~/ipfs/go-ipfs/go-ipfs-http-client/go.sum" }}


### PR DESCRIPTION
This test is actually testing is the ipfs binary (from the path).
Using the go-ipfs-http-client code.
But most PR only update the binary. HOWEVER Golang does not check PATH for caching.
So as far as golang knows: go-ipfs-http-client is old, it havn't changed, and it doesn't run it.

That leads us to this test not running on most important PR.