### PR TITLE
fix(core/commands): do not cache config

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ipfs/go-ipfs-cmds/cli"
 	cmdhttp "github.com/ipfs/go-ipfs-cmds/http"
 	u "github.com/ipfs/go-ipfs-util"
-	config "github.com/ipfs/go-ipfs/config"
 	logging "github.com/ipfs/go-log"
 	loggables "github.com/libp2p/go-libp2p-loggables"
 	ma "github.com/multiformats/go-multiaddr"
@@ -138,7 +137,6 @@ func mainRet() int {
 		// this is so that we can construct the node lazily.
 		return &oldcmds.Context{
 			ConfigRoot: repoPath,
-			LoadConfig: loadConfig,
 			ReqLog:     &oldcmds.ReqLog{},
 			Plugins:    plugins,
 			ConstructNode: func() (n *core.IpfsNode, err error) {
@@ -304,10 +302,6 @@ func getRepoPath(req *cmds.Request) (string, error) {
 		return "", err
 	}
 	return repoPath, nil
-}
-
-func loadConfig(path string) (*config.Config, error) {
-	return fsrepo.ConfigAt(path)
 }
 
 // startProfiling begins CPU profiling and returns a `stop` function to be

--- a/cmd/ipfs/pinmfs.go
+++ b/cmd/ipfs/pinmfs.go
@@ -36,7 +36,7 @@ const defaultRepinInterval = 5 * time.Minute
 
 type pinMFSContext interface {
 	Context() context.Context
-	GetConfigNoCache() (*config.Config, error)
+	GetConfig() (*config.Config, error)
 }
 
 type pinMFSNode interface {
@@ -104,7 +104,7 @@ func pinMFSOnChange(configPollInterval time.Duration, cctx pinMFSContext, node p
 		}
 
 		// reread the config, which may have changed in the meantime
-		cfg, err := cctx.GetConfigNoCache()
+		cfg, err := cctx.GetConfig()
 		if err != nil {
 			select {
 			case errCh <- fmt.Errorf("pinning reading config (%v)", err):

--- a/cmd/ipfs/pinmfs_test.go
+++ b/cmd/ipfs/pinmfs_test.go
@@ -24,7 +24,7 @@ func (x *testPinMFSContext) Context() context.Context {
 	return x.ctx
 }
 
-func (x *testPinMFSContext) GetConfigNoCache() (*config.Config, error) {
+func (x *testPinMFSContext) GetConfig() (*config.Config, error) {
 	return x.cfg, x.err
 }
 

--- a/cmd/ipfswatch/main.go
+++ b/cmd/ipfswatch/main.go
@@ -20,7 +20,6 @@ import (
 
 	fsnotify "github.com/fsnotify/fsnotify"
 	files "github.com/ipfs/go-ipfs-files"
-	config "github.com/ipfs/go-ipfs/config"
 	process "github.com/jbenet/goprocess"
 	homedir "github.com/mitchellh/go-homedir"
 )
@@ -217,9 +216,6 @@ func IsHidden(path string) bool {
 func cmdCtx(node *core.IpfsNode, repoPath string) commands.Context {
 	return commands.Context{
 		ConfigRoot: repoPath,
-		LoadConfig: func(path string) (*config.Config, error) {
-			return node.Repo.Config()
-		},
 		ConstructNode: func() (*core.IpfsNode, error) {
 			return node, nil
 		},

--- a/commands/context.go
+++ b/commands/context.go
@@ -26,30 +26,14 @@ type Context struct {
 
 	Plugins *loader.PluginLoader
 
-	config     *config.Config
-	LoadConfig func(path string) (*config.Config, error)
-
 	Gateway       bool
 	api           coreiface.CoreAPI
 	node          *core.IpfsNode
 	ConstructNode func() (*core.IpfsNode, error)
 }
 
-// GetConfig returns the config of the current Command execution
-// context. It may load it with the provided function.
 func (c *Context) GetConfig() (*config.Config, error) {
-	var err error
-	if c.config == nil {
-		if c.LoadConfig == nil {
-			return nil, errors.New("nil LoadConfig function")
-		}
-		c.config, err = c.LoadConfig(c.ConfigRoot)
-	}
-	return c.config, err
-}
-
-func (c *Context) GetConfigNoCache() (*config.Config, error) {
-	return c.LoadConfig(c.ConfigRoot)
+	return c.node.Repo.Config()
 }
 
 // GetNode returns the node of the current Command execution
@@ -61,12 +45,6 @@ func (c *Context) GetNode() (*core.IpfsNode, error) {
 			return nil, errors.New("nil ConstructNode function")
 		}
 		c.node, err = c.ConstructNode()
-		if err == nil {
-			// Pre-load the config from the repo to avoid re-parsing it from disk.
-			if cfg, err := c.node.Repo.Config(); err != nil {
-				c.config = cfg
-			}
-		}
 	}
 	return c.node, err
 }

--- a/commands/context.go
+++ b/commands/context.go
@@ -33,7 +33,11 @@ type Context struct {
 }
 
 func (c *Context) GetConfig() (*config.Config, error) {
-	return c.node.Repo.Config()
+	node, err := c.GetNode()
+	if err != nil {
+		return nil, err
+	}
+	return node.Repo.Config()
 }
 
 // GetNode returns the node of the current Command execution

--- a/core/commands/cmdenv/env.go
+++ b/core/commands/cmdenv/env.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ipfs/go-ipfs/core"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
-	config "github.com/ipfs/go-ipfs/config"
 	logging "github.com/ipfs/go-log"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	options "github.com/ipfs/interface-go-ipfs-core/options"
@@ -50,16 +49,6 @@ func GetApi(env cmds.Environment, req *cmds.Request) (coreiface.CoreAPI, error) 
 	}
 
 	return api, nil
-}
-
-// GetConfig extracts the config from the environment.
-func GetConfig(env cmds.Environment) (*config.Config, error) {
-	ctx, ok := env.(*commands.Context)
-	if !ok {
-		return nil, fmt.Errorf("expected env to be of type %T, got %T", ctx, env)
-	}
-
-	return ctx.GetConfig()
 }
 
 // GetConfigRoot extracts the config root from the environment

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	oldcmds "github.com/ipfs/go-ipfs/commands"
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
 	nodeMount "github.com/ipfs/go-ipfs/fuse/node"
 
@@ -81,7 +82,7 @@ baz
 		cmds.StringOption(mountIPNSPathOptionName, "n", "The path where IPNS should be mounted."),
 	},
 	Run: func(req *cmds.Request, res cmds.ResponseEmitter, env cmds.Environment) error {
-		cfg, err := cmdenv.GetConfig(env)
+		cfg, err := env.(*oldcmds.Context).GetConfig()
 		if err != nil {
 			return err
 		}

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -69,9 +69,6 @@ func MockCmdsCtx() (commands.Context, error) {
 
 	return commands.Context{
 		ConfigRoot: "/tmp/.mockipfsconfig",
-		LoadConfig: func(path string) (*config.Config, error) {
-			return &conf, nil
-		},
 		ConstructNode: func() (*core.IpfsNode, error) {
 			return node, nil
 		},

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -205,22 +205,6 @@ func checkInitialized(path string) error {
 	return nil
 }
 
-// ConfigAt returns an error if the FSRepo at the given path is not
-// initialized. This function allows callers to read the config file even when
-// another process is running and holding the lock.
-func ConfigAt(repoPath string) (*config.Config, error) {
-
-	// packageLock must be held to ensure that the Read is atomic.
-	packageLock.Lock()
-	defer packageLock.Unlock()
-
-	configFilename, err := config.Filename(repoPath)
-	if err != nil {
-		return nil, err
-	}
-	return serialize.Load(configFilename)
-}
-
 // configIsInitialized returns true if the repo is initialized at
 // provided |path|.
 func configIsInitialized(path string) bool {


### PR DESCRIPTION
Closes https://github.com/ipfs/go-ipfs/issues/7481.

From the issue description:
> The config attached to the command context is not the same config returned by repo.Config(). The commands context should just ask the repo for the config.