### PR TITLE
fix(core/commands): refactor dht post-processing logic

### DIFF
--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -112,7 +113,19 @@ var queryDhtCmd = &cmds.Command{
 			}()
 
 			for e := range events {
-				if err := res.Emit(e); err != nil {
+				pfm := pfuncMap{
+					routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
+						fmt.Fprintf(out, "%s\n", obj.ID)
+						return nil
+					},
+				}
+				verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+				qeo, err := processQueryEvent(e, verbose, pfm)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("QueryEventOut: %v\n", qeo)
+				if err := res.Emit(qeo); err != nil {
 					return err
 				}
 			}
@@ -121,18 +134,12 @@ var queryDhtCmd = &cmds.Command{
 		}
 	},
 	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
-			pfm := pfuncMap{
-				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
-					fmt.Fprintf(out, "%s\n", obj.ID)
-					return nil
-				},
-			}
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			return printEvent(out, w, verbose, pfm)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 const (
@@ -189,15 +196,6 @@ var findProvidersDhtCmd = &cmds.Command{
 			}
 		}()
 		for e := range events {
-			if err := res.Emit(e); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
 			pfm := pfuncMap{
 				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
 					if verbose {
@@ -219,12 +217,25 @@ var findProvidersDhtCmd = &cmds.Command{
 					return nil
 				},
 			}
-
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			return printEvent(out, w, verbose, pfm)
+			qeo, err := processQueryEvent(e, verbose, pfm)
+			if err != nil {
+				return err
+			}
+			if err := res.Emit(qeo); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 const (
@@ -305,15 +316,6 @@ var provideRefDhtCmd = &cmds.Command{
 		}()
 
 		for e := range events {
-			if err := res.Emit(e); err != nil {
-				return err
-			}
-		}
-
-		return provideErr
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
 			pfm := pfuncMap{
 				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
 					if verbose {
@@ -322,12 +324,25 @@ var provideRefDhtCmd = &cmds.Command{
 					return nil
 				},
 			}
-
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			return printEvent(out, w, verbose, pfm)
+			qeo, err := processQueryEvent(e, verbose, pfm)
+			if err != nil {
+				return err
+			}
+			if err := res.Emit(qeo); err != nil {
+				return err
+			}
+		}
+
+		return provideErr
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 func provideKeys(ctx context.Context, r routing.Routing, cids []cid.Cid) error {
@@ -416,15 +431,6 @@ var findPeerDhtCmd = &cmds.Command{
 		}()
 
 		for e := range events {
-			if err := res.Emit(e); err != nil {
-				return err
-			}
-		}
-
-		return findPeerErr
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
 			pfm := pfuncMap{
 				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
 					pi := obj.Responses[0]
@@ -434,12 +440,25 @@ var findPeerDhtCmd = &cmds.Command{
 					return nil
 				},
 			}
-
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			return printEvent(out, w, verbose, pfm)
+			qeo, err := processQueryEvent(e, verbose, pfm)
+			if err != nil {
+				return err
+			}
+			if err := res.Emit(qeo); err != nil {
+				return err
+			}
+		}
+
+		return findPeerErr
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 var getValueDhtCmd = &cmds.Command{
@@ -499,15 +518,6 @@ Different key types can specify other 'best' rules.
 		}()
 
 		for e := range events {
-			if err := res.Emit(e); err != nil {
-				return err
-			}
-		}
-
-		return getErr
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
 			pfm := pfuncMap{
 				routing.Value: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
 					if verbose {
@@ -522,12 +532,25 @@ Different key types can specify other 'best' rules.
 					return err
 				},
 			}
-
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
-			return printEvent(out, w, verbose, pfm)
+			qeo, err := processQueryEvent(e, verbose, pfm)
+			if err != nil {
+				return err
+			}
+			if err := res.Emit(qeo); err != nil {
+				return err
+			}
+		}
+
+		return getErr
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 var putValueDhtCmd = &cmds.Command{
@@ -601,15 +624,6 @@ identified by QmFoo.
 		}()
 
 		for e := range events {
-			if err := res.Emit(e); err != nil {
-				return err
-			}
-		}
-
-		return putErr
-	},
-	Encoders: cmds.EncoderMap{
-		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, out *routing.QueryEvent) error {
 			pfm := pfuncMap{
 				routing.FinalPeer: func(obj *routing.QueryEvent, out io.Writer, verbose bool) error {
 					if verbose {
@@ -622,66 +636,101 @@ identified by QmFoo.
 					return nil
 				},
 			}
-
 			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			qeo, err := processQueryEvent(e, verbose, pfm)
+			if err != nil {
+				return err
+			}
+			if err := res.Emit(qeo); err != nil {
+				return err
+			}
+		}
 
-			return printEvent(out, w, verbose, pfm)
+		return putErr
+	},
+	Encoders: cmds.EncoderMap{
+		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, qeo *QueryEventOut) error {
+			verbose, _ := req.Options[dhtVerboseOptionName].(bool)
+			return printEvent(qeo, w, verbose)
 		}),
 	},
-	Type: routing.QueryEvent{},
+	Type: QueryEventOut{},
 }
 
 type printFunc func(obj *routing.QueryEvent, out io.Writer, verbose bool) error
 type pfuncMap map[routing.QueryEventType]printFunc
 
-func printEvent(obj *routing.QueryEvent, out io.Writer, verbose bool, override pfuncMap) error {
+type QueryEventOut struct {
+	Time   string `json:",omitempty"`
+	Status string
+}
+
+func processQueryEvent(obj *routing.QueryEvent, verbose bool, override pfuncMap) (QueryEventOut, error) {
+	out := QueryEventOut{}
+
 	if verbose {
-		fmt.Fprintf(out, "%s: ", time.Now().Format("15:04:05.000"))
+		out.Time = time.Now().Format("15:04:05.000")
 	}
 
 	if override != nil {
 		if pf, ok := override[obj.Type]; ok {
-			return pf(obj, out, verbose)
+			b := new(bytes.Buffer)
+			err := pf(obj, b, verbose)
+			if err != nil {
+				return QueryEventOut{}, err
+			}
+			out.Status = b.String()
+			return out, nil
 		}
 	}
 
 	switch obj.Type {
 	case routing.SendingQuery:
 		if verbose {
-			fmt.Fprintf(out, "* querying %s\n", obj.ID)
+			out.Status = fmt.Sprintf("* querying %s\n", obj.ID)
 		}
 	case routing.Value:
 		if verbose {
-			fmt.Fprintf(out, "got value: '%s'\n", obj.Extra)
+			out.Status = fmt.Sprintf("got value: '%s'\n", obj.Extra)
 		} else {
-			fmt.Fprint(out, obj.Extra)
+			out.Status = fmt.Sprint(out, obj.Extra)
 		}
 	case routing.PeerResponse:
 		if verbose {
-			fmt.Fprintf(out, "* %s says use ", obj.ID)
+			out.Status = fmt.Sprintf("* %s says use ", obj.ID)
 			for _, p := range obj.Responses {
-				fmt.Fprintf(out, "%s ", p.ID)
+				out.Status += fmt.Sprintf("%s ", p.ID)
 			}
-			fmt.Fprintln(out)
+			out.Status += "\n"
 		}
 	case routing.QueryError:
 		if verbose {
-			fmt.Fprintf(out, "error: %s\n", obj.Extra)
+			out.Status = fmt.Sprintf("error: %s\n", obj.Extra)
 		}
 	case routing.DialingPeer:
 		if verbose {
-			fmt.Fprintf(out, "dialing peer: %s\n", obj.ID)
+			out.Status = fmt.Sprintf("dialing peer: %s\n", obj.ID)
 		}
 	case routing.AddingPeer:
 		if verbose {
-			fmt.Fprintf(out, "adding peer to query: %s\n", obj.ID)
+			out.Status = fmt.Sprintf("adding peer to query: %s\n", obj.ID)
 		}
 	case routing.FinalPeer:
 	default:
 		if verbose {
-			fmt.Fprintf(out, "unrecognized event type: %d\n", obj.Type)
+			out.Status = fmt.Sprintf("unrecognized event type: %d\n", obj.Type)
 		}
 	}
+	return out, nil
+}
+
+func printEvent(qeo *QueryEventOut, out io.Writer, verbose bool) error {
+	if verbose {
+		fmt.Fprintf(out, "%s: ", qeo.Time)
+	}
+
+	fmt.Fprintf(out, qeo.Status)
+
 	return nil
 }
 


### PR DESCRIPTION
In all DHT commands, not just `findprovs`, the post-processing of the `QueryEvent` was happening as part of the Text encoding, leaving all the other encoding types (json included but not limited to it) with the raw info in `QueryEvent`. Extracted post-processing logic in `processQueryEvent` function and added it to the `Run` part of the command. This was applied to all DHT commands.

Closes https://github.com/ipfs/go-ipfs/issues/8505.

-----------------------------------------

**BLOCKED:** While working on this I'm hitting a strange error caused from inside the `go-ipfs-cmds` library that I can't decipher. After spending considerable time I realize it's possible I'm missing how the commands library encoders work altogether and clearly need help. The nutshell of the error is:

Running
```
ipfs dht findprovs QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
```

correctly gives me the DHT providers in text format, like:
```
12D3KooWDZA1PKDa5NRWuPWRsc5Gmb43J2roVKYLCVkmrjzCu8QT
12D3KooWDi494How3rFVLNR7cbmHSAZoPGZbDnVoKL8aEbKEk3dv
12D3KooWAFNppo2bfat3BEiawrMp3onkq6ewuKHiGZaUH4BUqBVb
12D3KooWAXCSLQAaufZFqPmPBDMWmKZhuSktfopJYXjW7u11bdFG
...
```

Adding the [JSON encoder](https://github.com/ipfs/go-ipfs/commit/4727cb8ea9d8dbcf361bf7c9db0692a6ab7d86b8) to the command and changing nothing else gives me the error:
```
Error: json: cannot unmarshal number into Go value of type commands.QueryEventOut
```
Which I can trace it to:

https://github.com/ipfs/go-ipfs-cmds/blob/606d9c3693243daeeead54a3f9cecfecff7eda7e/http/response.go#L87

Basically the text output from before is being decoded as JSON and the decoder rightly complains that the number (`1` from the beginning of the addresses above) cannot be decoded to my new `QueryEventOut`. My question then is why are we decoding as JSON when that argument wasn't provided?
