### PR TITLE
feat(gw): tracing spans per response type

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -352,6 +352,7 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 	// Detect when explicit Accept header or ?format parameter are present
 	responseFormat := customResponseFormat(r)
 	trace.SpanFromContext(r.Context()).SetAttributes(attribute.String("ResponseFormat", responseFormat))
+	trace.SpanFromContext(r.Context()).SetAttributes(attribute.String("ResolvedPath", resolvedPath.String()))
 
 	// Finish early if client already has matching Etag
 	if r.Header.Get("If-None-Match") == getEtag(r, resolvedPath.Cid()) {
@@ -390,11 +391,11 @@ func (i *gatewayHandler) getOrHeadHandler(w http.ResponseWriter, r *http.Request
 		return
 	case "application/vnd.ipld.raw":
 		logger.Debugw("serving raw block", "path", contentPath)
-		i.serveRawBlock(w, r, resolvedPath.Cid(), contentPath, begin)
+		i.serveRawBlock(w, r, resolvedPath, contentPath, begin)
 		return
 	case "application/vnd.ipld.car", "application/vnd.ipld.car; version=1":
 		logger.Debugw("serving car stream", "path", contentPath)
-		i.serveCar(w, r, resolvedPath.Cid(), contentPath, begin)
+		i.serveCar(w, r, resolvedPath, contentPath, begin)
 		return
 	default: // catch-all for unsuported application/vnd.*
 		err := fmt.Errorf("unsupported format %q", responseFormat)

--- a/core/corehttp/gateway_handler_car.go
+++ b/core/corehttp/gateway_handler_car.go
@@ -7,16 +7,23 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs/tracing"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
 	gocar "github.com/ipld/go-car"
 	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // serveCar returns a CAR stream for specific DAG+selector
-func (i *gatewayHandler) serveCar(w http.ResponseWriter, r *http.Request, rootCid cid.Cid, contentPath ipath.Path, begin time.Time) {
-	ctx, cancel := context.WithCancel(r.Context())
+func (i *gatewayHandler) serveCar(w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, begin time.Time) {
+	ctx, span := tracing.Span(r.Context(), "Gateway", "ServeCar", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
+	defer span.End()
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	rootCid := resolvedPath.Cid()
 
 	// Set Content-Disposition
 	name := rootCid.String() + ".car"

--- a/core/corehttp/gateway_handler_unixfs.go
+++ b/core/corehttp/gateway_handler_unixfs.go
@@ -7,13 +7,18 @@ import (
 	"time"
 
 	files "github.com/ipfs/go-ipfs-files"
+	"github.com/ipfs/go-ipfs/tracing"
 	ipath "github.com/ipfs/interface-go-ipfs-core/path"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
 func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, resolvedPath ipath.Resolved, contentPath ipath.Path, begin time.Time, logger *zap.SugaredLogger) {
+	ctx, span := tracing.Span(r.Context(), "Gateway", "ServeUnixFs", trace.WithAttributes(attribute.String("path", resolvedPath.String())))
+	defer span.End()
 	// Handling UnixFS
-	dr, err := i.api.Unixfs().Get(r.Context(), resolvedPath)
+	dr, err := i.api.Unixfs().Get(ctx, resolvedPath)
 	if err != nil {
 		webError(w, "ipfs cat "+html.EscapeString(contentPath.String()), err, http.StatusNotFound)
 		return
@@ -23,7 +28,7 @@ func (i *gatewayHandler) serveUnixFs(w http.ResponseWriter, r *http.Request, res
 	// Handling Unixfs file
 	if f, ok := dr.(files.File); ok {
 		logger.Debugw("serving unixfs file", "path", contentPath)
-		i.serveFile(w, r, contentPath, resolvedPath.Cid(), f, begin)
+		i.serveFile(w, r, resolvedPath, contentPath, f, begin)
 		return
 	}
 

--- a/docs/debug-guide.md
+++ b/docs/debug-guide.md
@@ -7,6 +7,7 @@ This is a document for helping debug go-ipfs. Please add to it if you can!
 - [Analyzing the stack dump](#analyzing-the-stack-dump)
 - [Analyzing the CPU Profile](#analyzing-the-cpu-profile)
 - [Analyzing vars and memory statistics](#analyzing-vars-and-memory-statistics)
+- [Tracing](#tracing)
 - [Other](#other)
 
 ### Beginning
@@ -94,6 +95,11 @@ the quickest way to easily point out where the hot spots in the code are.
 ### Analyzing vars and memory statistics
 
 The output is JSON formatted and includes badger store statistics, the command line run, and the output from Go's [runtime.ReadMemStats](https://golang.org/pkg/runtime/#ReadMemStats). The [MemStats](https://golang.org/pkg/runtime/#MemStats) has useful information about memory allocation and garbage collection.
+
+### Tracing
+
+Experimental tracing via OpenTelemetry suite of tools is available.
+See `tracing/doc.go` for more details.
 
 ### Other
 

--- a/mk/golang.mk
+++ b/mk/golang.mk
@@ -70,7 +70,7 @@ test_go_fmt:
 TEST_GO += test_go_fmt
 
 test_go_lint: test/bin/golangci-lint
-	golangci-lint run ./...
+	golangci-lint run --timeout=3m ./...
 .PHONY: test_go_lint
 
 test_go: $(TEST_GO)


### PR DESCRIPTION
This PR extends #8595 with spans for each response type from https://github.com/ipfs/go-ipfs/pull/8758
Adds more visibility into how long generic lookup takes vs producing specific response type.


## Demo

| CAR | Block | File | Directory |
| ---- | ---- | ---- | ---- |
| ![2022-04-01_01-46](https://user-images.githubusercontent.com/157609/161167986-951d5c8c-9a5e-464d-bc20-81eb5ccbdc22.png) | ![block_2022-04-01_01-47](https://user-images.githubusercontent.com/157609/161167983-e8cac0ce-0575-4271-8cb8-4d44a0d5d786.png) |  ![2022-04-01_01-49](https://user-images.githubusercontent.com/157609/161167978-e19aa44c-f5a4-45f4-b7c7-14c313ab1dee.png) |  ![dir_2022-04-01_01-48](https://user-images.githubusercontent.com/157609/161167981-456ca52b-3e87-4042-916b-8db149071228.png) |

