### PR TITLE
chore: deprecate tar commands

### DIFF
--- a/core/commands/tar.go
+++ b/core/commands/tar.go
@@ -13,6 +13,7 @@ import (
 )
 
 var TarCmd = &cmds.Command{
+	Status: cmds.Deprecated, // https://github.com/ipfs/go-ipfs/issues/7951
 	Helptext: cmds.HelpText{
 		Tagline: "Utility functions for tar files in ipfs.",
 	},
@@ -24,6 +25,7 @@ var TarCmd = &cmds.Command{
 }
 
 var tarAddCmd = &cmds.Command{
+	Status: cmds.Deprecated, // https://github.com/ipfs/go-ipfs/issues/7951
 	Helptext: cmds.HelpText{
 		Tagline: "Import a tar file into IPFS.",
 		ShortDescription: `
@@ -74,6 +76,7 @@ represent it.
 }
 
 var tarCatCmd = &cmds.Command{
+	Status: cmds.Deprecated, // https://github.com/ipfs/go-ipfs/issues/7951
 	Helptext: cmds.HelpText{
 		Tagline: "Export a tar file from IPFS.",
 		ShortDescription: `


### PR DESCRIPTION
Closes #7951

It will scream in CLI `--help` and https://docs.ipfs.io/reference/http/api/ – see https://github.com/ipfs/ipfs-docs/pull/1086
