### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners are automatically requested for review when someone opens a pull
+# request that modifies code that they own. Code owners are not automatically
+# requested to review draft pull requests.
+
+# HTTP Gateway
+core/corehttp/  @lidel
+test/sharness/*gateway*.sh  @lidel


### PR DESCRIPTION
This adds CODEOWNERS file which automatically asks specific people for a review when specific paths are modified as a part of a PR.

To be specific, I've added myself, because I'd like to follow gateways changes. 