### PR TITLE
feat: detect default limit changes in go-libp2p-resource-manager

### DIFF
--- a/core/node/libp2p/rcmgr.go
+++ b/core/node/libp2p/rcmgr.go
@@ -69,7 +69,7 @@ func ResourceManager(cfg config.SwarmConfig) func(fx.Lifecycle, repo.Repo) (netw
 				return nil, opts, err
 			}
 
-			setDefaultServiceLimits(limiter) // see rcmgr_defaults.go
+			libp2p.SetDefaultServiceLimits(limiter)
 
 			ropts := []rcmgr.Option{rcmgr.WithMetrics(createRcmgrMetrics())}
 

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -1,27 +1,25 @@
 package libp2p
 
 import (
+	"encoding/json"
+	"fmt"
 	"math/bits"
+	"strings"
 
 	config "github.com/ipfs/go-ipfs/config"
-	"github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/libp2p/go-libp2p"
 	rcmgr "github.com/libp2p/go-libp2p-resource-manager"
-	"github.com/libp2p/go-libp2p/p2p/host/autonat"
-	relayv1 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv1/relay"
-	circuit "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/proto"
-	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
-	"github.com/libp2p/go-libp2p/p2p/protocol/holepunch"
-	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
-	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+
+	"github.com/wI2L/jsondiff"
 )
 
 // This file defines implicit limit defaults used when Swarm.ResourceMgr.Enabled
-// We keep vendored copy to ensure go-ipfs is not impacted when go-libp2p decides
-// to change defaults in any of the future releases.
 
 // adjustedDefaultLimits allows for tweaking defaults based on external factors,
 // such as values in Swarm.ConnMgr.HiWater config.
 func adjustedDefaultLimits(cfg config.SwarmConfig) rcmgr.DefaultLimitConfig {
+	// Run checks to avoid introducing regressions
+	checkImplicitDefaults()
 
 	// Return to use unmodified static limits based on values from go-libp2p 0.18
 	// return defaultLimits
@@ -30,7 +28,7 @@ func adjustedDefaultLimits(cfg config.SwarmConfig) rcmgr.DefaultLimitConfig {
 	// (based on https://github.com/filecoin-project/lotus/pull/8318/files)
 	// - give it more memory, up to 4G, min of 1G
 	// - if Swarm.ConnMgr.HighWater is too high, adjust Conn/FD/Stream limits
-	defaultLimits := staticDefaultLimits.WithSystemMemory(.125, 1<<30, 4<<30)
+	defaultLimits := rcmgr.DefaultLimits.WithSystemMemory(.125, 1<<30, 4<<30)
 
 	// Do we need to adjust due to Swarm.ConnMgr.HighWater?
 	if cfg.ConnMgr.Type == "basic" {
@@ -67,247 +65,592 @@ func logScale(val int) int {
 	return 1 << bitlen
 }
 
-// defaultLimits are the limits used by the default rcmgr limiter constructors.
-// This is  a vendored copy of
+// checkImplicitDefaults compares libp2p defaults agains expected ones
+// and panics when they don't match. This ensures we are not surprised
+// by silent default limit changes when we update go-libp2p dependencies.
+func checkImplicitDefaults() {
+	ok := true
+
+	// Check 1: did go-libp2p-resource-manager's DefaultLimits change?
+	defaults, err := json.Marshal(rcmgr.DefaultLimits)
+	if err != nil {
+		log.Fatal(err)
+	}
+	changes, err := jsonDiff([]byte(expectedDefaultLimits), defaults)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(changes) > 0 {
+		ok = false
+		log.Errorf("===> OOF! go-libp2p-resource-manager changed DefaultLimits\n"+
+			"=> changes ('test' represents the old value):\n%s\n"+
+			"=> go-libp2p-resource-manager DefaultLimits update needs a review:\n"+
+			"Please inspect if changes impact go-ipfs users, and update expectedDefaultLimits in rcmgr_defaults.go to remove this message",
+			strings.Join(changes, "\n"),
+		)
+	}
+
+	// Check 2: did go-libp2p's SetDefaultServiceLimits change?
+	testLimiter := rcmgr.NewStaticLimiter(rcmgr.DefaultLimits)
+	libp2p.SetDefaultServiceLimits(testLimiter)
+
+	serviceDefaults, err := json.Marshal(testLimiter)
+	if err != nil {
+		log.Fatal(err)
+	}
+	changes, err = jsonDiff([]byte(expectedDefaultServiceLimits), serviceDefaults)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(changes) > 0 {
+		ok = false
+		log.Errorf("===> OOF! go-libp2p changed DefaultServiceLimits\n"+
+			"=> changes ('test' represents the old value):\n%s\n"+
+			"=> go-libp2p SetDefaultServiceLimits update needs a review:\n"+
+			"Please inspect if changes impact go-ipfs users, and update expectedDefaultServiceLimits in rcmgr_defaults.go to remove this message",
+			strings.Join(changes, "\n"),
+		)
+	}
+	if !ok {
+		log.Fatal("daemon will refuse to run with the resource manager until this is resolved")
+	}
+}
+
+// jsonDiff compares two strings and returns diff in JSON Patch format
+func jsonDiff(old []byte, updated []byte) ([]string, error) {
+	// generate 'invertible' patch which includes old values as "test" op
+	patch, err := jsondiff.CompareJSONOpts(old, updated, jsondiff.Invertible())
+	changes := make([]string, len(patch))
+	if err != nil {
+		return changes, err
+	}
+	for i, op := range patch {
+		changes[i] = fmt.Sprintf("  %s", op)
+	}
+	return changes, nil
+}
+
 // https://github.com/libp2p/go-libp2p-resource-manager/blob/v0.1.5/limit_defaults.go#L49
-var staticDefaultLimits = rcmgr.DefaultLimitConfig{
-	SystemBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  4096,
-		StreamsOutbound: 16384,
-		Streams:         16384,
-		ConnsInbound:    256,
-		ConnsOutbound:   1024,
-		Conns:           1024,
-		FD:              512,
-	},
+const expectedDefaultLimits = `{
+  "SystemBaseLimit": {
+    "Streams": 16384,
+    "StreamsInbound": 4096,
+    "StreamsOutbound": 16384,
+    "Conns": 1024,
+    "ConnsInbound": 256,
+    "ConnsOutbound": 1024,
+    "FD": 512
+  },
+  "SystemMemory": {
+    "MemoryFraction": 0.125,
+    "MinMemory": 134217728,
+    "MaxMemory": 1073741824
+  },
+  "TransientBaseLimit": {
+    "Streams": 512,
+    "StreamsInbound": 128,
+    "StreamsOutbound": 512,
+    "Conns": 128,
+    "ConnsInbound": 32,
+    "ConnsOutbound": 128,
+    "FD": 128
+  },
+  "TransientMemory": {
+    "MemoryFraction": 1,
+    "MinMemory": 67108864,
+    "MaxMemory": 67108864
+  },
+  "ServiceBaseLimit": {
+    "Streams": 8192,
+    "StreamsInbound": 2048,
+    "StreamsOutbound": 8192,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0
+  },
+  "ServiceMemory": {
+    "MemoryFraction": 0.03125,
+    "MinMemory": 67108864,
+    "MaxMemory": 268435456
+  },
+  "ServicePeerBaseLimit": {
+    "Streams": 512,
+    "StreamsInbound": 256,
+    "StreamsOutbound": 512,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0
+  },
+  "ServicePeerMemory": {
+    "MemoryFraction": 0.0078125,
+    "MinMemory": 16777216,
+    "MaxMemory": 67108864
+  },
+  "ProtocolBaseLimit": {
+    "Streams": 4096,
+    "StreamsInbound": 1024,
+    "StreamsOutbound": 4096,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0
+  },
+  "ProtocolMemory": {
+    "MemoryFraction": 0.015625,
+    "MinMemory": 67108864,
+    "MaxMemory": 134217728
+  },
+  "ProtocolPeerBaseLimit": {
+    "Streams": 512,
+    "StreamsInbound": 128,
+    "StreamsOutbound": 256,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0
+  },
+  "ProtocolPeerMemory": {
+    "MemoryFraction": 0.0078125,
+    "MinMemory": 16777216,
+    "MaxMemory": 67108864
+  },
+  "PeerBaseLimit": {
+    "Streams": 1024,
+    "StreamsInbound": 512,
+    "StreamsOutbound": 1024,
+    "Conns": 16,
+    "ConnsInbound": 8,
+    "ConnsOutbound": 16,
+    "FD": 8
+  },
+  "PeerMemory": {
+    "MemoryFraction": 0.0078125,
+    "MinMemory": 67108864,
+    "MaxMemory": 134217728
+  },
+  "ConnBaseLimit": {
+    "Streams": 0,
+    "StreamsInbound": 0,
+    "StreamsOutbound": 0,
+    "Conns": 1,
+    "ConnsInbound": 1,
+    "ConnsOutbound": 1,
+    "FD": 1
+  },
+  "ConnMemory": 1048576,
+  "StreamBaseLimit": {
+    "Streams": 1,
+    "StreamsInbound": 1,
+    "StreamsOutbound": 1,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0
+  },
+  "StreamMemory": 16777216
+}`
 
-	SystemMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125,
-		MinMemory:      128 << 20,
-		MaxMemory:      1 << 30,
-	},
-
-	TransientBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  128,
-		StreamsOutbound: 512,
-		Streams:         512,
-		ConnsInbound:    32,
-		ConnsOutbound:   128,
-		Conns:           128,
-		FD:              128,
-	},
-
-	TransientMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 1,
-		MinMemory:      64 << 20,
-		MaxMemory:      64 << 20,
-	},
-
-	ServiceBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  2048,
-		StreamsOutbound: 8192,
-		Streams:         8192,
-	},
-
-	ServiceMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125 / 4,
-		MinMemory:      64 << 20,
-		MaxMemory:      256 << 20,
-	},
-
-	ServicePeerBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  256,
-		StreamsOutbound: 512,
-		Streams:         512,
-	},
-
-	ServicePeerMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125 / 16,
-		MinMemory:      16 << 20,
-		MaxMemory:      64 << 20,
-	},
-
-	ProtocolBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  1024,
-		StreamsOutbound: 4096,
-		Streams:         4096,
-	},
-
-	ProtocolMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125 / 8,
-		MinMemory:      64 << 20,
-		MaxMemory:      128 << 20,
-	},
-
-	ProtocolPeerBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  128,
-		StreamsOutbound: 256,
-		Streams:         512,
-	},
-
-	ProtocolPeerMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125 / 16,
-		MinMemory:      16 << 20,
-		MaxMemory:      64 << 20,
-	},
-
-	PeerBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  512,
-		StreamsOutbound: 1024,
-		Streams:         1024,
-		ConnsInbound:    8,
-		ConnsOutbound:   16,
-		Conns:           16,
-		FD:              8,
-	},
-
-	PeerMemory: rcmgr.MemoryLimit{
-		MemoryFraction: 0.125 / 16,
-		MinMemory:      64 << 20,
-		MaxMemory:      128 << 20,
-	},
-
-	ConnBaseLimit: rcmgr.BaseLimit{
-		ConnsInbound:  1,
-		ConnsOutbound: 1,
-		Conns:         1,
-		FD:            1,
-	},
-
-	ConnMemory: 1 << 20,
-
-	StreamBaseLimit: rcmgr.BaseLimit{
-		StreamsInbound:  1,
-		StreamsOutbound: 1,
-		Streams:         1,
-	},
-
-	StreamMemory: 16 << 20,
-}
-
-// setDefaultServiceLimits sets the default limits for bundled libp2p services.
-// This is a vendored copy of
-// https://github.com/libp2p/go-libp2p/blob/v0.18.0/limits.go
-func setDefaultServiceLimits(limiter *rcmgr.BasicLimiter) {
-	if limiter.ServiceLimits == nil {
-		limiter.ServiceLimits = make(map[string]rcmgr.Limit)
-	}
-	if limiter.ServicePeerLimits == nil {
-		limiter.ServicePeerLimits = make(map[string]rcmgr.Limit)
-	}
-	if limiter.ProtocolLimits == nil {
-		limiter.ProtocolLimits = make(map[protocol.ID]rcmgr.Limit)
-	}
-	if limiter.ProtocolPeerLimits == nil {
-		limiter.ProtocolPeerLimits = make(map[protocol.ID]rcmgr.Limit)
-	}
-
-	// identify
-	setServiceLimits(limiter, identify.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(128, 128, 256),    // max 256 streams -- symmetric
-		peerLimit(16, 16, 32))
-
-	setProtocolLimits(limiter, identify.ID,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 32<<20),
-		peerLimit(16, 16, 32))
-	setProtocolLimits(limiter, identify.IDPush,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 32<<20),
-		peerLimit(16, 16, 32))
-	setProtocolLimits(limiter, identify.IDDelta,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 32<<20),
-		peerLimit(16, 16, 32))
-
-	// ping
-	setServiceLimits(limiter, ping.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(128, 128, 128),    // max 128 streams - asymmetric
-		peerLimit(2, 3, 4))
-	setProtocolLimits(limiter, ping.ID,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 64<<20),
-		peerLimit(2, 3, 4))
-
-	// autonat
-	setServiceLimits(limiter, autonat.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(128, 128, 128),    // max 128 streams - asymmetric
-		peerLimit(2, 2, 2))
-	setProtocolLimits(limiter, autonat.AutoNATProto,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 64<<20),
-		peerLimit(2, 2, 2))
-
-	// holepunch
-	setServiceLimits(limiter, holepunch.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(128, 128, 256),    // max 256 streams - symmetric
-		peerLimit(2, 2, 2))
-	setProtocolLimits(limiter, holepunch.Protocol,
-		limiter.DefaultProtocolLimits.WithMemoryLimit(1, 4<<20, 64<<20),
-		peerLimit(2, 2, 2))
-
-	// relay/v1
-	setServiceLimits(limiter, relayv1.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(1024, 1024, 1024), // max 1024 streams - asymmetric
-		peerLimit(64, 64, 64))
-
-	// relay/v2
-	setServiceLimits(limiter, relayv2.ServiceName,
-		limiter.DefaultServiceLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20). // max 64MB service memory
-			WithStreamLimit(1024, 1024, 1024), // max 1024 streams - asymmetric
-		peerLimit(64, 64, 64))
-
-	// circuit protocols, both client and service
-	setProtocolLimits(limiter, circuit.ProtoIDv1,
-		limiter.DefaultProtocolLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20).
-			WithStreamLimit(1280, 1280, 1280),
-		peerLimit(128, 128, 128))
-	setProtocolLimits(limiter, circuit.ProtoIDv2Hop,
-		limiter.DefaultProtocolLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20).
-			WithStreamLimit(1280, 1280, 1280),
-		peerLimit(128, 128, 128))
-	setProtocolLimits(limiter, circuit.ProtoIDv2Stop,
-		limiter.DefaultProtocolLimits.
-			WithMemoryLimit(1, 4<<20, 64<<20).
-			WithStreamLimit(1280, 1280, 1280),
-		peerLimit(128, 128, 128))
-
-}
-
-func setServiceLimits(limiter *rcmgr.BasicLimiter, svc string, limit rcmgr.Limit, peerLimit rcmgr.Limit) {
-	if _, ok := limiter.ServiceLimits[svc]; !ok {
-		limiter.ServiceLimits[svc] = limit
-	}
-	if _, ok := limiter.ServicePeerLimits[svc]; !ok {
-		limiter.ServicePeerLimits[svc] = peerLimit
-	}
-}
-
-func setProtocolLimits(limiter *rcmgr.BasicLimiter, proto protocol.ID, limit rcmgr.Limit, peerLimit rcmgr.Limit) {
-	if _, ok := limiter.ProtocolLimits[proto]; !ok {
-		limiter.ProtocolLimits[proto] = limit
-	}
-	if _, ok := limiter.ProtocolPeerLimits[proto]; !ok {
-		limiter.ProtocolPeerLimits[proto] = peerLimit
-	}
-}
-
-func peerLimit(numStreamsIn, numStreamsOut, numStreamsTotal int) rcmgr.Limit {
-	return &rcmgr.StaticLimit{
-		// memory: 256kb for window buffers plus some change for message buffers per stream
-		Memory: int64(numStreamsTotal * (256<<10 + 16384)),
-		BaseLimit: rcmgr.BaseLimit{
-			StreamsInbound:  numStreamsIn,
-			StreamsOutbound: numStreamsOut,
-			Streams:         numStreamsTotal,
-		},
-	}
-}
+// https://github.com/libp2p/go-libp2p/blob/v0.18.0/limits.go#L17
+const expectedDefaultServiceLimits = `{
+  "SystemLimits": {
+    "Streams": 16384,
+    "StreamsInbound": 4096,
+    "StreamsOutbound": 16384,
+    "Conns": 1024,
+    "ConnsInbound": 256,
+    "ConnsOutbound": 1024,
+    "FD": 512,
+    "Memory": 1073741824
+  },
+  "TransientLimits": {
+    "Streams": 512,
+    "StreamsInbound": 128,
+    "StreamsOutbound": 512,
+    "Conns": 128,
+    "ConnsInbound": 32,
+    "ConnsOutbound": 128,
+    "FD": 128,
+    "Memory": 67108864
+  },
+  "DefaultServiceLimits": {
+    "Streams": 8192,
+    "StreamsInbound": 2048,
+    "StreamsOutbound": 8192,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0,
+    "Memory": 67108864
+  },
+  "DefaultServicePeerLimits": {
+    "Streams": 512,
+    "StreamsInbound": 256,
+    "StreamsOutbound": 512,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0,
+    "Memory": 16777216
+  },
+  "ServiceLimits": {
+    "libp2p.autonat": {
+      "Streams": 128,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "libp2p.holepunch": {
+      "Streams": 256,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "libp2p.identify": {
+      "Streams": 256,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "libp2p.ping": {
+      "Streams": 128,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "libp2p.relay/v1": {
+      "Streams": 1024,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 1024,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "libp2p.relay/v2": {
+      "Streams": 1024,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 1024,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    }
+  },
+  "ServicePeerLimits": {
+    "libp2p.autonat": {
+      "Streams": 2,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 2,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 557056
+    },
+    "libp2p.holepunch": {
+      "Streams": 2,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 2,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 557056
+    },
+    "libp2p.identify": {
+      "Streams": 32,
+      "StreamsInbound": 16,
+      "StreamsOutbound": 16,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 8912896
+    },
+    "libp2p.ping": {
+      "Streams": 4,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 3,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 1114112
+    },
+    "libp2p.relay/v1": {
+      "Streams": 64,
+      "StreamsInbound": 64,
+      "StreamsOutbound": 64,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 17825792
+    },
+    "libp2p.relay/v2": {
+      "Streams": 64,
+      "StreamsInbound": 64,
+      "StreamsOutbound": 64,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 17825792
+    }
+  },
+  "DefaultProtocolLimits": {
+    "Streams": 4096,
+    "StreamsInbound": 1024,
+    "StreamsOutbound": 4096,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0,
+    "Memory": 67108864
+  },
+  "DefaultProtocolPeerLimits": {
+    "Streams": 512,
+    "StreamsInbound": 128,
+    "StreamsOutbound": 256,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0,
+    "Memory": 16777216
+  },
+  "ProtocolLimits": {
+    "/ipfs/id/1.0.0": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 33554432
+    },
+    "/ipfs/id/push/1.0.0": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 33554432
+    },
+    "/ipfs/ping/1.0.0": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/libp2p/autonat/1.0.0": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/libp2p/circuit/relay/0.1.0": {
+      "Streams": 1280,
+      "StreamsInbound": 1280,
+      "StreamsOutbound": 1280,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/libp2p/circuit/relay/0.2.0/hop": {
+      "Streams": 1280,
+      "StreamsInbound": 1280,
+      "StreamsOutbound": 1280,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/libp2p/circuit/relay/0.2.0/stop": {
+      "Streams": 1280,
+      "StreamsInbound": 1280,
+      "StreamsOutbound": 1280,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/libp2p/dcutr": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 67108864
+    },
+    "/p2p/id/delta/1.0.0": {
+      "Streams": 4096,
+      "StreamsInbound": 1024,
+      "StreamsOutbound": 4096,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 33554432
+    }
+  },
+  "ProtocolPeerLimits": {
+    "/ipfs/id/1.0.0": {
+      "Streams": 32,
+      "StreamsInbound": 16,
+      "StreamsOutbound": 16,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 8912896
+    },
+    "/ipfs/id/push/1.0.0": {
+      "Streams": 32,
+      "StreamsInbound": 16,
+      "StreamsOutbound": 16,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 8912896
+    },
+    "/ipfs/ping/1.0.0": {
+      "Streams": 4,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 3,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 1114112
+    },
+    "/libp2p/autonat/1.0.0": {
+      "Streams": 2,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 2,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 557056
+    },
+    "/libp2p/circuit/relay/0.1.0": {
+      "Streams": 128,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 35651584
+    },
+    "/libp2p/circuit/relay/0.2.0/hop": {
+      "Streams": 128,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 35651584
+    },
+    "/libp2p/circuit/relay/0.2.0/stop": {
+      "Streams": 128,
+      "StreamsInbound": 128,
+      "StreamsOutbound": 128,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 35651584
+    },
+    "/libp2p/dcutr": {
+      "Streams": 2,
+      "StreamsInbound": 2,
+      "StreamsOutbound": 2,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 557056
+    },
+    "/p2p/id/delta/1.0.0": {
+      "Streams": 32,
+      "StreamsInbound": 16,
+      "StreamsOutbound": 16,
+      "Conns": 0,
+      "ConnsInbound": 0,
+      "ConnsOutbound": 0,
+      "FD": 0,
+      "Memory": 8912896
+    }
+  },
+  "DefaultPeerLimits": {
+    "Streams": 1024,
+    "StreamsInbound": 512,
+    "StreamsOutbound": 1024,
+    "Conns": 16,
+    "ConnsInbound": 8,
+    "ConnsOutbound": 16,
+    "FD": 8,
+    "Memory": 67108864
+  },
+  "PeerLimits": null,
+  "ConnLimits": {
+    "Streams": 0,
+    "StreamsInbound": 0,
+    "StreamsOutbound": 0,
+    "Conns": 1,
+    "ConnsInbound": 1,
+    "ConnsOutbound": 1,
+    "FD": 1,
+    "Memory": 1048576
+  },
+  "StreamLimits": {
+    "Streams": 1,
+    "StreamsInbound": 1,
+    "StreamsOutbound": 1,
+    "Conns": 0,
+    "ConnsInbound": 0,
+    "ConnsOutbound": 0,
+    "FD": 0,
+    "Memory": 16777216
+  }
+}`

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.0
+	github.com/wI2L/jsondiff v0.2.0
 	github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7
 	go.opencensus.io v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -1423,6 +1423,12 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e h1:T5PdfK/M1xyrHwynxMIVMWLS7f/qHwfslZphxtGnw7s=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
+github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
@@ -1433,6 +1439,8 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
+github.com/wI2L/jsondiff v0.2.0 h1:dE00WemBa1uCjrzQUUTE/17I6m5qAaN0EMFOg2Ynr/k=
+github.com/wI2L/jsondiff v0.2.0/go.mod h1:axTcwtBkY4TsKuV+RgoMhHyHKKFRI6nnjRLi8LLYQnA=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=
 github.com/warpfork/go-testmark v0.3.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-testmark v0.9.0 h1:nc+uaCiv5lFQLYjhuC2LTYeJ7JaC+gdDmsz9r0ISy0Y=


### PR DESCRIPTION
Part of https://github.com/ipfs/go-ipfs/issues/8761, based on #8680 

## What

This PR removes hardcoded defaults and switches to ones from go-libp2p.

To safeguard against silent changes that could impact our users, adds a simple check that will scream loud and clear every time go-libp2p libraries change any of the limit defaults related to go-libp2p-resource-manager. This was suggested during recent go-ipfs sync.

## How

- relevant structs are serialized to JSON zand compared
- if there are any unexpected changes, go-ipfs will refuse to start, forcing us to review impact of go-libp2p update
- diff between expected and actual limits is returned in JSON Patch format
  - Initially, I just printed JSON for "before" and "after" and compared normalized strings,
     but given how many values we have it was difficult to spot the change. 
  - Makes it easier to apply changes on top of expected limits in rcmgr_defaults.go

## Demo

Assuming next version of go-libp2p changed:
- [DefaultLimits in go-libp2p-resource-manager](https://github.com/libp2p/go-libp2p-resource-manager/blob/v0.1.5/limit_defaults.go#L49)
  - SystemBaseLimit/FD from 512 to 1024
  -  SystemBaseLimit/StreamsInbound from 4095 to 1024
-   [SetDefaultServiceLimits in go-libp2p](https://github.com/libp2p/go-libp2p/blob/v0.18.0/limits.go#L17)
    - StreamLimits/Memory from 16777216 to 0
    - SystemLimits/Streams from 16384 to 42

The daemon will refuse to start until the changes are reviewed, and expected values are updated in `rcmgr_defaults.go`:

```console
$ LIBP2P_RCMGR=1 ipfs daemon
Initializing daemon...
go-ipfs version: 0.13.0-dev-024bf885e-dirty
Repo version: 12
System version: amd64/linux
Golang version: go1.16.9
2022-04-07T23:47:00.068+0200	ERROR	p2pnode	libp2p/rcmgr_defaults.go:85	===> OOF! go-libp2p-resource-manager changed DefaultLimits
=> changes ('test' represents the old value):
  {"op":"test","path":"/SystemBaseLimit/FD","value":512}
  {"op":"replace","path":"/SystemBaseLimit/FD","value":1024}
  {"op":"test","path":"/SystemBaseLimit/StreamsInbound","value":4095}
  {"op":"replace","path":"/SystemBaseLimit/StreamsInbound","value":1024}
=> go-libp2p-resource-manager DefaultLimits update needs a review:
Please inspect if changes impact go-ipfs users, and update expectedDefaultLimits in rcmgr_defaults.go to remove this message
2022-04-07T23:47:00.068+0200	ERROR	p2pnode	libp2p/rcmgr_defaults.go:107	===> OOF! go-libp2p changed DefaultServiceLimits
=> changes ('test' represents the old value):
  {"op":"test","path":"/StreamLimits/Memory","value":16777216}
  {"op":"replace","path":"/StreamLimits/Memory","value":0}
  {"op":"test","path":"/SystemLimits/Streams","value":16384}
  {"op":"replace","path":"/SystemLimits/Streams","value":42}
=> go-libp2p SetDefaultServiceLimits update needs a review:
Please inspect if changes impact go-ipfs users, and update expectedDefaultServiceLimits in rcmgr_defaults.go to remove this message
2022-04-07T23:47:00.068+0200	FATAL	p2pnode	libp2p/rcmgr_defaults.go:115	daemon will refuse to run with the resource manager until this is resolved
```