### PR TITLE
Release v0.12.2

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -36,7 +36,7 @@ default_environment: &default_environment
 executors:
   golang:
     docker:
-      - image: cimg/go:1.16.12
+      - image: cimg/go:1.16.15
     working_directory: ~/ipfs/go-ipfs
     environment:
       <<: *default_environment
@@ -61,7 +61,7 @@ executors:
       E2E_IPFSD_TYPE: go
   dockerizer:
     docker:
-      - image: cimg/go:1.16.12
+      - image: cimg/go:1.16.15
     environment:
       IMAGE_NAME: ipfs/go-ipfs
       WIP_IMAGE_TAG: wip
@@ -150,8 +150,8 @@ jobs:
     - run: sudo apt update
     - run: |
         mkdir ~/localgo && cd ~/localgo
-        wget https://golang.org/dl/go1.16.12.linux-amd64.tar.gz
-        tar xfz go1.16.12.linux-amd64.tar.gz
+        wget https://golang.org/dl/go1.16.15.linux-amd64.tar.gz
+        tar xfz go1.16.15.linux-amd64.tar.gz
         echo "export PATH=$(pwd)/go/bin:\$PATH" >> ~/.bashrc
     - run: go version
     - run: sudo apt install socat net-tools

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -292,6 +292,9 @@ jobs:
           command: |
             git clone https://github.com/ipfs/go-ipfs-http-client.git
             git -C go-ipfs-http-client log -1
+            cd go-ipfs-http-client
+            git checkout v0.2.0
+            cd ..
       - restore_cache:
           keys:
             - v1-http-client-{{ checksum "~/ipfs/go-ipfs/go-ipfs-http-client/go.sum" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,50 @@
 # go-ipfs changelog
 
-## v0.12.1 2022-03-10
-This patch release [fixes](https://github.com/ipfs/go-ipfs/commit/816a128aaf963d72c4930852ce32b9a4e31924a1) a security issue with the `docker-compose.yaml` file, introduced in v0.11.0, in which the IPFS daemon API listens on all interfaces instead of only the loopback interface, which could allow remote callers to control your IPFS daemon. If you use the included `docker-compose.yaml` file, it is recommended to upgrade.
+## v0.12.2 and v0.11.1 2022-04-08
+
+This patch release fixes a security issue wherein traversing some malformed DAGs can cause the node to panic.
+
+See also the security advisory: https://github.com/ipfs/go-ipfs/security/advisories/GHSA-mcq2-w56r-5w2w
+
+Note: the v0.11.1 patch release contains the Docker compose fix from v0.12.1 as well
+
+### Changelog
+
+<details>
+<summary>Full Changelog</summary>
+- github.com/ipld/go-codec-dagpb (v1.3.0 -> v1.3.2):
+  - fix: use protowire for Links bytes decoding
+</details>
+
+### ❤ Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Rod Vagg | 1 | +34/-19 | 2 |
+
+## v0.12.1 2022-03-17
+
+This patch release [fixes](https://github.com/ipfs/go-ipfs/commit/816a128aaf963d72c4930852ce32b9a4e31924a1) a security issue with the `docker-compose.yaml` file in which the IPFS daemon API listens on all interfaces instead of only the loopback interface, which could allow remote callers to control your IPFS daemon. If you use the included `docker-compose.yaml` file, it is recommended to upgrade.
+
+See also the security advisory: https://github.com/ipfs/go-ipfs/security/advisories/GHSA-fx5p-f64h-93xc
+
+Thanks to @LynHyper for finding and disclosing this.
+
+### Changelog
+
+<details>
+<summary>Full Changelog</summary>
+
+- github.com/ipfs/go-ipfs:
+  -  fix: listen on loopback for API and gateway ports in docker-compose.yaml
+
+</details>
+
+### ❤ Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| guseggert | 1 | +10/-3 | 1 |
 
 ## v0.12.0 2022-02-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: when updating the go minor version here, also update the go-channel in snap/snapcraft.yml
-FROM golang:1.16.12-buster
+FROM golang:1.16.15-buster
 LABEL maintainer="Steven Allen <steven@stebalien.com>"
 
 # Install deps

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/ipfs/interface-go-ipfs-core v0.5.2
 	github.com/ipfs/tar-utils v0.0.2
 	github.com/ipld/go-car v0.3.2
-	github.com/ipld/go-codec-dagpb v1.3.0
+	github.com/ipld/go-codec-dagpb v1.3.2
 	github.com/ipld/go-ipld-prime v0.14.2
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/go-temp-err-catcher v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -583,8 +583,9 @@ github.com/ipfs/tar-utils v0.0.2/go.mod h1:4qlnRWgTVljIMhSG2SqRYn66NT+3wrv/kZt9V
 github.com/ipld/go-car v0.3.2 h1:V9wt/80FNfbMRWSD98W5br6fyjUAyVgI2lDOTZX16Lg=
 github.com/ipld/go-car v0.3.2/go.mod h1:WEjynkVt04dr0GwJhry0KlaTeSDEiEYyMPOxDBQ17KE=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
-github.com/ipld/go-codec-dagpb v1.3.0 h1:czTcaoAuNNyIYWs6Qe01DJ+sEX7B+1Z0LcXjSatMGe8=
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
+github.com/ipld/go-codec-dagpb v1.3.2 h1:MZQUIjanHXXfDuYmtWYT8nFbqfFsZuyHClj6VDmSXr4=
+github.com/ipld/go-codec-dagpb v1.3.2/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ package ipfs
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal
-const CurrentVersionNumber = "0.12.1"
+const CurrentVersionNumber = "0.12.2"
 
 const ApiVersion = "/go-ipfs/" + CurrentVersionNumber + "/"
 


### PR DESCRIPTION
Relates to [v0.11.1](https://github.com/ipfs/go-ipfs/pull/8860).

This will get merged into release and tagged on the release branch (and we can merge back into master as well).

TODO: 
- [x] Fix links in changelog
- [x] Review
