### PR TITLE
chore: improve new issue  links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,14 +4,14 @@ contact_links:
    url: https://ipfs.io/help
    about: All information about how and where to get help on IPFS.
  - name: Go-ipfs configuration reference
-   url: https://github.com/ipfs/go-ipfs/blob/master/docs/config.md
+   url: https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#readme
    about: Documentation on the different configuration settings
  - name: Go-ipfs experimental features docs
-   url: https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md
+   url: https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#readme
    about: Documentation on Private Networks, Filestore and other experimental features.
- - name: HTTP API Reference
-   url: https://docs.ipfs.io/reference/http/api/#api-v0-add
-   about: Documentation of all go-ipfs HTTP API endpoints.
+ - name: RPC API Reference
+   url: https://docs.ipfs.io/reference/http/api/
+   about: Documentation of all go-ipfs RPC API endpoints.
  - name: IPFS Official Forum
    url: https://discuss.ipfs.io
    about: Please post general questions, support requests, and discussions here.


### PR DESCRIPTION
Fixing the link to the RPC API  docs (it was pointing at `#api-v0-add` for some reason :see_no_evil: ) 