### PR TITLE
chore: deprecate /api/v0/dns

### DIFF
--- a/core/commands/dns.go
+++ b/core/commands/dns.go
@@ -17,40 +17,17 @@ const (
 )
 
 var DNSCmd = &cmds.Command{
+	Status: cmds.Deprecated, // https://github.com/ipfs/go-ipfs/issues/8607
 	Helptext: cmds.HelpText{
-		Tagline: "Resolve DNS links.",
+		Tagline: "Resolve DNSLink records.",
 		ShortDescription: `
-Multihashes are hard to remember, but domain names are usually easy to
-remember.  To create memorable aliases for multihashes, DNS TXT
-records can point to other DNS links, IPFS objects, IPNS keys, etc.
-This command resolves those links to the referenced object.
-`,
-		LongDescription: `
-Multihashes are hard to remember, but domain names are usually easy to
-remember.  To create memorable aliases for multihashes, DNS TXT
-records can point to other DNS links, IPFS objects, IPNS keys, etc.
-This command resolves those links to the referenced object.
+This command can only recursively resolve DNSLink TXT records.
+It will fail to recursively resolve through IPNS keys etc.
 
-Note: This command can only recursively resolve DNS links,
-it will fail to recursively resolve through IPNS keys etc.
-For general-purpose recursive resolution, use ipfs name resolve -r.
+DEPRECATED: superseded by 'ipfs resolve'
 
-For example, with this DNS TXT record:
-
-	> dig +short TXT _dnslink.ipfs.io
-	dnslink=/ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy
-
-The resolver will give:
-
-	> ipfs dns ipfs.io
-	/ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy
-
-The resolver can recursively resolve:
-
-	> dig +short TXT recursive.ipfs.io
-	dnslink=/ipns/ipfs.io
-	> ipfs dns -r recursive.ipfs.io
-	/ipfs/QmRzTuh2Lpuz7Gr39stNr6mTFdqAghsZec1JoUnfySUzcy
+For general-purpose recursive resolution, use 'ipfs resolve -r'.
+It will work across multiple DNSLinks and IPNS keys.
 `,
 	},
 

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -51,14 +51,13 @@ TEXT ENCODING COMMANDS
 ADVANCED COMMANDS
   daemon        Start a long-running daemon process
   mount         Mount an IPFS read-only mount point
-  resolve       Resolve any type of name
+  resolve       Resolve any type of content path
   name          Publish and resolve IPNS names
   key           Create and list IPNS name keypairs
-  dns           Resolve DNS links
   pin           Pin objects to local storage
   repo          Manipulate the IPFS repository
   stats         Various operational stats
-  p2p           Libp2p stream mounting
+  p2p           Libp2p stream mounting (experimental)
   filestore     Manage the filestore (experimental)
 
 NETWORK COMMANDS


### PR DESCRIPTION
Closes #8607  – will be picked up by https://github.com/ipfs/ipfs-docs/pull/1086 after go-ipfs 0.13 ships.