### PR TITLE
fix: error handling in 'pins remote ls'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/ipfs/go-mfs v0.2.1
 	github.com/ipfs/go-namesys v0.4.0
 	github.com/ipfs/go-path v0.2.2
-	github.com/ipfs/go-pinning-service-http-client v0.1.0
+	github.com/ipfs/go-pinning-service-http-client v0.1.1-0.20220415230352-d9ab12d34311
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.1.3
 	github.com/ipfs/go-verifcid v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ github.com/ipfs/go-peertaskqueue v0.7.0 h1:VyO6G4sbzX80K58N60cCaHsSsypbUNs1GjO5s
 github.com/ipfs/go-peertaskqueue v0.7.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68ow0Rrb04donIU=
 github.com/ipfs/go-pinning-service-http-client v0.1.0 h1:Au0P4NglL5JfzhNSZHlZ1qra+IcJyO3RWMd9EYCwqSY=
 github.com/ipfs/go-pinning-service-http-client v0.1.0/go.mod h1:tcCKmlkWWH9JUUkKs8CrOZBanacNc1dmKLfjlyXAMu4=
+github.com/ipfs/go-pinning-service-http-client v0.1.1-0.20220415230352-d9ab12d34311 h1:CDKefHCXqzXd0USY11xIjV3bBjHLoz+7D3SmloloIa4=
+github.com/ipfs/go-pinning-service-http-client v0.1.1-0.20220415230352-d9ab12d34311/go.mod h1:i6tC2nWOnJbZZUQPgxOlrg4CX8bhQZMh4II09FxvD58=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=
 github.com/ipfs/go-unixfs v0.3.1 h1:LrfED0OGfG98ZEegO4/xiprx2O+yS+krCMQSp7zLVv8=
 github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=


### PR DESCRIPTION

Context:  https://github.com/ipfs/go-pinning-service-http-client/issues/14
Needs: https://github.com/ipfs/go-pinning-service-http-client/pull/18

## TODO 
- [ ] switch to version from https://github.com/ipfs/go-pinning-service-http-client/pull/18 to see if CI E2E tests pass
- [ ] switch to released version of go-pinning-service-http-client