### PR TITLE
Test change to see if CircleCI permissions are fixed for our org

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,3 +496,5 @@ The go-ipfs project is dual-licensed under Apache 2.0 and MIT terms:
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/ipfs/go-ipfs/blob/master/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 - MIT license ([LICENSE-MIT](https://github.com/ipfs/go-ipfs/blob/master/LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+Test change to cause CircleCI jobs to run.


### PR DESCRIPTION
Per https://github.com/ipfs/go-ipfs/pull/8855#issuecomment-1099474157, I performed the following steps to try to fix our org permissions.

- Login to CircleCI
- Click Setup Project for go-ipfs
- Job runs and returns error “Use of setup workflows must be enabled in project settings (Project settings > Advanced → Dynamic config using setup workflows)”
- Clicked … > Project Settings > Advanced > Enable dynamic config using setup workflows
- Toggled this to on
