### PR TITLE
chore: replace ioutil with io and os

### DIFF
--- a/cmd/ipfs/add_migrations.go
+++ b/cmd/ipfs/add_migrations.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -154,7 +153,7 @@ func ipfsGet(ctx context.Context, ufs coreiface.UnixfsAPI, ipfsPath ipath.Path) 
 	if !ok {
 		return fmt.Errorf("not a file node: %q", ipfsPath)
 	}
-	_, err = io.Copy(ioutil.Discard, fnd)
+	_, err = io.Copy(io.Discard, fnd)
 	if err != nil {
 		return fmt.Errorf("cannot read migration: %w", err)
 	}

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	_ "expvar"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -331,7 +330,7 @@ func daemonFunc(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment
 
 		if cacheMigrations || pinMigrations {
 			// Create temp directory to store downloaded migration archives
-			migrations.DownloadDirectory, err = ioutil.TempDir("", "migrations")
+			migrations.DownloadDirectory, err = os.MkdirTemp("", "migrations")
 			if err != nil {
 				return err
 			}

--- a/cmd/ipfs/runmain_test.go
+++ b/cmd/ipfs/runmain_test.go
@@ -21,7 +21,7 @@ func TestRunMain(t *testing.T) {
 
 	p := os.Getenv("IPFS_COVER_RET_FILE")
 	if len(p) != 0 {
-		ioutil.WriteFile(p, []byte(fmt.Sprintf("%d\n", ret)), 0777)
+		os.WriteFile(p, []byte(fmt.Sprintf("%d\n", ret)), 0777)
 	}
 
 	// close outputs so go testing doesn't print anything

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -192,7 +191,7 @@ NOTE: For security reasons, this command will omit your private key and remote s
 			return err
 		}
 
-		data, err := ioutil.ReadFile(fname)
+		data, err := os.ReadFile(fname)
 		if err != nil {
 			return err
 		}

--- a/core/commands/dht.go
+++ b/core/commands/dht.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	cmdenv "github.com/ipfs/go-ipfs/core/commands/cmdenv"
@@ -580,7 +579,7 @@ identified by QmFoo.
 		}
 		defer file.Close()
 
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			return err
 		}

--- a/core/commands/keystore.go
+++ b/core/commands/keystore.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -276,7 +275,7 @@ elsewhere. For example, using openssl to get a PEM with public key:
 
 			switch exportFormat {
 			case keyFormatPemCleartextOption:
-				privKeyBytes, err := ioutil.ReadAll(outReader)
+				privKeyBytes, err := io.ReadAll(outReader)
 				if err != nil {
 					return err
 				}
@@ -344,7 +343,7 @@ The PEM format allows for key generation outside of the IPFS node:
 		}
 		defer file.Close()
 
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			return err
 		}

--- a/core/commands/multibase.go
+++ b/core/commands/multibase.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -66,7 +66,7 @@ but one can customize used base with -b:
 		if err != nil {
 			return fmt.Errorf("failed to access file: %w", err)
 		}
-		buf, err := ioutil.ReadAll(file)
+		buf, err := io.ReadAll(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file contents: %w", err)
 		}
@@ -105,7 +105,7 @@ This command expects multibase inside of a file or via stdin:
 		if err != nil {
 			return fmt.Errorf("failed to access file: %w", err)
 		}
-		encoded_data, err := ioutil.ReadAll(file)
+		encoded_data, err := io.ReadAll(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file contents: %w", err)
 		}
@@ -156,7 +156,7 @@ but one can customize used base with -b:
 		if err != nil {
 			return fmt.Errorf("failed to access file: %w", err)
 		}
-		encoded_data, err := ioutil.ReadAll(file)
+		encoded_data, err := io.ReadAll(file)
 		if err != nil {
 			return fmt.Errorf("failed to read file contents: %w", err)
 		}

--- a/core/commands/object/object.go
+++ b/core/commands/object/object.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"text/tabwriter"
 
 	cmds "github.com/ipfs/go-ipfs-cmds"
@@ -230,7 +229,7 @@ DEPRECATED and provided for legacy reasons. Use 'ipfs dag get' instead.
 			return err
 		}
 
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}

--- a/core/commands/pubsub.go
+++ b/core/commands/pubsub.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 
@@ -191,7 +190,7 @@ HTTP RPC ENCODING
 			return err
 		}
 		defer file.Close()
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			return err
 		}

--- a/core/coreapi/block.go
+++ b/core/coreapi/block.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -36,7 +35,7 @@ func (api *BlockAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Bloc
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(src)
+	data, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coreapi/object.go
+++ b/core/coreapi/object.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	cid "github.com/ipfs/go-cid"
 	pin "github.com/ipfs/go-ipfs-pinner"
@@ -79,7 +78,7 @@ func (api *ObjectAPI) Put(ctx context.Context, src io.Reader, opts ...caopts.Obj
 		attribute.String("inputenc", options.InputEnc),
 	)
 
-	data, err := ioutil.ReadAll(io.LimitReader(src, inputLimit+10))
+	data, err := io.ReadAll(io.LimitReader(src, inputLimit+10))
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +315,7 @@ func (api *ObjectAPI) patchData(ctx context.Context, path ipath.Path, r io.Reade
 		return nil, dag.ErrNotProtobuf
 	}
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coredag/cbor.go
+++ b/core/coredag/cbor.go
@@ -2,7 +2,6 @@ package coredag
 
 import (
 	"io"
-	"io/ioutil"
 
 	ipldcbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -18,7 +17,7 @@ func cborJSONParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error) 
 }
 
 func cborRawParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coredag/dagpb.go
+++ b/core/coredag/dagpb.go
@@ -2,7 +2,6 @@ package coredag
 
 import (
 	"io"
-	"io/ioutil"
 	"math"
 
 	"github.com/ipfs/go-merkledag"
@@ -13,7 +12,7 @@ import (
 )
 
 func dagpbJSONParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +30,7 @@ func dagpbJSONParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error)
 }
 
 func dagpbRawParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coredag/raw.go
+++ b/core/coredag/raw.go
@@ -2,7 +2,6 @@ package coredag
 
 import (
 	"io"
-	"io/ioutil"
 	"math"
 
 	"github.com/ipfs/go-merkledag"
@@ -18,7 +17,7 @@ func rawRawParser(r io.Reader, mhType uint64, mhLen int) ([]ipld.Node, error) {
 		mhType = mh.SHA2_256
 	}
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/core/corehttp/gateway_handler_block.go
+++ b/core/corehttp/gateway_handler_block.go
@@ -3,7 +3,7 @@ package corehttp
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -23,7 +23,7 @@ func (i *gatewayHandler) serveRawBlock(ctx context.Context, w http.ResponseWrite
 		webError(w, "ipfs block get "+blockCid.String(), err, http.StatusInternalServerError)
 		return
 	}
-	block, err := ioutil.ReadAll(blockReader)
+	block, err := io.ReadAll(blockReader)
 	if err != nil {
 		webError(w, "ipfs block get "+blockCid.String(), err, http.StatusInternalServerError)
 		return

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -3,7 +3,7 @@ package corehttp
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -267,7 +267,7 @@ func TestGatewayGet(t *testing.T) {
 		if contentType != "text/plain; charset=utf-8" {
 			t.Errorf("expected content type to be text/plain, got %s", contentType)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if resp.StatusCode != test.status {
 			t.Errorf("(%d) got %d, expected %d from %s", i, resp.StatusCode, test.status, urlstr)
 			t.Errorf("Body: %s", body)
@@ -335,7 +335,7 @@ func TestPretty404(t *testing.T) {
 		if resp.StatusCode != test.status {
 			t.Fatalf("got %d, expected %d, from %s", resp.StatusCode, test.status, test.path)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("error reading response from %s: %s", test.path, err)
 		}
@@ -482,7 +482,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	}
 
 	// expect correct links
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("error reading response: %s", err)
 	}
@@ -519,7 +519,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	}
 
 	// expect correct backlinks at root
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("error reading response: %s", err)
 	}
@@ -556,7 +556,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	}
 
 	// expect correct backlinks
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("error reading response: %s", err)
 	}
@@ -638,7 +638,7 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("error reading response: %s", err)
 	}

--- a/core/corehttp/lazyseek_test.go
+++ b/core/corehttp/lazyseek_test.go
@@ -3,7 +3,6 @@ package corehttp
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -37,7 +36,7 @@ func TestLazySeekerError(t *testing.T) {
 	}
 
 	// shouldn't have actually seeked.
-	b, err := ioutil.ReadAll(s)
+	b, err := io.ReadAll(s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +52,7 @@ func TestLazySeekerError(t *testing.T) {
 	if off != 0 {
 		t.Fatal("expected to seek to the start")
 	}
-	b, err = ioutil.ReadAll(s)
+	b, err = io.ReadAll(s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +69,7 @@ func TestLazySeekerError(t *testing.T) {
 		t.Fatal("expected to seek to the start")
 	}
 	// right here...
-	b, err = ioutil.ReadAll(s)
+	b, err = io.ReadAll(s)
 	if err == nil {
 		t.Fatalf("expected an error, got output %s", string(b))
 	}
@@ -120,7 +119,7 @@ func TestLazySeeker(t *testing.T) {
 	}
 
 	expectSeek(io.SeekEnd, 0, s.size, "")
-	b, err := ioutil.ReadAll(s)
+	b, err := io.ReadAll(s)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/coreunix/add_test.go
+++ b/core/coreunix/add_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -282,7 +281,7 @@ func testAddWPosInfo(t *testing.T, rawLeaves bool) {
 
 	data := make([]byte, 5*1024*1024)
 	rand.New(rand.NewSource(2)).Read(data) // Rand.Read never returns an error
-	fileData := ioutil.NopCloser(bytes.NewBuffer(data))
+	fileData := io.NopCloser(bytes.NewBuffer(data))
 	fileInfo := dummyFileInfo{"foo.txt", int64(len(data)), time.Now()}
 	file, _ := files.NewReaderPathFile(filepath.Join(os.TempDir(), "foo.txt"), fileData, &fileInfo)
 

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	bserv "github.com/ipfs/go-blockservice"
@@ -87,7 +86,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := ioutil.ReadAll(ndr)
+	out, err := io.ReadAll(ndr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/mock/mock.go
+++ b/core/mock/mock.go
@@ -3,7 +3,7 @@ package coremock
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	libp2p2 "github.com/ipfs/go-ipfs/core/node/libp2p"
 
@@ -75,7 +75,7 @@ func MockCmdsCtx() (commands.Context, error) {
 
 func MockPublicNode(ctx context.Context, mn mocknet.Mocknet) (*core.IpfsNode, error) {
 	ds := syncds.MutexWrap(datastore.NewMapDatastore())
-	cfg, err := config.Init(ioutil.Discard, 2048)
+	cfg, err := config.Init(io.Discard, 2048)
 	if err != nil {
 		return nil, err
 	}

--- a/coverage/main/main.go
+++ b/coverage/main/main.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -19,13 +19,13 @@ func main() {
 		fmt.Println("IPFS_COVER_DIR not defined")
 		os.Exit(1)
 	}
-	coverFile, err := ioutil.TempFile(coverDir, "coverage-")
+	coverFile, err := os.CreateTemp(coverDir, "coverage-")
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
 
-	retFile, err := ioutil.TempFile("", "cover-ret-file")
+	retFile, err := os.CreateTemp("", "cover-ret-file")
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -69,7 +69,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	b, err := ioutil.ReadAll(retFile)
+	b, err := io.ReadAll(retFile)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/docs/examples/go-ipfs-as-a-library/main.go
+++ b/docs/examples/go-ipfs-as-a-library/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -47,13 +47,13 @@ func setupPlugins(externalPluginsPath string) error {
 }
 
 func createTempRepo() (string, error) {
-	repoPath, err := ioutil.TempDir("", "ipfs-shell")
+	repoPath, err := os.MkdirTemp("", "ipfs-shell")
 	if err != nil {
 		return "", fmt.Errorf("failed to get temp dir: %s", err)
 	}
 
 	// Create a config with default options and a 2048 bit key
-	cfg, err := config.Init(ioutil.Discard, 2048)
+	cfg, err := config.Init(io.Discard, 2048)
 	if err != nil {
 		return "", err
 	}
@@ -279,7 +279,7 @@ func main() {
 
 	/// --- Part III: Getting the file and directory you added back
 
-	outputBasePath, err := ioutil.TempDir("", "example")
+	outputBasePath, err := os.MkdirTemp("", "example")
 	if err != nil {
 		panic(fmt.Errorf("could not create output dir (%v)", err))
 	}

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"os"
 	"sync"
@@ -57,12 +56,12 @@ func writeFileOrFail(t *testing.T, size int, path string) []byte {
 
 func writeFile(size int, path string) ([]byte, error) {
 	data := randBytes(size)
-	err := ioutil.WriteFile(path, data, 0666)
+	err := os.WriteFile(path, data, 0666)
 	return data, err
 }
 
 func verifyFile(t *testing.T, path string, wantData []byte) {
-	isData, err := ioutil.ReadFile(path)
+	isData, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +167,7 @@ func TestIpnsBasicIO(t *testing.T) {
 	fname := mnt.Dir + "/local/testfile"
 	data := writeFileOrFail(t, 10, fname)
 
-	rbuf, err := ioutil.ReadFile(fname)
+	rbuf, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +177,7 @@ func TestIpnsBasicIO(t *testing.T) {
 	}
 
 	fname2 := mnt.Dir + "/" + nd.Identity.Pretty() + "/testfile"
-	rbuf, err = ioutil.ReadFile(fname2)
+	rbuf, err = os.ReadFile(fname2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +203,7 @@ func TestFilePersistence(t *testing.T) {
 	_, mnt = setupIpnsTest(t, node)
 	defer mnt.Close()
 
-	rbuf, err := ioutil.ReadFile(mnt.Dir + fname)
+	rbuf, err := os.ReadFile(mnt.Dir + fname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +323,7 @@ func TestAppendFile(t *testing.T) {
 
 	data = append(data, nudata...)
 
-	rbuf, err := ioutil.ReadFile(fname)
+	rbuf, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +452,7 @@ func TestFSThrash(t *testing.T) {
 
 	wg.Wait()
 	for name, data := range files {
-		out, err := ioutil.ReadFile(name)
+		out, err := os.ReadFile(name)
 		if err != nil {
 			t.Error(err)
 		}
@@ -492,7 +491,7 @@ func TestMultiWrite(t *testing.T) {
 	}
 	fi.Close()
 
-	rbuf, err := ioutil.ReadFile(fpath)
+	rbuf, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fuse/node/mount_test.go
+++ b/fuse/node/mount_test.go
@@ -4,7 +4,6 @@
 package node
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -54,7 +53,7 @@ func TestExternalUnmount(t *testing.T) {
 	}
 
 	// get the test dir paths (/tmp/fusetestXXXX)
-	dir, err := ioutil.TempDir("", "fusetest")
+	dir, err := os.MkdirTemp("", "fusetest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fuse/readonly/ipfs_test.go
+++ b/fuse/readonly/ipfs_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -91,7 +90,7 @@ func TestIpfsBasicRead(t *testing.T) {
 	fi, data := randObj(t, nd, 10000)
 	k := fi.Cid()
 	fname := path.Join(mnt.Dir, k.String())
-	rbuf, err := ioutil.ReadFile(fname)
+	rbuf, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +189,7 @@ func TestIpfsStressRead(t *testing.T) {
 				relpath := strings.Replace(item.String(), item.Namespace(), "", 1)
 				fname := path.Join(mnt.Dir, relpath)
 
-				rbuf, err := ioutil.ReadFile(fname)
+				rbuf, err := os.ReadFile(fname)
 				if err != nil {
 					errs <- err
 				}
@@ -204,7 +203,7 @@ func TestIpfsStressRead(t *testing.T) {
 					errs <- err
 				}
 
-				data, err := ioutil.ReadAll(read.(files.File))
+				data, err := io.ReadAll(read.(files.File))
 				if err != nil {
 					errs <- err
 				}
@@ -260,12 +259,12 @@ func TestIpfsBasicDirRead(t *testing.T) {
 
 	dirname := path.Join(mnt.Dir, d1nd.Cid().String())
 	fname := path.Join(dirname, "actual")
-	rbuf, err := ioutil.ReadFile(fname)
+	rbuf, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	dirents, err := ioutil.ReadDir(dirname)
+	dirents, err := os.ReadDir(dirname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/fsrepo/config_test.go
+++ b/repo/fsrepo/config_test.go
@@ -2,7 +2,6 @@ package fsrepo_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -89,7 +88,7 @@ func TestDefaultDatastoreConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir, err := ioutil.TempDir("", "ipfs-datastore-config-test")
+	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +126,7 @@ func TestLevelDbConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir("", "ipfs-datastore-config-test")
+	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +164,7 @@ func TestFlatfsConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir("", "ipfs-datastore-config-test")
+	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +202,7 @@ func TestMeasureConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir("", "ipfs-datastore-config-test")
+	dir, err := os.MkdirTemp("", "ipfs-datastore-config-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -270,7 +269,7 @@ func initSpec(path string, conf map[string]interface{}) error {
 	}
 	bytes := dsc.DiskSpec().Bytes()
 
-	return ioutil.WriteFile(fn, bytes, 0600)
+	return os.WriteFile(fn, bytes, 0600)
 }
 
 // Init initializes a new FSRepo at the given path with the provided config.
@@ -338,7 +337,7 @@ func APIAddr(repoPath string) (ma.Multiaddr, error) {
 	// some hidden wisdom. However, I'm fixing it such that:
 	// 1. We don't read too little.
 	// 2. We don't truncate and succeed.
-	buf, err := ioutil.ReadAll(io.LimitReader(f, 2048))
+	buf, err := io.ReadAll(io.LimitReader(f, 2048))
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +453,7 @@ func (r *FSRepo) readSpec() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	b, err := ioutil.ReadFile(fn)
+	b, err := os.ReadFile(fn)
 	if err != nil {
 		return "", err
 	}
@@ -515,7 +514,7 @@ func (r *FSRepo) FileManager() *filestore.FileManager {
 }
 
 func (r *FSRepo) BackupConfig(prefix string) (string, error) {
-	temp, err := ioutil.TempFile(r.path, "config-"+prefix)
+	temp, err := os.CreateTemp(r.path, "config-"+prefix)
 	if err != nil {
 		return "", err
 	}
@@ -667,7 +666,7 @@ func (r *FSRepo) SwarmKey() ([]byte, error) {
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 var _ io.Closer = &FSRepo{}

--- a/repo/fsrepo/fsrepo_test.go
+++ b/repo/fsrepo/fsrepo_test.go
@@ -3,7 +3,6 @@ package fsrepo
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 
 // swap arg order
 func testRepoPath(p string, t *testing.T) string {
-	name, err := ioutil.TempDir("", p)
+	name, err := os.MkdirTemp("", p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/fsrepo/migrations/fetch.go
+++ b/repo/fsrepo/migrations/fetch.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,7 +88,7 @@ func FetchBinary(ctx context.Context, fetcher Fetcher, dist, ver, binName, out s
 		}
 	} else {
 		// Create temp directory to store download
-		tmpDir, err = ioutil.TempDir("", arcName)
+		tmpDir, err = os.MkdirTemp("", arcName)
 		if err != nil {
 			return "", err
 		}

--- a/repo/fsrepo/migrations/httpfetcher.go
+++ b/repo/fsrepo/migrations/httpfetcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -81,7 +80,7 @@ func (f *HttpFetcher) Fetch(ctx context.Context, filePath string) ([]byte, error
 
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
-		mes, err := ioutil.ReadAll(resp.Body)
+		mes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading error body: %s", err)
 		}
@@ -96,7 +95,7 @@ func (f *HttpFetcher) Fetch(ctx context.Context, filePath string) ([]byte, error
 	}
 	defer rc.Close()
 
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }
 
 func (f *HttpFetcher) Close() error {

--- a/repo/fsrepo/migrations/ipfsdir.go
+++ b/repo/fsrepo/migrations/ipfsdir.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -85,11 +84,11 @@ func WriteRepoVersion(ipfsDir string, version int) error {
 	}
 
 	vFilePath := filepath.Join(ipfsDir, versionFile)
-	return ioutil.WriteFile(vFilePath, []byte(fmt.Sprintf("%d\n", version)), 0644)
+	return os.WriteFile(vFilePath, []byte(fmt.Sprintf("%d\n", version)), 0644)
 }
 
 func repoVersion(ipfsDir string) (int, error) {
-	c, err := ioutil.ReadFile(filepath.Join(ipfsDir, versionFile))
+	c, err := os.ReadFile(filepath.Join(ipfsDir, versionFile))
 	if err != nil {
 		return 0, err
 	}

--- a/repo/fsrepo/migrations/ipfsdir_test.go
+++ b/repo/fsrepo/migrations/ipfsdir_test.go
@@ -1,7 +1,6 @@
 package migrations
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -139,7 +138,7 @@ func testRepoVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	vFilePath := filepath.Join(ipfsDir, versionFile)
-	err = ioutil.WriteFile(vFilePath, []byte("bad-version-data\n"), 0644)
+	err = os.WriteFile(vFilePath, []byte("bad-version-data\n"), 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher.go
+++ b/repo/fsrepo/migrations/ipfsfetcher/ipfsfetcher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -134,7 +133,7 @@ func (f *IpfsFetcher) Fetch(ctx context.Context, filePath string) ([]byte, error
 	}
 	defer rc.Close()
 
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }
 
 func (f *IpfsFetcher) Close() error {
@@ -171,7 +170,7 @@ func (f *IpfsFetcher) recordFetched(fetchedPath ipath.Path) {
 }
 
 func initTempNode(ctx context.Context, bootstrap []string, peers []peer.AddrInfo) (string, error) {
-	identity, err := config.CreateIdentity(ioutil.Discard, []options.KeyGenerateOption{
+	identity, err := config.CreateIdentity(io.Discard, []options.KeyGenerateOption{
 		options.Key.Type(options.Ed25519Key),
 	})
 	if err != nil {
@@ -183,7 +182,7 @@ func initTempNode(ctx context.Context, bootstrap []string, peers []peer.AddrInfo
 	}
 
 	// create temporary ipfs directory
-	dir, err := ioutil.TempDir("", "ipfs-temp")
+	dir, err := os.MkdirTemp("", "ipfs-temp")
 	if err != nil {
 		return "", fmt.Errorf("failed to get temp dir: %s", err)
 	}

--- a/repo/fsrepo/migrations/migrations.go
+++ b/repo/fsrepo/migrations/migrations.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -63,7 +62,7 @@ func RunMigration(ctx context.Context, fetcher Fetcher, targetVer int, ipfsDir s
 
 		logger.Println("Need", len(missing), "migrations, downloading.")
 
-		tmpDir, err := ioutil.TempDir("", "migrations")
+		tmpDir, err := os.MkdirTemp("", "migrations")
 		if err != nil {
 			return err
 		}

--- a/repo/fsrepo/migrations/unpack_test.go
+++ b/repo/fsrepo/migrations/unpack_test.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,7 +35,7 @@ func TestUnpackTgz(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	badTarGzip := filepath.Join(tmpDir, "bad.tar.gz")
-	err := ioutil.WriteFile(badTarGzip, []byte("bad-data\n"), 0644)
+	err := os.WriteFile(badTarGzip, []byte("bad-data\n"), 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +79,7 @@ func TestUnpackZip(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	badZip := filepath.Join(tmpDir, "bad.zip")
-	err := ioutil.WriteFile(badZip, []byte("bad-data\n"), 0644)
+	err := os.WriteFile(badZip, []byte("bad-data\n"), 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/test/bench/bench_cli_ipfs_add/main.go
+++ b/test/bench/bench_cli_ipfs_add/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -46,7 +45,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 		b.SetBytes(amount)
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				benchmarkError = err
 				b.Fatal(err)
@@ -73,7 +72,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 			}
 
 			const seed = 1
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			if err != nil {
 				benchmarkError = err
 				b.Fatal(err)

--- a/test/bench/offline_add/main.go
+++ b/test/bench/offline_add/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -38,7 +37,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 		b.SetBytes(amount)
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir, err := os.MkdirTemp("", "")
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -56,7 +55,7 @@ func benchmarkAdd(amount int64) (*testing.BenchmarkResult, error) {
 			}
 
 			const seed = 1
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/test/dependencies/ma-pipe-unidir/main.go
+++ b/test/dependencies/ma-pipe-unidir/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -58,7 +57,7 @@ func app() int {
 
 		if len(opts.PidFile) > 0 {
 			data := []byte(strconv.Itoa(os.Getpid()))
-			err := ioutil.WriteFile(opts.PidFile, data, 0644)
+			err := os.WriteFile(opts.PidFile, data, 0644)
 			if err != nil {
 				return 1
 			}
@@ -79,7 +78,7 @@ func app() int {
 
 		if len(opts.PidFile) > 0 {
 			data := []byte(strconv.Itoa(os.Getpid()))
-			err := ioutil.WriteFile(opts.PidFile, data, 0644)
+			err := os.WriteFile(opts.PidFile, data, 0644)
 			if err != nil {
 				return 1
 			}


### PR DESCRIPTION
`ioutil` was depcrecated in [Go 1.16](https://go.dev/doc/go1.16)
