### PR TITLE
chore: mark 'log tail' experimental

### DIFF
--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -105,6 +105,7 @@ subsystems of a running daemon.
 }
 
 var logTailCmd = &cmds.Command{
+	Status: cmds.Experimental,
 	Helptext: cmds.HelpText{
 		Tagline: "Read the event log.",
 		ShortDescription: `


### PR DESCRIPTION
This is one-line change to ensuring people are aware the `log tail` is unstable and will change.
This hint will be picked up by docs.ipfs.io thanks to https://github.com/ipfs/ipfs-docs/pull/1086.

Context: https://github.com/ipfs/go-ipfs/pull/8765#issuecomment-1109884874 