### PR TITLE
fix(ci): fix flaky t0081-repo-pinning.sh

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -177,7 +177,7 @@ jobs:
         git checkout FETCH_HEAD
     - run:
         cd rb-pinning-service-api &&
-        docker-compose pull &&
+        (while ! docker-compose pull; do sleep 5; done) &&
         docker-compose up -d
 
     - *make_out_dirs

--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -177,7 +177,7 @@ jobs:
         git checkout FETCH_HEAD
     - run:
         cd rb-pinning-service-api &&
-        (while ! docker-compose pull; do sleep 5; done) &&
+        (for i in {1..3}; do docker-compose pull && break || sleep 5; done) &&
         docker-compose up -d
 
     - *make_out_dirs


### PR DESCRIPTION
Sometimes docker pull fails, this will retry.

Ref. example of a failed job: https://app.circleci.com/pipelines/github/ipfs/go-ipfs/6709/workflows/ca83ade9-ebaa-4ed3-b77b-2147dbdf719a/jobs/72873?invite=true#step-107-29