### PR TITLE
Ensure that folder exists before moving ipfs binary.

### DIFF
--- a/cmd/ipfs/dist/install.sh
+++ b/cmd/ipfs/dist/install.sh
@@ -15,6 +15,7 @@ is_write_perm_missing=""
 for raw in $binpaths; do
   # Expand the $HOME variable.
   binpath=$(eval echo "$raw")
+  mkdir -p "$binpath"
   if mv "$bin" "$binpath/ipfs" ; then
     echo "Moved $bin to $binpath"
     exit 0


### PR DESCRIPTION
On macOS Monterey there is no `/usr/local/bin` folder and we need to create it.

Closes #8347.