### PR TITLE
ci: disable workflows in forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'ipfs/go-ipfs' || github.event_name == 'workflow_dispatch'
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   push_to_registry:
+    if: github.repository == 'ipfs/go-ipfs' || github.event_name == 'workflow_dispatch'
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/sync-release-assets.yml
+++ b/.github/workflows/sync-release-assets.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   sync-github-and-dist-ipfs-io:
+    if: github.repository == 'ipfs/go-ipfs' || github.event_name == 'workflow_dispatch'
     runs-on: "ubuntu-latest"
     steps:
       - uses: ipfs/download-ipfs-distribution-action@v1

--- a/.github/workflows/testground-on-push.yml
+++ b/.github/workflows/testground-on-push.yml
@@ -1,10 +1,14 @@
 ---
 name: Testground PR Checker
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
+
 
 jobs:
   testground:
+    if: github.repository == 'ipfs/go-ipfs' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     name: ${{ matrix.composition_file }}
     strategy:


### PR DESCRIPTION
This PR makes sure that none of the workflows, except for `go-test`, do not run in future forks of `go-ipfs`. 

It does so by adding a check whether `github.repository` (this variable holds the full name of a reposiotry in which the workflow is being run) is equal to `ipfs/go-ipfs`. 

It also ensures that each of the "disabled" workflows can be executed explicitly using `workflow_dispatch`. 