### PR TITLE
chore: rename to ipfs-banana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# go-ipfs
+# ipfs-banana
 
-![banner](https://ipfs.io/ipfs/bafykbzacecaesuqmivkauix25v6i6xxxsvsrtxknhgb5zak3xxsg2nb4dhs2u/ipfs.go.png)
+![ipfs-banana](https://user-images.githubusercontent.com/157609/167471494-dee3a355-b551-4fbf-98e0-2eb76e867b48.png)
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square&cacheSeconds=3600)](https://protocol.ai)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square&cacheSeconds=3600)](https://godoc.org/github.com/ipfs/go-ipfs)
 [![CircleCI](https://img.shields.io/circleci/build/github/ipfs/go-ipfs?style=flat-square&cacheSeconds=3600)](https://circleci.com/gh/ipfs/go-ipfs)
+
+## What is "IPFS Banana"?
+
+This repo provides "jack of all trades, master of none" implementation of IPFS.
+
+It should be enough to get you started, if you find it lacking, see [other implementations](https://ipfs.io/#install).
+
 
 ## What is IPFS?
 
@@ -12,8 +19,9 @@ IPFS is a global, versioned, peer-to-peer filesystem. It combines good ideas fro
 
 For more info see: https://docs.ipfs.io/introduction/overview/
 
+
 Before opening an issue, consider using one of the following locations to ensure you are opening your thread in the right place:
-  - go-ipfs _implementation_ bugs in [this repo](https://github.com/ipfs/go-ipfs/issues).
+  - ipfs-banana (previously named go-ipfs) _implementation_ bugs in [this repo](https://github.com/ipfs/go-ipfs/issues).
   - Documentation issues in [ipfs/docs issues](https://github.com/ipfs/ipfs-docs/issues).
   - IPFS _design_ in [ipfs/specs issues](https://github.com/ipfs/specs/issues).
   - Exploration of new ideas in [ipfs/notes issues](https://github.com/ipfs/notes/issues).
@@ -61,14 +69,14 @@ Before opening an issue, consider using one of the following locations to ensure
     - [Cross Compiling](#cross-compiling)
     - [OpenSSL](#openssl)
     - [Troubleshooting](#troubleshooting)
-  - [Updating go-ipfs](#updating-go-ipfs)
+  - [Updating](#updating)
 - [Getting Started](#getting-started)
   - [Some things to try](#some-things-to-try)
   - [Usage](#usage)
   - [Troubleshooting](#troubleshooting-1)
 - [Packages](#packages)
 - [Development](#development)
-  - [Map of go-ipfs Subsystems](#map-of-go-ipfs-subsystems)
+  - [Map of Implemented Subsystems](#map-of-implemented-subsystems)
   - [CLI, HTTP-API, Architecture Diagram](#cli-http-api-architecture-diagram)
   - [Testing](#testing)
   - [Development Dependencies](#development-dependencies)
@@ -310,7 +318,7 @@ dependencies as well.
 - Shell command completions can be generated with one of the `ipfs commands completion` subcommands. Read [docs/command-completion.md](docs/command-completion.md) to learn more.
 - See the [misc folder](https://github.com/ipfs/go-ipfs/tree/master/misc) for how to connect IPFS to systemd or whatever init system your distro uses.
 
-### Updating go-ipfs
+### Updating
 
 #### Using ipfs-update
 
@@ -318,9 +326,11 @@ IPFS has an updating tool that can be accessed through `ipfs update`. The tool i
 not installed alongside IPFS in order to keep that logic independent of the main
 codebase. To install `ipfs update`, [download it here](https://ipfs.io/ipns/dist.ipfs.io/#ipfs-update).
 
-#### Downloading IPFS builds using IPFS
+#### Downloading builds using IPFS
 
-List the available versions of go-ipfs:
+<!-- TODO: rename this section after we figure out if dist.ipfs.io sgould produce both /go-ipfs/ and /ipfs-banana/ -->
+
+List the available versions of "go-ipfs" implementation:
 
 ```
 $ ipfs cat /ipns/dist.ipfs.io/go-ipfs/versions
@@ -454,8 +464,8 @@ Some places to get you started on the codebase:
   - PubSub: https://github.com/libp2p/go-libp2p-pubsub
 - [IPFS : The `Add` command demystified](https://github.com/ipfs/go-ipfs/tree/master/docs/add-code-flow.md)
 
-### Map of go-ipfs Subsystems
-**WIP**: This is a high-level architecture diagram of the various sub-systems of go-ipfs. To be updated with how they interact. Anyone who has suggestions is welcome to comment [here](https://docs.google.com/drawings/d/1OVpBT2q-NtSJqlPX3buvjYhOnWfdzb85YEsM_njesME/edit) on how we can improve this!
+### Map of Implemented Subsystems
+**WIP**: This is a high-level architecture diagram of the various sub-systems of this specific implementation. To be updated with how they interact. Anyone who has suggestions is welcome to comment [here](https://docs.google.com/drawings/d/1OVpBT2q-NtSJqlPX3buvjYhOnWfdzb85YEsM_njesME/edit) on how we can improve this!
 <img src="https://docs.google.com/drawings/d/e/2PACX-1vS_n1FvSu6mdmSirkBrIIEib2gqhgtatD9awaP2_WdrGN4zTNeg620XQd9P95WT-IvognSxIIdCM5uE/pub?w=1446&amp;h=1036">
 
 ### CLI, HTTP-API, Architecture Diagram
@@ -492,7 +502,7 @@ Please reach out to us in one [chat](https://docs.ipfs.io/community/chat/) rooms
 
 ## License
 
-The go-ipfs project is dual-licensed under Apache 2.0 and MIT terms:
+This project is dual-licensed under Apache 2.0 and MIT terms:
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](https://github.com/ipfs/go-ipfs/blob/master/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 - MIT license ([LICENSE-MIT](https://github.com/ipfs/go-ipfs/blob/master/LICENSE-MIT) or http://opensource.org/licenses/MIT)


### PR DESCRIPTION
Renaming to banana until more memeable name comes along.

![ipfs-banana](https://user-images.githubusercontent.com/157609/167471494-dee3a355-b551-4fbf-98e0-2eb76e867b48.png)

In all seriousness, this PR aims to:
- flesh out the name that we are ok with
  - :point_right:  if you feel offended by ipfs-banana – time to propose better name is NOW
-  identify the minimal surface we need to change before July, given the limited bandwidth IPFS Stewards have