### PR TITLE
chore: mark fuse experimental

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -169,7 +169,7 @@ Headers.
 		cmds.StringOption(initConfigOptionKwd, "Path to existing configuration file to be loaded during --init"),
 		cmds.StringOption(initProfileOptionKwd, "Configuration profiles to apply for --init. See ipfs init --help for more"),
 		cmds.StringOption(routingOptionKwd, "Overrides the routing option").WithDefault(routingOptionDefaultKwd),
-		cmds.BoolOption(mountKwd, "Mounts IPFS to the filesystem"),
+		cmds.BoolOption(mountKwd, "Mounts IPFS to the filesystem using FUSE (experimental)"),
 		cmds.BoolOption(writableKwd, "Enable writing objects (with POST, PUT and DELETE)"),
 		cmds.StringOption(ipfsMountKwd, "Path to the mountpoint for IPFS (if using --mount). Defaults to config setting."),
 		cmds.StringOption(ipnsMountKwd, "Path to the mountpoint for IPNS (if using --mount). Defaults to config setting."),

--- a/core/commands/mount_nofuse.go
+++ b/core/commands/mount_nofuse.go
@@ -8,6 +8,7 @@ import (
 )
 
 var MountCmd = &cmds.Command{
+	Status: cmds.Experimental,
 	Helptext: cmds.HelpText{
 		Tagline: "Mounts ipfs to the filesystem (disabled).",
 		ShortDescription: `

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -21,6 +21,7 @@ const (
 )
 
 var MountCmd = &cmds.Command{
+	Status: cmds.Experimental,
 	Helptext: cmds.HelpText{
 		Tagline: "Mounts IPFS to the filesystem (read-only).",
 		ShortDescription: `

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -52,7 +52,6 @@ TEXT ENCODING COMMANDS
 
 ADVANCED COMMANDS
   daemon        Start a long-running daemon process
-  mount         Mount an IPFS read-only mount point
   resolve       Resolve any type of content path
   name          Publish and resolve IPNS names
   key           Create and list IPNS name keypairs
@@ -61,6 +60,7 @@ ADVANCED COMMANDS
   stats         Various operational stats
   p2p           Libp2p stream mounting (experimental)
   filestore     Manage the filestore (experimental)
+  mount         Mount an IPFS read-only mount point (experimental)
 
 NETWORK COMMANDS
   id            Show info about IPFS peers

--- a/docs/config.md
+++ b/docs/config.md
@@ -1035,6 +1035,8 @@ Default: `cache`
 
 ## `Mounts`
 
+**EXPERIMENTAL:** read about current limitations at [fuse.md](./fuse.md).
+
 FUSE mount point configuration options.
 
 ### `Mounts.IPFS`

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -19,6 +19,7 @@ the above issue.
 - [Private Networks](#private-networks)
 - [ipfs p2p](#ipfs-p2p)
 - [p2p http proxy](#p2p-http-proxy)
+- [FUSE](#fuse)
 - [Plugins](#plugins)
 - [Directory Sharding / HAMT](#directory-sharding--hamt)
 - [IPNS PubSub](#ipns-pubsub)
@@ -385,6 +386,15 @@ We also support the use of protocol names of the form /x/$NAME/http where $NAME 
 - [ ] Needs more people to use and report on how well it works / fits use cases
 - [ ] More documentation
 - [ ] Need better integration with the subdomain gateway feature.
+
+## FUSE
+
+FUSE makes it possible to mount `/ipfs` and `/ipns` namespaces in your OS,
+allowing argitrary apps access to IPFS using a subset of filesystem abstracitons.
+
+It is considered  EXPERIMENTAL due to limited (and buggy) support on some platforms.
+
+See [fuse.md](./fuse.md) for more details.
 
 ## Plugins
 

--- a/docs/fuse.md
+++ b/docs/fuse.md
@@ -1,5 +1,7 @@
 # FUSE
 
+**EXPERIMENTAL:** FUSE support is limited, YMMV.
+
 `go-ipfs` makes it possible to mount `/ipfs` and `/ipns` namespaces in your OS,
 allowing arbitrary apps access to IPFS.
 


### PR DESCRIPTION
FUSE  works only on some platforms, and does not work reliably.

This OR corrects our error of not setting expectations right and marks FUSE as EXPERIMENTAL.