### PR TITLE
fix(node/libp2p): disable rcmg checkImplicitDefaults

### DIFF
--- a/.circleci/main.yml
+++ b/.circleci/main.yml
@@ -32,6 +32,7 @@ default_environment: &default_environment
   CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
   CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
   GIT_PAGER: cat
+  IPFS_CHECK_RCMGR_DEFAULTS: 1
 
 executors:
   golang:

--- a/core/node/libp2p/rcmgr_defaults.go
+++ b/core/node/libp2p/rcmgr_defaults.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/bits"
+	"os"
 	"strings"
 
 	config "github.com/ipfs/go-ipfs/config"
@@ -19,7 +20,10 @@ import (
 // such as values in Swarm.ConnMgr.HiWater config.
 func adjustedDefaultLimits(cfg config.SwarmConfig) rcmgr.DefaultLimitConfig {
 	// Run checks to avoid introducing regressions
-	checkImplicitDefaults()
+	if os.Getenv("IPFS_CHECK_RCMGR_DEFAULTS") != "" {
+		// FIXME: Broken. Being tracked in https://github.com/ipfs/go-ipfs/issues/8949.
+		checkImplicitDefaults()
+	}
 
 	// Return to use unmodified static limits based on values from go-libp2p 0.18
 	// return defaultLimits


### PR DESCRIPTION
Quick band-aid for https://github.com/ipfs/go-ipfs/issues/8949 to fix master before https://github.com/ipfs/go-ipfs/pull/8954 lands.