### PR TITLE
fix(ci): make go-ipfs-as-a-library work without external peers

### DIFF
--- a/docs/examples/go-ipfs-as-a-library/main.go
+++ b/docs/examples/go-ipfs-as-a-library/main.go
@@ -196,12 +196,12 @@ func main() {
 	defer cancel()
 
 	// Spawn a local peer using a temporary path, for testing purposes
-	peerAPI, peerNode, err := spawnEphemeral(ctx)
+	ipfsA, nodeA, err := spawnEphemeral(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to spawn peer node: %s", err))
 	}
 
-	peerCidFile, err := peerAPI.Unixfs().Add(ctx,
+	peerCidFile, err := ipfsA.Unixfs().Add(ctx,
 		files.NewBytesFile([]byte("hello from ipfs 101 in go-ipfs")))
 	if err != nil {
 		panic(fmt.Errorf("could not add File: %s", err))
@@ -211,7 +211,7 @@ func main() {
 
 	// Spawn a node using a temporary path, creating a temporary repo for the run
 	fmt.Println("Spawning node on a temporary repo")
-	ipfs, _, err := spawnEphemeral(ctx)
+	ipfsB, _, err := spawnEphemeral(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to spawn ephemeral node: %s", err))
 	}
@@ -231,7 +231,7 @@ func main() {
 		panic(fmt.Errorf("could not get File: %s", err))
 	}
 
-	cidFile, err := ipfs.Unixfs().Add(ctx, someFile)
+	cidFile, err := ipfsB.Unixfs().Add(ctx, someFile)
 	if err != nil {
 		panic(fmt.Errorf("could not add File: %s", err))
 	}
@@ -243,7 +243,7 @@ func main() {
 		panic(fmt.Errorf("could not get File: %s", err))
 	}
 
-	cidDirectory, err := ipfs.Unixfs().Add(ctx, someDirectory)
+	cidDirectory, err := ipfsB.Unixfs().Add(ctx, someDirectory)
 	if err != nil {
 		panic(fmt.Errorf("could not add Directory: %s", err))
 	}
@@ -260,7 +260,7 @@ func main() {
 	outputPathFile := outputBasePath + strings.Split(cidFile.String(), "/")[2]
 	outputPathDirectory := outputBasePath + strings.Split(cidDirectory.String(), "/")[2]
 
-	rootNodeFile, err := ipfs.Unixfs().Get(ctx, cidFile)
+	rootNodeFile, err := ipfsB.Unixfs().Get(ctx, cidFile)
 	if err != nil {
 		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}
@@ -272,7 +272,7 @@ func main() {
 
 	fmt.Printf("got file back from IPFS (IPFS path: %s) and wrote it to %s\n", cidFile.String(), outputPathFile)
 
-	rootNodeDirectory, err := ipfs.Unixfs().Get(ctx, cidDirectory)
+	rootNodeDirectory, err := ipfsB.Unixfs().Get(ctx, cidDirectory)
 	if err != nil {
 		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}
@@ -288,7 +288,7 @@ func main() {
 
 	fmt.Println("\n-- Going to connect to a few nodes in the Network as bootstrappers --")
 
-	peerMa := fmt.Sprintf("/ip4/127.0.0.1/udp/4010/p2p/%s", peerNode.Identity.String())
+	peerMa := fmt.Sprintf("/ip4/127.0.0.1/udp/4010/p2p/%s", nodeA.Identity.String())
 
 	bootstrapNodes := []string{
 		// IPFS Bootstrapper nodes.
@@ -314,7 +314,7 @@ func main() {
 	}
 
 	go func() {
-		err := connectToPeers(ctx, ipfs, bootstrapNodes)
+		err := connectToPeers(ctx, ipfsB, bootstrapNodes)
 		if err != nil {
 			log.Printf("failed connect to peers: %s", err)
 		}
@@ -326,7 +326,7 @@ func main() {
 	outputPath := outputBasePath + exampleCIDStr
 	testCID := icorepath.New(exampleCIDStr)
 
-	rootNode, err := ipfs.Unixfs().Get(ctx, testCID)
+	rootNode, err := ipfsB.Unixfs().Get(ctx, testCID)
 	if err != nil {
 		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}

--- a/docs/examples/go-ipfs-as-a-library/main.go
+++ b/docs/examples/go-ipfs-as-a-library/main.go
@@ -86,7 +86,7 @@ func createTempRepo() (string, error) {
 /// ------ Spawning the node
 
 // Creates an IPFS node and returns its coreAPI
-func createNode(ctx context.Context, repoPath string) (icore.CoreAPI, error) {
+func createNode(ctx context.Context, repoPath string) (*core.IpfsNode, error) {
 	// Open the repo
 	repo, err := fsrepo.Open(repoPath)
 	if err != nil {
@@ -102,48 +102,36 @@ func createNode(ctx context.Context, repoPath string) (icore.CoreAPI, error) {
 		Repo: repo,
 	}
 
-	node, err := core.NewNode(ctx, nodeOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	// Attach the Core API to the constructed node
-	return coreapi.NewCoreAPI(node)
+	return core.NewNode(ctx, nodeOptions)
 }
 
-// Spawns a node on the default repo location, if the repo exists
-func spawnDefault(ctx context.Context) (icore.CoreAPI, error) {
-	defaultPath, err := config.PathRoot()
-	if err != nil {
-		// shouldn't be possible
-		return nil, err
-	}
-
-	if err := setupPlugins(defaultPath); err != nil {
-		return nil, err
-
-	}
-
-	return createNode(ctx, defaultPath)
-}
+var loadPluginsOnce sync.Once
 
 // Spawns a node to be used just for this run (i.e. creates a tmp repo)
-func spawnEphemeral(ctx context.Context) (icore.CoreAPI, error) {
-	if err := setupPlugins(""); err != nil {
-		return nil, err
+func spawnEphemeral(ctx context.Context) (icore.CoreAPI, *core.IpfsNode, error) {
+	var onceErr error
+	loadPluginsOnce.Do(func() {
+		onceErr = setupPlugins("")
+	})
+	if onceErr != nil {
+		return nil, nil, onceErr
 	}
 
 	// Create a Temporary Repo
 	repoPath, err := createTempRepo()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp repo: %s", err)
+		return nil, nil, fmt.Errorf("failed to create temp repo: %s", err)
 	}
 
-	// Spawning an ephemeral IPFS node
-	return createNode(ctx, repoPath)
-}
+	node, err := createNode(ctx, repoPath)
+	if err != nil {
+		return nil, nil, err
+	}
 
-//
+	api, err := coreapi.NewCoreAPI(node)
+
+	return api, node, err
+}
 
 func connectToPeers(ctx context.Context, ipfs icore.CoreAPI, peers []string) error {
 	var wg sync.WaitGroup
@@ -179,26 +167,6 @@ func connectToPeers(ctx context.Context, ipfs icore.CoreAPI, peers []string) err
 	return nil
 }
 
-func getUnixfsFile(path string) (files.File, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	st, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-
-	f, err := files.NewReaderPathFile(path, file, st)
-	if err != nil {
-		return nil, err
-	}
-
-	return f, nil
-}
-
 func getUnixfsNode(path string) (files.Node, error) {
 	st, err := os.Stat(path)
 	if err != nil {
@@ -227,18 +195,23 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	/*
-		// Spawn a node using the default path (~/.ipfs), assuming that a repo exists there already
-		fmt.Println("Spawning node on default repo")
-		ipfs, err := spawnDefault(ctx)
-		if err != nil {
-			panic(fmt.Errorf("failed to spawnDefault node: %s", err))
-		}
-	*/
+	// Spawn a local peer using a temporary path, for testing purposes
+	peerAPI, peerNode, err := spawnEphemeral(ctx)
+	if err != nil {
+		panic(fmt.Errorf("failed to spawn peer node: %s", err))
+	}
+
+	peerCidFile, err := peerAPI.Unixfs().Add(ctx,
+		files.NewBytesFile([]byte("hello from ipfs 101 in go-ipfs")))
+	if err != nil {
+		panic(fmt.Errorf("could not add File: %s", err))
+	}
+
+	fmt.Printf("Added file to peer with CID %s\n", peerCidFile.String())
 
 	// Spawn a node using a temporary path, creating a temporary repo for the run
 	fmt.Println("Spawning node on a temporary repo")
-	ipfs, err := spawnEphemeral(ctx)
+	ipfs, _, err := spawnEphemeral(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to spawn ephemeral node: %s", err))
 	}
@@ -255,24 +228,24 @@ func main() {
 
 	someFile, err := getUnixfsNode(inputPathFile)
 	if err != nil {
-		panic(fmt.Errorf("Could not get File: %s", err))
+		panic(fmt.Errorf("could not get File: %s", err))
 	}
 
 	cidFile, err := ipfs.Unixfs().Add(ctx, someFile)
 	if err != nil {
-		panic(fmt.Errorf("Could not add File: %s", err))
+		panic(fmt.Errorf("could not add File: %s", err))
 	}
 
 	fmt.Printf("Added file to IPFS with CID %s\n", cidFile.String())
 
 	someDirectory, err := getUnixfsNode(inputPathDirectory)
 	if err != nil {
-		panic(fmt.Errorf("Could not get File: %s", err))
+		panic(fmt.Errorf("could not get File: %s", err))
 	}
 
 	cidDirectory, err := ipfs.Unixfs().Add(ctx, someDirectory)
 	if err != nil {
-		panic(fmt.Errorf("Could not add Directory: %s", err))
+		panic(fmt.Errorf("could not add Directory: %s", err))
 	}
 
 	fmt.Printf("Added directory to IPFS with CID %s\n", cidDirectory.String())
@@ -289,24 +262,24 @@ func main() {
 
 	rootNodeFile, err := ipfs.Unixfs().Get(ctx, cidFile)
 	if err != nil {
-		panic(fmt.Errorf("Could not get file with CID: %s", err))
+		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}
 
 	err = files.WriteTo(rootNodeFile, outputPathFile)
 	if err != nil {
-		panic(fmt.Errorf("Could not write out the fetched CID: %s", err))
+		panic(fmt.Errorf("could not write out the fetched CID: %s", err))
 	}
 
-	fmt.Printf("Got file back from IPFS (IPFS path: %s) and wrote it to %s\n", cidFile.String(), outputPathFile)
+	fmt.Printf("got file back from IPFS (IPFS path: %s) and wrote it to %s\n", cidFile.String(), outputPathFile)
 
 	rootNodeDirectory, err := ipfs.Unixfs().Get(ctx, cidDirectory)
 	if err != nil {
-		panic(fmt.Errorf("Could not get file with CID: %s", err))
+		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}
 
 	err = files.WriteTo(rootNodeDirectory, outputPathDirectory)
 	if err != nil {
-		panic(fmt.Errorf("Could not write out the fetched CID: %s", err))
+		panic(fmt.Errorf("could not write out the fetched CID: %s", err))
 	}
 
 	fmt.Printf("Got directory back from IPFS (IPFS path: %s) and wrote it to %s\n", cidDirectory.String(), outputPathDirectory)
@@ -315,26 +288,29 @@ func main() {
 
 	fmt.Println("\n-- Going to connect to a few nodes in the Network as bootstrappers --")
 
+	peerMa := fmt.Sprintf("/ip4/127.0.0.1/udp/4010/p2p/%s", peerNode.Identity.String())
+
 	bootstrapNodes := []string{
 		// IPFS Bootstrapper nodes.
-		"/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-		"/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-		"/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-		"/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+		// "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
 
 		// IPFS Cluster Pinning nodes
-		"/ip4/138.201.67.219/tcp/4001/p2p/QmUd6zHcbkbcs7SMxwLs48qZVX3vpcM8errYS7xEczwRMA",
-		"/ip4/138.201.67.219/udp/4001/quic/p2p/QmUd6zHcbkbcs7SMxwLs48qZVX3vpcM8errYS7xEczwRMA",
-		"/ip4/138.201.67.220/tcp/4001/p2p/QmNSYxZAiJHeLdkBg38roksAR9So7Y5eojks1yjEcUtZ7i",
-		"/ip4/138.201.67.220/udp/4001/quic/p2p/QmNSYxZAiJHeLdkBg38roksAR9So7Y5eojks1yjEcUtZ7i",
-		"/ip4/138.201.68.74/tcp/4001/p2p/QmdnXwLrC8p1ueiq2Qya8joNvk3TVVDAut7PrikmZwubtR",
-		"/ip4/138.201.68.74/udp/4001/quic/p2p/QmdnXwLrC8p1ueiq2Qya8joNvk3TVVDAut7PrikmZwubtR",
-		"/ip4/94.130.135.167/tcp/4001/p2p/QmUEMvxS2e7iDrereVYc5SWPauXPyNwxcy9BXZrC1QTcHE",
-		"/ip4/94.130.135.167/udp/4001/quic/p2p/QmUEMvxS2e7iDrereVYc5SWPauXPyNwxcy9BXZrC1QTcHE",
+		// "/ip4/138.201.67.219/tcp/4001/p2p/QmUd6zHcbkbcs7SMxwLs48qZVX3vpcM8errYS7xEczwRMA",
+		// "/ip4/138.201.67.219/udp/4001/quic/p2p/QmUd6zHcbkbcs7SMxwLs48qZVX3vpcM8errYS7xEczwRMA",
+		// "/ip4/138.201.67.220/tcp/4001/p2p/QmNSYxZAiJHeLdkBg38roksAR9So7Y5eojks1yjEcUtZ7i",
+		// "/ip4/138.201.67.220/udp/4001/quic/p2p/QmNSYxZAiJHeLdkBg38roksAR9So7Y5eojks1yjEcUtZ7i",
+		// "/ip4/138.201.68.74/tcp/4001/p2p/QmdnXwLrC8p1ueiq2Qya8joNvk3TVVDAut7PrikmZwubtR",
+		// "/ip4/138.201.68.74/udp/4001/quic/p2p/QmdnXwLrC8p1ueiq2Qya8joNvk3TVVDAut7PrikmZwubtR",
+		// "/ip4/94.130.135.167/tcp/4001/p2p/QmUEMvxS2e7iDrereVYc5SWPauXPyNwxcy9BXZrC1QTcHE",
+		// "/ip4/94.130.135.167/udp/4001/quic/p2p/QmUEMvxS2e7iDrereVYc5SWPauXPyNwxcy9BXZrC1QTcHE",
 
 		// You can add more nodes here, for example, another IPFS node you might have running locally, mine was:
 		// "/ip4/127.0.0.1/tcp/4010/p2p/QmZp2fhDLxjYue2RiUvLwT9MWdnbDxam32qYFnGmxZDh5L",
 		// "/ip4/127.0.0.1/udp/4010/quic/p2p/QmZp2fhDLxjYue2RiUvLwT9MWdnbDxam32qYFnGmxZDh5L",
+		peerMa,
 	}
 
 	go func() {
@@ -344,7 +320,7 @@ func main() {
 		}
 	}()
 
-	exampleCIDStr := "QmUaoioqU7bxezBQZkUcgcSyokatMY71sxsALxQmRRrHrj"
+	exampleCIDStr := peerCidFile.Cid().String()
 
 	fmt.Printf("Fetching a file from the network with CID %s\n", exampleCIDStr)
 	outputPath := outputBasePath + exampleCIDStr
@@ -352,12 +328,12 @@ func main() {
 
 	rootNode, err := ipfs.Unixfs().Get(ctx, testCID)
 	if err != nil {
-		panic(fmt.Errorf("Could not get file with CID: %s", err))
+		panic(fmt.Errorf("could not get file with CID: %s", err))
 	}
 
 	err = files.WriteTo(rootNode, outputPath)
 	if err != nil {
-		panic(fmt.Errorf("Could not write out the fetched CID: %s", err))
+		panic(fmt.Errorf("could not write out the fetched CID: %s", err))
 	}
 
 	fmt.Printf("Wrote the file to %s\n", outputPath)


### PR DESCRIPTION
It was causing some build timeout errors because CircleCI was throttling
WAN connections.

It closes #8956 (was flaky test)
