### PR TITLE
fix: JS caching via Access-Control-Expose-Headers

### DIFF
--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -84,9 +84,12 @@ func GatewayOption(writable bool, paths ...string) ServeOption {
 
 		headers[ACEHeadersName] = cleanHeaderSet(
 			append([]string{
+				"Content-Length",
 				"Content-Range",
 				"X-Chunked-Output",
 				"X-Stream-Output",
+				"X-Ipfs-Path",
+				"X-Ipfs-Roots",
 			}, headers[ACEHeadersName]...))
 
 		var gateway http.Handler = newGatewayHandler(GatewayConfig{

--- a/test/sharness/t0112-gateway-cors.sh
+++ b/test/sharness/t0112-gateway-cors.sh
@@ -26,7 +26,10 @@ test_expect_success "GET response for Gateway resource looks good" '
   grep "< Access-Control-Allow-Origin: \*" curl_output &&
   grep "< Access-Control-Allow-Methods: GET" curl_output &&
   grep "< Access-Control-Allow-Headers: Range" curl_output &&
-  grep "< Access-Control-Expose-Headers: Content-Range" curl_output
+  grep "< Access-Control-Expose-Headers: Content-Range" curl_output &&
+  grep "< Access-Control-Expose-Headers: Content-Length" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
 '
 
 # HTTP OPTIONS Request
@@ -40,7 +43,10 @@ test_expect_success "OPTIONS response for Gateway resource looks good" '
   grep "< Access-Control-Allow-Origin: \*" curl_output &&
   grep "< Access-Control-Allow-Methods: GET" curl_output &&
   grep "< Access-Control-Allow-Headers: Range" curl_output &&
-  grep "< Access-Control-Expose-Headers: Content-Range" curl_output
+  grep "< Access-Control-Expose-Headers: Content-Range" curl_output &&
+  grep "< Access-Control-Expose-Headers: Content-Length" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output
 '
 
 test_kill_ipfs_daemon
@@ -63,6 +69,9 @@ test_expect_success "Access-Control-Allow-Headers extends" '
   grep "< Access-Control-Allow-Headers: Range" curl_output &&
   grep "< Access-Control-Allow-Headers: X-Custom1" curl_output &&
   grep "< Access-Control-Expose-Headers: Content-Range" curl_output &&
+  grep "< Access-Control-Expose-Headers: Content-Length" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Path" curl_output &&
+  grep "< Access-Control-Expose-Headers: X-Ipfs-Roots" curl_output &&
   grep "< Access-Control-Expose-Headers: X-Custom2" curl_output
 '
 


### PR DESCRIPTION
This fix safelists additional headers allowing JS running on websites to read them when IPFS resource is downloaded via Fetch API.

These headers allow for making smart caching decisions (https://github.com/ipfs/go-ipfs/pull/8720)  when IPFS resources are downloaded via Service Worker or a  similar middleware on the edge. 

@guseggert  If possible, we should include it in 0.13 (I forgot to safelist them in https://github.com/ipfs/go-ipfs/pull/8720), but if it is too late, then please reassign this to 0.14.