### PR TITLE
Update ipfs-sysusers.conf

### DIFF
--- a/misc/systemd/ipfs-sysusers.conf
+++ b/misc/systemd/ipfs-sysusers.conf
@@ -1,3 +1,1 @@
 u ipfs - "IPFS daemon" /var/lib/ipfs
-g ipfs -
-m ipfs ipfs


### PR DESCRIPTION
`g` and `m` do not need to be separately included, as `u` already creates a matching group for the user.
```
       u
           Create a system user and group of the specified name should they not exist yet. The user's primary group
           will be set to the group bearing the same name unless the ID field specifies it. The account will be
           created disabled, so that logins are not allowed.

       g
           Create a system group of the specified name should it not exist yet. Note that u implicitly creates a
           matching group. The group will be created with no password set.
```