### PR TITLE
fix(cmd/config): make config edit subcommand work on windows

### DIFF
--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -503,13 +503,13 @@ func editConfig(filename string) error {
 		return errors.New("ENV variable $EDITOR not set")
 	}
 
-	if runtime.GOOS == "windows" {
-		cmd := exec.Command("cmd", "/C", editor, filename)
-		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-		return cmd.Run()
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("cmd", "/C", editor, filename)
+	default:
+		cmd = exec.Command("sh", "-c", editor+" "+filename)
 	}
-
-	cmd := exec.Command("sh", "-c", editor+" "+filename)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Run()
 }

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/ipfs/go-ipfs/core/commands/cmdenv"
@@ -500,6 +501,12 @@ func editConfig(filename string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		return errors.New("ENV variable $EDITOR not set")
+	}
+
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command("cmd", "/C", editor, filename)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		return cmd.Run()
 	}
 
 	cmd := exec.Command("sh", "-c", editor+" "+filename)

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -503,13 +503,7 @@ func editConfig(filename string) error {
 		return errors.New("ENV variable $EDITOR not set")
 	}
 
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "windows":
-		cmd = exec.Command("cmd", "/C", editor, filename)
-	default:
-		cmd = exec.Command("sh", "-c", editor+" "+filename)
-	}
+	cmd := exec.Command(editor, filename)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
This is a tiny patch to make the `ipfs config edit` subcommand work on Windows.

Closing #8844