### PR TITLE
fix: remove mdns_legacy

### DIFF
--- a/config/discovery.go
+++ b/config/discovery.go
@@ -7,6 +7,7 @@ type Discovery struct {
 type MDNS struct {
 	Enabled bool
 
-	// Time in seconds between discovery rounds
-	Interval int
+	// DEPRECATED: the time between discovery rounds is no longer configurable
+	// See: https://github.com/ipfs/go-ipfs/pull/9048#discussion_r906814717
+	Interval *OptionalInteger `json:",omitempty"`
 }

--- a/config/init.go
+++ b/config/init.go
@@ -43,8 +43,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Identity:  identity,
 		Discovery: Discovery{
 			MDNS: MDNS{
-				Enabled:  true,
-				Interval: 10,
+				Enabled: true,
 			},
 		},
 

--- a/core/node/groups.go
+++ b/core/node/groups.go
@@ -159,7 +159,7 @@ func LibP2P(bcfg *BuildCfg, cfg *config.Config) fx.Option {
 		fx.Provide(libp2p.RelayService(enableRelayService, cfg.Swarm.RelayService)),
 		fx.Provide(libp2p.Transports(cfg.Swarm.Transports)),
 		fx.Invoke(libp2p.StartListening(cfg.Addresses.Swarm)),
-		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled, cfg.Discovery.MDNS.Interval)),
+		fx.Invoke(libp2p.SetupDiscovery(cfg.Discovery.MDNS.Enabled)),
 		fx.Provide(libp2p.ForceReachability(cfg.Internal.Libp2pForceReachability)),
 		fx.Provide(libp2p.HolePunching(cfg.Swarm.EnableHolePunching, enableRelayClient)),
 

--- a/core/node/libp2p/discovery.go
+++ b/core/node/libp2p/discovery.go
@@ -7,7 +7,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
-	legacymdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns_legacy"
 
 	"go.uber.org/fx"
 
@@ -49,12 +48,6 @@ func SetupDiscovery(useMdns bool, mdnsInterval int) func(helpers.MetricsCtx, fx.
 			if mdnsInterval == 0 {
 				mdnsInterval = 5
 			}
-			legacyService, err := legacymdns.NewMdnsService(mctx, host, time.Duration(mdnsInterval)*time.Second, legacymdns.ServiceTag)
-			if err != nil {
-				log.Error("mdns error: ", err)
-				return nil
-			}
-			legacyService.RegisterNotifee(handler)
 		}
 		return nil
 	}

--- a/core/node/libp2p/discovery.go
+++ b/core/node/libp2p/discovery.go
@@ -36,17 +36,13 @@ func DiscoveryHandler(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host) 
 	}
 }
 
-func SetupDiscovery(useMdns bool, mdnsInterval int) func(helpers.MetricsCtx, fx.Lifecycle, host.Host, *discoveryHandler) error {
+func SetupDiscovery(useMdns bool) func(helpers.MetricsCtx, fx.Lifecycle, host.Host, *discoveryHandler) error {
 	return func(mctx helpers.MetricsCtx, lc fx.Lifecycle, host host.Host, handler *discoveryHandler) error {
 		if useMdns {
 			service := mdns.NewMdnsService(host, mdns.ServiceName, handler)
 			if err := service.Start(); err != nil {
 				log.Error("error starting mdns service: ", err)
 				return nil
-			}
-
-			if mdnsInterval == 0 {
-				mdnsInterval = 5
 			}
 		}
 		return nil

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,10 +5,10 @@ is read once at node instantiation, either for an offline command, or when
 starting the daemon. Commands that execute on a running daemon do not read the
 config file at runtime.
 
-## Table of Contents
+# Table of Contents
 
 - [The go-ipfs config file](#the-go-ipfs-config-file)
-  - [Table of Contents](#table-of-contents)
+- [Table of Contents](#table-of-contents)
   - [Profiles](#profiles)
   - [Types](#types)
     - [`flag`](#flag)
@@ -108,13 +108,15 @@ config file at runtime.
     - [`Swarm.DisableBandwidthMetrics`](#swarmdisablebandwidthmetrics)
     - [`Swarm.DisableNatPortMap`](#swarmdisablenatportmap)
     - [`Swarm.EnableHolePunching`](#swarmenableholepunching)
+    - [`Swarm.EnableAutoRelay`](#swarmenableautorelay)
     - [`Swarm.RelayClient`](#swarmrelayclient)
       - [`Swarm.RelayClient.Enabled`](#swarmrelayclientenabled)
       - [`Swarm.RelayClient.StaticRelays`](#swarmrelayclientstaticrelays)
     - [`Swarm.RelayService`](#swarmrelayservice)
       - [`Swarm.RelayService.Enabled`](#swarmrelayserviceenabled)
-      - [`Swarm.RelayService.ConnectionDurationLimit`](#swarmrelayserviceconnectiondurationlimit)
-      - [`Swarm.RelayService.ConnectionDataLimit`](#swarmrelayserviceconnectiondatalimit)
+      - [`Swarm.RelayService.Limit`](#swarmrelayservicelimit)
+        - [`Swarm.RelayService.ConnectionDurationLimit`](#swarmrelayserviceconnectiondurationlimit)
+        - [`Swarm.RelayService.ConnectionDataLimit`](#swarmrelayserviceconnectiondatalimit)
       - [`Swarm.RelayService.ReservationTTL`](#swarmrelayservicereservationttl)
       - [`Swarm.RelayService.MaxReservations`](#swarmrelayservicemaxreservations)
       - [`Swarm.RelayService.MaxCircuits`](#swarmrelayservicemaxcircuits)
@@ -122,6 +124,8 @@ config file at runtime.
       - [`Swarm.RelayService.MaxReservationsPerPeer`](#swarmrelayservicemaxreservationsperpeer)
       - [`Swarm.RelayService.MaxReservationsPerIP`](#swarmrelayservicemaxreservationsperip)
       - [`Swarm.RelayService.MaxReservationsPerASN`](#swarmrelayservicemaxreservationsperasn)
+    - [`Swarm.EnableRelayHop`](#swarmenablerelayhop)
+    - [`Swarm.DisableRelay`](#swarmdisablerelay)
     - [`Swarm.EnableAutoNATService`](#swarmenableautonatservice)
     - [`Swarm.ConnMgr`](#swarmconnmgr)
       - [`Swarm.ConnMgr.Type`](#swarmconnmgrtype)
@@ -148,8 +152,6 @@ config file at runtime.
   - [`DNS`](#dns)
     - [`DNS.Resolvers`](#dnsresolvers)
     - [`DNS.MaxCacheTTL`](#dnsmaxcachettl)
-
-
 
 ## Profiles
 
@@ -574,15 +576,15 @@ Type: `object`
 
 ## `Discovery`
 
-Contains options for configuring ipfs node discovery mechanisms.
+Contains options for configuring IPFS node discovery mechanisms.
 
 ### `Discovery.MDNS`
 
-Options for multicast dns peer discovery.
+Options for [ZeroConf](https://github.com/libp2p/zeroconf#readme) Multicast DNS-SD peer discovery.
 
 #### `Discovery.MDNS.Enabled`
 
-A boolean value for whether or not mdns should be active.
+A boolean value for whether or not Multicast DNS-SD should be active.
 
 Default: `true`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -592,11 +592,8 @@ Type: `bool`
 
 #### `Discovery.MDNS.Interval`
 
-The number of seconds between discovery checks.
-
-Default: `5`
-
-Type: `integer` (integer seconds, 0 means the default)
+**REMOVED:**  this is not configurable any more
+in the [new mDNS implementation](https://github.com/libp2p/zeroconf#readme).
 
 ## `Gateway`
 

--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,6 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2 // indirect
 	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
-	github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1556,7 +1556,6 @@ github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1 h1:ctS9An
 github.com/whyrusleeping/go-sysinfo v0.0.0-20190219211824-4a357d4b90b1/go.mod h1:tKH72zYNt/exx6/5IQO6L9LoQ0rEjd5SbbWaDTs9Zso=
 github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvXwGvqIpk20FA=
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
-github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9 h1:Y1/FEOpaCpD21WxrmfeIYCFPuVPRCY2XZTWzTNHGw30=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=


### PR DESCRIPTION
This PR removes the ancient `mdns_legacy` implementation.

- The modern DNS-SD compatible [zeroconf implementation](https://github.com/libp2p/zeroconf#readme) (based on [new specs here](https://github.com/libp2p/specs/blob/master/discovery/mdns.md)) has been running next to the legacy one for a while (since v0.11)
  - This means we were sending twice as many packets, most likely contributing to issues like  ipfs/go-ipfs#8695
- [@libp2p/mdns](https://github.com/libp2p/js-libp2p-mdns) used by js-ipfs implements and runs both [old](https://github.com/libp2p/js-libp2p-mdns/tree/master/src/compat) and [new](https://github.com/libp2p/js-libp2p-mdns/tree/master/src), so we won't lose any interop connectivity. 

@marten-seemann @schomatis thoughts on removing old one? any concerns?
